### PR TITLE
fix(game-night): code review fixes — TimeProvider, domain exceptions,…

### DIFF
--- a/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/GameNightPlaylist/GameNightPlaylist.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/GameNightPlaylist/GameNightPlaylist.cs
@@ -1,4 +1,5 @@
 using Api.BoundedContexts.GameManagement.Domain.Events;
+using Api.Middleware.Exceptions;
 using Api.SharedKernel.Domain.Entities;
 
 namespace Api.BoundedContexts.GameManagement.Domain.Entities.GameNightPlaylist;
@@ -56,8 +57,8 @@ internal sealed class GameNightPlaylist : AggregateRoot<Guid>
         ScheduledDate = scheduledDate;
         IsShared = false;
         IsDeleted = false;
-        CreatedAt = DateTime.UtcNow;
-        UpdatedAt = DateTime.UtcNow;
+        CreatedAt = TimeProvider.System.GetUtcNow().UtcDateTime;
+        UpdatedAt = TimeProvider.System.GetUtcNow().UtcDateTime;
 
         AddDomainEvent(new PlaylistCreatedEvent(id, name, creatorUserId));
     }
@@ -81,7 +82,7 @@ internal sealed class GameNightPlaylist : AggregateRoot<Guid>
             throw new ArgumentException("Playlist name cannot exceed 200 characters", nameof(name));
 
         Name = name.Trim();
-        UpdatedAt = DateTime.UtcNow;
+        UpdatedAt = TimeProvider.System.GetUtcNow().UtcDateTime;
     }
 
     /// <summary>
@@ -90,7 +91,7 @@ internal sealed class GameNightPlaylist : AggregateRoot<Guid>
     public void UpdateScheduledDate(DateTime? date)
     {
         ScheduledDate = date;
-        UpdatedAt = DateTime.UtcNow;
+        UpdatedAt = TimeProvider.System.GetUtcNow().UtcDateTime;
     }
 
     /// <summary>
@@ -104,7 +105,7 @@ internal sealed class GameNightPlaylist : AggregateRoot<Guid>
             throw new ArgumentException("Position must be >= 1", nameof(position));
 
         if (_games.Any(g => g.SharedGameId == sharedGameId))
-            throw new InvalidOperationException($"Game {sharedGameId} is already in the playlist");
+            throw new ConflictException($"Game {sharedGameId} is already in the playlist");
 
         // Shift existing games at or after position
         for (var i = 0; i < _games.Count; i++)
@@ -119,10 +120,10 @@ internal sealed class GameNightPlaylist : AggregateRoot<Guid>
         {
             SharedGameId = sharedGameId,
             Position = position,
-            AddedAt = DateTime.UtcNow
+            AddedAt = TimeProvider.System.GetUtcNow().UtcDateTime
         });
 
-        UpdatedAt = DateTime.UtcNow;
+        UpdatedAt = TimeProvider.System.GetUtcNow().UtcDateTime;
     }
 
     /// <summary>
@@ -134,7 +135,7 @@ internal sealed class GameNightPlaylist : AggregateRoot<Guid>
             throw new ArgumentException("SharedGameId cannot be empty", nameof(sharedGameId));
 
         var game = _games.FirstOrDefault(g => g.SharedGameId == sharedGameId)
-            ?? throw new InvalidOperationException($"Game {sharedGameId} is not in the playlist");
+            ?? throw new NotFoundException("PlaylistGame", sharedGameId.ToString());
 
         var removedPosition = game.Position;
         _games.Remove(game);
@@ -148,7 +149,7 @@ internal sealed class GameNightPlaylist : AggregateRoot<Guid>
             }
         }
 
-        UpdatedAt = DateTime.UtcNow;
+        UpdatedAt = TimeProvider.System.GetUtcNow().UtcDateTime;
     }
 
     /// <summary>
@@ -175,7 +176,7 @@ internal sealed class GameNightPlaylist : AggregateRoot<Guid>
             _games[i] = _games[i] with { Position = newPosition };
         }
 
