### PR TITLE
feat(notifications): Phase 1 — correlation ID, unsubscribe, admin email mgmt, cleanup jobs

### DIFF
--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Application/Commands/EnqueueEmailCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Application/Commands/EnqueueEmailCommand.cs
@@ -15,5 +15,6 @@ internal record EnqueueEmailCommand(
     string FileName,
     string? DocumentUrl = null,
     string? ErrorMessage = null,
-    int? RetryCount = null
+    int? RetryCount = null,
+    Guid? CorrelationId = null
 ) : ICommand<Guid>;

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Application/Commands/RetryAllDeadLettersCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Application/Commands/RetryAllDeadLettersCommand.cs
@@ -1,0 +1,9 @@
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.UserNotifications.Application.Commands;
+
+/// <summary>
+/// Command to retry all dead-lettered emails.
+/// Issue #39: Admin email management.
+/// </summary>
+internal record RetryAllDeadLettersCommand() : ICommand<int>;

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Application/Commands/SendTestEmailCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Application/Commands/SendTestEmailCommand.cs
@@ -1,0 +1,9 @@
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.UserNotifications.Application.Commands;
+
+/// <summary>
+/// Command to send a test email immediately (not queued).
+/// Issue #39: Admin email management.
+/// </summary>
+internal record SendTestEmailCommand(string To) : ICommand<bool>;

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Application/Commands/UnsubscribeEmailCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Application/Commands/UnsubscribeEmailCommand.cs
@@ -1,0 +1,14 @@
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.UserNotifications.Application.Commands;
+
+/// <summary>
+/// Command to unsubscribe a user from a specific notification type via email link.
+/// GDPR-compliant one-click unsubscribe.
+/// Issue #38: Unsubscribe link in emails.
+/// </summary>
+internal record UnsubscribeEmailCommand(
+    Guid UserId,
+    string NotificationType,
+    string Source = "email_unsubscribe"
+) : ICommand<bool>;

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Application/DTOs/EmailQueueItemDto.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Application/DTOs/EmailQueueItemDto.cs
@@ -15,5 +15,6 @@ internal record EmailQueueItemDto(
     string? ErrorMessage,
     DateTime CreatedAt,
     DateTime? ProcessedAt,
-    DateTime? FailedAt
+    DateTime? FailedAt,
+    Guid? CorrelationId = null
 );

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Application/DTOs/NotificationDto.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Application/DTOs/NotificationDto.cs
@@ -15,5 +15,6 @@ internal record NotificationDto(
     string? Metadata,
     bool IsRead,
     DateTime CreatedAt,
-    DateTime? ReadAt
+    DateTime? ReadAt,
+    Guid? CorrelationId = null
 );

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Application/Handlers/EnqueueEmailCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Application/Handlers/EnqueueEmailCommandHandler.cs
@@ -86,7 +86,8 @@ internal class EnqueueEmailCommandHandler : ICommandHandler<EnqueueEmailCommand,
             command.UserId,
             command.To,
             command.Subject,
-            htmlBody);
+            htmlBody,
+            command.CorrelationId);
 
         await _emailQueueRepository.AddAsync(emailQueueItem, cancellationToken).ConfigureAwait(false);
         await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Application/Handlers/GetAdminEmailHistoryQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Application/Handlers/GetAdminEmailHistoryQueryHandler.cs
