### PR TITLE
test(ai): fill testing gaps for AI Platform — Issue #5

### DIFF
--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Services/LlmResilienceCombinedFailureTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Services/LlmResilienceCombinedFailureTests.cs
@@ -1,0 +1,292 @@
+using Api.BoundedContexts.Authentication.Domain.Entities;
+using Api.BoundedContexts.KnowledgeBase.Application.Services;
+using Api.BoundedContexts.KnowledgeBase.Domain.Enums;
+using Api.BoundedContexts.KnowledgeBase.Domain.Models;
+using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
+using Api.BoundedContexts.KnowledgeBase.Domain.Services;
+using Api.BoundedContexts.SystemConfiguration.Domain.Repositories;
+using Api.Configuration;
+using Api.Services;
+using Api.Services.LlmClients;
+using Api.Tests.Constants;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.KnowledgeBase.Application.Services;
+
+/// <summary>
+/// Combined failure scenario tests extending resilience coverage (Issue #5).
+/// Tests multi-service degradation paths not covered by single-failure chaos tests.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "KnowledgeBase")]
+[Trait("Issue", "5")]
+public sealed class LlmResilienceCombinedFailureTests
+{
+    private readonly Mock<ILlmClient> _ollamaMock = new();
+    private readonly Mock<ILlmClient> _openRouterMock = new();
+    private readonly Mock<ILlmRoutingStrategy> _routingStrategyMock = new();
+    private readonly Mock<IAiModelConfigurationRepository> _modelConfigMock = new();
+    private readonly Mock<IFreeModelQuotaTracker> _quotaTrackerMock = new();
+    private readonly Mock<ICircuitBreakerRegistry> _circuitBreakerRegistryMock = new();
+    private readonly Mock<ILlmCostService> _costServiceMock = new();
+    private readonly ILogger<HybridLlmService> _logger;
+    private readonly ILogger<LlmProviderSelector> _selectorLogger;
+
+    private const string OllamaModel = "llama3.3:70b";
+    private const string OpenRouterModel = "meta-llama/llama-3.3-70b-instruct:free";
+
+    public LlmResilienceCombinedFailureTests()
+    {
+        var loggerFactory = new LoggerFactory();
+        _logger = loggerFactory.CreateLogger<HybridLlmService>();
+        _selectorLogger = loggerFactory.CreateLogger<LlmProviderSelector>();
+
+        _ollamaMock.Setup(c => c.ProviderName).Returns("Ollama");
+        _ollamaMock.Setup(c => c.SupportsModel(It.IsAny<string>())).Returns(true);
+
+        _openRouterMock.Setup(c => c.ProviderName).Returns("OpenRouter");
+        _openRouterMock.Setup(c => c.SupportsModel(It.IsAny<string>())).Returns(true);
+
+        _modelConfigMock
+            .Setup(r => r.GetActiveAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Array.Empty<Api.BoundedContexts.SystemConfiguration.Domain.Entities.AiModelConfiguration>());
+
+        _quotaTrackerMock
+            .Setup(t => t.IsRpdExhaustedAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+        _quotaTrackerMock
+            .Setup(t => t.RecordRateLimitErrorAsync(
+                It.IsAny<string>(), It.IsAny<RateLimitErrorType>(),
+                It.IsAny<long?>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _circuitBreakerRegistryMock
+            .Setup(r => r.AllowsRequests(It.IsAny<string>()))
+            .Returns(true);
+        _circuitBreakerRegistryMock
+            .Setup(r => r.GetState(It.IsAny<string>()))
+            .Returns(CircuitState.Closed);
+    }
+
+    private IOptions<AiProviderSettings> CreateDefaultAiSettings() =>
+        Options.Create(new AiProviderSettings
+        {
+            PreferredProvider = "",
+            Providers = new Dictionary<string, ProviderConfig>
+            {
+                ["Ollama"] = new() { Enabled = true, BaseUrl = "http://meepleai-ollama:11434", Models = [OllamaModel] },
+                ["OpenRouter"] = new() { Enabled = true, BaseUrl = "https://openrouter.ai/api/v1", Models = [OpenRouterModel] }
+            },
+            FallbackChain = ["Ollama", "OpenRouter"]
+        });
+
+    private HybridLlmService CreateSut(IEmergencyOverrideService? emergencyOverrideService = null)
+    {
+        var clients = new[] { _ollamaMock.Object, _openRouterMock.Object };
+        var aiSettings = CreateDefaultAiSettings();
+
+        var selector = new LlmProviderSelector(
+            clients,
+            _routingStrategyMock.Object,
+            _circuitBreakerRegistryMock.Object,
+            aiSettings,
+            _modelConfigMock.Object,
+            _selectorLogger,
+            freeModelQuotaTracker: _quotaTrackerMock.Object,
+            emergencyOverrideService: emergencyOverrideService);
+
+        return new HybridLlmService(
+            clients,
+            selector,
+            _circuitBreakerRegistryMock.Object,
+            _costServiceMock.Object,
+            _logger);
+    }
+
+    private static LlmCompletionResult SuccessResult(string provider) =>
+        LlmCompletionResult.CreateSuccess(
+            $"Hello from {provider}!",
+            new LlmUsage(10, 5, 15),
+            new LlmCost { InputCost = 0m, OutputCost = 0m, ModelId = "test-model", Provider = provider },
+            new Dictionary<string, string>(StringComparer.Ordinal) { ["provider"] = provider });
+
+    // ─── Scenario 1: RPD exhausted + Circuit breaker open → Ollama ──────────────
+
+    /// <summary>
+    /// COMBINED: OpenRouter RPD quota exhausted AND circuit breaker open simultaneously.
+    /// Failure mode: Double degradation — quota depletion combined with circuit protection.
+    /// Expected recovery: Selector proactively routes to Ollama without ever calling OpenRouter.
+    /// </summary>
+    [Fact]
+    public async Task RpdExhausted_AND_CircuitBreakerOpen_FallsBackToOllama()
+    {
+        // Routing strategy nominates OpenRouter
+        _routingStrategyMock
+            .Setup(s => s.SelectProvider(It.IsAny<User?>(), It.IsAny<RagStrategy>(), It.IsAny<string?>()))
+            .Returns(LlmRoutingDecision.OpenRouter(OpenRouterModel, "default routing"));
+
+        // RPD quota is exhausted for the OpenRouter model
+        _quotaTrackerMock
+            .Setup(t => t.IsRpdExhaustedAsync(OpenRouterModel, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        // Circuit breaker is also open for OpenRouter
+        _circuitBreakerRegistryMock
+            .Setup(r => r.AllowsRequests("OpenRouter"))
+            .Returns(false);
+        _circuitBreakerRegistryMock
+            .Setup(r => r.GetState("OpenRouter"))
+            .Returns(CircuitState.Open);
+
+        // Ollama is healthy and responds successfully
+        _ollamaMock
+            .Setup(c => c.GenerateCompletionAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<double>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SuccessResult("Ollama"));
+
+        var sut = CreateSut();
+        var result = await sut.GenerateCompletionAsync("sys", "user");
+
+        Assert.True(result.Success);
+
+        // OpenRouter must never be called — proactive rerouting should prevent any attempt
+        _openRouterMock.Verify(
+            c => c.GenerateCompletionAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<double>(), It.IsAny<int>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    // ─── Scenario 2: OpenRouter 429 + Ollama fallback → rate limit recorded ─────
+
+    /// <summary>
+    /// COMBINED: OpenRouter throws 429, Ollama handles fallback, and the rate limit error
+    /// is recorded via the circuit breaker registry (RecordFailure path).
+    /// Failure mode: Rate limit burst with successful fallback.
+    /// Expected recovery: Request succeeds via Ollama; circuit breaker records the OpenRouter failure.
+    /// </summary>
+    [Fact]
+    public async Task OpenRouter429_AND_OllamaAvailable_RecordsRateLimitError()
+    {
+        // Routing strategy selects OpenRouter
+        _routingStrategyMock
+            .Setup(s => s.SelectProvider(It.IsAny<User?>(), It.IsAny<RagStrategy>(), It.IsAny<string?>()))
+            .Returns(LlmRoutingDecision.OpenRouter(OpenRouterModel, "default routing"));
+
+        // OpenRouter throws 429
+        _openRouterMock
+            .Setup(c => c.GenerateCompletionAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<double>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("429 Too Many Requests"));
+
+        // Ollama succeeds as fallback
+        _ollamaMock
+            .Setup(c => c.GenerateCompletionAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<double>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SuccessResult("Ollama"));
+
+        var sut = CreateSut();
+        var result = await sut.GenerateCompletionAsync("sys", "user");
+
+        // Request must succeed via Ollama fallback
+        Assert.True(result.Success);
+
+        // Circuit breaker registry must have recorded the OpenRouter failure
+        _circuitBreakerRegistryMock.Verify(
+            r => r.RecordFailure("OpenRouter", It.IsAny<long>()),
+            Times.Once);
+    }
+
+    // ─── Scenario 3: Success resets counter after intermittent failures ──────────
+
+    /// <summary>
+    /// COMBINED: Intermittent failures (4) followed by a success that resets the counter,
+    /// then 4 more failures — circuit must remain Closed because the success reset prevented
+    /// reaching the threshold of 5 consecutive failures.
+    /// Failure mode: Flaky provider with intermittent errors.
+    /// Expected recovery: Success resets failure counter, preventing false circuit opens.
+    /// </summary>
+    [Fact]
+    public void CircuitBreaker_SuccessResetsCounter_AfterIntermittentFailures()
+    {
+        var breaker = new CircuitBreakerState();
+
+        // 4 failures — just below threshold of 5
+        for (int i = 0; i < 4; i++)
+            breaker.RecordFailure();
+
+        Assert.Equal(CircuitState.Closed, breaker.State);
+        Assert.Equal(4, breaker.ConsecutiveFailures);
+
+        // 1 success resets the consecutive failure counter to 0
+        breaker.RecordSuccess();
+        Assert.Equal(0, breaker.ConsecutiveFailures);
+        Assert.Equal(CircuitState.Closed, breaker.State);
+
+        // 4 more failures — total historical failures = 8, but consecutive = 4 (below threshold)
+        for (int i = 0; i < 4; i++)
+            breaker.RecordFailure();
+
+        Assert.Equal(CircuitState.Closed, breaker.State);
+        Assert.Equal(4, breaker.ConsecutiveFailures);
+        Assert.True(breaker.AllowsRequests());
+    }
+
+    // ─── Scenario 4: Circuit open bypasses OpenRouter, routes to Ollama ─────────
+
+    /// <summary>
+    /// COMBINED: Circuit breaker is open for OpenRouter. Even though routing strategy selects
+    /// OpenRouter, the selector must detect the open circuit and fall back to Ollama.
+    /// Failure mode: Provider circuit tripped due to prior failures.
+    /// Expected recovery: Selector transparently reroutes to Ollama; OpenRouter never called.
+    /// </summary>
+    [Fact]
+    public async Task OpenRouterCircuitOpen_RoutingBypassesOpenRouter_UsesOllama()
+    {
+        // Routing strategy nominates OpenRouter
+        _routingStrategyMock
+            .Setup(s => s.SelectProvider(It.IsAny<User?>(), It.IsAny<RagStrategy>(), It.IsAny<string?>()))
+            .Returns(LlmRoutingDecision.OpenRouter(OpenRouterModel, "default routing"));
+
+        // Circuit breaker is open for OpenRouter — requests not allowed
+        _circuitBreakerRegistryMock
+            .Setup(r => r.AllowsRequests("OpenRouter"))
+            .Returns(false);
+        _circuitBreakerRegistryMock
+            .Setup(r => r.GetState("OpenRouter"))
+            .Returns(CircuitState.Open);
+
+        // Ollama circuit is healthy
+        _circuitBreakerRegistryMock
+            .Setup(r => r.AllowsRequests("Ollama"))
+            .Returns(true);
+        _circuitBreakerRegistryMock
+            .Setup(r => r.GetState("Ollama"))
+            .Returns(CircuitState.Closed);
+
+        // Ollama succeeds
+        _ollamaMock
+            .Setup(c => c.GenerateCompletionAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<double>(), It.IsAny<int>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SuccessResult("Ollama"));
+
+        var sut = CreateSut();
+        var result = await sut.GenerateCompletionAsync("sys", "user");
+
+        Assert.True(result.Success);
+
+        // OpenRouter must never be called — circuit breaker should prevent any attempt
+        _openRouterMock.Verify(
+            c => c.GenerateCompletionAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<double>(), It.IsAny<int>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Services/OpenRouterRateLimitTrackerGracefulDegradationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Services/OpenRouterRateLimitTrackerGracefulDegradationTests.cs
@@ -1,0 +1,330 @@
+using Api.BoundedContexts.KnowledgeBase.Application.Services;
+using Api.BoundedContexts.KnowledgeBase.Domain.Models;
+using Api.BoundedContexts.KnowledgeBase.Domain.Services;
+using Api.Tests.Constants;
+using Microsoft.Extensions.Logging;
+using Moq;
+using StackExchange.Redis;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.KnowledgeBase.Application.Services;
+
+/// <summary>
+/// Focused test suite for Redis failure graceful degradation in OpenRouterRateLimitTracker.
+/// Validates that all public methods degrade safely when Redis is unavailable or throws,
+/// ensuring the application continues to function without rate-limit tracking.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "KnowledgeBase")]
+[Trait("Issue", "5075")]
+public sealed class OpenRouterRateLimitTrackerGracefulDegradationTests
+{
+    private readonly Mock<IConnectionMultiplexer> _redisMock = new();
+    private readonly Mock<IDatabase> _dbMock = new();
+    private readonly Mock<IBatch> _batchMock = new();
+    private readonly Mock<IOpenRouterUsageService> _usageServiceMock = new();
+    private readonly ILogger<OpenRouterRateLimitTracker> _logger;
+
+    public OpenRouterRateLimitTrackerGracefulDegradationTests()
+    {
+        _redisMock
+            .Setup(r => r.GetDatabase(It.IsAny<int>(), It.IsAny<object>()))
+            .Returns(_dbMock.Object);
+
+        _dbMock
+            .Setup(d => d.CreateBatch(It.IsAny<object>()))
+            .Returns(_batchMock.Object);
+
+        _logger = new LoggerFactory().CreateLogger<OpenRouterRateLimitTracker>();
+    }
+
+    private OpenRouterRateLimitTracker CreateSut() => new(
+        _redisMock.Object, _usageServiceMock.Object, _logger);
+
+    // ─── RecordRequestAsync — Redis failure scenarios ──────────────────────────
+
+    [Fact]
+    public async Task RecordRequest_RedisWriteFails_DoesNotThrow()
+    {
+        // Arrange — batch.Execute() throws, simulating Redis connection loss mid-batch
+        SetupDefaultBatchTasks();
+
+        _batchMock
+            .Setup(b => b.Execute())
+            .Throws(new RedisConnectionException(
+                ConnectionFailureType.UnableToConnect, "Connection refused"));
+
+        var sut = CreateSut();
+
+        // Act — must not propagate the exception
+        var exception = await Record.ExceptionAsync(() =>
+            sut.RecordRequestAsync("openrouter", "gpt-4o", totalTokens: 500));
+
+        // Assert
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public async Task RecordRequest_GetDatabaseThrows_DoesNotThrow()
+    {
+        // Arrange — Redis multiplexer itself is broken
+        _redisMock
+            .Setup(r => r.GetDatabase(It.IsAny<int>(), It.IsAny<object>()))
+            .Throws(new RedisConnectionException(
+                ConnectionFailureType.InternalFailure, "Multiplexer disposed"));
+
+        var sut = CreateSut();
+
+        // Act
+        var exception = await Record.ExceptionAsync(() =>
+            sut.RecordRequestAsync("openrouter", "gpt-4o", totalTokens: 250));
+
+        // Assert
+        Assert.Null(exception);
+    }
+
+    // ─── GetCurrentStatusAsync — Redis failure scenarios ───────────────────────
+
+    [Fact]
+    public async Task GetCurrentStatus_RedisReadFails_ReturnsEmptyStatus()
+    {
+        // Arrange — first Redis call (SortedSetRemoveRangeByScoreAsync) throws
+        _dbMock
+            .Setup(d => d.SortedSetRemoveRangeByScoreAsync(
+                It.IsAny<RedisKey>(), It.IsAny<double>(), It.IsAny<double>(),
+                It.IsAny<Exclude>(), It.IsAny<CommandFlags>()))
+            .ThrowsAsync(new RedisConnectionException(
+                ConnectionFailureType.UnableToConnect, "Connection refused"));
+
+        var sut = CreateSut();
+
+        // Act
+        var status = await sut.GetCurrentStatusAsync("openrouter");
+
+        // Assert — all fields should be zero/default (graceful degradation)
+        Assert.Equal(0, status.CurrentRpm);
+        Assert.Equal(0, status.LimitRpm);
+        Assert.Equal(0, status.CurrentTpm);
+        Assert.Equal(0, status.LimitTpm);
+        Assert.Equal(0.0, status.UtilizationPercent);
+        Assert.False(status.IsThrottled);
+    }
+
+    [Fact]
+    public async Task GetCurrentStatus_SortedSetLengthThrows_ReturnsEmptyStatus()
+    {
+        // Arrange — eviction succeeds but count query fails
+        _dbMock
+            .Setup(d => d.SortedSetRemoveRangeByScoreAsync(
+                It.IsAny<RedisKey>(), It.IsAny<double>(), It.IsAny<double>(),
+                It.IsAny<Exclude>(), It.IsAny<CommandFlags>()))
+            .ReturnsAsync(0L);
+
+        _dbMock
+            .Setup(d => d.SortedSetLengthAsync(
+                It.IsAny<RedisKey>(), It.IsAny<double>(), It.IsAny<double>(),
+                It.IsAny<Exclude>(), It.IsAny<CommandFlags>()))
+            .ThrowsAsync(new RedisTimeoutException("Timeout performing ZCARD", CommandStatus.Unknown));
+
+        var sut = CreateSut();
+
+        // Act
+        var status = await sut.GetCurrentStatusAsync("openrouter");
+
+        // Assert
+        Assert.Equal(0, status.CurrentRpm);
+        Assert.Equal(0, status.LimitRpm);
+        Assert.False(status.IsThrottled);
+    }
+
+    [Fact]
+    public async Task GetCurrentStatus_RedisAvailable_ReturnsActualCounts()
+    {
+        // Arrange — Redis is healthy and returns real data
+        _dbMock
+            .Setup(d => d.SortedSetRemoveRangeByScoreAsync(
+                It.IsAny<RedisKey>(), It.IsAny<double>(), It.IsAny<double>(),
+                It.IsAny<Exclude>(), It.IsAny<CommandFlags>()))
+            .ReturnsAsync(2L); // evicted 2 stale entries
+
+        _dbMock
+            .Setup(d => d.SortedSetLengthAsync(
+                It.Is<RedisKey>(k => k.ToString().Contains("rpm:")),
+                It.IsAny<double>(), It.IsAny<double>(),
+                It.IsAny<Exclude>(), It.IsAny<CommandFlags>()))
+            .ReturnsAsync(42L);
+
+        _dbMock
+            .Setup(d => d.SortedSetRangeByScoreAsync(
+                It.Is<RedisKey>(k => k.ToString().Contains("tpm:")),
+                It.IsAny<double>(), It.IsAny<double>(),
+                It.IsAny<Exclude>(), It.IsAny<Order>(),
+                It.IsAny<long>(), It.IsAny<long>(), It.IsAny<CommandFlags>()))
+            .ReturnsAsync(new RedisValue[] { "abc123:300", "def456:700" });
+
+        _usageServiceMock
+            .Setup(u => u.GetAccountStatusAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new OpenRouterAccountStatus
+            {
+                RateLimitRequests = 200,
+                RateLimitInterval = "minute"
+            });
+
+        var sut = CreateSut();
+
+        // Act
+        var status = await sut.GetCurrentStatusAsync("openrouter");
+
+        // Assert — real data flows through when Redis is healthy
+        Assert.Equal(42, status.CurrentRpm);
+        Assert.True(status.CurrentRpm > 0);
+        Assert.Equal(200, status.LimitRpm);
+        Assert.Equal(1000, status.CurrentTpm); // 300 + 700
+        Assert.Equal(0.21, status.UtilizationPercent, precision: 5); // 42/200
+        Assert.False(status.IsThrottled);
+    }
+
+    // ─── IsApproachingLimitAsync — Redis failure scenarios ─────────────────────
+
+    [Fact]
+    public async Task IsApproachingLimit_RedisDown_ReturnsFalse()
+    {
+        // Arrange — Redis is completely unavailable
+        _dbMock
+            .Setup(d => d.SortedSetRemoveRangeByScoreAsync(
+                It.IsAny<RedisKey>(), It.IsAny<double>(), It.IsAny<double>(),
+                It.IsAny<Exclude>(), It.IsAny<CommandFlags>()))
+            .ThrowsAsync(new RedisConnectionException(
+                ConnectionFailureType.UnableToConnect, "Connection refused"));
+
+        var sut = CreateSut();
+
+        // Act — should return safe default (false) rather than throwing
+        var approaching = await sut.IsApproachingLimitAsync("openrouter", thresholdPercent: 80);
+
+        // Assert — false is the safe default: we don't block requests when we can't measure
+        Assert.False(approaching);
+    }
+
+    [Fact]
+    public async Task IsApproachingLimit_RedisDown_DoesNotCallUsageService()
+    {
+        // Arrange — Redis fails on first call inside GetCurrentStatusAsync
+        _dbMock
+            .Setup(d => d.SortedSetRemoveRangeByScoreAsync(
+                It.IsAny<RedisKey>(), It.IsAny<double>(), It.IsAny<double>(),
+                It.IsAny<Exclude>(), It.IsAny<CommandFlags>()))
+            .ThrowsAsync(new RedisConnectionException(
+                ConnectionFailureType.UnableToConnect, "Connection refused"));
+
+        var sut = CreateSut();
+
+        // Act
+        await sut.IsApproachingLimitAsync("openrouter");
+
+        // Assert — when Redis fails early, the catch returns empty status
+        // so LimitRpm=0 and the method returns false before needing usage service.
+        // But since the exception is caught inside GetCurrentStatusAsync, the usage
+        // service call (which is also inside the try block) is never reached.
+        _usageServiceMock.Verify(
+            u => u.GetAccountStatusAsync(It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    // ─── RecordRequestAsync — happy path batch verification ───────────────────
+
+    [Fact]
+    public async Task RecordRequest_WithTokens_CallsRedisInBatch()
+    {
+        // Arrange — set up batch operations to complete successfully
+        SetupDefaultBatchTasks();
+
+        var sut = CreateSut();
+
+        // Act
+        await sut.RecordRequestAsync("openrouter", "gpt-4o", totalTokens: 1200);
+
+        // Assert — batch was created and executed
+        _dbMock.Verify(d => d.CreateBatch(It.IsAny<object>()), Times.Once);
+        _batchMock.Verify(b => b.Execute(), Times.Once);
+
+        // RPM: ZADD + ZREMRANGEBYSCORE + EXPIRE
+        _batchMock.Verify(b => b.SortedSetAddAsync(
+            It.Is<RedisKey>(k => k.ToString() == "openrouter:rpm:openrouter"),
+            It.IsAny<RedisValue>(), It.IsAny<double>(),
+            It.IsAny<SortedSetWhen>(), It.IsAny<CommandFlags>()), Times.Once);
+
+        _batchMock.Verify(b => b.SortedSetRemoveRangeByScoreAsync(
+            It.Is<RedisKey>(k => k.ToString() == "openrouter:rpm:openrouter"),
+            It.IsAny<double>(), It.IsAny<double>(),
+            It.IsAny<Exclude>(), It.IsAny<CommandFlags>()), Times.Once);
+
+        _batchMock.Verify(b => b.KeyExpireAsync(
+            It.Is<RedisKey>(k => k.ToString() == "openrouter:rpm:openrouter"),
+            It.IsAny<TimeSpan?>(), It.IsAny<ExpireWhen>(), It.IsAny<CommandFlags>()), Times.Once);
+
+        // TPM: ZADD + ZREMRANGEBYSCORE + EXPIRE (because totalTokens > 0)
+        _batchMock.Verify(b => b.SortedSetAddAsync(
+            It.Is<RedisKey>(k => k.ToString() == "openrouter:tpm:openrouter"),
+            It.IsAny<RedisValue>(), It.IsAny<double>(),
+            It.IsAny<SortedSetWhen>(), It.IsAny<CommandFlags>()), Times.Once);
+
+        _batchMock.Verify(b => b.SortedSetRemoveRangeByScoreAsync(
+            It.Is<RedisKey>(k => k.ToString() == "openrouter:tpm:openrouter"),
+            It.IsAny<double>(), It.IsAny<double>(),
+            It.IsAny<Exclude>(), It.IsAny<CommandFlags>()), Times.Once);
+
+        _batchMock.Verify(b => b.KeyExpireAsync(
+            It.Is<RedisKey>(k => k.ToString() == "openrouter:tpm:openrouter"),
+            It.IsAny<TimeSpan?>(), It.IsAny<ExpireWhen>(), It.IsAny<CommandFlags>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task RecordRequest_ZeroTokens_SkipsTpmBatch()
+    {
+        // Arrange
+        SetupDefaultBatchTasks();
+
+        var sut = CreateSut();
+
+        // Act
+        await sut.RecordRequestAsync("openrouter", "gpt-4o", totalTokens: 0);
+
+        // Assert — RPM operations still happen
+        _batchMock.Verify(b => b.SortedSetAddAsync(
+            It.Is<RedisKey>(k => k.ToString().Contains("rpm:")),
+            It.IsAny<RedisValue>(), It.IsAny<double>(),
+            It.IsAny<SortedSetWhen>(), It.IsAny<CommandFlags>()), Times.Once);
+
+        // TPM operations should NOT happen
+        _batchMock.Verify(b => b.SortedSetAddAsync(
+            It.Is<RedisKey>(k => k.ToString().Contains("tpm:")),
+            It.IsAny<RedisValue>(), It.IsAny<double>(),
+            It.IsAny<SortedSetWhen>(), It.IsAny<CommandFlags>()), Times.Never);
+
+        _batchMock.Verify(b => b.Execute(), Times.Once);
+    }
+
+    // ─── Helper ────────────────────────────────────────────────────────────────
+
+    private void SetupDefaultBatchTasks()
+    {
+        _batchMock
+            .Setup(b => b.SortedSetAddAsync(
+                It.IsAny<RedisKey>(), It.IsAny<RedisValue>(), It.IsAny<double>(),
+                It.IsAny<SortedSetWhen>(), It.IsAny<CommandFlags>()))
+            .ReturnsAsync(true);
+
+        _batchMock
+            .Setup(b => b.SortedSetRemoveRangeByScoreAsync(
+                It.IsAny<RedisKey>(), It.IsAny<double>(), It.IsAny<double>(),
+                It.IsAny<Exclude>(), It.IsAny<CommandFlags>()))
+            .ReturnsAsync(0L);
+
+        _batchMock
+            .Setup(b => b.KeyExpireAsync(
+                It.IsAny<RedisKey>(), It.IsAny<TimeSpan?>(),
+                It.IsAny<ExpireWhen>(), It.IsAny<CommandFlags>()))
+            .ReturnsAsync(true);
+    }
+}

--- a/apps/web/src/__tests__/config/admin-dashboard-navigation.test.ts
+++ b/apps/web/src/__tests__/config/admin-dashboard-navigation.test.ts
@@ -2,10 +2,10 @@
  * Admin Dashboard Navigation Config Tests - Issue #4844
  *
  * Covers:
- * - isSectionActive: baseRoute matching
+ * - isSectionActive: baseRoute + additionalRoutes matching
  * - getActiveSection: route-to-section mapping
  * - isSidebarItemActive: activePattern and prefix matching
- * - DASHBOARD_SECTIONS: Documents item present in knowledge-base
+ * - DASHBOARD_SECTIONS: Documents item present in content section
  */
 
 import { describe, it, expect } from 'vitest';
@@ -24,7 +24,7 @@ import {
 describe('getSection', () => {
   it('returns section by id', () => {
     expect(getSection('overview')?.id).toBe('overview');
-    expect(getSection('knowledge-base')?.id).toBe('knowledge-base');
+    expect(getSection('content')?.id).toBe('content');
   });
 
   it('returns undefined for unknown id', () => {
@@ -34,7 +34,7 @@ describe('getSection', () => {
 
 describe('getSidebarItems', () => {
   it('returns items for known section', () => {
-    const items = getSidebarItems('knowledge-base');
+    const items = getSidebarItems('content');
     expect(items.length).toBeGreaterThan(0);
   });
 
@@ -46,26 +46,27 @@ describe('getSidebarItems', () => {
 // ─── isSectionActive ─────────────────────────────────────────────────────────
 
 describe('isSectionActive', () => {
-  const kb = DASHBOARD_SECTIONS.find(s => s.id === 'knowledge-base')!;
+  const content = DASHBOARD_SECTIONS.find(s => s.id === 'content')!;
   const overview = DASHBOARD_SECTIONS.find(s => s.id === 'overview')!;
 
   describe('baseRoute matching', () => {
     it('matches exact baseRoute', () => {
-      expect(isSectionActive(kb, '/admin/knowledge-base')).toBe(true);
+      expect(isSectionActive(content, '/admin/shared-games')).toBe(true);
     });
 
     it('matches sub-routes under baseRoute', () => {
-      expect(isSectionActive(kb, '/admin/knowledge-base/vectors')).toBe(true);
-      expect(isSectionActive(kb, '/admin/knowledge-base/settings')).toBe(true);
+      expect(isSectionActive(content, '/admin/shared-games/all')).toBe(true);
+      expect(isSectionActive(content, '/admin/shared-games/new')).toBe(true);
     });
 
-    it('matches documents sub-route under baseRoute', () => {
-      expect(isSectionActive(kb, '/admin/knowledge-base/documents')).toBe(true);
+    it('matches additionalRoutes for knowledge-base', () => {
+      expect(isSectionActive(content, '/admin/knowledge-base')).toBe(true);
+      expect(isSectionActive(content, '/admin/knowledge-base/documents')).toBe(true);
     });
 
     it('does not match unrelated routes', () => {
-      expect(isSectionActive(kb, '/admin/users')).toBe(false);
-      expect(isSectionActive(kb, '/admin/agents')).toBe(false);
+      expect(isSectionActive(content, '/admin/users')).toBe(false);
+      expect(isSectionActive(content, '/admin/agents')).toBe(false);
     });
   });
 
@@ -74,8 +75,8 @@ describe('isSectionActive', () => {
       expect(isSectionActive(overview, '/admin/overview')).toBe(true);
     });
 
-    it('overview section is not active for /admin/knowledge-base', () => {
-      expect(isSectionActive(overview, '/admin/knowledge-base')).toBe(false);
+    it('overview section is not active for /admin/shared-games', () => {
+      expect(isSectionActive(overview, '/admin/shared-games')).toBe(false);
     });
   });
 });
@@ -87,27 +88,35 @@ describe('getActiveSection', () => {
     expect(getActiveSection('/admin/overview')?.id).toBe('overview');
   });
 
-  it('returns knowledge-base for /admin/knowledge-base', () => {
-    expect(getActiveSection('/admin/knowledge-base')?.id).toBe('knowledge-base');
+  it('returns content for /admin/knowledge-base (additionalRoute)', () => {
+    expect(getActiveSection('/admin/knowledge-base')?.id).toBe('content');
   });
 
-  it('returns knowledge-base for /admin/knowledge-base/vectors', () => {
-    expect(getActiveSection('/admin/knowledge-base/vectors')?.id).toBe('knowledge-base');
+  it('returns content for /admin/knowledge-base/vectors', () => {
+    expect(getActiveSection('/admin/knowledge-base/vectors')?.id).toBe('content');
   });
 
-  it('returns knowledge-base for /admin/knowledge-base/documents', () => {
-    expect(getActiveSection('/admin/knowledge-base/documents')?.id).toBe('knowledge-base');
+  it('returns content for /admin/knowledge-base/documents', () => {
+    expect(getActiveSection('/admin/knowledge-base/documents')?.id).toBe('content');
   });
 
-  it('returns agents for /admin/agents', () => {
-    expect(getActiveSection('/admin/agents')?.id).toBe('agents');
+  it('returns ai for /admin/agents', () => {
+    expect(getActiveSection('/admin/agents')?.id).toBe('ai');
+  });
+
+  it('returns system for /admin/monitor', () => {
+    expect(getActiveSection('/admin/monitor')?.id).toBe('system');
+  });
+
+  it('returns system for /admin/config (additionalRoute)', () => {
+    expect(getActiveSection('/admin/config')?.id).toBe('system');
   });
 
   it('returns undefined for unknown route', () => {
     expect(getActiveSection('/totally/unknown')).toBeUndefined();
   });
 
-  it('does not return knowledge-base for /admin/pdfstuff (no prefix false-positive)', () => {
+  it('does not return content for /admin/pdfstuff (no prefix false-positive)', () => {
     expect(getActiveSection('/admin/pdfstuff')).toBeUndefined();
   });
 });
@@ -115,11 +124,11 @@ describe('getActiveSection', () => {
 // ─── isSidebarItemActive ──────────────────────────────────────────────────────
 
 describe('isSidebarItemActive', () => {
-  const kbItems = getSidebarItems('knowledge-base');
-  const documentsItem = kbItems.find(i => i.href === '/admin/knowledge-base/documents');
-  const overviewItem = kbItems.find(i => i.href === '/admin/knowledge-base');
+  const contentItems = getSidebarItems('content');
+  const documentsItem = contentItems.find(i => i.href === '/admin/knowledge-base/documents');
+  const kbOverviewItem = contentItems.find(i => i.href === '/admin/knowledge-base');
 
-  it('documents item exists in knowledge-base sidebar', () => {
+  it('documents item exists in content sidebar', () => {
     expect(documentsItem).toBeDefined();
     expect(documentsItem?.label).toBe('Documents');
   });
@@ -136,30 +145,32 @@ describe('isSidebarItemActive', () => {
     expect(isSidebarItemActive(documentsItem!, '/admin/knowledge-base')).toBe(false);
   });
 
-  it('overview item is active on /admin/knowledge-base', () => {
-    expect(isSidebarItemActive(overviewItem!, '/admin/knowledge-base')).toBe(true);
+  it('kb overview item is active on /admin/knowledge-base', () => {
+    expect(isSidebarItemActive(kbOverviewItem!, '/admin/knowledge-base')).toBe(true);
   });
 
-  it('overview item is NOT active on /admin/knowledge-base/vectors (activePattern exact)', () => {
-    expect(isSidebarItemActive(overviewItem!, '/admin/knowledge-base/vectors')).toBe(false);
+  it('kb overview item is NOT active on /admin/knowledge-base/vectors (activePattern exact)', () => {
+    expect(isSidebarItemActive(kbOverviewItem!, '/admin/knowledge-base/vectors')).toBe(false);
   });
 });
 
 // ─── DASHBOARD_SECTIONS structure ────────────────────────────────────────────
 
 describe('DASHBOARD_SECTIONS structure', () => {
-  it('has 5 sections', () => {
-    expect(DASHBOARD_SECTIONS).toHaveLength(5);
+  it('has 6 sections', () => {
+    expect(DASHBOARD_SECTIONS).toHaveLength(6);
   });
 
-  it('knowledge-base section has no additionalRoutes', () => {
-    const kb = DASHBOARD_SECTIONS.find(s => s.id === 'knowledge-base')!;
-    expect(kb.additionalRoutes).toBeUndefined();
+  it('content section has additionalRoutes including knowledge-base', () => {
+    const content = DASHBOARD_SECTIONS.find(s => s.id === 'content')!;
+    expect(content.additionalRoutes).toContain('/admin/knowledge-base');
   });
 
-  it('knowledge-base sidebar contains Documents item pointing to /admin/knowledge-base/documents', () => {
-    const kb = DASHBOARD_SECTIONS.find(s => s.id === 'knowledge-base')!;
-    const documentsItem = kb.sidebarItems.find(i => i.href === '/admin/knowledge-base/documents');
+  it('content sidebar contains Documents item pointing to /admin/knowledge-base/documents', () => {
+    const content = DASHBOARD_SECTIONS.find(s => s.id === 'content')!;
+    const documentsItem = content.sidebarItems.find(
+      i => i.href === '/admin/knowledge-base/documents'
+    );
     expect(documentsItem).toBeDefined();
     expect(documentsItem?.label).toBe('Documents');
   });

--- a/apps/web/src/app/admin/(dashboard)/agents/ab-testing/[id]/__tests__/page.test.tsx
+++ b/apps/web/src/app/admin/(dashboard)/agents/ab-testing/[id]/__tests__/page.test.tsx
@@ -1,0 +1,206 @@
+import React from 'react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import { AbTestEvaluationPageInner } from '../page';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+  usePathname: () => '/admin/agents/ab-testing/test-id',
+}));
+
+vi.mock('next/link', () => ({
+  default: ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+vi.mock('../../../NavConfig', () => ({
+  AgentsNavConfig: () => null,
+}));
+
+const mockGetAbTest = vi.fn();
+const mockEvaluateAbTest = vi.fn();
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    admin: {
+      getAbTest: (...args: unknown[]) => mockGetAbTest(...args),
+      evaluateAbTest: (...args: unknown[]) => mockEvaluateAbTest(...args),
+    },
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createWrapper() {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Mock data
+// ---------------------------------------------------------------------------
+
+const mockSession = {
+  id: 'test-id',
+  createdBy: '00000000-0000-0000-0000-000000000001',
+  query: 'What are the rules for Catan?',
+  status: 'Generated',
+  createdAt: '2026-03-10T12:00:00Z',
+  completedAt: null,
+  totalCost: 0.0042,
+  variants: [
+    {
+      id: '00000000-0000-0000-0000-000000000010',
+      label: 'A',
+      response: 'Catan is a game about building settlements...',
+      tokensUsed: 150,
+      latencyMs: 2000,
+      costUsd: 0.002,
+      failed: false,
+    },
+    {
+      id: '00000000-0000-0000-0000-000000000020',
+      label: 'B',
+      response: 'In Catan, players collect resources...',
+      tokensUsed: 120,
+      latencyMs: 1500,
+      costUsd: 0.0022,
+      failed: false,
+    },
+  ],
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('AbTestEvaluationPageInner', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows loading state initially', () => {
+    // Never resolve so the query stays in loading state
+    mockGetAbTest.mockReturnValue(new Promise(() => {}));
+
+    render(<AbTestEvaluationPageInner id="test-id" />, {
+      wrapper: createWrapper(),
+    });
+
+    // The Loader2 spinner has the animate-spin class inside a centering container
+    const spinner = document.querySelector('.animate-spin');
+    expect(spinner).toBeTruthy();
+  });
+
+  it('renders session query and variant responses after loading', async () => {
+    mockGetAbTest.mockResolvedValue(mockSession);
+
+    render(<AbTestEvaluationPageInner id="test-id" />, {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('What are the rules for Catan?')).toBeInTheDocument();
+    });
+
+    // Both variant responses should be visible
+    expect(screen.getByText('Catan is a game about building settlements...')).toBeInTheDocument();
+    expect(screen.getByText('In Catan, players collect resources...')).toBeInTheDocument();
+  });
+
+  it('shows "not found" message when session is null', async () => {
+    mockGetAbTest.mockResolvedValue(null);
+
+    render(<AbTestEvaluationPageInner id="missing-id" />, {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('A/B test session not found.')).toBeInTheDocument();
+    });
+  });
+
+  it('renders star rating buttons for each dimension per variant', async () => {
+    mockGetAbTest.mockResolvedValue(mockSession);
+
+    render(<AbTestEvaluationPageInner id="test-id" />, {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('What are the rules for Catan?')).toBeInTheDocument();
+    });
+
+    // 4 dimensions (Accuracy, Completeness, Clarity, Tone) x 2 variants = 8 labels
+    const accuracyLabels = screen.getAllByText('Accuracy');
+    expect(accuracyLabels).toHaveLength(2);
+
+    const completenessLabels = screen.getAllByText('Completeness');
+    expect(completenessLabels).toHaveLength(2);
+
+    const clarityLabels = screen.getAllByText('Clarity');
+    expect(clarityLabels).toHaveLength(2);
+
+    const toneLabels = screen.getAllByText('Tone');
+    expect(toneLabels).toHaveLength(2);
+
+    // Each dimension has 5 stars per variant: 5 stars x 4 dims x 2 variants = 40 star buttons
+    const starButtons = screen.getAllByRole('button', { name: /star/i });
+    expect(starButtons).toHaveLength(40);
+  });
+
+  it('submit button is disabled when not all variants are scored', async () => {
+    mockGetAbTest.mockResolvedValue(mockSession);
+
+    render(<AbTestEvaluationPageInner id="test-id" />, {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('What are the rules for Catan?')).toBeInTheDocument();
+    });
+
+    const submitButton = screen.getByRole('button', {
+      name: /submit evaluation/i,
+    });
+    expect(submitButton).toBeDisabled();
+
+    // Guidance text should indicate scoring is incomplete
+    expect(screen.getByText('Score all variants to submit evaluation.')).toBeInTheDocument();
+  });
+
+  it('shows variant labels (A, B) and metadata (tokens, latency)', async () => {
+    mockGetAbTest.mockResolvedValue(mockSession);
+
+    render(<AbTestEvaluationPageInner id="test-id" />, {
+      wrapper: createWrapper(),
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('What are the rules for Catan?')).toBeInTheDocument();
+    });
+
+    // Variant labels rendered as "Variant A" and "Variant B"
+    expect(screen.getByText('Variant A')).toBeInTheDocument();
+    expect(screen.getByText('Variant B')).toBeInTheDocument();
+
+    // Metadata: latencyMs + tokensUsed shown as "2000ms · 150 tokens" etc.
+    expect(screen.getByText(/2000ms/)).toBeInTheDocument();
+    expect(screen.getByText(/150 tokens/)).toBeInTheDocument();
+    expect(screen.getByText(/1500ms/)).toBeInTheDocument();
+    expect(screen.getByText(/120 tokens/)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/admin/(dashboard)/agents/ab-testing/new/__tests__/page.test.tsx
+++ b/apps/web/src/app/admin/(dashboard)/agents/ab-testing/new/__tests__/page.test.tsx
@@ -1,0 +1,211 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockPush = vi.fn();
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+  usePathname: () => '/admin/agents/ab-testing/new',
+}));
+
+vi.mock('../../../NavConfig', () => ({
+  AgentsNavConfig: () => null,
+}));
+
+const mockCreateAbTest = vi.fn();
+vi.mock('@/lib/api', () => ({
+  api: {
+    admin: {
+      createAbTest: (...args: unknown[]) => mockCreateAbTest(...args),
+    },
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Component under test
+// ---------------------------------------------------------------------------
+
+import NewAbTestPage from '../page';
+
+// The 8 model display names exactly as they appear in the component.
+const MODEL_NAMES = [
+  'GPT-4o',
+  'GPT-4o Mini',
+  'Claude 3.5 Sonnet',
+  'Claude 3 Haiku',
+  'Gemini 2.0 Flash',
+  'Llama 3.1 70B',
+  'Mistral Large',
+  'Qwen 2.5 72B',
+];
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/** Click the label row for a given model name to toggle its checkbox. */
+function toggleModel(name: string) {
+  // Each model row is a <label> containing the model name as a <span>.
+  // Clicking anywhere on that label triggers the Radix Checkbox.
+  const span = screen.getByText(name);
+  // Walk up to the wrapping <label> and click it.
+  const label = span.closest('label');
+  expect(label).toBeTruthy();
+  fireEvent.click(label!);
+}
+
+/** Fill the query textarea with the given text. */
+function fillQuery(text: string) {
+  const textarea = screen.getByPlaceholderText(/what are the rules for setting up/i);
+  fireEvent.change(textarea, { target: { value: text } });
+}
+
+/** Return the "Generate Comparison" / "Generating Responses..." button. */
+function getGenerateButton() {
+  // During generation the label changes, so find by role.
+  return screen.getByRole('button', {
+    name: /generate comparison|generating responses/i,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('NewAbTestPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // 1. Renders the page heading
+  it('renders the page title "New A/B Test"', () => {
+    render(<NewAbTestPage />);
+
+    expect(screen.getByRole('heading', { name: /new a\/b test/i })).toBeInTheDocument();
+  });
+
+  // 2. All 8 model checkboxes are present
+  it('renders all 8 model checkboxes', () => {
+    render(<NewAbTestPage />);
+
+    for (const name of MODEL_NAMES) {
+      expect(screen.getByText(name)).toBeInTheDocument();
+    }
+
+    // Exactly 8 checkbox roles
+    const checkboxes = screen.getAllByRole('checkbox');
+    expect(checkboxes).toHaveLength(8);
+  });
+
+  // 3. Generate button is disabled when no models and no query
+  it('disables the Generate button when no models are selected or no query is entered', () => {
+    render(<NewAbTestPage />);
+
+    const btn = getGenerateButton();
+    expect(btn).toBeDisabled();
+  });
+
+  // 4. Selecting models updates their checked state
+  it('can select models and they show a checked state', () => {
+    render(<NewAbTestPage />);
+
+    const checkboxes = screen.getAllByRole('checkbox');
+    // All start unchecked
+    checkboxes.forEach(cb => {
+      expect(cb).toHaveAttribute('data-state', 'unchecked');
+    });
+
+    toggleModel('GPT-4o');
+    toggleModel('Mistral Large');
+
+    // The two toggled checkboxes should now be checked
+    expect(checkboxes[0]).toHaveAttribute('data-state', 'checked');
+    expect(checkboxes[6]).toHaveAttribute('data-state', 'checked');
+  });
+
+  // 5. Cannot select more than MAX_MODELS (4)
+  it('cannot select more than 4 models', () => {
+    render(<NewAbTestPage />);
+
+    // Select 4 models
+    toggleModel('GPT-4o');
+    toggleModel('GPT-4o Mini');
+    toggleModel('Claude 3.5 Sonnet');
+    toggleModel('Claude 3 Haiku');
+
+    // Attempt to select a 5th
+    toggleModel('Gemini 2.0 Flash');
+
+    const checkboxes = screen.getAllByRole('checkbox');
+    // Gemini (index 4) should remain unchecked
+    expect(checkboxes[4]).toHaveAttribute('data-state', 'unchecked');
+
+    // Only 4 are checked
+    const checked = checkboxes.filter(cb => cb.getAttribute('data-state') === 'checked');
+    expect(checked).toHaveLength(4);
+  });
+
+  // 6. Button enabled when query + 2 models
+  it('enables the Generate button when a query is entered and at least 2 models are selected', () => {
+    render(<NewAbTestPage />);
+
+    fillQuery('Explain the rules of Catan');
+    toggleModel('GPT-4o');
+
+    // Still disabled with only 1 model
+    expect(getGenerateButton()).toBeDisabled();
+
+    toggleModel('Claude 3.5 Sonnet');
+
+    // Now enabled
+    expect(getGenerateButton()).toBeEnabled();
+  });
+
+  // 7. Successful submission calls createAbTest and redirects
+  it('calls createAbTest on submit and redirects to the result page', async () => {
+    mockCreateAbTest.mockResolvedValueOnce({ id: 'abc-123' });
+
+    render(<NewAbTestPage />);
+
+    fillQuery('Compare model creativity');
+    toggleModel('GPT-4o');
+    toggleModel('Claude 3.5 Sonnet');
+
+    fireEvent.click(getGenerateButton());
+
+    await waitFor(() => {
+      expect(mockCreateAbTest).toHaveBeenCalledTimes(1);
+      expect(mockCreateAbTest).toHaveBeenCalledWith({
+        query: 'Compare model creativity',
+        modelIds: ['openai/gpt-4o', 'anthropic/claude-3.5-sonnet'],
+      });
+    });
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith('/admin/agents/ab-testing/abc-123');
+    });
+  });
+
+  // 8. Failed submission shows error alert
+  it('shows an error alert when createAbTest fails', async () => {
+    mockCreateAbTest.mockRejectedValueOnce(new Error('Service unavailable'));
+
+    render(<NewAbTestPage />);
+
+    fillQuery('Test query');
+    toggleModel('GPT-4o');
+    toggleModel('Claude 3 Haiku');
+
+    fireEvent.click(getGenerateButton());
+
+    await waitFor(() => {
+      expect(screen.getByText('Service unavailable')).toBeInTheDocument();
+    });
+
+    // Should NOT have redirected
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/app/admin/(dashboard)/agents/ab-testing/results/__tests__/page.test.tsx
+++ b/apps/web/src/app/admin/(dashboard)/agents/ab-testing/results/__tests__/page.test.tsx
@@ -1,0 +1,214 @@
+import React from 'react';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import AbTestAnalyticsPage from '../page';
+
+// ────── Mocks ──────
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+  usePathname: () => '/admin/agents/ab-testing/results',
+}));
+
+vi.mock('next/link', () => ({
+  default: ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
+}));
+
+vi.mock('../../../NavConfig', () => ({
+  AgentsNavConfig: () => null,
+}));
+
+// Mock recharts to avoid SVG rendering issues in jsdom
+vi.mock('recharts', () => ({
+  BarChart: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="bar-chart">{children}</div>
+  ),
+  Bar: () => null,
+  XAxis: () => null,
+  YAxis: () => null,
+  CartesianGrid: () => null,
+  Tooltip: () => null,
+  ResponsiveContainer: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  RadarChart: ({ children }: { children: React.ReactNode }) => (
+    <div data-testid="radar-chart">{children}</div>
+  ),
+  Radar: () => null,
+  PolarGrid: () => null,
+  PolarAngleAxis: () => null,
+  PolarRadiusAxis: () => null,
+}));
+
+const mockGetAbTestAnalytics = vi.fn();
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    admin: {
+      getAbTestAnalytics: (...args: unknown[]) => mockGetAbTestAnalytics(...args),
+    },
+  },
+}));
+
+// ────── Fixtures ──────
+
+const mockAnalytics = {
+  totalTests: 15,
+  completedTests: 12,
+  totalCost: 0.156,
+  modelWinRates: [
+    { modelId: 'openai/gpt-4o', wins: 6, total: 12, winRate: 0.5 },
+    {
+      modelId: 'anthropic/claude-3.5-sonnet',
+      wins: 4,
+      total: 12,
+      winRate: 0.333,
+    },
+  ],
+  modelAvgScores: [
+    {
+      modelId: 'openai/gpt-4o',
+      avgAccuracy: 4.2,
+      avgCompleteness: 3.8,
+      avgClarity: 4.5,
+      avgTone: 4.0,
+      avgOverall: 4.125,
+      evaluationCount: 12,
+    },
+    {
+      modelId: 'anthropic/claude-3.5-sonnet',
+      avgAccuracy: 4.0,
+      avgCompleteness: 4.1,
+      avgClarity: 4.3,
+      avgTone: 4.2,
+      avgOverall: 4.15,
+      evaluationCount: 12,
+    },
+  ],
+};
+
+const emptyAnalytics = {
+  totalTests: 0,
+  completedTests: 0,
+  totalCost: 0,
+  modelWinRates: [],
+  modelAvgScores: [],
+};
+
+// ────── Helpers ──────
+
+function createWrapper() {
+  const qc = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return ({ children }: { children: React.ReactNode }) => (
+    <QueryClientProvider client={qc}>{children}</QueryClientProvider>
+  );
+}
+
+// ────── Tests ──────
+
+describe('AbTestAnalyticsPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows loading state initially', () => {
+    // Never resolve so the query stays in loading state
+    mockGetAbTestAnalytics.mockReturnValue(new Promise(() => {}));
+
+    render(<AbTestAnalyticsPage />, { wrapper: createWrapper() });
+
+    // The Loader2 spinner renders with the animate-spin class
+    const spinner = document.querySelector('.animate-spin');
+    expect(spinner).toBeTruthy();
+  });
+
+  it('shows empty state with "No data yet" when totalTests is 0', async () => {
+    mockGetAbTestAnalytics.mockResolvedValue(emptyAnalytics);
+
+    render(<AbTestAnalyticsPage />, { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(screen.getByText('No data yet')).toBeInTheDocument();
+    });
+
+    // "Create First Test" link pointing to the new test page
+    const createLink = screen.getByText('Create First Test').closest('a');
+    expect(createLink).toHaveAttribute('href', '/admin/agents/ab-testing/new');
+  });
+
+  it('shows KPI cards with correct values when data exists', async () => {
+    mockGetAbTestAnalytics.mockResolvedValue(mockAnalytics);
+
+    render(<AbTestAnalyticsPage />, { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(screen.getByText('Total Tests')).toBeInTheDocument();
+    });
+
+    // Total Tests = 15
+    expect(screen.getByText('15')).toBeInTheDocument();
+    // Completed = 12 (also appears in evaluation count cells, so use getAllByText)
+    const twelveElements = screen.getAllByText('12');
+    expect(twelveElements.length).toBeGreaterThanOrEqual(1);
+    // Total Cost = $0.1560
+    expect(screen.getByText('$0.1560')).toBeInTheDocument();
+    // Completion Rate = Math.round((12/15)*100) = 80%
+    expect(screen.getByText('80%')).toBeInTheDocument();
+  });
+
+  it('renders page title "A/B Test Analytics"', async () => {
+    mockGetAbTestAnalytics.mockResolvedValue(mockAnalytics);
+
+    render(<AbTestAnalyticsPage />, { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(screen.getByText('A/B Test Analytics')).toBeInTheDocument();
+    });
+  });
+
+  it('shows "New Test" link button', async () => {
+    mockGetAbTestAnalytics.mockResolvedValue(mockAnalytics);
+
+    render(<AbTestAnalyticsPage />, { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(screen.getByText('New Test')).toBeInTheDocument();
+    });
+
+    const newTestLink = screen.getByText('New Test').closest('a');
+    expect(newTestLink).toHaveAttribute('href', '/admin/agents/ab-testing/new');
+  });
+
+  it('shows leaderboard table with model names when data exists', async () => {
+    mockGetAbTestAnalytics.mockResolvedValue(mockAnalytics);
+
+    render(<AbTestAnalyticsPage />, { wrapper: createWrapper() });
+
+    await waitFor(() => {
+      expect(screen.getByText('Model Leaderboard')).toBeInTheDocument();
+    });
+
+    // Model short names (after the "/" split)
+    expect(screen.getByText('Model Leaderboard')).toBeInTheDocument();
+
+    // Table headers
+    expect(screen.getByText('Avg Score')).toBeInTheDocument();
+    expect(screen.getByText('Accuracy')).toBeInTheDocument();
+    expect(screen.getByText('Completeness')).toBeInTheDocument();
+    expect(screen.getByText('Clarity')).toBeInTheDocument();
+    expect(screen.getByText('Tone')).toBeInTheDocument();
+    expect(screen.getByText('Evaluations')).toBeInTheDocument();
+
+    // Model names appear in the table rows (short names extracted from modelId)
+    // gpt-4o appears in both the table and possibly the chart legend; use getAllByText
+    const gpt4oElements = screen.getAllByText('gpt-4o');
+    expect(gpt4oElements.length).toBeGreaterThanOrEqual(1);
+
+    const claudeElements = screen.getAllByText('claude-3.5-sonnet');
+    expect(claudeElements.length).toBeGreaterThanOrEqual(1);
+  });
+});

--- a/apps/web/src/components/admin/strategies/__tests__/StrategyEditor.test.tsx
+++ b/apps/web/src/components/admin/strategies/__tests__/StrategyEditor.test.tsx
@@ -1,0 +1,115 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { StrategyEditor } from '../StrategyEditor';
+import type { CreateStrategy } from '@/lib/api/schemas/strategies.schemas';
+
+const mockOnSubmit = vi.fn();
+
+function renderEditor(props: Partial<React.ComponentProps<typeof StrategyEditor>> = {}) {
+  return render(<StrategyEditor onSubmit={mockOnSubmit} {...props} />);
+}
+
+describe('StrategyEditor', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders form with name, description fields and template buttons', () => {
+    renderEditor();
+
+    expect(screen.getByLabelText('Strategy Name')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('My Custom Strategy')).toBeInTheDocument();
+    expect(screen.getByLabelText('Description')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText('Describe this strategy...')).toBeInTheDocument();
+    expect(screen.getByText('Quick Templates:')).toBeInTheDocument();
+  });
+
+  it('shows empty state message when no steps are present', () => {
+    renderEditor();
+
+    expect(
+      screen.getByText(/No steps added\. Click "Add Step" or load a template\./)
+    ).toBeInTheDocument();
+  });
+
+  it('shows Add Step button', () => {
+    renderEditor();
+
+    expect(screen.getByRole('button', { name: /Add Step/i })).toBeInTheDocument();
+  });
+
+  it('renders template buttons for FAST, BALANCED, and PRECISE', () => {
+    renderEditor();
+
+    expect(screen.getByRole('button', { name: 'FAST' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'BALANCED' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'PRECISE' })).toBeInTheDocument();
+  });
+
+  it('fills form fields when a template button is clicked', async () => {
+    const user = userEvent.setup();
+    renderEditor();
+
+    const nameInput = screen.getByPlaceholderText('My Custom Strategy') as HTMLInputElement;
+    const descInput = screen.getByPlaceholderText(
+      'Describe this strategy...'
+    ) as HTMLTextAreaElement;
+
+    expect(nameInput.value).toBe('');
+
+    await user.click(screen.getByRole('button', { name: 'FAST' }));
+
+    await waitFor(() => {
+      expect(nameInput.value).toBe('Fast Retrieval');
+    });
+    expect(descInput.value).toBe('Quick vector search with single generation step');
+    // Template loaded steps, so empty state should disappear
+    expect(screen.queryByText(/No steps added/)).not.toBeInTheDocument();
+  });
+
+  it('shows "Save Strategy" button and "Saving..." when isLoading is true', () => {
+    const { rerender } = render(<StrategyEditor onSubmit={mockOnSubmit} isLoading={false} />);
+
+    const submitBtn = screen.getByRole('button', { name: 'Save Strategy' });
+    expect(submitBtn).toBeInTheDocument();
+    expect(submitBtn).not.toBeDisabled();
+
+    rerender(<StrategyEditor onSubmit={mockOnSubmit} isLoading={true} />);
+
+    const savingBtn = screen.getByRole('button', { name: 'Saving...' });
+    expect(savingBtn).toBeInTheDocument();
+    expect(savingBtn).toBeDisabled();
+  });
+
+  it('renders with defaultValues when provided', () => {
+    const defaults: Partial<CreateStrategy> = {
+      name: 'Pre-filled Strategy',
+      description: 'Already has a description',
+      steps: [
+        { type: 'retrieval', config: { topK: 3 }, order: 0 },
+        { type: 'generation', config: {}, order: 1 },
+      ],
+    };
+
+    renderEditor({ defaultValues: defaults });
+
+    const nameInput = screen.getByPlaceholderText('My Custom Strategy') as HTMLInputElement;
+    const descInput = screen.getByPlaceholderText(
+      'Describe this strategy...'
+    ) as HTMLTextAreaElement;
+
+    expect(nameInput.value).toBe('Pre-filled Strategy');
+    expect(descInput.value).toBe('Already has a description');
+    // Steps are rendered, so empty state should not show
+    expect(screen.queryByText(/No steps added/)).not.toBeInTheDocument();
+    // Pipeline Preview should be visible with steps
+    expect(screen.getByText('Pipeline Preview')).toBeInTheDocument();
+  });
+
+  it('shows Pipeline Steps heading', () => {
+    renderEditor();
+
+    expect(screen.getByText('Pipeline Steps')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/config/__tests__/admin-dashboard-navigation.test.ts
+++ b/apps/web/src/config/__tests__/admin-dashboard-navigation.test.ts
@@ -4,13 +4,20 @@ import { DASHBOARD_SECTIONS, getActiveSection, getSection } from '../admin-dashb
 
 describe('admin-dashboard-navigation', () => {
   describe('DASHBOARD_SECTIONS', () => {
-    it('should have 10 sections total', () => {
-      expect(DASHBOARD_SECTIONS).toHaveLength(10);
+    it('should have 6 sections total', () => {
+      expect(DASHBOARD_SECTIONS).toHaveLength(6);
     });
 
     it('should have unique section ids', () => {
       const ids = DASHBOARD_SECTIONS.map(s => s.id);
       expect(new Set(ids).size).toBe(ids.length);
+    });
+
+    it('should include all expected section ids', () => {
+      const ids = DASHBOARD_SECTIONS.map(s => s.id);
+      expect(ids).toEqual(
+        expect.arrayContaining(['overview', 'content', 'ai', 'users', 'system', 'analytics'])
+      );
     });
   });
 
@@ -21,61 +28,61 @@ describe('admin-dashboard-navigation', () => {
       expect(section!.id).toBe('overview');
     });
 
-    it('should resolve agents/pipeline section', () => {
+    it('should resolve agents routes to ai section', () => {
       const section = getActiveSection('/admin/agents/pipeline');
       expect(section).toBeDefined();
-      expect(section!.id).toBe('agents');
+      expect(section!.id).toBe('ai');
     });
 
-    it('should resolve knowledge-base section', () => {
+    it('should resolve knowledge-base routes to content section', () => {
       const section = getActiveSection('/admin/knowledge-base');
       expect(section).toBeDefined();
-      expect(section!.id).toBe('knowledge-base');
+      expect(section!.id).toBe('content');
     });
   });
 
-  describe('new hub sections', () => {
-    it('should resolve monitor section', () => {
+  describe('merged sections', () => {
+    it('should resolve /admin/monitor to system section', () => {
       const section = getActiveSection('/admin/monitor');
       expect(section).toBeDefined();
-      expect(section!.id).toBe('monitor');
+      expect(section!.id).toBe('system');
     });
 
-    it('should resolve config section', () => {
+    it('should resolve /admin/config to system section', () => {
       const section = getActiveSection('/admin/config');
       expect(section).toBeDefined();
-      expect(section!.id).toBe('config');
+      expect(section!.id).toBe('system');
     });
 
-    it('should resolve analytics section', () => {
+    it('should resolve /admin/analytics to analytics section', () => {
       const section = getActiveSection('/admin/analytics');
       expect(section).toBeDefined();
       expect(section!.id).toBe('analytics');
     });
 
-    it('should resolve ai section', () => {
+    it('should resolve /admin/ai to ai section', () => {
       const section = getActiveSection('/admin/ai');
       expect(section).toBeDefined();
       expect(section!.id).toBe('ai');
     });
 
-    it('should resolve content section', () => {
+    it('should resolve /admin/content to content section', () => {
       const section = getActiveSection('/admin/content');
       expect(section).toBeDefined();
       expect(section!.id).toBe('content');
     });
   });
 
-  describe('new section sidebar items', () => {
-    it('monitor section should have Alerts sidebar item', () => {
-      const section = getSection('monitor');
+  describe('section sidebar items', () => {
+    it('system section should have Alerts sidebar item', () => {
+      const section = getSection('system');
       expect(section).toBeDefined();
       const alertsItem = section!.sidebarItems.find(i => i.label === 'Alerts');
       expect(alertsItem).toBeDefined();
     });
 
-    it('config section should have Feature Flags sidebar item', () => {
-      const section = getSection('config');
+    it('system section should have Feature Flags sidebar item', () => {
+      const section = getSection('system');
       expect(section).toBeDefined();
       const flagsItem = section!.sidebarItems.find(i => i.label === 'Feature Flags');
       expect(flagsItem).toBeDefined();
@@ -88,28 +95,24 @@ describe('admin-dashboard-navigation', () => {
       expect(auditItem).toBeDefined();
     });
 
-    it('ai section should have Agents sidebar item', () => {
+    it('ai section should have All Agents sidebar item', () => {
       const section = getSection('ai');
       expect(section).toBeDefined();
-      const agentsItem = section!.sidebarItems.find(i => i.label === 'Agents');
+      const agentsItem = section!.sidebarItems.find(i => i.label === 'All Agents');
       expect(agentsItem).toBeDefined();
     });
 
-    it('content section should have Games sidebar item', () => {
+    it('content section should have All Games sidebar item', () => {
       const section = getSection('content');
       expect(section).toBeDefined();
-      const gamesItem = section!.sidebarItems.find(i => i.label === 'Games');
+      const gamesItem = section!.sidebarItems.find(i => i.label === 'All Games');
       expect(gamesItem).toBeDefined();
     });
   });
 
-  describe('new section groups', () => {
-    it('monitor should be in core group', () => {
-      expect(getSection('monitor')!.group).toBe('core');
-    });
-
-    it('config should be in core group', () => {
-      expect(getSection('config')!.group).toBe('core');
+  describe('section groups', () => {
+    it('system should be in core group', () => {
+      expect(getSection('system')!.group).toBe('core');
     });
 
     it('analytics should be in core group', () => {


### PR DESCRIPTION
## Summary
- Fix 2 stale admin-dashboard-navigation test files (expected 10/5 sections → updated to 6)
- Add A/B Testing frontend unit tests: new page (8), evaluation page (6), results page (6)
- Add StrategyEditor component unit tests (8 tests)
- Add LlmResilienceCombinedFailureTests: multi-service failure scenarios (4 tests)
- Add OpenRouterRateLimitTrackerGracefulDegradationTests: Redis failure paths (9 tests)

**Total: 41 new tests + 48 updated tests**

## Coverage by area

| Area | Before | After | Status |
|------|--------|-------|--------|
| A/B Testing frontend | 0 unit tests | 20 unit tests | ✅ Covered |
| StrategyEditor | 0 unit tests | 8 unit tests | ✅ Covered |
| Admin nav config | 48 failing tests | 48 passing tests | ✅ Fixed |
| Resilience (combined failures) | 0 tests | 4 tests | ✅ Covered |
| Redis graceful degradation | 0 tests | 9 tests | ✅ Covered |
| Advanced Chat Analytics | N/A | N/A | ⏭️ Deferred (no source code) |
| Real-Time Monitoring | N/A | N/A | ⏭️ Deferred (no source code) |

## Test plan
- [x] All new frontend tests pass (`pnpm test --run "ab-testing"` → 49 passed)
- [x] StrategyEditor tests pass (`pnpm test --run "StrategyEditor"` → 8 passed)
- [x] Admin nav config tests pass (48 passed)
- [x] Backend resilience tests pass (`dotnet test --filter "LlmResilienceCombinedFailure|OpenRouterRateLimitTrackerGracefulDegradation"` → 13 passed)
- [x] Pre-commit hooks pass (lint, prettier, TypeScript)
- [x] Pre-push hooks pass (frontend build, backend build)

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)