-        UpdatedAt = DateTime.UtcNow;
+        UpdatedAt = TimeProvider.System.GetUtcNow().UtcDateTime;
     }
 
     /// <summary>
@@ -188,7 +189,7 @@ internal sealed class GameNightPlaylist : AggregateRoot<Guid>
             .Replace("+", "-")
             .TrimEnd('=');
         IsShared = true;
-        UpdatedAt = DateTime.UtcNow;
+        UpdatedAt = TimeProvider.System.GetUtcNow().UtcDateTime;
         return ShareToken;
     }
 
@@ -199,7 +200,7 @@ internal sealed class GameNightPlaylist : AggregateRoot<Guid>
     {
         ShareToken = null;
         IsShared = false;
-        UpdatedAt = DateTime.UtcNow;
+        UpdatedAt = TimeProvider.System.GetUtcNow().UtcDateTime;
     }
 
     /// <summary>
@@ -208,11 +209,11 @@ internal sealed class GameNightPlaylist : AggregateRoot<Guid>
     public void SoftDelete()
     {
         if (IsDeleted)
-            throw new InvalidOperationException("Playlist is already deleted");
+            throw new ConflictException("Playlist is already deleted");
 
         IsDeleted = true;
-        DeletedAt = DateTime.UtcNow;
-        UpdatedAt = DateTime.UtcNow;
+        DeletedAt = TimeProvider.System.GetUtcNow().UtcDateTime;
+        UpdatedAt = TimeProvider.System.GetUtcNow().UtcDateTime;
     }
 
     /// <summary>

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Services/GameSessionOrchestratorService.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Services/GameSessionOrchestratorService.cs
@@ -156,18 +156,10 @@ internal sealed class GameSessionOrchestratorService : IGameSessionOrchestratorS
 
         try
         {
-            var kbCardGameIds = new List<Guid>();
-
-            foreach (var gameId in allGameIds)
-            {
-                var docs = await _vectorDocumentRepository.GetByGameIdAsync(gameId, ct).ConfigureAwait(false);
-                if (docs.Count > 0)
-                {
-                    kbCardGameIds.Add(gameId);
-                }
-            }
-
-            return kbCardGameIds;
+            // Single batch query instead of N+1 per-game lookups (Issue #5578)
+            return await _vectorDocumentRepository
+                .GetGameIdsWithDocumentsAsync(allGameIds, ct)
+                .ConfigureAwait(false);
         }
         catch (Exception ex)
         {

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Handlers/AskArbiterCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Handlers/AskArbiterCommandHandler.cs
@@ -5,6 +5,7 @@ using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
 using Api.BoundedContexts.KnowledgeBase.Domain.ValueObjects;
 using Api.Infrastructure;
 using Api.Infrastructure.Entities;
+using Api.Middleware.Exceptions;
 using Api.Services;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
@@ -63,7 +64,7 @@ internal sealed class AskArbiterCommandHandler : IRequestHandler<AskArbiterComma
 
         if (agent == null)
         {
-            throw new InvalidOperationException($"Agent {command.AgentId} not found");
+            throw new NotFoundException("Agent", command.AgentId.ToString());
         }
 
         // 2. Load agent configuration and selected documents

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/RagPromptAssemblyService.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/RagPromptAssemblyService.cs
@@ -92,13 +92,13 @@ internal sealed class RagPromptAssemblyService : IRagPromptAssemblyService
         ArgumentNullException.ThrowIfNull(gameTitle);
         ArgumentNullException.ThrowIfNull(userQuestion);
 
-        // Step 0: Resolve expansion game IDs (Issue #5588)
+        // Step 0: Resolve expansion game IDs once (Issue #5588)
         var expansionGameIds = await _expansionResolver
             .GetExpansionGameIdsAsync(gameId, ct).ConfigureAwait(false);
         var hasExpansions = expansionGameIds.Count > 0;
 
-        // Step 1: Retrieve RAG context (includes expansion boost)
-        var (ragContext, citations) = await RetrieveRagContextAsync(userQuestion, gameId, ct).ConfigureAwait(false);
+        // Step 1: Retrieve RAG context (includes expansion boost), passing pre-resolved expansion IDs
+        var (ragContext, citations) = await RetrieveRagContextAsync(userQuestion, gameId, expansionGameIds, ct).ConfigureAwait(false);
 
         // Step 2: Build system prompt (persona + RAG chunks + expansion priority)
         var systemPrompt = BuildSystemPrompt(agentTypology, gameTitle, gameState, ragContext, hasExpansions);
@@ -119,15 +119,13 @@ internal sealed class RagPromptAssemblyService : IRagPromptAssemblyService
     }
 
     private async Task<(string ragContext, List<ChunkCitation> citations)> RetrieveRagContextAsync(
-        string userQuestion, Guid gameId, CancellationToken ct)
+        string userQuestion, Guid gameId, IReadOnlyList<Guid> expansionGameIds, CancellationToken ct)
     {
         var citations = new List<ChunkCitation>();
 
         try
         {
-            // Issue #5588: Resolve expansion game IDs for score boosting
-            var expansionGameIds = await _expansionResolver
-                .GetExpansionGameIdsAsync(gameId, ct).ConfigureAwait(false);
+            // Issue #5588: Use pre-resolved expansion game IDs for score boosting
             var expansionGameIdStrings = new HashSet<string>(
                 expansionGameIds.Select(id => id.ToString()),
                 StringComparer.OrdinalIgnoreCase);

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Repositories/IVectorDocumentRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Repositories/IVectorDocumentRepository.cs
@@ -84,6 +84,14 @@ internal interface IVectorDocumentRepository
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Returns the subset of game IDs that have at least one indexed vector document.
+    /// Used by GameSessionOrchestratorService to avoid N+1 queries (Issue #5578).
+    /// </summary>
+    Task<List<Guid>> GetGameIdsWithDocumentsAsync(
+        IEnumerable<Guid> gameIds,
+        CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Returns true if at least one of the given VectorDocument IDs belongs to the specified game.
     /// Used by AgentDefinition validators (Issue #5140) to enforce KB card game ownership.
     /// </summary>

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/Persistence/VectorDocumentRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/Persistence/VectorDocumentRepository.cs
@@ -219,6 +219,23 @@ internal class VectorDocumentRepository : RepositoryBase, IVectorDocumentReposit
         return new VectorDocumentIndexingInfo(inferredStatusViaInternal, 0, null);
     }
 
+    public async Task<List<Guid>> GetGameIdsWithDocumentsAsync(
+        IEnumerable<Guid> gameIds,
+        CancellationToken cancellationToken = default)
+    {
+        var idList = gameIds.ToList();
+        if (idList.Count == 0)
+            return new List<Guid>();
+
+        return await DbContext.VectorDocuments
+            .AsNoTracking()
+            .Where(vd => vd.GameId.HasValue && idList.Contains(vd.GameId.Value))
+            .Select(vd => vd.GameId!.Value)
+            .Distinct()
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+
     public async Task<bool> AnyBelongsToGameAsync(
         IEnumerable<Guid> ids,
         Guid gameId,

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/Entities/GameNightPlaylist/GameNightPlaylistTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/Entities/GameNightPlaylist/GameNightPlaylistTests.cs
@@ -1,4 +1,5 @@
 using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightPlaylist;
+using Api.Middleware.Exceptions;
 using Api.Tests.Constants;
 using Xunit;
 
@@ -182,14 +183,14 @@ public class GameNightPlaylistTests
     }
 
     [Fact]
-    public void AddGame_DuplicateGame_ThrowsInvalidOperation()
+    public void AddGame_DuplicateGame_ThrowsConflictException()
     {
         var playlist = CreatePlaylist();
         var gameId = Guid.NewGuid();
 
         playlist.AddGame(gameId, 1);
 
-        Assert.Throws<InvalidOperationException>(() => playlist.AddGame(gameId, 2));
+        Assert.Throws<ConflictException>(() => playlist.AddGame(gameId, 2));
     }
 
     [Fact]
@@ -230,10 +231,10 @@ public class GameNightPlaylistTests
     }
 
     [Fact]
-    public void RemoveGame_NonExistent_ThrowsInvalidOperation()
+    public void RemoveGame_NonExistent_ThrowsNotFoundException()
     {
         var playlist = CreatePlaylist();
-        Assert.Throws<InvalidOperationException>(() => playlist.RemoveGame(Guid.NewGuid()));
+        Assert.Throws<NotFoundException>(() => playlist.RemoveGame(Guid.NewGuid()));
     }
 
     [Fact]
@@ -352,12 +353,12 @@ public class GameNightPlaylistTests
     }
 
     [Fact]
-    public void SoftDelete_AlreadyDeleted_ThrowsInvalidOperation()
+    public void SoftDelete_AlreadyDeleted_ThrowsConflictException()
     {
         var playlist = CreatePlaylist();
         playlist.SoftDelete();
 
-        Assert.Throws<InvalidOperationException>(() => playlist.SoftDelete());
+        Assert.Throws<ConflictException>(() => playlist.SoftDelete());
     }
 
     #endregion

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Infrastructure/Services/GameSessionOrchestratorServiceTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Infrastructure/Services/GameSessionOrchestratorServiceTests.cs
@@ -114,11 +114,28 @@ public class GameSessionOrchestratorServiceTests
             .ReturnsAsync(links);
     }
 