@@ -1,0 +1,51 @@
+using Api.BoundedContexts.UserNotifications.Application.DTOs;
+using Api.BoundedContexts.UserNotifications.Application.Queries;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.UserNotifications;
+using Api.SharedKernel.Application.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.UserNotifications.Application.Handlers;
+
+/// <summary>
+/// Handler for GetAdminEmailHistoryQuery.
+/// Returns paginated email history with optional search.
+/// Issue #39: Admin email management.
+/// </summary>
+internal class GetAdminEmailHistoryQueryHandler : IQueryHandler<GetAdminEmailHistoryQuery, AdminEmailHistoryResult>
+{
+    private readonly MeepleAiDbContext _dbContext;
+
+    public GetAdminEmailHistoryQueryHandler(MeepleAiDbContext dbContext)
+    {
+        _dbContext = dbContext;
+    }
+
+    public async Task<AdminEmailHistoryResult> Handle(GetAdminEmailHistoryQuery query, CancellationToken cancellationToken)
+    {
+        var dbQuery = _dbContext.Set<EmailQueueEntity>().AsNoTracking();
+
+        if (!string.IsNullOrWhiteSpace(query.Search))
+        {
+            // EF.Functions.ILike is PostgreSQL case-insensitive LIKE
+            var searchPattern = $"%{query.Search}%";
+            dbQuery = dbQuery.Where(e =>
+                EF.Functions.ILike(e.To, searchPattern) ||
+                EF.Functions.ILike(e.Subject, searchPattern));
+        }
+
+        var totalCount = await dbQuery.CountAsync(cancellationToken).ConfigureAwait(false);
+
+        var items = await dbQuery
+            .OrderByDescending(e => e.CreatedAt)
+            .Skip(query.Skip)
+            .Take(query.Take)
+            .Select(e => new EmailQueueItemDto(
+                e.Id, e.UserId, e.To, e.Subject, e.Status,
+                e.RetryCount, e.MaxRetries, e.ErrorMessage,
+                e.CreatedAt, e.ProcessedAt, e.FailedAt, e.CorrelationId))
+            .ToListAsync(cancellationToken).ConfigureAwait(false);
+
+        return new AdminEmailHistoryResult(items, totalCount, query.Skip, query.Take);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Application/Handlers/RetryAllDeadLettersCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Application/Handlers/RetryAllDeadLettersCommandHandler.cs
@@ -1,0 +1,54 @@
+using Api.BoundedContexts.UserNotifications.Application.Commands;
+using Api.BoundedContexts.UserNotifications.Domain.Repositories;
+using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.UserNotifications.Application.Handlers;
+
+/// <summary>
+/// Handler for RetryAllDeadLettersCommand.
+/// Resets all dead-lettered emails to pending.
+/// Issue #39: Admin email management.
+/// </summary>
+internal class RetryAllDeadLettersCommandHandler : ICommandHandler<RetryAllDeadLettersCommand, int>
+{
+    private readonly IEmailQueueRepository _emailQueueRepository;
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly ILogger<RetryAllDeadLettersCommandHandler> _logger;
+
+    public RetryAllDeadLettersCommandHandler(
+        IEmailQueueRepository emailQueueRepository,
+        IUnitOfWork unitOfWork,
+        ILogger<RetryAllDeadLettersCommandHandler> logger)
+    {
+        _emailQueueRepository = emailQueueRepository;
+        _unitOfWork = unitOfWork;
+        _logger = logger;
+    }
+
+    public async Task<int> Handle(RetryAllDeadLettersCommand command, CancellationToken cancellationToken)
+    {
+        var deadLetters = await _emailQueueRepository
+            .GetDeadLetterAsync(0, 1000, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (deadLetters.Count == 0)
+        {
+            _logger.LogInformation("No dead letter emails to retry");
+            return 0;
+        }
+
+        foreach (var email in deadLetters)
+        {
+            email.ResetToPending();
+            await _emailQueueRepository.UpdateAsync(email, cancellationToken).ConfigureAwait(false);
+        }
+
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        _logger.LogInformation("Admin bulk retry: {Count} dead letter emails reset to pending", deadLetters.Count);
+
+        return deadLetters.Count;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Application/Handlers/SendTestEmailCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Application/Handlers/SendTestEmailCommandHandler.cs
@@ -1,0 +1,64 @@
+using System.Globalization;
+using Api.BoundedContexts.UserNotifications.Application.Commands;
+using Api.Services;
+using Api.SharedKernel.Application.Interfaces;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.UserNotifications.Application.Handlers;
+
+/// <summary>
+/// Handler for SendTestEmailCommand.
+/// Sends a test email immediately bypassing the queue.
+/// Issue #39: Admin email management.
+/// </summary>
+internal class SendTestEmailCommandHandler : ICommandHandler<SendTestEmailCommand, bool>
+{
+    private readonly IEmailService _emailService;
+    private readonly ILogger<SendTestEmailCommandHandler> _logger;
+
+    public SendTestEmailCommandHandler(
+        IEmailService emailService,
+        ILogger<SendTestEmailCommandHandler> logger)
+    {
+        _emailService = emailService;
+        _logger = logger;
+    }
+
+    public async Task<bool> Handle(SendTestEmailCommand command, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        try
+        {
+            var timestamp = DateTime.UtcNow.ToString("yyyy-MM-dd HH:mm:ss", CultureInfo.InvariantCulture);
+            var htmlBody = $"""
+            <div style="font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; max-width: 480px; margin: 0 auto; padding: 32px;">
+                <h1 style="font-size: 24px; color: #333;">&#127922; MeepleAI Test Email</h1>
+                <p style="color: #666; line-height: 1.6;">
+                    This is a test email from the MeepleAI admin panel.<br>
+                    If you received this, your email configuration is working correctly.
+                </p>
+                <p style="font-size: 12px; color: #999; margin-top: 32px;">
+                    Sent at: {timestamp} UTC
+                </p>
+            </div>
+            """;
+
+            await _emailService.SendRawEmailAsync(
+                command.To,
+                "MeepleAI Test Email",
+                htmlBody,
+                cancellationToken).ConfigureAwait(false);
+
+            _logger.LogInformation("Admin test email sent to {To}", command.To);
+            return true;
+        }
+#pragma warning disable CA1031
+        catch (Exception ex)
+#pragma warning restore CA1031
+        {
+            _logger.LogError(ex, "Failed to send test email to {To}", command.To);
+            return false;
+        }
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Application/Handlers/UnsubscribeEmailCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Application/Handlers/UnsubscribeEmailCommandHandler.cs
@@ -1,0 +1,62 @@
+using Api.BoundedContexts.UserNotifications.Application.Commands;
+using Api.BoundedContexts.UserNotifications.Domain.Repositories;
+using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.UserNotifications.Application.Handlers;
+
+/// <summary>
+/// Handler for UnsubscribeEmailCommand.
+/// Disables email preference for a specific notification type.
+/// Logs the change for audit trail.
+/// Issue #38: GDPR-compliant unsubscribe.
+/// </summary>
+internal class UnsubscribeEmailCommandHandler : ICommandHandler<UnsubscribeEmailCommand, bool>
+{
+    private readonly INotificationPreferencesRepository _preferencesRepository;
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly ILogger<UnsubscribeEmailCommandHandler> _logger;
+
+    public UnsubscribeEmailCommandHandler(
+        INotificationPreferencesRepository preferencesRepository,
+        IUnitOfWork unitOfWork,
+        ILogger<UnsubscribeEmailCommandHandler> logger)
+    {
+        _preferencesRepository = preferencesRepository;
+        _unitOfWork = unitOfWork;
+        _logger = logger;
+    }
+
+    public async Task<bool> Handle(UnsubscribeEmailCommand command, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        var preferences = await _preferencesRepository
+            .GetByUserIdAsync(command.UserId, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (preferences == null)
+        {
+            _logger.LogWarning("Unsubscribe: No preferences found for user {UserId}", command.UserId);
+            return false;
+        }
+
+        // Disable email for the specific notification type
+        // Currently preferences are grouped by PDF processing events
+        // For now, disable all email preferences as a simple implementation
+        preferences.UpdateEmailPreferences(
+            onReady: false,
+            onFailed: false,
+            onRetry: false);
+
+        await _preferencesRepository.UpdateAsync(preferences, cancellationToken).ConfigureAwait(false);
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        _logger.LogInformation(
+            "Unsubscribe: User {UserId} unsubscribed from email notifications (type: {NotificationType}, source: {Source})",
+            command.UserId, command.NotificationType, command.Source);
+
+        return true;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Application/Queries/GetAdminEmailHistoryQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Application/Queries/GetAdminEmailHistoryQuery.cs
@@ -1,0 +1,21 @@
+using Api.BoundedContexts.UserNotifications.Application.DTOs;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.UserNotifications.Application.Queries;
+
+/// <summary>
+/// Query to get paginated email history for admin dashboard with search.
+/// Issue #39: Admin email management real API.
+/// </summary>
+internal record GetAdminEmailHistoryQuery(
+    int Skip = 0,
+    int Take = 20,
+    string? Search = null
+) : IQuery<AdminEmailHistoryResult>;
+
+internal record AdminEmailHistoryResult(
+    List<EmailQueueItemDto> Items,
+    int TotalCount,
+    int Skip,
+    int Take
+);

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Application/Services/IUnsubscribeTokenService.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Application/Services/IUnsubscribeTokenService.cs
@@ -1,0 +1,11 @@
+namespace Api.BoundedContexts.UserNotifications.Application.Services;
+
+/// <summary>
+/// Service for generating and validating email unsubscribe JWT tokens.
+/// Issue #38: GDPR-compliant unsubscribe.
+/// </summary>
+internal interface IUnsubscribeTokenService
+{
+    string GenerateToken(Guid userId, string notificationType);
+    string GenerateUnsubscribeUrl(Guid userId, string notificationType);
+}

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Domain/Aggregates/EmailQueueItem.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Domain/Aggregates/EmailQueueItem.cs
@@ -30,6 +30,7 @@ internal sealed class EmailQueueItem : AggregateRoot<Guid>
     public DateTime CreatedAt { get; private set; }
     public DateTime? ProcessedAt { get; private set; }
     public DateTime? FailedAt { get; private set; }
+    public Guid? CorrelationId { get; private set; }
 
 #pragma warning disable CS8618
     private EmailQueueItem() : base() { }
@@ -40,7 +41,8 @@ internal sealed class EmailQueueItem : AggregateRoot<Guid>
         Guid userId,
         string to,
         string subject,
-        string htmlBody)
+        string htmlBody,
+        Guid? correlationId = null)
         : base(id)
     {
         UserId = userId;
@@ -55,14 +57,15 @@ internal sealed class EmailQueueItem : AggregateRoot<Guid>
         CreatedAt = DateTime.UtcNow;
         ProcessedAt = null;
         FailedAt = null;
+        CorrelationId = correlationId;
     }
 
     /// <summary>
     /// Factory method to create a new email queue item.
     /// </summary>
-    public static EmailQueueItem Create(Guid userId, string to, string subject, string htmlBody)
+    public static EmailQueueItem Create(Guid userId, string to, string subject, string htmlBody, Guid? correlationId = null)
     {
-        return new EmailQueueItem(Guid.NewGuid(), userId, to, subject, htmlBody);
+        return new EmailQueueItem(Guid.NewGuid(), userId, to, subject, htmlBody, correlationId);
     }
 
     /// <summary>
@@ -154,7 +157,8 @@ internal sealed class EmailQueueItem : AggregateRoot<Guid>
         string? errorMessage,
         DateTime createdAt,
         DateTime? processedAt,
-        DateTime? failedAt)
+        DateTime? failedAt,
+        Guid? correlationId = null)
     {
         var item = new EmailQueueItem(id, userId, to, subject, htmlBody);
         item.Status = status;
@@ -165,6 +169,7 @@ internal sealed class EmailQueueItem : AggregateRoot<Guid>
         item.CreatedAt = createdAt;
         item.ProcessedAt = processedAt;
         item.FailedAt = failedAt;
+        item.CorrelationId = correlationId;
         return item;
     }
 }

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Domain/Aggregates/Notification.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Domain/Aggregates/Notification.cs
@@ -19,6 +19,7 @@ internal sealed class Notification : AggregateRoot<Guid>
     public bool IsRead { get; private set; }
     public DateTime CreatedAt { get; private set; }
     public DateTime? ReadAt { get; private set; }
+    public Guid? CorrelationId { get; private set; }
 
 #pragma warning disable CS8618
     private Notification() : base() { }
@@ -35,6 +36,7 @@ internal sealed class Notification : AggregateRoot<Guid>
     /// <param name="message">Detailed notification message</param>
     /// <param name="link">Optional deep-link target (e.g., /chat/thread-id)</param>
     /// <param name="metadata">Optional JSON metadata for additional context</param>
+    /// <param name="correlationId">Optional correlation ID for cross-channel tracking</param>
     public Notification(
         Guid id,
         Guid userId,
@@ -43,7 +45,8 @@ internal sealed class Notification : AggregateRoot<Guid>
         string title,
         string message,
         string? link = null,
-        string? metadata = null)
+        string? metadata = null,
+        Guid? correlationId = null)
         : base(id)
     {
         UserId = userId;
@@ -55,6 +58,7 @@ internal sealed class Notification : AggregateRoot<Guid>
         Message = !string.IsNullOrWhiteSpace(message) ? message : throw new ArgumentException("Message cannot be empty", nameof(message));
         Link = link;
         Metadata = metadata;
+        CorrelationId = correlationId;
         IsRead = false;
         CreatedAt = DateTime.UtcNow;
         ReadAt = null;

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/DependencyInjection/UserNotificationsServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/DependencyInjection/UserNotificationsServiceExtensions.cs
@@ -30,6 +30,7 @@ internal static class UserNotificationsServiceExtensions
         // Register services
         services.AddSingleton<IEmailTemplateService, EmailTemplateService>(); // Issue #4417
         services.AddSingleton<IUserNotificationBroadcaster, InMemoryUserNotificationBroadcaster>(); // Issue #5005
+        services.AddSingleton<IUnsubscribeTokenService, UnsubscribeTokenService>(); // Issue #38
 
         // Register Unit of Work (shared across bounded contexts)
         services.AddScoped<IUnitOfWork, EfCoreUnitOfWork>();
@@ -91,6 +92,34 @@ internal static class UserNotificationsServiceExtensions
                 .WithIdentity("email-processor-trigger", "notifications")
                 .WithCronSchedule("0/30 * * * * ?")  // Every 30 seconds
                 .WithDescription("Processes queued emails with retry and dead letter handling"));
+        });
+
+        // ISSUE-40: Dead letter monitor job - hourly
+        services.AddQuartz(q =>
+        {
+            q.AddJob<DeadLetterMonitorJob>(opts => opts
+                .WithIdentity("dead-letter-monitor-job", "notifications")
+                .StoreDurably(true));
+
+            q.AddTrigger(opts => opts
+                .ForJob("dead-letter-monitor-job", "notifications")
+                .WithIdentity("dead-letter-monitor-trigger", "notifications")
+                .WithCronSchedule("0 0 * * * ?")  // Every hour at minute 0
+                .WithDescription("Monitors dead letter queue and alerts admin when threshold exceeded"));
+        });
+
+        // ISSUE-41: Notification cleanup job - daily at 3 AM UTC
+        services.AddQuartz(q =>
+        {
+            q.AddJob<NotificationCleanupJob>(opts => opts
+                .WithIdentity("notification-cleanup-job", "notifications")
+                .StoreDurably(true));
+
+            q.AddTrigger(opts => opts
+                .ForJob("notification-cleanup-job", "notifications")
+                .WithIdentity("notification-cleanup-trigger", "notifications")
+                .WithCronSchedule("0 0 3 * * ?")  // Daily at 3:00 AM UTC
+                .WithDescription("Cleans up read notifications and old email queue items past retention period"));
         });
 
         // Note: AddQuartzHostedService is called once in Administration context

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Persistence/EmailQueueRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Persistence/EmailQueueRepository.cs
@@ -185,7 +185,8 @@ internal class EmailQueueRepository : RepositoryBase, IEmailQueueRepository
             ErrorMessage = item.ErrorMessage,
             CreatedAt = item.CreatedAt,
             ProcessedAt = item.ProcessedAt,
-            FailedAt = item.FailedAt
+            FailedAt = item.FailedAt,
+            CorrelationId = item.CorrelationId
         };
     }
 
@@ -204,6 +205,7 @@ internal class EmailQueueRepository : RepositoryBase, IEmailQueueRepository
             errorMessage: entity.ErrorMessage,
             createdAt: entity.CreatedAt,
             processedAt: entity.ProcessedAt,
-            failedAt: entity.FailedAt);
+            failedAt: entity.FailedAt,
+            correlationId: entity.CorrelationId);
     }
 }

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Persistence/NotificationRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Persistence/NotificationRepository.cs
@@ -147,7 +147,8 @@ internal class NotificationRepository : RepositoryBase, INotificationRepository
             Metadata = notification.Metadata,
             IsRead = notification.IsRead,
             CreatedAt = notification.CreatedAt,
-            ReadAt = notification.ReadAt
+            ReadAt = notification.ReadAt,
+            CorrelationId = notification.CorrelationId
         };
     }
 
@@ -164,7 +165,8 @@ internal class NotificationRepository : RepositoryBase, INotificationRepository
             notification.Metadata,
             notification.IsRead,
             notification.CreatedAt,
-            notification.ReadAt
+            notification.ReadAt,
+            notification.CorrelationId
         );
 
     // Persistence → Domain mapping
@@ -178,7 +180,8 @@ internal class NotificationRepository : RepositoryBase, INotificationRepository
             title: entity.Title,
             message: entity.Message,
             link: entity.Link,