+    private readonly Dictionary<Guid, List<VectorDocument>> _vectorDocSetups = new();
+
     private void SetupVectorDocuments(Guid gameId, List<VectorDocument> docs)
     {
+        _vectorDocSetups[gameId] = docs;
+
         _vectorDocRepoMock
             .Setup(x => x.GetByGameIdAsync(gameId, It.IsAny<CancellationToken>()))
             .ReturnsAsync(docs);
+
+        // Re-setup batch query to reflect all registered game IDs
+        _vectorDocRepoMock
+            .Setup(x => x.GetGameIdsWithDocumentsAsync(
+                It.IsAny<IEnumerable<Guid>>(),
+                It.IsAny<CancellationToken>()))
+            .Returns<IEnumerable<Guid>, CancellationToken>((ids, _) =>
+            {
+                var result = ids
+                    .Where(id => _vectorDocSetups.TryGetValue(id, out var d) && d.Count > 0)
+                    .ToList();
+                return Task.FromResult(result);
+            });
     }
 
     private void SetupRulebookAnalyses(Guid sharedGameId, List<RulebookAnalysis> analyses)
@@ -354,7 +371,7 @@ public class GameSessionOrchestratorServiceTests
         SetupEntityLinks(gameId, new List<EntityLink>());
 
         _vectorDocRepoMock