-            metadata: entity.Metadata
+            metadata: entity.Metadata,
+            correlationId: entity.CorrelationId
         );
 
         // Restore read status with original timestamp (not MarkAsRead which overwrites)

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Scheduling/DeadLetterMonitorJob.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Scheduling/DeadLetterMonitorJob.cs
@@ -1,0 +1,74 @@
+using Api.BoundedContexts.UserNotifications.Domain.Repositories;
+using Api.Services;
+using Microsoft.Extensions.Logging;
+using Quartz;
+
+namespace Api.BoundedContexts.UserNotifications.Infrastructure.Scheduling;
+
+/// <summary>
+/// Quartz.NET job that monitors dead letter email accumulation.
+/// Sends admin alert when dead letters exceed threshold.
+/// Issue #40: Dead letter monitor with throttled alerts.
+/// </summary>
+[DisallowConcurrentExecution]
+internal sealed class DeadLetterMonitorJob : IJob
+{
+    private readonly IEmailQueueRepository _emailQueueRepository;
+    private readonly IAlertingService _alertingService;
+    private readonly ILogger<DeadLetterMonitorJob> _logger;
+
+    private const int DeadLetterThreshold = 10;
+    private const string AlertType = "dead_letter_accumulation";
+
+    public DeadLetterMonitorJob(
+        IEmailQueueRepository emailQueueRepository,
+        IAlertingService alertingService,
+        ILogger<DeadLetterMonitorJob> logger)
+    {
+        _emailQueueRepository = emailQueueRepository ?? throw new ArgumentNullException(nameof(emailQueueRepository));
+        _alertingService = alertingService ?? throw new ArgumentNullException(nameof(alertingService));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task Execute(IJobExecutionContext context)
+    {
+        _logger.LogDebug("Starting dead letter monitor job");
+
+        try
+        {
+            var deadLetterCount = await _emailQueueRepository
+                .GetDeadLetterCountAsync(context.CancellationToken)
+                .ConfigureAwait(false);
+
+            _logger.LogDebug("Dead letter count: {Count}", deadLetterCount);
+
+            if (deadLetterCount > DeadLetterThreshold)
+            {
+                // IAlertingService has built-in throttling (1 per hour per alert type)
+                await _alertingService.SendAlertAsync(
+                    AlertType,
+                    "warning",
+                    $"\u26a0\ufe0f {deadLetterCount} emails in dead letter queue \u2014 requires attention",
+                    new Dictionary<string, object>(StringComparer.Ordinal)
+                    {
+                        ["deadLetterCount"] = deadLetterCount,
+                        ["threshold"] = DeadLetterThreshold
+                    },
+                    context.CancellationToken).ConfigureAwait(false);
+
+                _logger.LogWarning(
+                    "Dead letter threshold exceeded: {Count} > {Threshold}",
+                    deadLetterCount, DeadLetterThreshold);
+            }
+
+            context.Result = new { Success = true, DeadLetterCount = deadLetterCount };
+        }
+#pragma warning disable CA1031
+        catch (Exception ex)
+#pragma warning restore CA1031
+        {
+            _logger.LogError(ex, "Dead letter monitor job failed");
+            context.Result = new { Success = false, Error = ex.Message };
+        }
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Scheduling/NotificationCleanupJob.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Scheduling/NotificationCleanupJob.cs
@@ -1,0 +1,108 @@
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.UserNotifications;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Quartz;
+
+namespace Api.BoundedContexts.UserNotifications.Infrastructure.Scheduling;
+
+/// <summary>
+/// Quartz.NET job that cleans up old read notifications and processed emails.
+/// Only deletes READ notifications older than retention period.
+/// Unread notifications are NEVER deleted.
+/// Issue #41: Notification cleanup with configurable TTL.
+/// </summary>
+[DisallowConcurrentExecution]
+internal sealed class NotificationCleanupJob : IJob
+{
+    private readonly MeepleAiDbContext _dbContext;
+    private readonly IConfiguration _configuration;
+    private readonly ILogger<NotificationCleanupJob> _logger;
+
+    private const int DefaultRetentionDays = 90;
+    private const int BatchSize = 1000;
+
+    public NotificationCleanupJob(
+        MeepleAiDbContext dbContext,
+        IConfiguration configuration,
+        ILogger<NotificationCleanupJob> logger)
+    {
+        _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+        _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task Execute(IJobExecutionContext context)
+    {
+        _logger.LogInformation("Starting notification cleanup job");
+
+        var retentionDays = _configuration.GetValue("Notifications:RetentionDays", DefaultRetentionDays);
+        var cutoffDate = DateTime.UtcNow.AddDays(-retentionDays);
+
+        try
+        {
+            // 1. Clean up read notifications older than retention period (batch delete)
+            var totalNotificationsDeleted = 0;
+            int batchDeleted;
+
+            do
+            {
+                batchDeleted = await _dbContext.Set<NotificationEntity>()
+                    .Where(n => n.IsRead && n.CreatedAt < cutoffDate)
+                    .OrderBy(n => n.CreatedAt)
+                    .Take(BatchSize)
+                    .ExecuteDeleteAsync(context.CancellationToken)
+                    .ConfigureAwait(false);
+
+                totalNotificationsDeleted += batchDeleted;
+
+                if (batchDeleted > 0)
+                {
+                    _logger.LogDebug("Deleted {Count} read notifications in batch", batchDeleted);
+                }
+            }
+            while (batchDeleted == BatchSize && !context.CancellationToken.IsCancellationRequested);
+
+            // 2. Clean up sent/dead_letter email queue items older than retention period
+            var totalEmailsDeleted = 0;
+
+            do
+            {
+                batchDeleted = await _dbContext.Set<EmailQueueEntity>()
+                    .Where(e => (e.Status == "sent" || e.Status == "dead_letter") && e.CreatedAt < cutoffDate)
+                    .OrderBy(e => e.CreatedAt)
+                    .Take(BatchSize)
+                    .ExecuteDeleteAsync(context.CancellationToken)
+                    .ConfigureAwait(false);
+
+                totalEmailsDeleted += batchDeleted;
+
+                if (batchDeleted > 0)
+                {
+                    _logger.LogDebug("Deleted {Count} old email queue items in batch", batchDeleted);
+                }
+            }
+            while (batchDeleted == BatchSize && !context.CancellationToken.IsCancellationRequested);
+
+            _logger.LogInformation(
+                "Notification cleanup completed: {NotificationsDeleted} read notifications, {EmailsDeleted} email queue items deleted (retention: {Days} days)",
+                totalNotificationsDeleted, totalEmailsDeleted, retentionDays);
+
+            context.Result = new
+            {
+                Success = true,
+                NotificationsDeleted = totalNotificationsDeleted,
+                EmailsDeleted = totalEmailsDeleted,
+                RetentionDays = retentionDays
+            };
+        }
+#pragma warning disable CA1031
+        catch (Exception ex)
+#pragma warning restore CA1031
+        {
+            _logger.LogError(ex, "Notification cleanup job failed");
+            context.Result = new { Success = false, Error = ex.Message };
+        }
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Services/UnsubscribeTokenService.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Services/UnsubscribeTokenService.cs
@@ -1,0 +1,57 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+using Api.BoundedContexts.UserNotifications.Application.Services;
+using Microsoft.Extensions.Configuration;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Api.BoundedContexts.UserNotifications.Infrastructure.Services;
+
+/// <summary>
+/// JWT-based unsubscribe token generator.
+/// Tokens expire after 30 days.
+/// Issue #38: GDPR-compliant unsubscribe.
+/// </summary>
+internal class UnsubscribeTokenService : IUnsubscribeTokenService
+{
+    private readonly IConfiguration _configuration;
+    private static readonly TimeSpan TokenExpiry = TimeSpan.FromDays(30);
+
+    public UnsubscribeTokenService(IConfiguration configuration)
+    {
+        _configuration = configuration;
+    }
+
+    public string GenerateToken(Guid userId, string notificationType)
+    {
+        var jwtSecret = _configuration["Jwt:Secret"] ?? _configuration["Authentication:JwtSecret"] ?? "";
+        if (string.IsNullOrEmpty(jwtSecret))
+            throw new InvalidOperationException("JWT secret not configured");
+
+        var key = new SymmetricSecurityKey(Encoding.UTF8.GetBytes(jwtSecret));
+        var credentials = new SigningCredentials(key, SecurityAlgorithms.HmacSha256);
+
+        var claims = new[]
+        {
+            new Claim("userId", userId.ToString()),
+            new Claim("notificationType", notificationType),
+            new Claim("purpose", "unsubscribe")
+        };
+
+        var token = new JwtSecurityToken(
+            claims: claims,
+            expires: DateTime.UtcNow.Add(TokenExpiry),
+            signingCredentials: credentials);
+
+        return new JwtSecurityTokenHandler().WriteToken(token);
+    }
+
+    public string GenerateUnsubscribeUrl(Guid userId, string notificationType)
+    {
+        var token = GenerateToken(userId, notificationType);
+#pragma warning disable S1075 // URIs should not be hardcoded - Default/Fallback value
+        var baseUrl = _configuration["Authentication:OAuth:CallbackBaseUrl"] ?? _configuration["App:BaseUrl"] ?? "http://localhost:8080";
+#pragma warning restore S1075
+        return $"{baseUrl}/api/v1/notifications/unsubscribe?token={Uri.EscapeDataString(token)}";
+    }
+}

--- a/apps/api/src/Api/Infrastructure/Entities/UserNotifications/EmailQueueEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/UserNotifications/EmailQueueEntity.cs
@@ -62,4 +62,10 @@ public class EmailQueueEntity
 
     [Column("failed_at")]
     public DateTime? FailedAt { get; set; }
+
+    /// <summary>
+    /// Optional correlation ID for cross-channel notification tracking.
+    /// </summary>
+    [Column("correlation_id")]
+    public Guid? CorrelationId { get; set; }
 }

--- a/apps/api/src/Api/Infrastructure/Entities/UserNotifications/NotificationEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/UserNotifications/NotificationEntity.cs
@@ -87,4 +87,10 @@ public class NotificationEntity
     /// </summary>
     [Column("read_at")]
     public DateTime? ReadAt { get; set; }
+
+    /// <summary>
+    /// Optional correlation ID for cross-channel notification tracking.
+    /// </summary>
+    [Column("correlation_id")]
+    public Guid? CorrelationId { get; set; }
 }

--- a/apps/api/src/Api/Infrastructure/EntityConfigurations/UserNotifications/EmailQueueEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/EntityConfigurations/UserNotifications/EmailQueueEntityConfiguration.cs
@@ -29,6 +29,12 @@ internal class EmailQueueEntityConfiguration : IEntityTypeConfiguration<EmailQue
         builder.Property(e => e.CreatedAt).HasColumnName("created_at").IsRequired();
         builder.Property(e => e.ProcessedAt).HasColumnName("processed_at");
         builder.Property(e => e.FailedAt).HasColumnName("failed_at");
+        builder.Property(e => e.CorrelationId).HasColumnName("correlation_id");
+
+        // CorrelationId index for cross-channel tracking
+        builder.HasIndex(e => e.CorrelationId)
+            .HasDatabaseName("IX_email_queue_items_correlation_id")
+            .HasFilter("correlation_id IS NOT NULL");
 
         // Primary index: batch pickup of pending/failed emails ready for retry
         builder.HasIndex(e => new { e.Status, e.NextRetryAt })

--- a/apps/api/src/Api/Infrastructure/EntityConfigurations/UserNotifications/NotificationEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/EntityConfigurations/UserNotifications/NotificationEntityConfiguration.cs
@@ -27,6 +27,12 @@ internal class NotificationEntityConfiguration : IEntityTypeConfiguration<Notifi
         builder.Property(e => e.IsRead).HasColumnName("is_read").IsRequired();
         builder.Property(e => e.CreatedAt).HasColumnName("created_at").IsRequired();
         builder.Property(e => e.ReadAt).HasColumnName("read_at");
+        builder.Property(e => e.CorrelationId).HasColumnName("correlation_id");
+
+        // CorrelationId index for cross-channel tracking
+        builder.HasIndex(e => e.CorrelationId)
+            .HasDatabaseName("IX_notifications_correlation_id")
+            .HasFilter("correlation_id IS NOT NULL");
 
         // Critical indexes for notification queries (Issue #2053 code review)
         // Primary query: get user notifications ordered by creation date

--- a/apps/api/src/Api/Infrastructure/Migrations/20260310125842_AddCorrelationId.Designer.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260310125842_AddCorrelationId.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Api.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -12,9 +13,11 @@ using Pgvector;
 namespace Api.Infrastructure.Migrations
 {
     [DbContext(typeof(MeepleAiDbContext))]
-    partial class MeepleAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260310125842_AddCorrelationId")]
+    partial class AddCorrelationId
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/Api/Infrastructure/Migrations/20260310125842_AddCorrelationId.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260310125842_AddCorrelationId.cs
@@ -1,0 +1,59 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddCorrelationId : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<Guid>(
+                name: "correlation_id",
+                table: "notifications",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "correlation_id",
+                table: "email_queue_items",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_notifications_correlation_id",
+                table: "notifications",
+                column: "correlation_id",
+                filter: "correlation_id IS NOT NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_email_queue_items_correlation_id",
+                table: "email_queue_items",
+                column: "correlation_id",
+                filter: "correlation_id IS NOT NULL");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_notifications_correlation_id",
+                table: "notifications");
+
+            migrationBuilder.DropIndex(
+                name: "IX_email_queue_items_correlation_id",
+                table: "email_queue_items");
+
+            migrationBuilder.DropColumn(
+                name: "correlation_id",
+                table: "notifications");
+
+            migrationBuilder.DropColumn(
+                name: "correlation_id",
+                table: "email_queue_items");
+        }
+    }
+}

--- a/apps/api/src/Api/Program.cs
+++ b/apps/api/src/Api/Program.cs
@@ -546,6 +546,7 @@ v1Api.MapAlertConfigEndpoints();       // Alert rules (Issue #921)
 v1Api.MapAlertConfigurationEndpoints(); // Alert configuration (Issue #915)
 v1Api.MapNotificationEndpoints();      // User notifications (Issue #2053)
 v1Api.MapNotificationPreferencesEndpoints(); // Notification preferences (Issue #4220)
+v1Api.MapUnsubscribeEndpoints();       // Issue #38: GDPR-compliant email unsubscribe
 v1Api.MapCollectionWizardEndpoints();  // Issue #4823: Collection wizard game preview
 v1Api.MapUserLibraryEndpoints();       // User game library
 v1Api.MapEntityLinkUserEndpoints();    // Entity link user endpoints (Issue #5137)

--- a/apps/api/src/Api/Routing/AdminEmailEndpoints.cs
+++ b/apps/api/src/Api/Routing/AdminEmailEndpoints.cs
@@ -8,6 +8,7 @@ namespace Api.Routing;
 /// <summary>
 /// Admin endpoints for email queue monitoring and management.
 /// Issue #4430: Email queue dashboard monitoring.
+/// Issue #39: Admin email management (history, retry-all, test).
 /// </summary>
 internal static class AdminEmailEndpoints
 {
@@ -28,6 +29,19 @@ internal static class AdminEmailEndpoints
         group.MapPost("/{id:guid}/retry", AdminRetryEmail)
             .WithName("AdminRetryEmail")
             .WithSummary("Admin force-retry a dead-lettered email");
+
+        // Issue #39: Admin email management endpoints
+        group.MapGet("/history", GetEmailHistory)
+            .WithName("GetEmailHistory")
+            .WithSummary("List email history with pagination and search");
+
+        group.MapPost("/retry-all-dead-letters", RetryAllDeadLetters)
+            .WithName("RetryAllDeadLetters")
+            .WithSummary("Retry all dead-lettered emails");
+
+        group.MapPost("/test", SendTestEmail)
+            .WithName("SendTestEmail")
+            .WithSummary("Send a test email (immediate, not queued)");
     }
 
     private static async Task<IResult> GetEmailQueueStats(
@@ -56,4 +70,34 @@ internal static class AdminEmailEndpoints
         var result = await mediator.Send(new AdminRetryEmailCommand(id), cancellationToken).ConfigureAwait(false);
         return result ? Results.Ok(new { success = true }) : Results.NotFound();
     }
+
+    private static async Task<IResult> GetEmailHistory(
+        IMediator mediator,
+        int skip = 0,
+        int take = 20,
+        string? search = null,
+        CancellationToken cancellationToken = default)
+    {
+        var result = await mediator.Send(new GetAdminEmailHistoryQuery(skip, take, search), cancellationToken).ConfigureAwait(false);
+        return Results.Ok(result);
+    }
+
+    private static async Task<IResult> RetryAllDeadLetters(
+        IMediator mediator,
+        CancellationToken cancellationToken)
+    {
+        var result = await mediator.Send(new RetryAllDeadLettersCommand(), cancellationToken).ConfigureAwait(false);
+        return Results.Ok(new { retried = result });
+    }
+
+    private static async Task<IResult> SendTestEmail(
+        SendTestEmailRequest request,
+        IMediator mediator,
+        CancellationToken cancellationToken)
+    {
+        var result = await mediator.Send(new SendTestEmailCommand(request.To), cancellationToken).ConfigureAwait(false);
+        return result ? Results.Ok(new { success = true }) : Results.BadRequest(new { error = "Failed to send test email" });
+    }
 }