-            .Setup(x => x.GetByGameIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .Setup(x => x.GetGameIdsWithDocumentsAsync(It.IsAny<IEnumerable<Guid>>(), It.IsAny<CancellationToken>()))
             .ThrowsAsync(new InvalidOperationException("Qdrant unavailable"));
 
         // Act

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/AskArbiterCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/AskArbiterCommandHandlerTests.cs
@@ -325,7 +325,7 @@ public sealed class AskArbiterCommandHandlerTests : IDisposable
     #region Handler Integration Tests
 
     [Fact]
-    public async Task Handle_AgentNotFound_ThrowsInvalidOperationException()
+    public async Task Handle_AgentNotFound_ThrowsNotFoundException()
     {
         // Arrange
         _mockAgentRepository
@@ -335,7 +335,7 @@ public sealed class AskArbiterCommandHandlerTests : IDisposable
         var command = CreateCommand();
 
         // Act & Assert
-        await Assert.ThrowsAsync<InvalidOperationException>(
+        await Assert.ThrowsAsync<Api.Middleware.Exceptions.NotFoundException>(
             () => _handler.Handle(command, CancellationToken.None));
     }
 


### PR DESCRIPTION
… N+1 query (#5578)

- Replace DateTime.UtcNow with TimeProvider.System.GetUtcNow().UtcDateTime in GameNightPlaylist
- Use NotFoundException/ConflictException instead of InvalidOperationException in GameNightPlaylist domain
- Use NotFoundException instead of InvalidOperationException in AskArbiterCommandHandler
- Fix duplicate expansion resolver call in RagPromptAssemblyService (called once, passed to RetrieveRagContextAsync)
- Fix N+1 query in GameSessionOrchestratorService.CollectKbCardGameIdsAsync with batch GetGameIdsWithDocumentsAsync
- Update all affected tests to match new exception types and batch query method

## Summary

<!-- Briefly describe what this PR does -->
<!-- See [Contributing Guidelines](../CONTRIBUTING.md) for detailed PR process -->

## Related Issue

<!-- Link to the issue this PR addresses (e.g., Closes #123) -->

Closes #

## Type of Change

<!-- Check the relevant option(s) -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Performance improvement
- [ ] Test addition/improvement
- [ ] Configuration/infrastructure change

## Changes Made

<!-- List the key changes made in this PR -->

-
-
-

## Testing

<!-- Describe the testing performed -->

### Test Coverage

- [ ] Unit tests added/updated
- [ ] Integration tests added/updated
- [ ] E2E tests added/updated (if applicable)
- [ ] All tests passing locally
- [ ] **Test names follow BDD convention** (see [Testing Guidelines](../CONTRIBUTING.md#testing-guidelines))

### Coverage Metrics

<!--
Run coverage and report the delta. See docs/05-testing/backend/coverage-baseline-2026-01-27.md for baseline.

Backend: cd apps/api && dotnet test --collect:"XPlat Code Coverage"
Frontend: cd apps/web && pnpm test:coverage
-->

| Metric | Before | After | Delta |
|--------|--------|-------|-------|
| Backend Line Coverage | | | |
| Backend Branch Coverage | | | |
| Frontend Statement Coverage | | | |

#### Coverage Requirements

- [ ] **Backend coverage ≥50%** (or no decrease from baseline)
- [ ] **Frontend coverage ≥85%** (or no decrease from baseline)
- [ ] New code has appropriate test coverage
- [ ] No coverage regressions in modified files

#### Bounded Context Coverage (Backend)

<!-- If modifying a specific bounded context, verify its coverage -->

| Bounded Context | Tests Before | Tests After | Notes |
|-----------------|--------------|-------------|-------|
| | | | |

### Manual Testing

<!-- Describe any manual testing performed -->

-

## Checklist

- [ ] Code follows project style guidelines (see [CONTRIBUTING.md](../CONTRIBUTING.md#coding-standards))
- [ ] Self-review of code completed
- [ ] Comments added for complex logic
- [ ] Documentation updated (if applicable)
- [ ] No new warnings introduced
- [ ] Tests added/updated and passing
- [ ] **Test names follow BDD-style naming convention** (see [Testing Guidelines](../CONTRIBUTING.md#testing-guidelines))
- [ ] **Coverage metrics reported above** (see [Coverage Baseline](../docs/05-testing/backend/coverage-baseline-2026-01-27.md))
- [ ] **No coverage regressions** (coverage delta ≥0%)
- [ ] Changes are backwards compatible (or breaking changes documented)
- [ ] No secrets or API keys committed (see [SECURITY.md](../SECURITY.md))

## Screenshots/Recordings (if applicable)

<!-- Add screenshots or recordings demonstrating the changes -->

## Additional Notes

<!-- Any additional context or information -->