+
+internal record SendTestEmailRequest(string To);

--- a/apps/api/src/Api/Routing/UnsubscribeEndpoints.cs
+++ b/apps/api/src/Api/Routing/UnsubscribeEndpoints.cs
@@ -16,7 +16,7 @@ internal static class UnsubscribeEndpoints
 {
     public static void MapUnsubscribeEndpoints(this IEndpointRouteBuilder app)
     {
-        app.MapGet("/api/v1/notifications/unsubscribe", HandleUnsubscribe)
+        app.MapGet("/notifications/unsubscribe", HandleUnsubscribe)
             .WithTags("Notifications - Unsubscribe")
             .WithName("UnsubscribeFromEmail")
             .WithSummary("One-click email unsubscribe (GDPR)")

--- a/apps/api/src/Api/Routing/UnsubscribeEndpoints.cs
+++ b/apps/api/src/Api/Routing/UnsubscribeEndpoints.cs
@@ -1,0 +1,112 @@
+using System.IdentityModel.Tokens.Jwt;
+using System.Security.Claims;
+using System.Text;
+using Api.BoundedContexts.UserNotifications.Application.Commands;
+using MediatR;
+using Microsoft.Extensions.Configuration;
+using Microsoft.IdentityModel.Tokens;
+
+namespace Api.Routing;
+
+/// <summary>
+/// Public endpoint for email unsubscribe (no auth required - token-based).
+/// Issue #38: GDPR-compliant unsubscribe with JWT token.
+/// </summary>
+internal static class UnsubscribeEndpoints
+{
+    public static void MapUnsubscribeEndpoints(this IEndpointRouteBuilder app)
+    {
+        app.MapGet("/api/v1/notifications/unsubscribe", HandleUnsubscribe)
+            .WithTags("Notifications - Unsubscribe")
+            .WithName("UnsubscribeFromEmail")
+            .WithSummary("One-click email unsubscribe (GDPR)")
+            .AllowAnonymous();
+    }
+
+    private static async Task<IResult> HandleUnsubscribe(
+        string token,
+        IMediator mediator,
+        IConfiguration configuration,
+        CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(token))
+            return Results.Content(GenerateHtmlPage("Invalid Request", "Missing unsubscribe token."), "text/html");
+
+        try
+        {
+            // Validate JWT token
+            var jwtSecret = configuration["Jwt:Secret"] ?? configuration["Authentication:JwtSecret"] ?? "";
+            if (string.IsNullOrEmpty(jwtSecret))
+            {
+                return Results.Content(GenerateHtmlPage("Error", "Service configuration error."), "text/html");
+            }
+
+            var tokenHandler = new JwtSecurityTokenHandler();
+            var key = Encoding.UTF8.GetBytes(jwtSecret);
+
+            var principal = tokenHandler.ValidateToken(token, new TokenValidationParameters
+            {
+                ValidateIssuerSigningKey = true,
+                IssuerSigningKey = new SymmetricSecurityKey(key),
+                ValidateIssuer = false,
+                ValidateAudience = false,
+                ValidateLifetime = true,
+                ClockSkew = TimeSpan.FromMinutes(5)
+            }, out _);
+
+            var userIdClaim = principal.FindFirst("userId")?.Value ?? principal.FindFirst(ClaimTypes.NameIdentifier)?.Value;
+            var notificationTypeClaim = principal.FindFirst("notificationType")?.Value;
+
+            if (string.IsNullOrEmpty(userIdClaim) || !Guid.TryParse(userIdClaim, out var userId))
+                return Results.Content(GenerateHtmlPage("Invalid Token", "The unsubscribe link is invalid."), "text/html");
+
+            var notificationType = notificationTypeClaim ?? "all";
+
+            var result = await mediator.Send(
+                new UnsubscribeEmailCommand(userId, notificationType),
+                cancellationToken).ConfigureAwait(false);
+
+            return result
+                ? Results.Content(GenerateHtmlPage("Unsubscribed", $"You have been unsubscribed from {notificationType.Replace('_', ' ')} email notifications."), "text/html")
+                : Results.Content(GenerateHtmlPage("Error", "Could not process your unsubscribe request."), "text/html");
+        }
+        catch (SecurityTokenExpiredException)
+        {
+            return Results.Content(GenerateHtmlPage("Link Expired", "This unsubscribe link has expired. Please use a more recent email or manage your preferences in the app."), "text/html");
+        }
+#pragma warning disable CA1031
+        catch (Exception)
+#pragma warning restore CA1031
+        {
+            return Results.Content(GenerateHtmlPage("Error", "Could not process your unsubscribe request. The link may be invalid."), "text/html");
+        }
+    }
+
+    private static string GenerateHtmlPage(string title, string message)
+    {
+        return $$"""
+        <!DOCTYPE html>
+        <html lang="en">
+        <head>
+            <meta charset="UTF-8">
+            <meta name="viewport" content="width=device-width, initial-scale=1.0">
+            <title>MeepleAI - {{title}}</title>
+            <style>
+                body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, sans-serif; display: flex; justify-content: center; align-items: center; min-height: 100vh; margin: 0; background: #f8f9fa; color: #333; }
+                .card { background: white; border-radius: 12px; padding: 48px; max-width: 480px; text-align: center; box-shadow: 0 2px 8px rgba(0,0,0,0.08); }
+                h1 { font-size: 24px; margin-bottom: 16px; }
+                p { color: #666; line-height: 1.6; }
+                .logo { font-size: 32px; margin-bottom: 24px; }
+            </style>
+        </head>
+        <body>
+            <div class="card">
+                <div class="logo">&#127922;</div>
+                <h1>{{title}}</h1>
+                <p>{{message}}</p>
+            </div>
+        </body>
+        </html>
+        """;
+    }
+}

--- a/apps/web/src/app/admin/(dashboard)/monitor/EmailManagementTab.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/EmailManagementTab.tsx
@@ -2,45 +2,25 @@
 
 import { useState } from 'react';
 
-import { AlertCircle, RefreshCw, Send, Clock, XCircle, Loader2 } from 'lucide-react';
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+import {
+  RefreshCw,
+  Send,
+  Clock,
+  XCircle,
+  Loader2,
+  CheckCircle,
+  Search,
+  Mail,
+  RotateCcw,
+} from 'lucide-react';
 
 import { toast } from '@/components/layout';
+import { createAdminClient, type EmailQueueItem } from '@/lib/api/clients/adminClient';
+import { HttpClient } from '@/lib/api/core/httpClient';
 
-interface DeadLetterEmail {
-  id: string;
-  recipient: string;
-  subject: string;
-  error: string;
-  failedAt: string;
-  retries: number;
-}
-
-const PLACEHOLDER_DEAD_LETTERS: DeadLetterEmail[] = [
-  {
-    id: '1',
-    recipient: 'user@example.com',
-    subject: 'Welcome to MeepleAI',
-    error: 'SMTP connection timeout',
-    failedAt: '2 hours ago',
-    retries: 2,
-  },
-  {
-    id: '2',
-    recipient: 'admin@boardgame.io',
-    subject: 'Game Approval Notification',
-    error: 'Recipient mailbox full',
-    failedAt: '5 hours ago',
-    retries: 1,
-  },
-  {
-    id: '3',
-    recipient: 'player@test.dev',
-    subject: 'Password Reset',
-    error: 'Invalid recipient address',
-    failedAt: '1 day ago',
-    retries: 3,
-  },
-];
+const httpClient = new HttpClient();
+const adminClient = createAdminClient({ httpClient });
 
 function StatCard({
   label,
@@ -49,7 +29,7 @@ function StatCard({
   color,
 }: {
   label: string;
-  value: string;
+  value: string | number;
   icon: React.ComponentType<{ className?: string }>;
   color: string;
 }) {
@@ -68,57 +48,178 @@ function StatCard({
   );
 }
 
-export function EmailManagementTab() {
-  const [retryingId, setRetryingId] = useState<string | null>(null);
+function formatDate(dateStr: string | null | undefined): string {
+  if (!dateStr) return '—';
+  try {
+    return new Date(dateStr).toLocaleString();
+  } catch {
+    return dateStr;
+  }
+}
 
-  async function handleRetry(email: DeadLetterEmail) {
+function formatRelative(dateStr: string | null | undefined): string {
+  if (!dateStr) return '—';
+  try {
+    const date = new Date(dateStr);
+    const now = new Date();
+    const diffMs = now.getTime() - date.getTime();
+    const diffMins = Math.floor(diffMs / 60000);
+    if (diffMins < 1) return 'just now';
+    if (diffMins < 60) return `${diffMins}m ago`;
+    const diffHours = Math.floor(diffMins / 60);
+    if (diffHours < 24) return `${diffHours}h ago`;
+    const diffDays = Math.floor(diffHours / 24);
+    return `${diffDays}d ago`;
+  } catch {
+    return dateStr;
+  }
+}
+
+export function EmailManagementTab() {
+  const queryClient = useQueryClient();
+  const [retryingId, setRetryingId] = useState<string | null>(null);
+  const [searchTerm, setSearchTerm] = useState('');
+  const [testEmailTo, setTestEmailTo] = useState('');
+
+  // Queries
+  const statsQuery = useQuery({
+    queryKey: ['admin', 'email-stats'],
+    queryFn: () => adminClient.getEmailQueueStats(),
+    refetchInterval: 30000, // Auto-refresh every 30s
+  });
+
+  const deadLetterQuery = useQuery({
+    queryKey: ['admin', 'dead-letter-emails'],
+    queryFn: () => adminClient.getDeadLetterEmails({ take: 50 }),
+  });
+
+  const historyQuery = useQuery({
+    queryKey: ['admin', 'email-history', searchTerm],
+    queryFn: () => adminClient.getEmailHistory({ take: 20, search: searchTerm || undefined }),
+  });
+
+  // Mutations
+  const retryMutation = useMutation({
+    mutationFn: (id: string) => adminClient.retryEmail(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ['admin', 'email-stats'] });
+      queryClient.invalidateQueries({ queryKey: ['admin', 'dead-letter-emails'] });
+      toast.success('Email queued for retry');
+    },
+    onError: () => toast.error('Failed to retry email'),
+  });
+
+  const retryAllMutation = useMutation({
+    mutationFn: () => adminClient.retryAllDeadLetters(),
+    onSuccess: count => {
+      queryClient.invalidateQueries({ queryKey: ['admin', 'email-stats'] });
+      queryClient.invalidateQueries({ queryKey: ['admin', 'dead-letter-emails'] });
+      toast.success(`${count} emails queued for retry`);
+    },
+    onError: () => toast.error('Failed to retry dead letters'),
+  });
+
+  const sendTestMutation = useMutation({
+    mutationFn: (to: string) => adminClient.sendTestEmail(to),
+    onSuccess: () => {
+      toast.success('Test email sent');
+      setTestEmailTo('');
+    },
+    onError: () => toast.error('Failed to send test email'),
+  });
+
+  async function handleRetry(email: EmailQueueItem) {
     setRetryingId(email.id);
     try {
-      await new Promise(resolve => setTimeout(resolve, 600));
-      toast.info(`Retry for "${email.subject}": API endpoint not yet connected`);
+      await retryMutation.mutateAsync(email.id);
     } finally {
       setRetryingId(null);
     }
   }
 
+  const stats = statsQuery.data;
+  const deadLetters = deadLetterQuery.data?.items ?? [];
+  const history = historyQuery.data?.items ?? [];
+
   return (
     <div className="space-y-6">
-      {/* Info banner */}
-      <div className="flex items-center gap-2 rounded-xl border border-amber-200/60 dark:border-amber-800/40 bg-amber-50/50 dark:bg-amber-900/10 px-4 py-3">
-        <AlertCircle className="h-4 w-4 text-amber-600 dark:text-amber-400 shrink-0" />
-        <p className="text-xs text-amber-700 dark:text-amber-300">
-          Showing placeholder data. Email management will display real stats once the email service
-          API is connected.
-        </p>
-      </div>
-
       {/* Stats cards */}
-      <div className="grid gap-4 sm:grid-cols-3">
+      <div className="grid gap-4 sm:grid-cols-4">
         <StatCard
-          label="Emails Sent (24h)"
-          value="—"
+          label="Sent (24h)"
+          value={stats?.sentLast24Hours ?? '—'}
           icon={Send}
           color="bg-emerald-100/80 dark:bg-emerald-900/30 text-emerald-700 dark:text-emerald-400"
         />
         <StatCard
+          label="Sent (1h)"
+          value={stats?.sentLastHour ?? '—'}
+          icon={CheckCircle}
+          color="bg-blue-100/80 dark:bg-blue-900/30 text-blue-700 dark:text-blue-400"
+        />
+        <StatCard
           label="Pending"
-          value="—"
+          value={stats?.pendingCount ?? '—'}
           icon={Clock}
           color="bg-amber-100/80 dark:bg-amber-900/30 text-amber-700 dark:text-amber-400"
         />
         <StatCard
-          label="Failed (Dead Letter)"
-          value={String(PLACEHOLDER_DEAD_LETTERS.length)}
+          label="Dead Letter"
+          value={stats?.deadLetterCount ?? '—'}
           icon={XCircle}
           color="bg-red-100/80 dark:bg-red-900/30 text-red-700 dark:text-red-400"
         />
       </div>
 
+      {/* Send Test Email */}
+      <div className="rounded-2xl border border-slate-200/60 dark:border-zinc-700/40 bg-white/70 dark:bg-zinc-800/50 backdrop-blur-sm p-5">
+        <h2 className="font-quicksand text-sm font-semibold text-foreground mb-3">
+          Send Test Email
+        </h2>
+        <div className="flex gap-2">
+          <input
+            type="email"
+            value={testEmailTo}
+            onChange={e => setTestEmailTo(e.target.value)}
+            placeholder="recipient@example.com"
+            className="flex-1 rounded-lg border border-slate-200/60 dark:border-zinc-700/40 bg-white/50 dark:bg-zinc-900/50 px-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-amber-400/40"
+          />
+          <button
+            onClick={() => testEmailTo && sendTestMutation.mutate(testEmailTo)}
+            disabled={!testEmailTo || sendTestMutation.isPending}
+            className="inline-flex items-center gap-1.5 rounded-lg bg-amber-100/80 dark:bg-amber-900/30 px-4 py-2 text-sm font-semibold text-amber-900 dark:text-amber-300 transition-colors hover:bg-amber-200/80 dark:hover:bg-amber-900/50 disabled:opacity-60"
+          >
+            {sendTestMutation.isPending ? (
+              <Loader2 className="h-4 w-4 animate-spin" />
+            ) : (
+              <Mail className="h-4 w-4" />
+            )}
+            Send Test
+          </button>
+        </div>
+      </div>
+
       {/* Dead letter queue */}
       <div>
-        <h2 className="font-quicksand text-sm font-semibold text-foreground mb-3">
-          Dead Letter Queue
-        </h2>
+        <div className="flex items-center justify-between mb-3">
+          <h2 className="font-quicksand text-sm font-semibold text-foreground">
+            Dead Letter Queue ({deadLetters.length})
+          </h2>
+          {deadLetters.length > 0 && (
+            <button
+              onClick={() => retryAllMutation.mutate()}
+              disabled={retryAllMutation.isPending}
+              className="inline-flex items-center gap-1.5 rounded-lg bg-amber-100/80 dark:bg-amber-900/30 px-3 py-1.5 text-xs font-semibold text-amber-900 dark:text-amber-300 transition-colors hover:bg-amber-200/80 dark:hover:bg-amber-900/50 disabled:opacity-60"
+            >
+              {retryAllMutation.isPending ? (
+                <Loader2 className="h-3 w-3 animate-spin" />
+              ) : (
+                <RotateCcw className="h-3 w-3" />
+              )}
+              Retry All
+            </button>
+          )}
+        </div>
         <div className="rounded-2xl border border-slate-200/60 dark:border-zinc-700/40 bg-white/70 dark:bg-zinc-800/50 backdrop-blur-sm overflow-hidden">
           <div className="overflow-x-auto">
             <table className="w-full text-sm">
@@ -145,23 +246,36 @@ export function EmailManagementTab() {
                 </tr>
               </thead>
               <tbody>
-                {PLACEHOLDER_DEAD_LETTERS.map(email => {
+                {deadLetters.length === 0 && (
+                  <tr>
+                    <td colSpan={6} className="px-4 py-8 text-center text-muted-foreground text-sm">
+                      No dead letter emails
+                    </td>
+                  </tr>
+                )}
+                {deadLetters.map((email: EmailQueueItem) => {
                   const isRetrying = retryingId === email.id;
                   return (
                     <tr
                       key={email.id}
                       className="border-b border-slate-100/60 dark:border-zinc-800/40 last:border-0"
                     >
-                      <td className="px-4 py-3 font-medium text-foreground">{email.recipient}</td>
-                      <td className="px-4 py-3 text-muted-foreground">{email.subject}</td>
+                      <td className="px-4 py-3 font-medium text-foreground">{email.to}</td>
+                      <td className="px-4 py-3 text-muted-foreground max-w-[200px] truncate">
+                        {email.subject}
+                      </td>
                       <td className="px-4 py-3">
-                        <span className="inline-flex items-center gap-1 text-red-600 dark:text-red-400 text-xs">
-                          <XCircle className="h-3 w-3" />
-                          {email.error}
+                        <span className="inline-flex items-center gap-1 text-red-600 dark:text-red-400 text-xs max-w-[200px] truncate">
+                          <XCircle className="h-3 w-3 shrink-0" />
+                          {email.errorMessage ?? 'Unknown error'}
                         </span>
                       </td>
-                      <td className="px-4 py-3 text-muted-foreground text-xs">{email.failedAt}</td>
-                      <td className="px-4 py-3 text-muted-foreground text-xs">{email.retries}</td>
+                      <td className="px-4 py-3 text-muted-foreground text-xs">
+                        {formatRelative(email.failedAt)}
+                      </td>
+                      <td className="px-4 py-3 text-muted-foreground text-xs">
+                        {email.retryCount}/{email.maxRetries}
+                      </td>
                       <td className="px-4 py-3 text-right">
                         <button
                           onClick={() => handleRetry(email)}
@@ -184,6 +298,121 @@ export function EmailManagementTab() {
           </div>
         </div>
       </div>
+
+      {/* Email History */}
+      <div>
+        <h2 className="font-quicksand text-sm font-semibold text-foreground mb-3">Email History</h2>
+        <div className="mb-3">
+          <div className="relative">
+            <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+            <input
+              type="text"
+              value={searchTerm}
+              onChange={e => setSearchTerm(e.target.value)}
+              placeholder="Search by email or subject..."
+              className="w-full rounded-lg border border-slate-200/60 dark:border-zinc-700/40 bg-white/50 dark:bg-zinc-900/50 pl-9 pr-3 py-2 text-sm text-foreground placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-amber-400/40"
+            />
+          </div>
+        </div>
+        <div className="rounded-2xl border border-slate-200/60 dark:border-zinc-700/40 bg-white/70 dark:bg-zinc-800/50 backdrop-blur-sm overflow-hidden">
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b border-slate-200/60 dark:border-zinc-700/40">
+                  <th className="text-left px-4 py-3 text-xs font-medium text-muted-foreground">
+                    Recipient
+                  </th>
+                  <th className="text-left px-4 py-3 text-xs font-medium text-muted-foreground">
+                    Subject
+                  </th>
+                  <th className="text-left px-4 py-3 text-xs font-medium text-muted-foreground">
+                    Status
+                  </th>
+                  <th className="text-left px-4 py-3 text-xs font-medium text-muted-foreground">
+                    Created
+                  </th>
+                  <th className="text-left px-4 py-3 text-xs font-medium text-muted-foreground">
+                    Processed
+                  </th>
+                </tr>
+              </thead>
+              <tbody>
+                {history.length === 0 && (
+                  <tr>
+                    <td colSpan={5} className="px-4 py-8 text-center text-muted-foreground text-sm">
+                      {historyQuery.isLoading ? 'Loading...' : 'No emails found'}
+                    </td>
+                  </tr>
+                )}
+                {history.map((email: EmailQueueItem) => (
+                  <tr
+                    key={email.id}
+                    className="border-b border-slate-100/60 dark:border-zinc-800/40 last:border-0"
+                  >
+                    <td className="px-4 py-3 font-medium text-foreground">{email.to}</td>
+                    <td className="px-4 py-3 text-muted-foreground max-w-[250px] truncate">
+                      {email.subject}
+                    </td>
+                    <td className="px-4 py-3">
+                      <StatusBadge status={email.status} />
+                    </td>
+                    <td className="px-4 py-3 text-muted-foreground text-xs">
+                      {formatDate(email.createdAt)}
+                    </td>
+                    <td className="px-4 py-3 text-muted-foreground text-xs">
+                      {formatDate(email.processedAt)}
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
     </div>
+  );
+}
+
+function StatusBadge({ status }: { status: string }) {
+  const config: Record<string, { bg: string; text: string; label: string }> = {
+    sent: {
+      bg: 'bg-emerald-100/80 dark:bg-emerald-900/30',
+      text: 'text-emerald-700 dark:text-emerald-400',
+      label: 'Sent',
+    },
+    pending: {
+      bg: 'bg-amber-100/80 dark:bg-amber-900/30',
+      text: 'text-amber-700 dark:text-amber-400',
+      label: 'Pending',
+    },
+    processing: {
+      bg: 'bg-blue-100/80 dark:bg-blue-900/30',
+      text: 'text-blue-700 dark:text-blue-400',
+      label: 'Processing',
+    },
+    failed: {
+      bg: 'bg-orange-100/80 dark:bg-orange-900/30',
+      text: 'text-orange-700 dark:text-orange-400',
+      label: 'Failed',
+    },
+    dead_letter: {
+      bg: 'bg-red-100/80 dark:bg-red-900/30',
+      text: 'text-red-700 dark:text-red-400',
+      label: 'Dead Letter',
+    },
+  };
+
+  const c = config[status] ?? {
+    bg: 'bg-slate-100/80 dark:bg-slate-900/30',
+    text: 'text-slate-700 dark:text-slate-400',
+    label: status,
+  };
+
+  return (
+    <span
+      className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${c.bg} ${c.text}`}
+    >
+      {c.label}
+    </span>
   );
 }

--- a/apps/web/src/lib/api/clients/adminClient.ts
+++ b/apps/web/src/lib/api/clients/adminClient.ts
@@ -2728,10 +2728,157 @@ export function createAdminClient({ httpClient }: CreateAdminClientParams) {
         }
       );
     },
+
+    // ========== Email Queue Management (Issue #39) ==========
+
+    /**
+     * Get email queue statistics.
+     * GET /api/v1/admin/emails/stats
+     */
+    async getEmailQueueStats(): Promise<EmailQueueStats> {
+      const result = await httpClient.get('/api/v1/admin/emails/stats', EmailQueueStatsSchema);
+      return (
+        result ?? {
+          pendingCount: 0,
+          processingCount: 0,
+          sentCount: 0,
+          failedCount: 0,
+          deadLetterCount: 0,
+          sentLastHour: 0,
+          sentLast24Hours: 0,
+        }
+      );
+    },
+
+    /**
+     * Get email history with pagination and optional search.
+     * GET /api/v1/admin/emails/history
+     */
+    async getEmailHistory(params?: {
+      skip?: number;
+      take?: number;
+      search?: string;
+    }): Promise<EmailHistoryResult> {
+      const queryParams = new URLSearchParams();
+      if (params?.skip !== undefined) queryParams.append('skip', String(params.skip));
+      if (params?.take !== undefined) queryParams.append('take', String(params.take));
+      if (params?.search) queryParams.append('search', params.search);
+      const qs = queryParams.toString();
+      const url = qs ? `/api/v1/admin/emails/history?${qs}` : '/api/v1/admin/emails/history';
+      const result = await httpClient.get(url, EmailHistoryResultSchema);
+      return result ?? { items: [], totalCount: 0, skip: 0, take: 20 };
+    },
+
+    /**
+     * Get dead-lettered emails with pagination.
+     * GET /api/v1/admin/emails/dead-letter
+     */
+    async getDeadLetterEmails(params?: {
+      skip?: number;
+      take?: number;
+    }): Promise<DeadLetterResult> {
+      const queryParams = new URLSearchParams();
+      if (params?.skip !== undefined) queryParams.append('skip', String(params.skip));
+      if (params?.take !== undefined) queryParams.append('take', String(params.take));
+      const qs = queryParams.toString();
+      const url = qs
+        ? `/api/v1/admin/emails/dead-letter?${qs}`
+        : '/api/v1/admin/emails/dead-letter';
+      const result = await httpClient.get(url, DeadLetterResultSchema);
+      return result ?? { items: [], totalCount: 0, skip: 0, take: 20 };
+    },
+
+    /**
+     * Retry a single dead-lettered email.
+     * POST /api/v1/admin/emails/{id}/retry
+     */
+    async retryEmail(id: string): Promise<boolean> {
+      const result = await httpClient.post(
+        `/api/v1/admin/emails/${encodeURIComponent(id)}/retry`,
+        {},
+        z.object({ success: z.boolean() })
+      );
+      return result?.success ?? false;
+    },
+
+    /**
+     * Retry all dead-lettered emails.
+     * POST /api/v1/admin/emails/retry-all-dead-letters
+     */
+    async retryAllDeadLetters(): Promise<number> {
+      const result = await httpClient.post(
+        '/api/v1/admin/emails/retry-all-dead-letters',
+        {},
+        z.object({ retried: z.number() })
+      );
+      return result?.retried ?? 0;
+    },
+
+    /**
+     * Send a test email (immediate, not queued).
+     * POST /api/v1/admin/emails/test
+     */
+    async sendTestEmail(to: string): Promise<boolean> {
+      const result = await httpClient.post(
+        '/api/v1/admin/emails/test',
+        { to },
+        z.object({ success: z.boolean() })
+      );
+      return result?.success ?? false;
+    },
   };
 }
 
 export type AdminClient = ReturnType<typeof createAdminClient>;
+
+// ========== Email Queue Schemas (Issue #39) ==========
+
+const EmailQueueStatsSchema = z.object({
+  pendingCount: z.number(),
+  processingCount: z.number(),
+  sentCount: z.number(),
+  failedCount: z.number(),
+  deadLetterCount: z.number(),
+  sentLastHour: z.number(),
+  sentLast24Hours: z.number(),
+});
+
+export type EmailQueueStats = z.infer<typeof EmailQueueStatsSchema>;
+
+const EmailQueueItemSchema = z.object({
+  id: z.string(),
+  userId: z.string(),
+  to: z.string(),
+  subject: z.string(),
+  status: z.string(),
+  retryCount: z.number(),
+  maxRetries: z.number(),
+  errorMessage: z.string().nullable(),
+  createdAt: z.string(),
+  processedAt: z.string().nullable(),
+  failedAt: z.string().nullable(),
+  correlationId: z.string().nullable().optional(),
+});
+
+export type EmailQueueItem = z.infer<typeof EmailQueueItemSchema>;
+
+const EmailHistoryResultSchema = z.object({
+  items: z.array(EmailQueueItemSchema),
+  totalCount: z.number(),
+  skip: z.number(),
+  take: z.number(),
+});
+
+export type EmailHistoryResult = z.infer<typeof EmailHistoryResultSchema>;
+
+const DeadLetterResultSchema = z.object({
+  items: z.array(EmailQueueItemSchema),
+  totalCount: z.number(),
+  skip: z.number(),
+  take: z.number(),
+});
+
+export type DeadLetterResult = z.infer<typeof DeadLetterResultSchema>;
 
 // ========== Qdrant Admin Types (Issue #4877) ==========
 


### PR DESCRIPTION
## Summary

Phase 1 (Quick Wins) of Epic #33 — Email, Notifications & Calendar system.

### Issues Resolved
- **#37**: Cross-channel correlation ID on Notification + EmailQueueItem aggregates
- **#38**: One-click email unsubscribe (JWT tokens, public endpoint, HTML response)
- **#39**: Admin email management (history with search, retry-all dead letters, send test email)
- **#40**: Dead letter monitor job (hourly, alerts via IAlertingService when >10 dead letters)
- **#41**: Notification cleanup job (daily 3AM, batch 1000, configurable retention)

### Changes
**Backend (31 files)**:
- Domain: CorrelationId on Notification + EmailQueueItem aggregates
- Application: 6 new commands/queries + handlers (unsubscribe, history, retry-all, send-test, etc.)
- Infrastructure: UnsubscribeTokenService (JWT 30-day), DeadLetterMonitorJob, NotificationCleanupJob
- Routing: UnsubscribeEndpoints (public, AllowAnonymous), 3 new admin email endpoints
- EF Migration: AddCorrelationId with filtered indexes
- DI: New job registrations + IUnsubscribeTokenService

**Frontend (2 files)**:
- `adminClient.ts`: 6 new methods + Zod schemas for email management
- `EmailManagementTab.tsx`: Full rewrite — real API integration with React Query

### Testing
- 30 backend unit tests pass
- TypeScript clean, Next.js build passes
- Frontend uses useQuery with 30s auto-refetch for stats

Closes #37, #38, #39, #40, #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>