### PR TITLE
feat(game-nights): Phase 2 — Game Night calendar backend

### DIFF
--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNights/CancelGameNightCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNights/CancelGameNightCommand.cs
@@ -1,0 +1,12 @@
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.GameManagement.Application.Commands.GameNights;
+
+/// <summary>
+/// Command to cancel a game night event.
+/// Issue #46: GameNight API endpoints.
+/// </summary>
+internal record CancelGameNightCommand(
+    Guid GameNightId,
+    Guid UserId
+) : ICommand;

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNights/CreateGameNightCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNights/CreateGameNightCommand.cs
@@ -1,0 +1,18 @@
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.GameManagement.Application.Commands.GameNights;
+
+/// <summary>
+/// Command to create a new game night event in Draft status.
+/// Issue #46: GameNight API endpoints.
+/// </summary>
+internal record CreateGameNightCommand(
+    Guid UserId,
+    string Title,
+    DateTimeOffset ScheduledAt,
+    string? Description = null,
+    string? Location = null,
+    int? MaxPlayers = null,
+    List<Guid>? GameIds = null,
+    List<Guid>? InvitedUserIds = null
+) : ICommand<Guid>;

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNights/InviteToGameNightCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNights/InviteToGameNightCommand.cs
@@ -1,0 +1,13 @@
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.GameManagement.Application.Commands.GameNights;
+
+/// <summary>
+/// Command to invite additional users to a published game night.
+/// Issue #46: GameNight API endpoints.
+/// </summary>
+internal record InviteToGameNightCommand(
+    Guid GameNightId,
+    Guid UserId,
+    List<Guid> InvitedUserIds
+) : ICommand;

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNights/PublishGameNightCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNights/PublishGameNightCommand.cs
@@ -1,0 +1,12 @@
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.GameManagement.Application.Commands.GameNights;
+
+/// <summary>
+/// Command to publish a draft game night, making it visible and sending invitations.
+/// Issue #46: GameNight API endpoints.
+/// </summary>
+internal record PublishGameNightCommand(
+    Guid GameNightId,
+    Guid UserId
+) : ICommand;

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNights/RespondToGameNightCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNights/RespondToGameNightCommand.cs
@@ -1,0 +1,14 @@
+using Api.BoundedContexts.GameManagement.Domain.Enums;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.GameManagement.Application.Commands.GameNights;
+
+/// <summary>
+/// Command to respond (RSVP) to a game night invitation.
+/// Issue #46: GameNight API endpoints.
+/// </summary>
+internal record RespondToGameNightCommand(
+    Guid GameNightId,
+    Guid UserId,
+    RsvpStatus Response
+) : ICommand;

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNights/UpdateGameNightCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNights/UpdateGameNightCommand.cs
@@ -1,0 +1,18 @@
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.GameManagement.Application.Commands.GameNights;
+
+/// <summary>
+/// Command to update an existing game night event.
+/// Issue #46: GameNight API endpoints.
+/// </summary>
+internal record UpdateGameNightCommand(
+    Guid GameNightId,
+    Guid UserId,
+    string Title,
+    DateTimeOffset ScheduledAt,
+    string? Description = null,
+    string? Location = null,
+    int? MaxPlayers = null,
+    List<Guid>? GameIds = null
+) : ICommand;

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/DTOs/GameNights/GameNightDto.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/DTOs/GameNights/GameNightDto.cs
@@ -1,0 +1,25 @@
+using Api.BoundedContexts.GameManagement.Domain.Enums;
+
+namespace Api.BoundedContexts.GameManagement.Application.DTOs.GameNights;
+
+/// <summary>
+/// DTO representing a game night event.
+/// Issue #46: GameNight API endpoints.
+/// Issue #43: Added OrganizerName, PendingCount for richer client display.
+/// </summary>
+public sealed record GameNightDto(
+    Guid Id,
+    Guid OrganizerId,
+    string OrganizerName,
+    string Title,
+    string? Description,
+    DateTimeOffset ScheduledAt,
+    string? Location,
+    int? MaxPlayers,
+    List<Guid> GameIds,
+    GameNightStatus Status,
+    int AcceptedCount,
+    int PendingCount,
+    int TotalInvited,
+    DateTimeOffset CreatedAt,
+    DateTimeOffset? UpdatedAt);

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/DTOs/GameNights/GameNightMapperHelper.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/DTOs/GameNights/GameNightMapperHelper.cs
@@ -1,0 +1,47 @@
+using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
+using Api.BoundedContexts.GameManagement.Domain.Enums;
+
+namespace Api.BoundedContexts.GameManagement.Application.DTOs.GameNights;
+
+/// <summary>
+/// Mapper helper for GameNight domain entities to DTOs.
+/// Issue #46: GameNight API endpoints.
+/// Issue #43: Added OrganizerName, UserName, PendingCount enrichment.
+/// </summary>
+internal static class GameNightMapperHelper
+{
+    public static GameNightDto MapToDto(GameNightEvent gameNight, string organizerName)
+    {
+        ArgumentNullException.ThrowIfNull(gameNight);
+
+        return new GameNightDto(
+            Id: gameNight.Id,
+            OrganizerId: gameNight.OrganizerId,
+            OrganizerName: organizerName,
+            Title: gameNight.Title,
+            Description: gameNight.Description,
+            ScheduledAt: gameNight.ScheduledAt,
+            Location: gameNight.Location,
+            MaxPlayers: gameNight.MaxPlayers,
+            GameIds: gameNight.GameIds,
+            Status: gameNight.Status,
+            AcceptedCount: gameNight.AcceptedCount,
+            PendingCount: gameNight.Rsvps.Count(r => r.Status == RsvpStatus.Pending),
+            TotalInvited: gameNight.Rsvps.Count,
+            CreatedAt: gameNight.CreatedAt,
+            UpdatedAt: gameNight.UpdatedAt);
+    }
+
+    public static GameNightRsvpDto MapToRsvpDto(GameNightRsvp rsvp, string userName)
+    {
+        ArgumentNullException.ThrowIfNull(rsvp);
+
+        return new GameNightRsvpDto(
+            Id: rsvp.Id,
+            UserId: rsvp.UserId,
+            UserName: userName,
+            Status: rsvp.Status,
+            RespondedAt: rsvp.RespondedAt,
+            CreatedAt: rsvp.CreatedAt);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/DTOs/GameNights/GameNightRsvpDto.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/DTOs/GameNights/GameNightRsvpDto.cs
@@ -1,0 +1,16 @@
+using Api.BoundedContexts.GameManagement.Domain.Enums;
+
+namespace Api.BoundedContexts.GameManagement.Application.DTOs.GameNights;
+
+/// <summary>
+/// DTO representing an RSVP to a game night.
+/// Issue #46: GameNight API endpoints.
+/// Issue #43: Added UserName for richer client display.
+/// </summary>
+public sealed record GameNightRsvpDto(
+    Guid Id,
+    Guid UserId,
+    string UserName,
+    RsvpStatus Status,
+    DateTimeOffset? RespondedAt,
+    DateTimeOffset CreatedAt);

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Handlers/GameNights/CancelGameNightCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Handlers/GameNights/CancelGameNightCommandHandler.cs
@@ -34,7 +34,14 @@ internal sealed class CancelGameNightCommandHandler : ICommandHandler<CancelGame
         if (gameNight.OrganizerId != command.UserId)
             throw new UnauthorizedAccessException("Only the organizer can cancel a game night");
 
-        gameNight.Cancel();
+        try
+        {
+            gameNight.Cancel();
+        }
+        catch (InvalidOperationException ex)
+        {
+            throw new ConflictException(ex.Message);
+        }
 
         await _repository.UpdateAsync(gameNight, cancellationToken).ConfigureAwait(false);
         await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Handlers/GameNights/CancelGameNightCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Handlers/GameNights/CancelGameNightCommandHandler.cs
@@ -1,0 +1,42 @@
+using Api.BoundedContexts.GameManagement.Application.Commands.GameNights;
+using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Infrastructure.Persistence;
+
+namespace Api.BoundedContexts.GameManagement.Application.Handlers.GameNights;
+
+/// <summary>
+/// Handles cancellation of a game night event.
+/// Issue #46: GameNight API endpoints.
+/// Issue #43: Uses NotFoundException, calls UpdateAsync, publishes domain events via aggregate.
+/// </summary>
+internal sealed class CancelGameNightCommandHandler : ICommandHandler<CancelGameNightCommand>
+{
+    private readonly IGameNightEventRepository _repository;
+    private readonly IUnitOfWork _unitOfWork;
+
+    public CancelGameNightCommandHandler(
+        IGameNightEventRepository repository,
+        IUnitOfWork unitOfWork)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+    }
+
+    public async Task Handle(CancelGameNightCommand command, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        var gameNight = await _repository.GetByIdAsync(command.GameNightId, cancellationToken).ConfigureAwait(false)
+            ?? throw new NotFoundException("GameNightEvent", command.GameNightId.ToString());
+
+        if (gameNight.OrganizerId != command.UserId)
+            throw new UnauthorizedAccessException("Only the organizer can cancel a game night");
+
+        gameNight.Cancel();
+
+        await _repository.UpdateAsync(gameNight, cancellationToken).ConfigureAwait(false);
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Handlers/GameNights/CreateGameNightCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Handlers/GameNights/CreateGameNightCommandHandler.cs
@@ -38,6 +38,12 @@ internal sealed class CreateGameNightCommandHandler : ICommandHandler<CreateGame
             maxPlayers: command.MaxPlayers,
             gameIds: command.GameIds);
 
+        // Pre-create RSVP entries for invited users so PublishHandler sends invitations.
+        if (command.InvitedUserIds is { Count: > 0 })
+        {
+            gameNight.PreInvite(command.InvitedUserIds);
+        }
+
         await _repository.AddAsync(gameNight, cancellationToken).ConfigureAwait(false);
         await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
 

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Handlers/GameNights/CreateGameNightCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Handlers/GameNights/CreateGameNightCommandHandler.cs
@@ -1,0 +1,46 @@
+using Api.BoundedContexts.GameManagement.Application.Commands.GameNights;
+using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
+using Api.Infrastructure;
+using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.GameManagement.Application.Handlers.GameNights;
+
+/// <summary>
+/// Handles creation of a new game night event.
+/// Issue #46: GameNight API endpoints.
+/// Issue #43: Returns enriched DTO with OrganizerName.
+/// </summary>
+internal sealed class CreateGameNightCommandHandler : ICommandHandler<CreateGameNightCommand, Guid>
+{
+    private readonly IGameNightEventRepository _repository;
+    private readonly IUnitOfWork _unitOfWork;
+
+    public CreateGameNightCommandHandler(
+        IGameNightEventRepository repository,
+        IUnitOfWork unitOfWork)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+    }
+
+    public async Task<Guid> Handle(CreateGameNightCommand command, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        var gameNight = GameNightEvent.Create(
+            organizerId: command.UserId,
+            title: command.Title,
+            scheduledAt: command.ScheduledAt,
+            description: command.Description,
+            location: command.Location,
+            maxPlayers: command.MaxPlayers,
+            gameIds: command.GameIds);
+
+        await _repository.AddAsync(gameNight, cancellationToken).ConfigureAwait(false);
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        return gameNight.Id;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Handlers/GameNights/GetGameNightByIdQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Handlers/GameNights/GetGameNightByIdQueryHandler.cs
@@ -1,0 +1,50 @@
+using Api.BoundedContexts.GameManagement.Application.DTOs.GameNights;
+using Api.BoundedContexts.GameManagement.Application.Queries.GameNights;
+using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
+using Api.Infrastructure;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Application.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.GameManagement.Application.Handlers.GameNights;
+
+/// <summary>
+/// Handles retrieval of a game night by ID.
+/// Issue #46: GameNight API endpoints.
+/// Issue #43: Enriches DTO with OrganizerName, uses NotFoundException.
+/// </summary>
+internal sealed class GetGameNightByIdQueryHandler : IQueryHandler<GetGameNightByIdQuery, GameNightDto>
+{
+    private readonly IGameNightEventRepository _repository;
+    private readonly MeepleAiDbContext _context;
+
+    public GetGameNightByIdQueryHandler(
+        IGameNightEventRepository repository,
+        MeepleAiDbContext context)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+    }
+
+    public async Task<GameNightDto> Handle(GetGameNightByIdQuery query, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        var gameNight = await _repository.GetByIdAsync(query.GameNightId, cancellationToken).ConfigureAwait(false)
+            ?? throw new NotFoundException("GameNightEvent", query.GameNightId.ToString());
+
+        var organizerName = await GetUserDisplayNameAsync(gameNight.OrganizerId, cancellationToken).ConfigureAwait(false);
+
+        return GameNightMapperHelper.MapToDto(gameNight, organizerName);
+    }
+
+    private async Task<string> GetUserDisplayNameAsync(Guid userId, CancellationToken cancellationToken)
+    {
+        var user = await _context.Users
+            .AsNoTracking()
+            .FirstOrDefaultAsync(u => u.Id == userId, cancellationToken)
+            .ConfigureAwait(false);
+
+        return user?.DisplayName ?? user?.Email ?? "Unknown";
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Handlers/GameNights/GetGameNightRsvpsQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Handlers/GameNights/GetGameNightRsvpsQueryHandler.cs
@@ -1,0 +1,54 @@
+using Api.BoundedContexts.GameManagement.Application.DTOs.GameNights;
+using Api.BoundedContexts.GameManagement.Application.Queries.GameNights;
+using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
+using Api.Infrastructure;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Application.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.GameManagement.Application.Handlers.GameNights;
+
+/// <summary>
+/// Handles retrieval of RSVPs for a game night.
+/// Issue #46: GameNight API endpoints.
+/// Issue #43: Enriches DTO with UserName via batch user lookup, uses NotFoundException.
+/// </summary>
+internal sealed class GetGameNightRsvpsQueryHandler : IQueryHandler<GetGameNightRsvpsQuery, IReadOnlyList<GameNightRsvpDto>>
+{
+    private readonly IGameNightEventRepository _repository;
+    private readonly MeepleAiDbContext _context;
+
+    public GetGameNightRsvpsQueryHandler(
+        IGameNightEventRepository repository,
+        MeepleAiDbContext context)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+    }
+
+    public async Task<IReadOnlyList<GameNightRsvpDto>> Handle(GetGameNightRsvpsQuery query, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        var gameNight = await _repository.GetByIdAsync(query.GameNightId, cancellationToken).ConfigureAwait(false)
+            ?? throw new NotFoundException("GameNightEvent", query.GameNightId.ToString());
+
+        var userIds = gameNight.Rsvps.Select(r => r.UserId).Distinct().ToList();
+        var userNames = await GetUserDisplayNamesAsync(userIds, cancellationToken).ConfigureAwait(false);
+
+        return gameNight.Rsvps.Select(r => GameNightMapperHelper.MapToRsvpDto(
+            r, userNames.GetValueOrDefault(r.UserId, "Unknown"))).ToList();
+    }
+
+    private async Task<Dictionary<Guid, string>> GetUserDisplayNamesAsync(List<Guid> userIds, CancellationToken cancellationToken)
+    {
+        var users = await _context.Users
+            .AsNoTracking()
+            .Where(u => userIds.Contains(u.Id))
+            .Select(u => new { u.Id, u.DisplayName, u.Email })
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return users.ToDictionary(u => u.Id, u => u.DisplayName ?? u.Email ?? "Unknown");
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Handlers/GameNights/GetMyGameNightsQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Handlers/GameNights/GetMyGameNightsQueryHandler.cs
@@ -1,0 +1,52 @@
+using Api.BoundedContexts.GameManagement.Application.DTOs.GameNights;
+using Api.BoundedContexts.GameManagement.Application.Queries.GameNights;
+using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
+using Api.Infrastructure;
+using Api.SharedKernel.Application.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.GameManagement.Application.Handlers.GameNights;
+
+/// <summary>
+/// Handles retrieval of game nights where the user is organizer or invited.
+/// Issue #46: GameNight API endpoints.
+/// Issue #43: Enriches DTO with OrganizerName via batch user lookup.
+/// </summary>
+internal sealed class GetMyGameNightsQueryHandler : IQueryHandler<GetMyGameNightsQuery, IReadOnlyList<GameNightDto>>
+{
+    private readonly IGameNightEventRepository _repository;
+    private readonly MeepleAiDbContext _context;
+
+    public GetMyGameNightsQueryHandler(
+        IGameNightEventRepository repository,
+        MeepleAiDbContext context)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+    }
+
+    public async Task<IReadOnlyList<GameNightDto>> Handle(GetMyGameNightsQuery query, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        var events = await _repository.GetByUserAsync(query.UserId, cancellationToken).ConfigureAwait(false);
+
+        var organizerIds = events.Select(e => e.OrganizerId).Distinct().ToList();
+        var organizerNames = await GetUserDisplayNamesAsync(organizerIds, cancellationToken).ConfigureAwait(false);
+
+        return events.Select(e => GameNightMapperHelper.MapToDto(
+            e, organizerNames.GetValueOrDefault(e.OrganizerId, "Unknown"))).ToList();
+    }
+
+    private async Task<Dictionary<Guid, string>> GetUserDisplayNamesAsync(List<Guid> userIds, CancellationToken cancellationToken)
+    {
+        var users = await _context.Users
+            .AsNoTracking()
+            .Where(u => userIds.Contains(u.Id))
+            .Select(u => new { u.Id, u.DisplayName, u.Email })
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return users.ToDictionary(u => u.Id, u => u.DisplayName ?? u.Email ?? "Unknown");
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Handlers/GameNights/GetUpcomingGameNightsQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Handlers/GameNights/GetUpcomingGameNightsQueryHandler.cs
@@ -1,0 +1,52 @@
+using Api.BoundedContexts.GameManagement.Application.DTOs.GameNights;
+using Api.BoundedContexts.GameManagement.Application.Queries.GameNights;
+using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
+using Api.Infrastructure;
+using Api.SharedKernel.Application.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.GameManagement.Application.Handlers.GameNights;
+
+/// <summary>
+/// Handles retrieval of upcoming published game nights.
+/// Issue #46: GameNight API endpoints.
+/// Issue #43: Enriches DTO with OrganizerName via batch user lookup.
+/// </summary>
+internal sealed class GetUpcomingGameNightsQueryHandler : IQueryHandler<GetUpcomingGameNightsQuery, IReadOnlyList<GameNightDto>>
+{
+    private readonly IGameNightEventRepository _repository;
+    private readonly MeepleAiDbContext _context;
+
+    public GetUpcomingGameNightsQueryHandler(
+        IGameNightEventRepository repository,
+        MeepleAiDbContext context)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+    }
+
+    public async Task<IReadOnlyList<GameNightDto>> Handle(GetUpcomingGameNightsQuery query, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        var events = await _repository.GetUpcomingAsync(cancellationToken).ConfigureAwait(false);
+
+        var organizerIds = events.Select(e => e.OrganizerId).Distinct().ToList();
+        var organizerNames = await GetUserDisplayNamesAsync(organizerIds, cancellationToken).ConfigureAwait(false);
+
+        return events.Select(e => GameNightMapperHelper.MapToDto(
+            e, organizerNames.GetValueOrDefault(e.OrganizerId, "Unknown"))).ToList();
+    }
+
+    private async Task<Dictionary<Guid, string>> GetUserDisplayNamesAsync(List<Guid> userIds, CancellationToken cancellationToken)
+    {
+        var users = await _context.Users
+            .AsNoTracking()
+            .Where(u => userIds.Contains(u.Id))
+            .Select(u => new { u.Id, u.DisplayName, u.Email })
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return users.ToDictionary(u => u.Id, u => u.DisplayName ?? u.Email ?? "Unknown");
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Handlers/GameNights/InviteToGameNightCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Handlers/GameNights/InviteToGameNightCommandHandler.cs
@@ -34,7 +34,14 @@ internal sealed class InviteToGameNightCommandHandler : ICommandHandler<InviteTo
         if (gameNight.OrganizerId != command.UserId)
             throw new UnauthorizedAccessException("Only the organizer can invite users to a game night");
 
-        gameNight.AddInvitees(command.InvitedUserIds);
+        try
+        {
+            gameNight.AddInvitees(command.InvitedUserIds);
+        }
+        catch (InvalidOperationException ex)
+        {
+            throw new ConflictException(ex.Message);
+        }
 
         await _repository.UpdateAsync(gameNight, cancellationToken).ConfigureAwait(false);
         await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Handlers/GameNights/InviteToGameNightCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Handlers/GameNights/InviteToGameNightCommandHandler.cs
@@ -1,0 +1,42 @@
+using Api.BoundedContexts.GameManagement.Application.Commands.GameNights;
+using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Infrastructure.Persistence;
+
+namespace Api.BoundedContexts.GameManagement.Application.Handlers.GameNights;
+
+/// <summary>
+/// Handles inviting additional users to a published game night.
+/// Issue #46: GameNight API endpoints.
+/// Issue #43: Uses NotFoundException, calls UpdateAsync.
+/// </summary>
+internal sealed class InviteToGameNightCommandHandler : ICommandHandler<InviteToGameNightCommand>
+{
+    private readonly IGameNightEventRepository _repository;
+    private readonly IUnitOfWork _unitOfWork;
+
+    public InviteToGameNightCommandHandler(
+        IGameNightEventRepository repository,
+        IUnitOfWork unitOfWork)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+    }
+
+    public async Task Handle(InviteToGameNightCommand command, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        var gameNight = await _repository.GetByIdAsync(command.GameNightId, cancellationToken).ConfigureAwait(false)
+            ?? throw new NotFoundException("GameNightEvent", command.GameNightId.ToString());
+
+        if (gameNight.OrganizerId != command.UserId)
+            throw new UnauthorizedAccessException("Only the organizer can invite users to a game night");
+
+        gameNight.AddInvitees(command.InvitedUserIds);
+
+        await _repository.UpdateAsync(gameNight, cancellationToken).ConfigureAwait(false);
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Handlers/GameNights/PublishGameNightCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Handlers/GameNights/PublishGameNightCommandHandler.cs
@@ -1,0 +1,44 @@
+using Api.BoundedContexts.GameManagement.Application.Commands.GameNights;
+using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Infrastructure.Persistence;
+
+namespace Api.BoundedContexts.GameManagement.Application.Handlers.GameNights;
+
+/// <summary>
+/// Handles publishing a draft game night, sending invitations.
+/// Issue #46: GameNight API endpoints.
+/// Issue #43: Uses NotFoundException, calls UpdateAsync, publishes domain events via aggregate.
+/// </summary>
+internal sealed class PublishGameNightCommandHandler : ICommandHandler<PublishGameNightCommand>
+{
+    private readonly IGameNightEventRepository _repository;
+    private readonly IUnitOfWork _unitOfWork;
+
+    public PublishGameNightCommandHandler(
+        IGameNightEventRepository repository,
+        IUnitOfWork unitOfWork)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+    }
+
+    public async Task Handle(PublishGameNightCommand command, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        var gameNight = await _repository.GetByIdAsync(command.GameNightId, cancellationToken).ConfigureAwait(false)
+            ?? throw new NotFoundException("GameNightEvent", command.GameNightId.ToString());
+
+        if (gameNight.OrganizerId != command.UserId)
+            throw new UnauthorizedAccessException("Only the organizer can publish a game night");
+
+        // Publish with existing invited user IDs from RSVPs (if any were pre-invited)
+        var existingInvitedIds = gameNight.Rsvps.Select(r => r.UserId).ToList();
+        gameNight.Publish(existingInvitedIds);
+
+        await _repository.UpdateAsync(gameNight, cancellationToken).ConfigureAwait(false);
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Handlers/GameNights/PublishGameNightCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Handlers/GameNights/PublishGameNightCommandHandler.cs
@@ -34,9 +34,16 @@ internal sealed class PublishGameNightCommandHandler : ICommandHandler<PublishGa
         if (gameNight.OrganizerId != command.UserId)
             throw new UnauthorizedAccessException("Only the organizer can publish a game night");
 
-        // Publish with existing invited user IDs from RSVPs (if any were pre-invited)
+        // Publish with invited user IDs from existing RSVPs (pre-invited during Create)
         var existingInvitedIds = gameNight.Rsvps.Select(r => r.UserId).ToList();
-        gameNight.Publish(existingInvitedIds);
+        try
+        {
+            gameNight.Publish(existingInvitedIds);
+        }
+        catch (InvalidOperationException ex)
+        {
+            throw new ConflictException(ex.Message);
+        }
 
         await _repository.UpdateAsync(gameNight, cancellationToken).ConfigureAwait(false);
         await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Handlers/GameNights/RespondToGameNightCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Handlers/GameNights/RespondToGameNightCommandHandler.cs
@@ -1,0 +1,67 @@
+using Api.BoundedContexts.GameManagement.Application.Commands.GameNights;
+using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
+using Api.BoundedContexts.GameManagement.Domain.Enums;
+using Api.BoundedContexts.GameManagement.Domain.Events;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Infrastructure.Persistence;
+using MediatR;
+
+namespace Api.BoundedContexts.GameManagement.Application.Handlers.GameNights;
+
+/// <summary>
+/// Handles RSVP responses to game night invitations.
+/// Issue #46: GameNight API endpoints.
+/// Issue #43: Uses NotFoundException, checks IsFull for Accept, publishes GameNightRsvpReceivedEvent.
+/// </summary>
+internal sealed class RespondToGameNightCommandHandler : ICommandHandler<RespondToGameNightCommand>
+{
+    private readonly IGameNightEventRepository _repository;
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly IMediator _mediator;
+
+    public RespondToGameNightCommandHandler(
+        IGameNightEventRepository repository,
+        IUnitOfWork unitOfWork,
+        IMediator mediator)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+        _mediator = mediator ?? throw new ArgumentNullException(nameof(mediator));
+    }
+
+    public async Task Handle(RespondToGameNightCommand command, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        var gameNight = await _repository.GetByIdAsync(command.GameNightId, cancellationToken).ConfigureAwait(false)
+            ?? throw new NotFoundException("GameNightEvent", command.GameNightId.ToString());
+
+        var rsvp = gameNight.GetRsvp(command.UserId)
+            ?? throw new NotFoundException("GameNightRsvp", $"EventId={command.GameNightId}, UserId={command.UserId}");
+
+        switch (command.Response)
+        {
+            case RsvpStatus.Accepted:
+                if (gameNight.IsFull)
+                    throw new InvalidOperationException("This game night is full and cannot accept more players");
+                rsvp.Accept();
+                break;
+            case RsvpStatus.Declined:
+                rsvp.Decline();
+                break;
+            case RsvpStatus.Maybe:
+                rsvp.SetMaybe();
+                break;
+            default:
+                throw new ArgumentOutOfRangeException(nameof(command), $"Invalid RSVP response: {command.Response}");
+        }
+
+        await _repository.UpdateAsync(gameNight, cancellationToken).ConfigureAwait(false);
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        await _mediator.Publish(
+            new GameNightRsvpReceivedEvent(command.GameNightId, command.UserId, command.Response, gameNight.OrganizerId),
+            cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Handlers/GameNights/RespondToGameNightCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Handlers/GameNights/RespondToGameNightCommandHandler.cs
@@ -5,29 +5,25 @@ using Api.BoundedContexts.GameManagement.Domain.Events;
 using Api.Middleware.Exceptions;
 using Api.SharedKernel.Application.Interfaces;
 using Api.SharedKernel.Infrastructure.Persistence;
-using MediatR;
 
 namespace Api.BoundedContexts.GameManagement.Application.Handlers.GameNights;
 
 /// <summary>
 /// Handles RSVP responses to game night invitations.
 /// Issue #46: GameNight API endpoints.
-/// Issue #43: Uses NotFoundException, checks IsFull for Accept, publishes GameNightRsvpReceivedEvent.
+/// Issue #43: Uses NotFoundException, checks IsFull for Accept, raises domain event via aggregate.
 /// </summary>
 internal sealed class RespondToGameNightCommandHandler : ICommandHandler<RespondToGameNightCommand>
 {
     private readonly IGameNightEventRepository _repository;
     private readonly IUnitOfWork _unitOfWork;
-    private readonly IMediator _mediator;
 
     public RespondToGameNightCommandHandler(
         IGameNightEventRepository repository,
-        IUnitOfWork unitOfWork,
-        IMediator mediator)
+        IUnitOfWork unitOfWork)
     {
         _repository = repository ?? throw new ArgumentNullException(nameof(repository));
         _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
-        _mediator = mediator ?? throw new ArgumentNullException(nameof(mediator));
     }
 
     public async Task Handle(RespondToGameNightCommand command, CancellationToken cancellationToken)
@@ -44,7 +40,7 @@ internal sealed class RespondToGameNightCommandHandler : ICommandHandler<Respond
         {
             case RsvpStatus.Accepted:
                 if (gameNight.IsFull)
-                    throw new InvalidOperationException("This game night is full and cannot accept more players");
+                    throw new ConflictException("This game night is full and cannot accept more players");
                 rsvp.Accept();
                 break;
             case RsvpStatus.Declined:
@@ -57,11 +53,10 @@ internal sealed class RespondToGameNightCommandHandler : ICommandHandler<Respond
                 throw new ArgumentOutOfRangeException(nameof(command), $"Invalid RSVP response: {command.Response}");
         }
 
+        // Use domain event pattern for consistency — dispatched by UnitOfWork after SaveChanges.
+        gameNight.AddRsvpReceivedEvent(command.UserId, command.Response, gameNight.OrganizerId);
+
         await _repository.UpdateAsync(gameNight, cancellationToken).ConfigureAwait(false);
         await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
-
-        await _mediator.Publish(
-            new GameNightRsvpReceivedEvent(command.GameNightId, command.UserId, command.Response, gameNight.OrganizerId),
-            cancellationToken).ConfigureAwait(false);
     }
 }

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Handlers/GameNights/UpdateGameNightCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Handlers/GameNights/UpdateGameNightCommandHandler.cs
@@ -34,13 +34,20 @@ internal sealed class UpdateGameNightCommandHandler : ICommandHandler<UpdateGame
         if (gameNight.OrganizerId != command.UserId)
             throw new UnauthorizedAccessException("Only the organizer can update a game night");
 
-        gameNight.Update(
-            command.Title,
-            command.Description,
-            command.ScheduledAt,
-            command.Location,
-            command.MaxPlayers,
-            command.GameIds);
+        try
+        {
+            gameNight.Update(
+                command.Title,
+                command.Description,
+                command.ScheduledAt,
+                command.Location,
+                command.MaxPlayers,
+                command.GameIds);
+        }
+        catch (InvalidOperationException ex)
+        {
+            throw new ConflictException(ex.Message);
+        }
 
         await _repository.UpdateAsync(gameNight, cancellationToken).ConfigureAwait(false);
         await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Handlers/GameNights/UpdateGameNightCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Handlers/GameNights/UpdateGameNightCommandHandler.cs
@@ -1,0 +1,48 @@
+using Api.BoundedContexts.GameManagement.Application.Commands.GameNights;
+using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Infrastructure.Persistence;
+
+namespace Api.BoundedContexts.GameManagement.Application.Handlers.GameNights;
+
+/// <summary>
+/// Handles updating a game night event.
+/// Issue #46: GameNight API endpoints.
+/// Issue #43: Uses NotFoundException, calls UpdateAsync.
+/// </summary>
+internal sealed class UpdateGameNightCommandHandler : ICommandHandler<UpdateGameNightCommand>
+{
+    private readonly IGameNightEventRepository _repository;
+    private readonly IUnitOfWork _unitOfWork;
+
+    public UpdateGameNightCommandHandler(
+        IGameNightEventRepository repository,
+        IUnitOfWork unitOfWork)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+    }
+
+    public async Task Handle(UpdateGameNightCommand command, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        var gameNight = await _repository.GetByIdAsync(command.GameNightId, cancellationToken).ConfigureAwait(false)
+            ?? throw new NotFoundException("GameNightEvent", command.GameNightId.ToString());
+
+        if (gameNight.OrganizerId != command.UserId)
+            throw new UnauthorizedAccessException("Only the organizer can update a game night");
+
+        gameNight.Update(
+            command.Title,
+            command.Description,
+            command.ScheduledAt,
+            command.Location,
+            command.MaxPlayers,
+            command.GameIds);
+
+        await _repository.UpdateAsync(gameNight, cancellationToken).ConfigureAwait(false);
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNights/GetGameNightByIdQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNights/GetGameNightByIdQuery.cs
@@ -1,0 +1,10 @@
+using Api.BoundedContexts.GameManagement.Application.DTOs.GameNights;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.GameManagement.Application.Queries.GameNights;
+
+/// <summary>
+/// Query to get a game night by its ID.
+/// Issue #46: GameNight API endpoints.
+/// </summary>
+internal record GetGameNightByIdQuery(Guid GameNightId) : IQuery<GameNightDto>;

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNights/GetGameNightRsvpsQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNights/GetGameNightRsvpsQuery.cs
@@ -1,0 +1,10 @@
+using Api.BoundedContexts.GameManagement.Application.DTOs.GameNights;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.GameManagement.Application.Queries.GameNights;
+
+/// <summary>
+/// Query to get RSVPs for a game night.
+/// Issue #46: GameNight API endpoints.
+/// </summary>
+internal record GetGameNightRsvpsQuery(Guid GameNightId) : IQuery<IReadOnlyList<GameNightRsvpDto>>;

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNights/GetMyGameNightsQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNights/GetMyGameNightsQuery.cs
@@ -1,0 +1,10 @@
+using Api.BoundedContexts.GameManagement.Application.DTOs.GameNights;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.GameManagement.Application.Queries.GameNights;
+
+/// <summary>
+/// Query to get game nights where the user is organizer or invited.
+/// Issue #46: GameNight API endpoints.
+/// </summary>
+internal record GetMyGameNightsQuery(Guid UserId) : IQuery<IReadOnlyList<GameNightDto>>;

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNights/GetUpcomingGameNightsQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNights/GetUpcomingGameNightsQuery.cs
@@ -1,0 +1,10 @@
+using Api.BoundedContexts.GameManagement.Application.DTOs.GameNights;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.GameManagement.Application.Queries.GameNights;
+
+/// <summary>
+/// Query to get upcoming published game nights.
+/// Issue #46: GameNight API endpoints.
+/// </summary>
+internal record GetUpcomingGameNightsQuery() : IQuery<IReadOnlyList<GameNightDto>>;

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Services/IGameNightEmailService.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Services/IGameNightEmailService.cs
@@ -1,0 +1,46 @@
+namespace Api.BoundedContexts.GameManagement.Application.Services;
+
+/// <summary>
+/// Service for sending game night-related emails with HTML templates.
+/// Issue #44/#47: Game night notification types and email templates.
+/// </summary>
+internal interface IGameNightEmailService
+{
+    Task SendGameNightInvitationEmailAsync(
+        string toEmail,
+        string organizerName,
+        string title,
+        DateTimeOffset scheduledAt,
+        string? location,
+        IReadOnlyList<string> gameNames,
+        string rsvpAcceptUrl,
+        string rsvpDeclineUrl,
+        string unsubscribeUrl,
+        CancellationToken ct = default);
+
+    Task SendGameNightReminder24hEmailAsync(
+        string toEmail,
+        string title,
+        DateTimeOffset scheduledAt,
+        string? location,
+        int confirmedCount,
+        bool isPending,
+        string unsubscribeUrl,
+        CancellationToken ct = default);
+
+    Task SendGameNightCancelledEmailAsync(
+        string toEmail,
+        string organizerName,
+        string title,
+        DateTimeOffset scheduledAt,
+        string unsubscribeUrl,
+        CancellationToken ct = default);
+
+    Task SendGameNightRsvpConfirmationEmailAsync(
+        string toEmail,
+        string title,
+        DateTimeOffset scheduledAt,
+        string? location,
+        string unsubscribeUrl,
+        CancellationToken ct = default);
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Validators/GameNights/CreateGameNightCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Validators/GameNights/CreateGameNightCommandValidator.cs
@@ -24,7 +24,7 @@ internal sealed class CreateGameNightCommandValidator : AbstractValidator<Create
             .WithMessage("Title cannot exceed 200 characters");
 
         RuleFor(x => x.ScheduledAt)
-            .GreaterThan(DateTimeOffset.UtcNow.AddHours(1))
+            .Must(scheduledAt => scheduledAt > DateTimeOffset.UtcNow.AddHours(1))
             .WithMessage("Scheduled time must be at least 1 hour in the future");
 
         RuleFor(x => x.Description)

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Validators/GameNights/CreateGameNightCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Validators/GameNights/CreateGameNightCommandValidator.cs
@@ -1,0 +1,53 @@
+using Api.BoundedContexts.GameManagement.Application.Commands.GameNights;
+using FluentValidation;
+
+namespace Api.BoundedContexts.GameManagement.Application.Validators.GameNights;
+
+/// <summary>
+/// Validator for CreateGameNightCommand.
+/// Issue #43: Game Night CRUD validators.
+/// </summary>
+internal sealed class CreateGameNightCommandValidator : AbstractValidator<CreateGameNightCommand>
+{
+    public CreateGameNightCommandValidator()
+    {
+        RuleFor(x => x.UserId)
+            .NotEmpty()
+            .WithMessage("User ID is required");
+
+        RuleFor(x => x.Title)
+            .NotEmpty()
+            .WithMessage("Title is required")
+            .MinimumLength(3)
+            .WithMessage("Title must be at least 3 characters")
+            .MaximumLength(200)
+            .WithMessage("Title cannot exceed 200 characters");
+
+        RuleFor(x => x.ScheduledAt)
+            .GreaterThan(DateTimeOffset.UtcNow.AddHours(1))
+            .WithMessage("Scheduled time must be at least 1 hour in the future");
+
+        RuleFor(x => x.Description)
+            .MaximumLength(2000)
+            .When(x => x.Description != null)
+            .WithMessage("Description cannot exceed 2000 characters");
+
+        RuleFor(x => x.Location)
+            .MaximumLength(500)
+            .When(x => x.Location != null)
+            .WithMessage("Location cannot exceed 500 characters");
+
+        RuleFor(x => x.MaxPlayers)
+            .InclusiveBetween(2, 50)
+            .When(x => x.MaxPlayers.HasValue)
+            .WithMessage("Max players must be between 2 and 50");
+
+        RuleFor(x => x.GameIds)
+            .Must(ids => ids == null || ids.Count <= 20)
+            .WithMessage("Cannot include more than 20 games");
+
+        RuleFor(x => x.InvitedUserIds)
+            .Must(ids => ids == null || ids.Count <= 49)
+            .WithMessage("Cannot invite more than 49 users");
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Validators/GameNights/RespondToGameNightCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Validators/GameNights/RespondToGameNightCommandValidator.cs
@@ -1,0 +1,29 @@
+using Api.BoundedContexts.GameManagement.Application.Commands.GameNights;
+using Api.BoundedContexts.GameManagement.Domain.Enums;
+using FluentValidation;
+
+namespace Api.BoundedContexts.GameManagement.Application.Validators.GameNights;
+
+/// <summary>
+/// Validator for RespondToGameNightCommand.
+/// Issue #43: Game Night CRUD validators.
+/// </summary>
+internal sealed class RespondToGameNightCommandValidator : AbstractValidator<RespondToGameNightCommand>
+{
+    public RespondToGameNightCommandValidator()
+    {
+        RuleFor(x => x.UserId)
+            .NotEmpty()
+            .WithMessage("User ID is required");
+
+        RuleFor(x => x.GameNightId)
+            .NotEmpty()
+            .WithMessage("Game night ID is required");
+
+        RuleFor(x => x.Response)
+            .IsInEnum()
+            .WithMessage("Invalid RSVP response value")
+            .Must(r => r != RsvpStatus.Pending)
+            .WithMessage("Cannot set RSVP status to Pending");
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Validators/GameNights/UpdateGameNightCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Validators/GameNights/UpdateGameNightCommandValidator.cs
@@ -1,0 +1,53 @@
+using Api.BoundedContexts.GameManagement.Application.Commands.GameNights;
+using FluentValidation;
+
+namespace Api.BoundedContexts.GameManagement.Application.Validators.GameNights;
+
+/// <summary>
+/// Validator for UpdateGameNightCommand.
+/// Issue #43: Game Night CRUD validators.
+/// </summary>
+internal sealed class UpdateGameNightCommandValidator : AbstractValidator<UpdateGameNightCommand>
+{
+    public UpdateGameNightCommandValidator()
+    {
+        RuleFor(x => x.UserId)
+            .NotEmpty()
+            .WithMessage("User ID is required");
+
+        RuleFor(x => x.GameNightId)
+            .NotEmpty()
+            .WithMessage("Game night ID is required");
+
+        RuleFor(x => x.Title)
+            .NotEmpty()
+            .WithMessage("Title is required")
+            .MinimumLength(3)
+            .WithMessage("Title must be at least 3 characters")
+            .MaximumLength(200)
+            .WithMessage("Title cannot exceed 200 characters");
+
+        RuleFor(x => x.ScheduledAt)
+            .GreaterThan(DateTimeOffset.UtcNow.AddHours(1))
+            .WithMessage("Scheduled time must be at least 1 hour in the future");
+
+        RuleFor(x => x.Description)
+            .MaximumLength(2000)
+            .When(x => x.Description != null)
+            .WithMessage("Description cannot exceed 2000 characters");
+
+        RuleFor(x => x.Location)
+            .MaximumLength(500)
+            .When(x => x.Location != null)
+            .WithMessage("Location cannot exceed 500 characters");
+
+        RuleFor(x => x.MaxPlayers)
+            .InclusiveBetween(2, 50)
+            .When(x => x.MaxPlayers.HasValue)
+            .WithMessage("Max players must be between 2 and 50");
+
+        RuleFor(x => x.GameIds)
+            .Must(ids => ids == null || ids.Count <= 20)
+            .WithMessage("Cannot include more than 20 games");
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Validators/GameNights/UpdateGameNightCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Validators/GameNights/UpdateGameNightCommandValidator.cs
@@ -28,7 +28,7 @@ internal sealed class UpdateGameNightCommandValidator : AbstractValidator<Update
             .WithMessage("Title cannot exceed 200 characters");
 
         RuleFor(x => x.ScheduledAt)
-            .GreaterThan(DateTimeOffset.UtcNow.AddHours(1))
+            .Must(scheduledAt => scheduledAt > DateTimeOffset.UtcNow.AddHours(1))
             .WithMessage("Scheduled time must be at least 1 hour in the future");
 
         RuleFor(x => x.Description)

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/GameNightEvent/GameNightEvent.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/GameNightEvent/GameNightEvent.cs
@@ -1,0 +1,228 @@
+using Api.BoundedContexts.GameManagement.Domain.Enums;
+using Api.BoundedContexts.GameManagement.Domain.Events;
+using Api.SharedKernel.Domain.Entities;
+
+namespace Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
+
+/// <summary>
+/// Aggregate root representing a game night event — a scheduled gathering for board gaming.
+/// Supports RSVP management, reminders, and lifecycle transitions (Draft → Published → Completed/Cancelled).
+/// Issue #42: GameNightEvent + GameNightRsvp domain entities.
+/// </summary>
+#pragma warning disable MA0049
+internal sealed class GameNightEvent : AggregateRoot<Guid>
+#pragma warning restore MA0049
+{
+    private readonly List<GameNightRsvp> _rsvps = new();
+
+    public Guid OrganizerId { get; private set; }
+    public string Title { get; private set; }
+    public string? Description { get; private set; }
+    public DateTimeOffset ScheduledAt { get; private set; }
+    public string? Location { get; private set; }
+    public int? MaxPlayers { get; private set; }
+    public List<Guid> GameIds { get; private set; } = [];
+    public GameNightStatus Status { get; private set; }
+    public DateTimeOffset? Reminder24hSentAt { get; private set; }
+    public DateTimeOffset? Reminder1hSentAt { get; private set; }
+    public DateTimeOffset CreatedAt { get; private set; }
+    public DateTimeOffset? UpdatedAt { get; private set; }
+    public IReadOnlyList<GameNightRsvp> Rsvps => _rsvps.AsReadOnly();
+
+    /// <summary>
+    /// Private constructor for EF Core.
+    /// </summary>
+#pragma warning disable CS8618
+    private GameNightEvent() : base()
+#pragma warning restore CS8618
+    {
+    }
+
+    /// <summary>
+    /// Creates a new game night event.
+    /// </summary>
+    internal GameNightEvent(
+        Guid id,
+        Guid organizerId,
+        string title,
+        DateTimeOffset scheduledAt,
+        string? description = null,
+        string? location = null,
+        int? maxPlayers = null,
+        List<Guid>? gameIds = null) : base(id)
+    {
+        if (organizerId == Guid.Empty)
+            throw new ArgumentException("OrganizerId cannot be empty", nameof(organizerId));
+        if (string.IsNullOrWhiteSpace(title))
+            throw new ArgumentException("Title cannot be empty", nameof(title));
+        if (title.Length > 200)
+            throw new ArgumentException("Title cannot exceed 200 characters", nameof(title));
+        if (maxPlayers.HasValue && maxPlayers.Value < 2)
+            throw new ArgumentException("MaxPlayers must be >= 2", nameof(maxPlayers));
+
+        OrganizerId = organizerId;
+        Title = title.Trim();
+        Description = description?.Trim();
+        ScheduledAt = scheduledAt;
+        Location = location?.Trim();
+        MaxPlayers = maxPlayers;
+        GameIds = gameIds ?? [];
+        Status = GameNightStatus.Draft;
+        CreatedAt = DateTimeOffset.UtcNow;
+    }
+
+    /// <summary>
+    /// Factory method to create a new game night event.
+    /// </summary>
+    public static GameNightEvent Create(
+        Guid organizerId,
+        string title,
+        DateTimeOffset scheduledAt,
+        string? description = null,
+        string? location = null,
+        int? maxPlayers = null,
+        List<Guid>? gameIds = null)
+    {
+        return new GameNightEvent(Guid.NewGuid(), organizerId, title, scheduledAt, description, location, maxPlayers, gameIds);
+    }
+
+    /// <summary>
+    /// Updates the game night event details. Cannot update cancelled or completed events.
+    /// </summary>
+    public void Update(string title, string? description, DateTimeOffset scheduledAt, string? location, int? maxPlayers, List<Guid>? gameIds)
+    {
+        if (Status == GameNightStatus.Cancelled || Status == GameNightStatus.Completed)
+            throw new InvalidOperationException($"Cannot update a {Status} game night");
+
+        if (string.IsNullOrWhiteSpace(title))
+            throw new ArgumentException("Title cannot be empty", nameof(title));
+        if (title.Length > 200)
+            throw new ArgumentException("Title cannot exceed 200 characters", nameof(title));
+        if (maxPlayers.HasValue && maxPlayers.Value < 2)
+            throw new ArgumentException("MaxPlayers must be >= 2", nameof(maxPlayers));
+
+        Title = title.Trim();
+        Description = description?.Trim();
+        ScheduledAt = scheduledAt;
+        Location = location?.Trim();
+        MaxPlayers = maxPlayers;
+        GameIds = gameIds ?? GameIds;
+        UpdatedAt = DateTimeOffset.UtcNow;
+    }
+
+    /// <summary>
+    /// Publishes the game night and creates RSVP entries for invited users.
+    /// Raises a GameNightPublishedEvent.
+    /// </summary>
+    public void Publish(List<Guid> invitedUserIds)
+    {
+        if (Status != GameNightStatus.Draft)
+            throw new InvalidOperationException("Only draft game nights can be published");
+
+        Status = GameNightStatus.Published;
+        UpdatedAt = DateTimeOffset.UtcNow;
+
+        foreach (var userId in invitedUserIds)
+        {
+            var rsvp = GameNightRsvp.Create(Id, userId);
+            _rsvps.Add(rsvp);
+        }
+
+        AddDomainEvent(new GameNightPublishedEvent(Id, OrganizerId, Title, ScheduledAt, invitedUserIds));
+    }
+
+    /// <summary>
+    /// Cancels the game night. Idempotent if already cancelled.
+    /// Raises a GameNightCancelledEvent.
+    /// </summary>
+    public void Cancel()
+    {
+        if (Status == GameNightStatus.Cancelled)
+            return; // idempotent
+
+        if (Status == GameNightStatus.Completed)
+            throw new InvalidOperationException("Cannot cancel a completed game night");
+
+        Status = GameNightStatus.Cancelled;
+        UpdatedAt = DateTimeOffset.UtcNow;
+
+        var invitedUserIds = _rsvps.Select(r => r.UserId).ToList();
+        AddDomainEvent(new GameNightCancelledEvent(Id, OrganizerId, Title, invitedUserIds));
+    }
+
+    /// <summary>
+    /// Marks the game night as completed. Only published events can be completed.
+    /// </summary>
+    public void Complete()
+    {
+        if (Status != GameNightStatus.Published)
+            throw new InvalidOperationException("Only published game nights can be completed");
+
+        Status = GameNightStatus.Completed;
+        UpdatedAt = DateTimeOffset.UtcNow;
+    }
+
+    /// <summary>
+    /// Adds additional invitees to a published game night. Skips users already invited.
+    /// Raises a GameNightPublishedEvent for the newly invited users only.
+    /// </summary>
+    public void AddInvitees(List<Guid> userIds)
+    {
+        if (Status != GameNightStatus.Published)
+            throw new InvalidOperationException("Can only invite to published game nights");
+
+        var existingUserIds = _rsvps.Select(r => r.UserId).ToHashSet();
+        var newUserIds = userIds.Where(id => !existingUserIds.Contains(id)).ToList();
+
+        foreach (var userId in newUserIds)
+        {
+            var rsvp = GameNightRsvp.Create(Id, userId);
+            _rsvps.Add(rsvp);
+        }
+
+        if (newUserIds.Count > 0)
+        {
+            AddDomainEvent(new GameNightPublishedEvent(Id, OrganizerId, Title, ScheduledAt, newUserIds));
+        }
+    }
+
+    /// <summary>
+    /// Gets the RSVP for a specific user, or null if not invited.
+    /// </summary>
+    public GameNightRsvp? GetRsvp(Guid userId) => _rsvps.FirstOrDefault(r => r.UserId == userId);
+
+    /// <summary>
+    /// Gets the number of accepted RSVPs.
+    /// </summary>
+    public int AcceptedCount => _rsvps.Count(r => r.Status == RsvpStatus.Accepted);
+
+    /// <summary>
+    /// Returns true if the game night has reached its maximum player count.
+    /// </summary>
+    public bool IsFull => MaxPlayers.HasValue && AcceptedCount >= MaxPlayers.Value;
+
+    /// <summary>
+    /// Marks that the 24-hour reminder has been sent.
+    /// </summary>
+    public void MarkReminder24hSent()
+    {
+        Reminder24hSentAt = DateTimeOffset.UtcNow;
+    }
+
+    /// <summary>
+    /// Marks that the 1-hour reminder has been sent.
+    /// </summary>
+    public void MarkReminder1hSent()
+    {
+        Reminder1hSentAt = DateTimeOffset.UtcNow;
+    }
+
+    /// <summary>
+    /// Internal method to restore RSVPs list from persistence.
+    /// </summary>
+    internal void RestoreRsvps(IEnumerable<GameNightRsvp> rsvps)
+    {
+        _rsvps.Clear();
+        _rsvps.AddRange(rsvps);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/GameNightEvent/GameNightEvent.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/GameNightEvent/GameNightEvent.cs
@@ -187,9 +187,35 @@ internal sealed class GameNightEvent : AggregateRoot<Guid>
     }
 
     /// <summary>
+    /// Pre-invites users during Draft creation. RSVPs are created with Pending status
+    /// but no domain events are raised until Publish().
+    /// </summary>
+    public void PreInvite(List<Guid> userIds)
+    {
+        if (Status != GameNightStatus.Draft)
+            throw new InvalidOperationException("Can only pre-invite to draft game nights");
+
+        foreach (var userId in userIds)
+        {
+            if (_rsvps.All(r => r.UserId != userId))
+            {
+                _rsvps.Add(GameNightRsvp.Create(Id, userId));
+            }
+        }
+    }
+
+    /// <summary>
     /// Gets the RSVP for a specific user, or null if not invited.
     /// </summary>
     public GameNightRsvp? GetRsvp(Guid userId) => _rsvps.FirstOrDefault(r => r.UserId == userId);
+
+    /// <summary>
+    /// Raises a GameNightRsvpReceivedEvent domain event for notification dispatch.
+    /// </summary>
+    public void AddRsvpReceivedEvent(Guid responderId, RsvpStatus response, Guid organizerId)
+    {
+        AddDomainEvent(new GameNightRsvpReceivedEvent(Id, responderId, response, organizerId));
+    }
 
     /// <summary>
     /// Gets the number of accepted RSVPs.

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/GameNightEvent/GameNightRsvp.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/GameNightEvent/GameNightRsvp.cs
@@ -1,0 +1,73 @@
+using Api.BoundedContexts.GameManagement.Domain.Enums;
+
+namespace Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
+
+/// <summary>
+/// Entity representing an RSVP to a game night event.
+/// Owned by the GameNightEvent aggregate root.
+/// Issue #42: GameNightEvent + GameNightRsvp domain entities.
+/// </summary>
+public sealed class GameNightRsvp
+{
+    public Guid Id { get; private set; }
+    public Guid EventId { get; private set; }
+    public Guid UserId { get; private set; }
+    public RsvpStatus Status { get; private set; }
+    public DateTimeOffset? RespondedAt { get; private set; }
+    public DateTimeOffset CreatedAt { get; private set; }
+
+#pragma warning disable CS8618
+    private GameNightRsvp() { } // EF Core
+#pragma warning restore CS8618
+
+    internal static GameNightRsvp Create(Guid eventId, Guid userId)
+    {
+        if (eventId == Guid.Empty) throw new ArgumentException("EventId required", nameof(eventId));
+        if (userId == Guid.Empty) throw new ArgumentException("UserId required", nameof(userId));
+
+        return new GameNightRsvp
+        {
+            Id = Guid.NewGuid(),
+            EventId = eventId,
+            UserId = userId,
+            Status = RsvpStatus.Pending,
+            CreatedAt = DateTimeOffset.UtcNow
+        };
+    }
+
+    /// <summary>
+    /// Reconstitutes an RSVP from persistence data.
+    /// </summary>
+    internal static GameNightRsvp Reconstitute(
+        Guid id, Guid eventId, Guid userId, RsvpStatus status,
+        DateTimeOffset? respondedAt, DateTimeOffset createdAt)
+    {
+        return new GameNightRsvp
+        {
+            Id = id,
+            EventId = eventId,
+            UserId = userId,
+            Status = status,
+            RespondedAt = respondedAt,
+            CreatedAt = createdAt
+        };
+    }
+
+    public void Accept()
+    {
+        Status = RsvpStatus.Accepted;
+        RespondedAt = DateTimeOffset.UtcNow;
+    }
+
+    public void Decline()
+    {
+        Status = RsvpStatus.Declined;
+        RespondedAt = DateTimeOffset.UtcNow;
+    }
+
+    public void SetMaybe()
+    {
+        Status = RsvpStatus.Maybe;
+        RespondedAt = DateTimeOffset.UtcNow;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/GameNightEvent/IGameNightEventRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/GameNightEvent/IGameNightEventRepository.cs
@@ -1,0 +1,26 @@
+using Api.SharedKernel.Infrastructure.Persistence;
+
+namespace Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
+
+/// <summary>
+/// Repository interface for GameNightEvent aggregate.
+/// Issue #42: GameNightEvent + GameNightRsvp domain entities.
+/// </summary>
+internal interface IGameNightEventRepository : IRepository<GameNightEvent, Guid>
+{
+    /// <summary>
+    /// Gets upcoming published game nights ordered by scheduled date.
+    /// </summary>
+    Task<IReadOnlyList<GameNightEvent>> GetUpcomingAsync(CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets game nights where the user is organizer or invited.
+    /// </summary>
+    Task<IReadOnlyList<GameNightEvent>> GetByUserAsync(Guid userId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Gets published events with ScheduledAt between from and to, for reminder scheduling.
+    /// </summary>
+    Task<IReadOnlyList<GameNightEvent>> GetEventsNeedingReminderAsync(
+        DateTimeOffset from, DateTimeOffset to, CancellationToken cancellationToken = default);
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Enums/GameNightStatus.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Enums/GameNightStatus.cs
@@ -1,0 +1,13 @@
+namespace Api.BoundedContexts.GameManagement.Domain.Enums;
+
+/// <summary>
+/// Status of a game night event.
+/// Issue #42: GameNightEvent + GameNightRsvp domain entities.
+/// </summary>
+public enum GameNightStatus
+{
+    Draft = 0,
+    Published = 1,
+    Cancelled = 2,
+    Completed = 3
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Enums/RsvpStatus.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Enums/RsvpStatus.cs
@@ -1,0 +1,13 @@
+namespace Api.BoundedContexts.GameManagement.Domain.Enums;
+
+/// <summary>
+/// RSVP response status for a game night invitation.
+/// Issue #42: GameNightEvent + GameNightRsvp domain entities.
+/// </summary>
+public enum RsvpStatus
+{
+    Pending = 0,
+    Accepted = 1,
+    Declined = 2,
+    Maybe = 3
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Events/GameNightCancelledEvent.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Events/GameNightCancelledEvent.cs
@@ -1,0 +1,23 @@
+using Api.SharedKernel.Domain.Events;
+
+namespace Api.BoundedContexts.GameManagement.Domain.Events;
+
+/// <summary>
+/// Domain event raised when a game night is cancelled.
+/// Issue #42: GameNightEvent + GameNightRsvp domain entities.
+/// </summary>
+internal sealed class GameNightCancelledEvent : DomainEventBase
+{
+    public Guid GameNightEventId { get; }
+    public Guid OrganizerId { get; }
+    public string Title { get; }
+    public List<Guid> InvitedUserIds { get; }
+
+    public GameNightCancelledEvent(Guid gameNightEventId, Guid organizerId, string title, List<Guid> invitedUserIds)
+    {
+        GameNightEventId = gameNightEventId;
+        OrganizerId = organizerId;
+        Title = title;
+        InvitedUserIds = invitedUserIds;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Events/GameNightPublishedEvent.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Events/GameNightPublishedEvent.cs
@@ -1,0 +1,25 @@
+using Api.SharedKernel.Domain.Events;
+
+namespace Api.BoundedContexts.GameManagement.Domain.Events;
+
+/// <summary>
+/// Domain event raised when a game night is published and invitations are sent.
+/// Issue #42: GameNightEvent + GameNightRsvp domain entities.
+/// </summary>
+internal sealed class GameNightPublishedEvent : DomainEventBase
+{
+    public Guid GameNightEventId { get; }
+    public Guid OrganizerId { get; }
+    public string Title { get; }
+    public DateTimeOffset ScheduledAt { get; }
+    public List<Guid> InvitedUserIds { get; }
+
+    public GameNightPublishedEvent(Guid gameNightEventId, Guid organizerId, string title, DateTimeOffset scheduledAt, List<Guid> invitedUserIds)
+    {
+        GameNightEventId = gameNightEventId;
+        OrganizerId = organizerId;
+        Title = title;
+        ScheduledAt = scheduledAt;
+        InvitedUserIds = invitedUserIds;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Events/GameNightReminder1hEvent.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Events/GameNightReminder1hEvent.cs
@@ -1,0 +1,21 @@
+using Api.SharedKernel.Domain.Events;
+
+namespace Api.BoundedContexts.GameManagement.Domain.Events;
+
+/// <summary>
+/// Domain event raised when the 1-hour reminder is sent for a game night.
+/// Issue #42: GameNightEvent + GameNightRsvp domain entities.
+/// </summary>
+internal sealed class GameNightReminder1hEvent : DomainEventBase
+{
+    public Guid GameNightEventId { get; }
+    public string Title { get; }
+    public DateTimeOffset ScheduledAt { get; }
+
+    public GameNightReminder1hEvent(Guid gameNightEventId, string title, DateTimeOffset scheduledAt)
+    {
+        GameNightEventId = gameNightEventId;
+        Title = title;
+        ScheduledAt = scheduledAt;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Events/GameNightReminder24hEvent.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Events/GameNightReminder24hEvent.cs
@@ -1,0 +1,23 @@
+using Api.SharedKernel.Domain.Events;
+
+namespace Api.BoundedContexts.GameManagement.Domain.Events;
+
+/// <summary>
+/// Domain event raised when the 24-hour reminder is sent for a game night.
+/// Issue #42: GameNightEvent + GameNightRsvp domain entities.
+/// </summary>
+internal sealed class GameNightReminder24hEvent : DomainEventBase
+{
+    public Guid GameNightEventId { get; }
+    public string Title { get; }
+    public DateTimeOffset ScheduledAt { get; }
+    public string? Location { get; }
+
+    public GameNightReminder24hEvent(Guid gameNightEventId, string title, DateTimeOffset scheduledAt, string? location)
+    {
+        GameNightEventId = gameNightEventId;
+        Title = title;
+        ScheduledAt = scheduledAt;
+        Location = location;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Events/GameNightRsvpReceivedEvent.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Events/GameNightRsvpReceivedEvent.cs
@@ -1,0 +1,24 @@
+using Api.BoundedContexts.GameManagement.Domain.Enums;
+using Api.SharedKernel.Domain.Events;
+
+namespace Api.BoundedContexts.GameManagement.Domain.Events;
+
+/// <summary>
+/// Domain event raised when a user responds to a game night invitation.
+/// Issue #42: GameNightEvent + GameNightRsvp domain entities.
+/// </summary>
+internal sealed class GameNightRsvpReceivedEvent : DomainEventBase
+{
+    public Guid GameNightEventId { get; }
+    public Guid UserId { get; }
+    public RsvpStatus RsvpStatus { get; }
+    public Guid OrganizerId { get; }
+
+    public GameNightRsvpReceivedEvent(Guid gameNightEventId, Guid userId, RsvpStatus rsvpStatus, Guid organizerId)
+    {
+        GameNightEventId = gameNightEventId;
+        UserId = userId;
+        RsvpStatus = rsvpStatus;
+        OrganizerId = organizerId;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/DependencyInjection/GameManagementServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/DependencyInjection/GameManagementServiceExtensions.cs
@@ -1,4 +1,5 @@
 using Api.BoundedContexts.GameManagement.Application.Services;
+using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
 using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightPlaylist;
 using Api.BoundedContexts.GameManagement.Domain.Entities.SessionAttachment;
 using Api.BoundedContexts.GameManagement.Domain.Entities.SessionSnapshot;
@@ -8,9 +9,11 @@ using Api.BoundedContexts.GameManagement.Domain.Entities.WhiteboardState;
 using Api.BoundedContexts.GameManagement.Domain.Repositories;
 using Api.BoundedContexts.GameManagement.Domain.Services;
 using Api.BoundedContexts.GameManagement.Infrastructure.Persistence;
+using Api.BoundedContexts.GameManagement.Infrastructure.Scheduling;
 using Api.BoundedContexts.GameManagement.Infrastructure.Services;
 using Api.SharedKernel.Infrastructure.Persistence;
 using Microsoft.Extensions.DependencyInjection;
+using Quartz;
 
 namespace Api.BoundedContexts.GameManagement.Infrastructure.DependencyInjection;
 
@@ -39,6 +42,7 @@ internal static class GameManagementServiceExtensions
         services.AddScoped<IWhiteboardStateRepository, WhiteboardStateRepository>(); // Issue #4971: Whiteboard base toolkit
         services.AddScoped<ISessionAttachmentRepository, SessionAttachmentRepository>(); // Issue #5360: Session photo attachments
         services.AddScoped<IGameNightPlaylistRepository, GameNightPlaylistRepository>(); // Issue #5582: Game Night Playlist
+        services.AddScoped<IGameNightEventRepository, GameNightEventRepository>(); // Issue #42: Game Night Event
 
         // Register Unit of Work (shared across bounded contexts)
         services.AddScoped<IUnitOfWork, EfCoreUnitOfWork>();
@@ -64,8 +68,25 @@ internal static class GameManagementServiceExtensions
         // Issue #5579: GameSessionContext cross-context orchestrator
         services.AddScoped<IGameSessionOrchestratorService, GameSessionOrchestratorService>();
 
+        // Issue #44/#47: Game night email templates
+        services.AddScoped<IGameNightEmailService, GameNightEmailService>();
+
         // Issue #5366: Session attachment cleanup background job
         services.AddHostedService<SessionAttachmentCleanupJob>();
+
+        // Issue #45: Game Night Reminder job - runs every 15 minutes
+        services.AddQuartz(q =>
+        {
+            q.AddJob<GameNightReminderJob>(opts => opts
+                .WithIdentity("game-night-reminder-job", "game-management")
+                .StoreDurably(true));
+
+            q.AddTrigger(opts => opts
+                .ForJob("game-night-reminder-job", "game-management")
+                .WithIdentity("game-night-reminder-trigger", "game-management")
+                .WithCronSchedule("0 0/15 * * * ?")  // Every 15 minutes
+                .WithDescription("Sends 24h and 1h reminders for upcoming game nights"));
+        });
 
         // MediatR handlers are auto-registered via assembly scanning in Program.cs
 

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Persistence/GameNightEventRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Persistence/GameNightEventRepository.cs
@@ -71,8 +71,8 @@ internal class GameNightEventRepository : RepositoryBase, IGameNightEventReposit
     public async Task<IReadOnlyList<GameNightEvent>> GetEventsNeedingReminderAsync(
         DateTimeOffset from, DateTimeOffset to, CancellationToken cancellationToken = default)
     {
+        // No AsNoTracking — reminder job must persist SentAt flag changes via SaveChangesAsync.
         var entities = await DbContext.GameNightEvents
-            .AsNoTracking()
             .Include(e => e.Rsvps)
             .Where(e => e.Status == nameof(GameNightStatus.Published) && e.ScheduledAt >= from && e.ScheduledAt <= to)
             .ToListAsync(cancellationToken).ConfigureAwait(false);

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Persistence/GameNightEventRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Persistence/GameNightEventRepository.cs
@@ -1,0 +1,205 @@
+using System.Text.Json;
+using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
+using Api.BoundedContexts.GameManagement.Domain.Enums;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.GameManagement;
+using Api.SharedKernel.Application.Services;
+using Api.SharedKernel.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.GameManagement.Infrastructure.Persistence;
+
+/// <summary>
+/// EF Core implementation of GameNightEvent repository.
+/// Maps between domain GameNightEvent aggregate and GameNightEventEntity persistence model.
+/// Issue #42: GameNightEvent + GameNightRsvp domain entities.
+/// </summary>
+internal class GameNightEventRepository : RepositoryBase, IGameNightEventRepository
+{
+    public GameNightEventRepository(MeepleAiDbContext dbContext, IDomainEventCollector eventCollector)
+        : base(dbContext, eventCollector)
+    {
+    }
+
+    public async Task<GameNightEvent?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        var entity = await DbContext.GameNightEvents
+            .AsNoTracking()
+            .Include(e => e.Rsvps)
+            .FirstOrDefaultAsync(e => e.Id == id, cancellationToken).ConfigureAwait(false);
+
+        return entity != null ? MapToDomain(entity) : null;
+    }
+
+    public async Task<IReadOnlyList<GameNightEvent>> GetAllAsync(CancellationToken cancellationToken = default)
+    {
+        var entities = await DbContext.GameNightEvents
+            .AsNoTracking()
+            .Include(e => e.Rsvps)
+            .OrderByDescending(e => e.ScheduledAt)
+            .ToListAsync(cancellationToken).ConfigureAwait(false);
+
+        return entities.Select(MapToDomain).ToList();
+    }
+
+    public async Task<IReadOnlyList<GameNightEvent>> GetUpcomingAsync(CancellationToken cancellationToken = default)
+    {
+        var entities = await DbContext.GameNightEvents
+            .AsNoTracking()
+            .Include(e => e.Rsvps)
+            .Where(e => e.Status == nameof(GameNightStatus.Published) && e.ScheduledAt > DateTimeOffset.UtcNow)
+            .OrderBy(e => e.ScheduledAt)
+            .Take(50)
+            .ToListAsync(cancellationToken).ConfigureAwait(false);
+
+        return entities.Select(MapToDomain).ToList();
+    }
+
+    public async Task<IReadOnlyList<GameNightEvent>> GetByUserAsync(Guid userId, CancellationToken cancellationToken = default)
+    {
+        var entities = await DbContext.GameNightEvents
+            .AsNoTracking()
+            .Include(e => e.Rsvps)
+            .Where(e => e.OrganizerId == userId || e.Rsvps.Any(r => r.UserId == userId))
+            .OrderByDescending(e => e.ScheduledAt)
+            .Take(50)
+            .ToListAsync(cancellationToken).ConfigureAwait(false);
+
+        return entities.Select(MapToDomain).ToList();
+    }
+
+    public async Task<IReadOnlyList<GameNightEvent>> GetEventsNeedingReminderAsync(
+        DateTimeOffset from, DateTimeOffset to, CancellationToken cancellationToken = default)
+    {
+        var entities = await DbContext.GameNightEvents
+            .AsNoTracking()
+            .Include(e => e.Rsvps)
+            .Where(e => e.Status == nameof(GameNightStatus.Published) && e.ScheduledAt >= from && e.ScheduledAt <= to)
+            .ToListAsync(cancellationToken).ConfigureAwait(false);
+
+        return entities.Select(MapToDomain).ToList();
+    }
+
+    public async Task AddAsync(GameNightEvent gameNight, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(gameNight);
+        CollectDomainEvents(gameNight);
+
+        var entity = MapToPersistence(gameNight);
+        await DbContext.GameNightEvents.AddAsync(entity, cancellationToken).ConfigureAwait(false);
+    }
+
+    public Task UpdateAsync(GameNightEvent gameNight, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(gameNight);
+        CollectDomainEvents(gameNight);
+
+        var entity = MapToPersistence(gameNight);
+        DbContext.GameNightEvents.Update(entity);
+        return Task.CompletedTask;
+    }
+
+    public Task DeleteAsync(GameNightEvent gameNight, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(gameNight);
+        var entity = MapToPersistence(gameNight);
+        DbContext.GameNightEvents.Remove(entity);
+        return Task.CompletedTask;
+    }
+
+    public async Task<bool> ExistsAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        return await DbContext.GameNightEvents
+            .AsNoTracking()
+            .AnyAsync(e => e.Id == id, cancellationToken).ConfigureAwait(false);
+    }
+
+    private static GameNightEventEntity MapToPersistence(GameNightEvent domain)
+    {
+        ArgumentNullException.ThrowIfNull(domain);
+
+        var entity = new GameNightEventEntity
+        {
+            Id = domain.Id,
+            OrganizerId = domain.OrganizerId,
+            Title = domain.Title,
+            Description = domain.Description,
+            ScheduledAt = domain.ScheduledAt,
+            Location = domain.Location,
+            MaxPlayers = domain.MaxPlayers,
+            GameIdsJson = JsonSerializer.Serialize(domain.GameIds),
+            Status = domain.Status.ToString(),
+            Reminder24hSentAt = domain.Reminder24hSentAt,
+            Reminder1hSentAt = domain.Reminder1hSentAt,
+            CreatedAt = domain.CreatedAt,
+            UpdatedAt = domain.UpdatedAt
+        };
+
+        foreach (var rsvp in domain.Rsvps)
+        {
+            entity.Rsvps.Add(new GameNightRsvpEntity
+            {
+                Id = rsvp.Id,
+                EventId = rsvp.EventId,
+                UserId = rsvp.UserId,
+                Status = rsvp.Status.ToString(),
+                RespondedAt = rsvp.RespondedAt,
+                CreatedAt = rsvp.CreatedAt
+            });
+        }
+
+        return entity;
+    }
+
+    private static GameNightEvent MapToDomain(GameNightEventEntity entity)
+    {
+        var gameIds = string.IsNullOrEmpty(entity.GameIdsJson)
+            ? new List<Guid>()
+            : JsonSerializer.Deserialize<List<Guid>>(entity.GameIdsJson) ?? [];
+
+        var status = Enum.Parse<GameNightStatus>(entity.Status);
+
+        // Use the internal constructor to reconstitute from persistence
+        var evt = new GameNightEvent(
+            id: entity.Id,
+            organizerId: entity.OrganizerId,
+            title: entity.Title,
+            scheduledAt: entity.ScheduledAt,
+            description: entity.Description,
+            location: entity.Location,
+            maxPlayers: entity.MaxPlayers,
+            gameIds: gameIds);
+
+        // Restore state from persistence via reflection (same pattern as GameNightPlaylistRepository)
+        var statusProp = typeof(GameNightEvent).GetProperty(nameof(GameNightEvent.Status));
+        statusProp?.SetValue(evt, status);
+
+        var createdAtProp = typeof(GameNightEvent).GetProperty(nameof(GameNightEvent.CreatedAt));
+        createdAtProp?.SetValue(evt, entity.CreatedAt);
+
+        var updatedAtProp = typeof(GameNightEvent).GetProperty(nameof(GameNightEvent.UpdatedAt));
+        updatedAtProp?.SetValue(evt, entity.UpdatedAt);
+
+        var reminder24hProp = typeof(GameNightEvent).GetProperty(nameof(GameNightEvent.Reminder24hSentAt));
+        reminder24hProp?.SetValue(evt, entity.Reminder24hSentAt);
+
+        var reminder1hProp = typeof(GameNightEvent).GetProperty(nameof(GameNightEvent.Reminder1hSentAt));
+        reminder1hProp?.SetValue(evt, entity.Reminder1hSentAt);
+
+        // Restore RSVPs
+        var rsvps = entity.Rsvps.Select(r => GameNightRsvp.Reconstitute(
+            id: r.Id,
+            eventId: r.EventId,
+            userId: r.UserId,
+            status: Enum.Parse<RsvpStatus>(r.Status),
+            respondedAt: r.RespondedAt,
+            createdAt: r.CreatedAt)).ToList();
+
+        evt.RestoreRsvps(rsvps);
+
+        // Clear domain events from reconstruction
+        evt.ClearDomainEvents();
+
+        return evt;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Scheduling/GameNightReminderJob.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Scheduling/GameNightReminderJob.cs
@@ -87,6 +87,7 @@ internal sealed class GameNightReminderJob : IJob
                         ct).ConfigureAwait(false);
 
                     gameNight.MarkReminder24hSent();
+                    await _repository.UpdateAsync(gameNight, ct).ConfigureAwait(false);
                     await _dbContext.SaveChangesAsync(ct).ConfigureAwait(false);
 
                     reminder24hCount++;
@@ -125,6 +126,7 @@ internal sealed class GameNightReminderJob : IJob
                         ct).ConfigureAwait(false);
 
                     gameNight.MarkReminder1hSent();
+                    await _repository.UpdateAsync(gameNight, ct).ConfigureAwait(false);
                     await _dbContext.SaveChangesAsync(ct).ConfigureAwait(false);
 
                     reminder1hCount++;

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Scheduling/GameNightReminderJob.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Scheduling/GameNightReminderJob.cs
@@ -1,0 +1,144 @@
+using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
+using Api.BoundedContexts.GameManagement.Domain.Events;
+using Api.Infrastructure;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using Quartz;
+
+namespace Api.BoundedContexts.GameManagement.Infrastructure.Scheduling;
+
+/// <summary>
+/// Quartz.NET job for sending game night reminders at 24h and 1h before the event.
+/// Runs every 15 minutes, checks for events within the reminder windows.
+/// Issue #45: GameNightReminderJob (Quartz) for automated reminders.
+/// </summary>
+[DisallowConcurrentExecution]
+internal sealed class GameNightReminderJob : IJob
+{
+    private readonly IGameNightEventRepository _repository;
+    private readonly IMediator _mediator;
+    private readonly MeepleAiDbContext _dbContext;
+    private readonly ILogger<GameNightReminderJob> _logger;
+
+    public GameNightReminderJob(
+        IGameNightEventRepository repository,
+        IMediator mediator,
+        MeepleAiDbContext dbContext,
+        ILogger<GameNightReminderJob> logger)
+    {
+        _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _mediator = mediator ?? throw new ArgumentNullException(nameof(mediator));
+        _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task Execute(IJobExecutionContext context)
+    {
+        _logger.LogDebug("Starting game night reminder job: FireTime={FireTime}", context.FireTimeUtc);
+
+        var reminder24hCount = 0;
+        var reminder1hCount = 0;
+
+        try
+        {
+            var now = DateTimeOffset.UtcNow;
+
+            // 24h window: events where ScheduledAt is between now+23h45m and now+24h15m
+            await ProcessReminders24h(now, context.CancellationToken).ConfigureAwait(false);
+
+            // 1h window: events where ScheduledAt is between now+45m and now+1h15m
+            await ProcessReminders1h(now, context.CancellationToken).ConfigureAwait(false);
+
+            _logger.LogInformation(
+                "Game night reminder job completed: 24hReminders={Reminder24h}, 1hReminders={Reminder1h}",
+                reminder24hCount, reminder1hCount);
+
+            context.Result = new { Success = true, Reminder24h = reminder24hCount, Reminder1h = reminder1hCount };
+        }
+#pragma warning disable CA1031 // Do not catch general exception types
+        catch (Exception ex)
+#pragma warning restore CA1031
+        {
+            _logger.LogError(ex, "Game night reminder job failed");
+            context.Result = new { Success = false, Error = ex.Message };
+        }
+
+        return;
+
+        async Task ProcessReminders24h(DateTimeOffset now, CancellationToken ct)
+        {
+            var from24h = now.AddHours(23).AddMinutes(45);
+            var to24h = now.AddHours(24).AddMinutes(15);
+
+            var events24h = await _repository.GetEventsNeedingReminderAsync(from24h, to24h, ct).ConfigureAwait(false);
+
+            foreach (var gameNight in events24h)
+            {
+                if (ct.IsCancellationRequested)
+                    break;
+
+                if (gameNight.Reminder24hSentAt is not null)
+                    continue;
+
+                try
+                {
+                    await _mediator.Publish(
+                        new GameNightReminder24hEvent(gameNight.Id, gameNight.Title, gameNight.ScheduledAt, gameNight.Location),
+                        ct).ConfigureAwait(false);
+
+                    gameNight.MarkReminder24hSent();
+                    await _dbContext.SaveChangesAsync(ct).ConfigureAwait(false);
+
+                    reminder24hCount++;
+                    _logger.LogInformation(
+                        "Sent 24h reminder for game night {GameNightId} '{Title}' scheduled at {ScheduledAt}",
+                        gameNight.Id, gameNight.Title, gameNight.ScheduledAt);
+                }
+#pragma warning disable CA1031
+                catch (Exception ex)
+#pragma warning restore CA1031
+                {
+                    _logger.LogError(ex, "Failed to send 24h reminder for game night {GameNightId}", gameNight.Id);
+                }
+            }
+        }
+
+        async Task ProcessReminders1h(DateTimeOffset now, CancellationToken ct)
+        {
+            var from1h = now.AddMinutes(45);
+            var to1h = now.AddHours(1).AddMinutes(15);
+
+            var events1h = await _repository.GetEventsNeedingReminderAsync(from1h, to1h, ct).ConfigureAwait(false);
+
+            foreach (var gameNight in events1h)
+            {
+                if (ct.IsCancellationRequested)
+                    break;
+
+                if (gameNight.Reminder1hSentAt is not null)
+                    continue;
+
+                try
+                {
+                    await _mediator.Publish(
+                        new GameNightReminder1hEvent(gameNight.Id, gameNight.Title, gameNight.ScheduledAt),
+                        ct).ConfigureAwait(false);
+
+                    gameNight.MarkReminder1hSent();
+                    await _dbContext.SaveChangesAsync(ct).ConfigureAwait(false);
+
+                    reminder1hCount++;
+                    _logger.LogInformation(
+                        "Sent 1h reminder for game night {GameNightId} '{Title}' scheduled at {ScheduledAt}",
+                        gameNight.Id, gameNight.Title, gameNight.ScheduledAt);
+                }
+#pragma warning disable CA1031
+                catch (Exception ex)
+#pragma warning restore CA1031
+                {
+                    _logger.LogError(ex, "Failed to send 1h reminder for game night {GameNightId}", gameNight.Id);
+                }
+            }
+        }
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Services/GameNightEmailService.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Services/GameNightEmailService.cs
@@ -1,0 +1,218 @@
+using System.Globalization;
+using System.Text;
+using Api.BoundedContexts.GameManagement.Application.Services;
+using Api.Services;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.GameManagement.Infrastructure.Services;
+
+/// <summary>
+/// Sends game night-related emails with responsive HTML templates via IEmailService.SendRawEmailAsync.
+/// Issue #44/#47: Game night notification types and email templates.
+/// </summary>
+internal sealed class GameNightEmailService : IGameNightEmailService
+{
+    private readonly IEmailService _emailService;
+    private readonly ILogger<GameNightEmailService> _logger;
+
+    public GameNightEmailService(IEmailService emailService, ILogger<GameNightEmailService> logger)
+    {
+        _emailService = emailService ?? throw new ArgumentNullException(nameof(emailService));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task SendGameNightInvitationEmailAsync(
+        string toEmail,
+        string organizerName,
+        string title,
+        DateTimeOffset scheduledAt,
+        string? location,
+        IReadOnlyList<string> gameNames,
+        string rsvpAcceptUrl,
+        string rsvpDeclineUrl,
+        string unsubscribeUrl,
+        CancellationToken ct = default)
+    {
+        var formattedDate = scheduledAt.ToString("dddd, MMMM d, yyyy 'at' h:mm tt", CultureInfo.InvariantCulture);
+        var locationHtml = !string.IsNullOrWhiteSpace(location)
+            ? $"""<tr><td style="padding:8px 0;color:#6b7280;font-size:14px;">Location</td><td style="padding:8px 0;font-size:14px;font-weight:600;">{Encode(location)}</td></tr>"""
+            : "";
+
+        var gamesHtml = new StringBuilder();
+        if (gameNames.Count > 0)
+        {
+            gamesHtml.Append("""<tr><td style="padding:8px 0;color:#6b7280;font-size:14px;">Games</td><td style="padding:8px 0;font-size:14px;">""");
+            foreach (var game in gameNames)
+            {
+                gamesHtml.Append(CultureInfo.InvariantCulture, $"""<span style="display:inline-block;background:#fef3c7;color:#92400e;padding:2px 10px;border-radius:12px;font-size:13px;margin:2px 4px 2px 0;">{Encode(game)}</span>""");
+            }
+            gamesHtml.Append("</td></tr>");
+        }
+
+        var subject = $"You're Invited: {title} - MeepleAI";
+        var body = WrapInLayout(subject, $"""
+            <h1 style="margin:0 0 8px;font-size:24px;color:#1f2937;">Game Night Invitation</h1>
+            <p style="margin:0 0 24px;color:#6b7280;font-size:16px;">{Encode(organizerName)} has invited you to a game night!</p>
+
+            <div style="background:#f9fafb;border-radius:12px;padding:20px;margin-bottom:24px;">
+                <h2 style="margin:0 0 16px;font-size:20px;color:#1f2937;">{Encode(title)}</h2>
+                <table style="width:100%;border-collapse:collapse;">
+                    <tr><td style="padding:8px 0;color:#6b7280;font-size:14px;">When</td><td style="padding:8px 0;font-size:14px;font-weight:600;">{formattedDate}</td></tr>
+                    {locationHtml}
+                    {gamesHtml}
+                </table>
+            </div>
+
+            <div style="text-align:center;margin-bottom:16px;">
+                <a href="{Encode(rsvpAcceptUrl)}" style="display:inline-block;background:#059669;color:#ffffff;padding:12px 32px;border-radius:8px;text-decoration:none;font-weight:600;font-size:16px;margin-right:12px;">Accept</a>
+                <a href="{Encode(rsvpDeclineUrl)}" style="display:inline-block;background:#dc2626;color:#ffffff;padding:12px 32px;border-radius:8px;text-decoration:none;font-weight:600;font-size:16px;">Decline</a>
+            </div>
+        """, unsubscribeUrl);
+
+        await _emailService.SendRawEmailAsync(toEmail, subject, body, ct).ConfigureAwait(false);
+        _logger.LogInformation("Game night invitation email sent to {Email} for event {Title}", toEmail, title);
+    }
+
+    public async Task SendGameNightReminder24hEmailAsync(
+        string toEmail,
+        string title,
+        DateTimeOffset scheduledAt,
+        string? location,
+        int confirmedCount,
+        bool isPending,
+        string unsubscribeUrl,
+        CancellationToken ct = default)
+    {
+        var formattedDate = scheduledAt.ToString("dddd, MMMM d, yyyy 'at' h:mm tt", CultureInfo.InvariantCulture);
+        var locationHtml = !string.IsNullOrWhiteSpace(location)
+            ? $"""<p style="margin:4px 0;font-size:14px;color:#6b7280;">Location: <strong>{Encode(location)}</strong></p>"""
+            : "";
+
+        var pendingCta = isPending
+            ? """<div style="background:#fef3c7;border-radius:8px;padding:16px;margin-bottom:24px;text-align:center;"><p style="margin:0;color:#92400e;font-size:14px;font-weight:600;">You haven't responded yet. Will you be joining?</p></div>"""
+            : "";
+
+        var subject = $"Reminder: {title} is tomorrow! - MeepleAI";
+        var body = WrapInLayout(subject, $"""
+            <h1 style="margin:0 0 8px;font-size:24px;color:#1f2937;">Game Night Tomorrow!</h1>
+            <p style="margin:0 0 24px;color:#6b7280;font-size:16px;">Your game night is coming up in 24 hours.</p>
+
+            <div style="background:#f9fafb;border-radius:12px;padding:20px;margin-bottom:24px;">
+                <h2 style="margin:0 0 12px;font-size:20px;color:#1f2937;">{Encode(title)}</h2>
+                <p style="margin:4px 0;font-size:14px;color:#6b7280;">When: <strong>{formattedDate}</strong></p>
+                {locationHtml}
+                <p style="margin:4px 0;font-size:14px;color:#6b7280;">Confirmed attendees: <strong>{confirmedCount}</strong></p>
+            </div>
+
+            {pendingCta}
+        """, unsubscribeUrl);
+
+        await _emailService.SendRawEmailAsync(toEmail, subject, body, ct).ConfigureAwait(false);
+        _logger.LogInformation("Game night 24h reminder email sent to {Email} for event {Title}", toEmail, title);
+    }
+
+    public async Task SendGameNightCancelledEmailAsync(
+        string toEmail,
+        string organizerName,
+        string title,
+        DateTimeOffset scheduledAt,
+        string unsubscribeUrl,
+        CancellationToken ct = default)
+    {
+        var formattedDate = scheduledAt.ToString("dddd, MMMM d, yyyy 'at' h:mm tt", CultureInfo.InvariantCulture);
+
+        var subject = $"Cancelled: {title} - MeepleAI";
+        var body = WrapInLayout(subject, $"""
+            <h1 style="margin:0 0 8px;font-size:24px;color:#dc2626;">Game Night Cancelled</h1>
+            <p style="margin:0 0 24px;color:#6b7280;font-size:16px;">{Encode(organizerName)} has cancelled the following game night.</p>
+
+            <div style="background:#fef2f2;border-radius:12px;padding:20px;margin-bottom:24px;border-left:4px solid #dc2626;">
+                <h2 style="margin:0 0 8px;font-size:20px;color:#1f2937;text-decoration:line-through;">{Encode(title)}</h2>
+                <p style="margin:4px 0;font-size:14px;color:#6b7280;">Was scheduled for: <strong>{formattedDate}</strong></p>
+            </div>
+
+            <p style="color:#6b7280;font-size:14px;text-align:center;">We hope to see you at the next one!</p>
+        """, unsubscribeUrl);
+
+        await _emailService.SendRawEmailAsync(toEmail, subject, body, ct).ConfigureAwait(false);
+        _logger.LogInformation("Game night cancelled email sent to {Email} for event {Title}", toEmail, title);
+    }
+
+    public async Task SendGameNightRsvpConfirmationEmailAsync(
+        string toEmail,
+        string title,
+        DateTimeOffset scheduledAt,
+        string? location,
+        string unsubscribeUrl,
+        CancellationToken ct = default)
+    {
+        var formattedDate = scheduledAt.ToString("dddd, MMMM d, yyyy 'at' h:mm tt", CultureInfo.InvariantCulture);
+        var locationHtml = !string.IsNullOrWhiteSpace(location)
+            ? $"""<p style="margin:4px 0;font-size:14px;color:#6b7280;">Location: <strong>{Encode(location)}</strong></p>"""
+            : "";
+
+        var subject = $"RSVP Confirmed: {title} - MeepleAI";
+        var body = WrapInLayout(subject, $"""
+            <h1 style="margin:0 0 8px;font-size:24px;color:#059669;">You're In!</h1>
+            <p style="margin:0 0 24px;color:#6b7280;font-size:16px;">Your RSVP has been confirmed for the game night.</p>
+
+            <div style="background:#ecfdf5;border-radius:12px;padding:20px;margin-bottom:24px;border-left:4px solid #059669;">
+                <h2 style="margin:0 0 8px;font-size:20px;color:#1f2937;">{Encode(title)}</h2>
+                <p style="margin:4px 0;font-size:14px;color:#6b7280;">When: <strong>{formattedDate}</strong></p>
+                {locationHtml}
+            </div>
+
+            <p style="color:#6b7280;font-size:14px;text-align:center;">See you there!</p>
+        """, unsubscribeUrl);
+
+        await _emailService.SendRawEmailAsync(toEmail, subject, body, ct).ConfigureAwait(false);
+        _logger.LogInformation("Game night RSVP confirmation email sent to {Email} for event {Title}", toEmail, title);
+    }
+
+    /// <summary>
+    /// Wraps email content in a responsive HTML layout with MeepleAI branding.
+    /// </summary>
+    private static string WrapInLayout(string title, string content, string unsubscribeUrl)
+    {
+        return $"""
+        <!DOCTYPE html>
+        <html lang="en">
+        <head>
+            <meta charset="utf-8"/>
+            <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+            <title>{Encode(title)}</title>
+        </head>
+        <body style="margin:0;padding:0;background-color:#f3f4f6;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,'Helvetica Neue',Arial,sans-serif;">
+            <table role="presentation" cellpadding="0" cellspacing="0" style="width:100%;background-color:#f3f4f6;">
+                <tr><td style="padding:32px 16px;">
+                    <table role="presentation" cellpadding="0" cellspacing="0" style="max-width:600px;margin:0 auto;width:100%;">
+                        <!-- Header -->
+                        <tr><td style="background:linear-gradient(135deg,#f59e0b,#d97706);padding:24px 32px;border-radius:12px 12px 0 0;text-align:center;">
+                            <span style="font-size:28px;">&#127922;</span>
+                            <span style="color:#ffffff;font-size:20px;font-weight:700;vertical-align:middle;margin-left:8px;">MeepleAI</span>
+                        </td></tr>
+                        <!-- Body -->
+                        <tr><td style="background:#ffffff;padding:32px;border-radius:0 0 12px 12px;">
+                            {content}
+                        </td></tr>
+                        <!-- Footer -->
+                        <tr><td style="padding:24px 32px;text-align:center;">
+                            <p style="margin:0 0 8px;font-size:12px;color:#9ca3af;">You received this email because you have a MeepleAI account.</p>
+                            <a href="{Encode(unsubscribeUrl)}" style="font-size:12px;color:#6b7280;text-decoration:underline;">Manage notification preferences</a>
+                        </td></tr>
+                    </table>
+                </td></tr>
+            </table>
+        </body>
+        </html>
+        """;
+    }
+
+    /// <summary>
+    /// HTML-encodes a string for safe embedding in HTML attributes and content.
+    /// </summary>
+    private static string Encode(string? value)
+    {
+        return System.Net.WebUtility.HtmlEncode(value ?? string.Empty);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Application/EventHandlers/GameNightCancelledNotificationHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Application/EventHandlers/GameNightCancelledNotificationHandler.cs
@@ -1,0 +1,129 @@
+using Api.BoundedContexts.Authentication.Infrastructure.Persistence;
+using Api.BoundedContexts.GameManagement.Application.Services;
+using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
+using Api.BoundedContexts.GameManagement.Domain.Events;
+using Api.BoundedContexts.UserNotifications.Domain.Aggregates;
+using Api.BoundedContexts.UserNotifications.Domain.Repositories;
+using Api.BoundedContexts.UserNotifications.Domain.ValueObjects;
+using Api.Infrastructure;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using System.Text.Json;
+
+namespace Api.BoundedContexts.UserNotifications.Application.EventHandlers;
+
+/// <summary>
+/// Handles GameNightCancelledEvent to notify ALL invitees via in-app + email.
+/// Issue #47: Game night cancellation notifications.
+/// </summary>
+internal sealed class GameNightCancelledNotificationHandler : INotificationHandler<GameNightCancelledEvent>
+{
+    private readonly INotificationRepository _notificationRepository;
+    private readonly INotificationPreferencesRepository _preferencesRepository;
+    private readonly IUserRepository _userRepository;
+    private readonly IGameNightEventRepository _gameNightEventRepository;
+    private readonly IGameNightEmailService _emailService;
+    private readonly MeepleAiDbContext _dbContext;
+    private readonly ILogger<GameNightCancelledNotificationHandler> _logger;
+
+    public GameNightCancelledNotificationHandler(
+        INotificationRepository notificationRepository,
+        INotificationPreferencesRepository preferencesRepository,
+        IUserRepository userRepository,
+        IGameNightEventRepository gameNightEventRepository,
+        IGameNightEmailService emailService,
+        MeepleAiDbContext dbContext,
+        ILogger<GameNightCancelledNotificationHandler> logger)
+    {
+        _notificationRepository = notificationRepository ?? throw new ArgumentNullException(nameof(notificationRepository));
+        _preferencesRepository = preferencesRepository ?? throw new ArgumentNullException(nameof(preferencesRepository));
+        _userRepository = userRepository ?? throw new ArgumentNullException(nameof(userRepository));
+        _gameNightEventRepository = gameNightEventRepository ?? throw new ArgumentNullException(nameof(gameNightEventRepository));
+        _emailService = emailService ?? throw new ArgumentNullException(nameof(emailService));
+        _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task Handle(GameNightCancelledEvent notification, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var correlationId = Guid.NewGuid();
+
+            // Resolve organizer name
+            var organizer = await _userRepository.GetByIdAsync(notification.OrganizerId, cancellationToken).ConfigureAwait(false);
+            var organizerName = organizer?.DisplayName ?? "The organizer";
+
+            // Load the full event to get ScheduledAt (not on the cancelled event)
+            var gameNightEvent = await _gameNightEventRepository.GetByIdAsync(notification.GameNightEventId, cancellationToken).ConfigureAwait(false);
+            var scheduledAt = gameNightEvent?.ScheduledAt ?? DateTimeOffset.UtcNow;
+
+            foreach (var invitedUserId in notification.InvitedUserIds)
+            {
+                try
+                {
+                    var prefs = await _preferencesRepository.GetByUserIdAsync(invitedUserId, cancellationToken).ConfigureAwait(false);
+
+                    // In-app notification
+                    if (prefs == null || prefs.InAppOnGameNightInvitation)
+                    {
+                        var inAppNotification = new Notification(
+                            id: Guid.NewGuid(),
+                            userId: invitedUserId,
+                            type: NotificationType.GameNightCancelled,
+                            severity: NotificationSeverity.Warning,
+                            title: "Game Night Cancelled",
+                            message: $"{organizerName} cancelled \"{notification.Title}\"",
+                            link: $"/game-nights/{notification.GameNightEventId}",
+                            metadata: JsonSerializer.Serialize(new Dictionary<string, object>(StringComparer.Ordinal)
+                            {
+                                ["gameNightEventId"] = notification.GameNightEventId,
+                                ["organizerId"] = notification.OrganizerId
+                            }),
+                            correlationId: correlationId);
+
+                        await _notificationRepository.AddAsync(inAppNotification, cancellationToken).ConfigureAwait(false);
+                    }
+
+                    // Email notification
+                    if (prefs == null || prefs.EmailOnGameNightInvitation)
+                    {
+                        var user = await _userRepository.GetByIdAsync(invitedUserId, cancellationToken).ConfigureAwait(false);
+                        if (user != null)
+                        {
+                            await _emailService.SendGameNightCancelledEmailAsync(
+                                toEmail: user.Email,
+                                organizerName: organizerName,
+                                title: notification.Title,
+                                scheduledAt: scheduledAt,
+                                unsubscribeUrl: "/settings/notifications",
+                                ct: cancellationToken).ConfigureAwait(false);
+                        }
+                    }
+                }
+#pragma warning disable CA1031
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex,
+                        "Failed to send cancellation notification to user {UserId} for event {EventId}",
+                        invitedUserId, notification.GameNightEventId);
+                }
+#pragma warning restore CA1031
+            }
+
+            await _dbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+            _logger.LogInformation(
+                "Game night cancelled notifications sent for event {EventId} to {Count} invitees (correlationId: {CorrelationId})",
+                notification.GameNightEventId, notification.InvitedUserIds.Count, correlationId);
+        }
+#pragma warning disable CA1031
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "Failed to handle GameNightCancelledEvent for event {EventId}",
+                notification.GameNightEventId);
+        }
+#pragma warning restore CA1031
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Application/EventHandlers/GameNightPublishedNotificationHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Application/EventHandlers/GameNightPublishedNotificationHandler.cs
@@ -1,0 +1,126 @@
+using Api.BoundedContexts.Authentication.Infrastructure.Persistence;
+using Api.BoundedContexts.GameManagement.Application.Services;
+using Api.BoundedContexts.GameManagement.Domain.Events;
+using Api.BoundedContexts.UserNotifications.Domain.Aggregates;
+using Api.BoundedContexts.UserNotifications.Domain.Repositories;
+using Api.BoundedContexts.UserNotifications.Domain.ValueObjects;
+using Api.Infrastructure;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using System.Text.Json;
+
+namespace Api.BoundedContexts.UserNotifications.Application.EventHandlers;
+
+/// <summary>
+/// Handles GameNightPublishedEvent to notify each invited user via in-app notification and email.
+/// Issue #44/#47: Game night notification types.
+/// </summary>
+internal sealed class GameNightPublishedNotificationHandler : INotificationHandler<GameNightPublishedEvent>
+{
+    private readonly INotificationRepository _notificationRepository;
+    private readonly INotificationPreferencesRepository _preferencesRepository;
+    private readonly IUserRepository _userRepository;
+    private readonly IGameNightEmailService _emailService;
+    private readonly MeepleAiDbContext _dbContext;
+    private readonly ILogger<GameNightPublishedNotificationHandler> _logger;
+
+    public GameNightPublishedNotificationHandler(
+        INotificationRepository notificationRepository,
+        INotificationPreferencesRepository preferencesRepository,
+        IUserRepository userRepository,
+        IGameNightEmailService emailService,
+        MeepleAiDbContext dbContext,
+        ILogger<GameNightPublishedNotificationHandler> logger)
+    {
+        _notificationRepository = notificationRepository ?? throw new ArgumentNullException(nameof(notificationRepository));
+        _preferencesRepository = preferencesRepository ?? throw new ArgumentNullException(nameof(preferencesRepository));
+        _userRepository = userRepository ?? throw new ArgumentNullException(nameof(userRepository));
+        _emailService = emailService ?? throw new ArgumentNullException(nameof(emailService));
+        _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task Handle(GameNightPublishedEvent notification, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var correlationId = Guid.NewGuid();
+
+            // Resolve organizer name
+            var organizer = await _userRepository.GetByIdAsync(notification.OrganizerId, cancellationToken).ConfigureAwait(false);
+            var organizerName = organizer?.DisplayName ?? "Someone";
+
+            foreach (var invitedUserId in notification.InvitedUserIds)
+            {
+                try
+                {
+                    var prefs = await _preferencesRepository.GetByUserIdAsync(invitedUserId, cancellationToken).ConfigureAwait(false);
+
+                    // In-app notification (default if no preferences exist)
+                    if (prefs == null || prefs.InAppOnGameNightInvitation)
+                    {
+                        var inAppNotification = new Notification(
+                            id: Guid.NewGuid(),
+                            userId: invitedUserId,
+                            type: NotificationType.GameNightInvitation,
+                            severity: NotificationSeverity.Info,
+                            title: "Game Night Invitation",
+                            message: $"{organizerName} invited you to \"{notification.Title}\"",
+                            link: $"/game-nights/{notification.GameNightEventId}",
+                            metadata: JsonSerializer.Serialize(new Dictionary<string, object>(StringComparer.Ordinal)
+                            {
+                                ["gameNightEventId"] = notification.GameNightEventId,
+                                ["organizerId"] = notification.OrganizerId,
+                                ["scheduledAt"] = notification.ScheduledAt
+                            }),
+                            correlationId: correlationId);
+
+                        await _notificationRepository.AddAsync(inAppNotification, cancellationToken).ConfigureAwait(false);
+                    }
+
+                    // Email notification
+                    if (prefs == null || prefs.EmailOnGameNightInvitation)
+                    {
+                        var user = await _userRepository.GetByIdAsync(invitedUserId, cancellationToken).ConfigureAwait(false);
+                        if (user != null)
+                        {
+                            await _emailService.SendGameNightInvitationEmailAsync(
+                                toEmail: user.Email,
+                                organizerName: organizerName,
+                                title: notification.Title,
+                                scheduledAt: notification.ScheduledAt,
+                                location: null, // Location not available on the published event
+                                gameNames: [],
+                                rsvpAcceptUrl: $"/game-nights/{notification.GameNightEventId}/rsvp?action=accept",
+                                rsvpDeclineUrl: $"/game-nights/{notification.GameNightEventId}/rsvp?action=decline",
+                                unsubscribeUrl: "/settings/notifications",
+                                ct: cancellationToken).ConfigureAwait(false);
+                        }
+                    }
+                }
+#pragma warning disable CA1031
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex,
+                        "Failed to send game night invitation notification to user {UserId} for event {EventId}",
+                        invitedUserId, notification.GameNightEventId);
+                }
+#pragma warning restore CA1031
+            }
+
+            await _dbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+            _logger.LogInformation(
+                "Game night published notifications sent for event {EventId} to {Count} invited users (correlationId: {CorrelationId})",
+                notification.GameNightEventId, notification.InvitedUserIds.Count, correlationId);
+        }
+#pragma warning disable CA1031
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "Failed to handle GameNightPublishedEvent for event {EventId}",
+                notification.GameNightEventId);
+        }
+#pragma warning restore CA1031
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Application/EventHandlers/GameNightReminder1hNotificationHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Application/EventHandlers/GameNightReminder1hNotificationHandler.cs
@@ -1,0 +1,113 @@
+using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
+using Api.BoundedContexts.GameManagement.Domain.Enums;
+using Api.BoundedContexts.GameManagement.Domain.Events;
+using Api.BoundedContexts.UserNotifications.Domain.Aggregates;
+using Api.BoundedContexts.UserNotifications.Domain.Repositories;
+using Api.BoundedContexts.UserNotifications.Domain.ValueObjects;
+using Api.Infrastructure;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using System.Text.Json;
+
+namespace Api.BoundedContexts.UserNotifications.Application.EventHandlers;
+
+/// <summary>
+/// Handles GameNightReminder1hEvent to send 1-hour reminders.
+/// In-app notification only to accepted users (no email — too close to event time).
+/// Issue #44: Game night reminder notifications.
+/// </summary>
+internal sealed class GameNightReminder1hNotificationHandler : INotificationHandler<GameNightReminder1hEvent>
+{
+    private readonly INotificationRepository _notificationRepository;
+    private readonly INotificationPreferencesRepository _preferencesRepository;
+    private readonly IGameNightEventRepository _gameNightEventRepository;
+    private readonly MeepleAiDbContext _dbContext;
+    private readonly ILogger<GameNightReminder1hNotificationHandler> _logger;
+
+    public GameNightReminder1hNotificationHandler(
+        INotificationRepository notificationRepository,
+        INotificationPreferencesRepository preferencesRepository,
+        IGameNightEventRepository gameNightEventRepository,
+        MeepleAiDbContext dbContext,
+        ILogger<GameNightReminder1hNotificationHandler> logger)
+    {
+        _notificationRepository = notificationRepository ?? throw new ArgumentNullException(nameof(notificationRepository));
+        _preferencesRepository = preferencesRepository ?? throw new ArgumentNullException(nameof(preferencesRepository));
+        _gameNightEventRepository = gameNightEventRepository ?? throw new ArgumentNullException(nameof(gameNightEventRepository));
+        _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task Handle(GameNightReminder1hEvent notification, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var correlationId = Guid.NewGuid();
+
+            // Load the full event with RSVPs
+            var gameNightEvent = await _gameNightEventRepository.GetByIdAsync(notification.GameNightEventId, cancellationToken).ConfigureAwait(false);
+            if (gameNightEvent == null)
+            {
+                _logger.LogWarning("GameNightEvent {EventId} not found for 1h reminder", notification.GameNightEventId);
+                return;
+            }
+
+            var notifiedCount = 0;
+
+            foreach (var rsvp in gameNightEvent.Rsvps)
+            {
+                // Only notify accepted users for 1h reminder
+                if (rsvp.Status != RsvpStatus.Accepted)
+                    continue;
+
+                try
+                {
+                    var prefs = await _preferencesRepository.GetByUserIdAsync(rsvp.UserId, cancellationToken).ConfigureAwait(false);
+
+                    if (prefs == null || prefs.InAppOnGameNightInvitation)
+                    {
+                        var inAppNotification = new Notification(
+                            id: Guid.NewGuid(),
+                            userId: rsvp.UserId,
+                            type: NotificationType.GameNightReminder1h,
+                            severity: NotificationSeverity.Warning,
+                            title: "Game Night Starting Soon!",
+                            message: $"\"{notification.Title}\" starts in about 1 hour. Get ready!",
+                            link: $"/game-nights/{notification.GameNightEventId}",
+                            metadata: JsonSerializer.Serialize(new Dictionary<string, object>(StringComparer.Ordinal)
+                            {
+                                ["gameNightEventId"] = notification.GameNightEventId,
+                                ["scheduledAt"] = notification.ScheduledAt
+                            }),
+                            correlationId: correlationId);
+
+                        await _notificationRepository.AddAsync(inAppNotification, cancellationToken).ConfigureAwait(false);
+                        notifiedCount++;
+                    }
+                }
+#pragma warning disable CA1031
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex,
+                        "Failed to send 1h reminder to user {UserId} for event {EventId}",
+                        rsvp.UserId, notification.GameNightEventId);
+                }
+#pragma warning restore CA1031
+            }
+
+            await _dbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+            _logger.LogInformation(
+                "1h reminder notifications sent to {Count} accepted users for event {EventId} (correlationId: {CorrelationId})",
+                notifiedCount, notification.GameNightEventId, correlationId);
+        }
+#pragma warning disable CA1031
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "Failed to handle GameNightReminder1hEvent for event {EventId}",
+                notification.GameNightEventId);
+        }
+#pragma warning restore CA1031
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Application/EventHandlers/GameNightReminder24hNotificationHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Application/EventHandlers/GameNightReminder24hNotificationHandler.cs
@@ -1,0 +1,141 @@
+using Api.BoundedContexts.Authentication.Infrastructure.Persistence;
+using Api.BoundedContexts.GameManagement.Application.Services;
+using Api.BoundedContexts.GameManagement.Domain.Entities.GameNightEvent;
+using Api.BoundedContexts.GameManagement.Domain.Enums;
+using Api.BoundedContexts.GameManagement.Domain.Events;
+using Api.BoundedContexts.UserNotifications.Domain.Aggregates;
+using Api.BoundedContexts.UserNotifications.Domain.Repositories;
+using Api.BoundedContexts.UserNotifications.Domain.ValueObjects;
+using Api.Infrastructure;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using System.Text.Json;
+
+namespace Api.BoundedContexts.UserNotifications.Application.EventHandlers;
+
+/// <summary>
+/// Handles GameNightReminder24hEvent to send 24-hour reminders to accepted and pending RSVPs.
+/// Accepted users: in-app + email. Pending users: email with "respond" CTA.
+/// Issue #44: Game night reminder notifications.
+/// </summary>
+internal sealed class GameNightReminder24hNotificationHandler : INotificationHandler<GameNightReminder24hEvent>
+{
+    private readonly INotificationRepository _notificationRepository;
+    private readonly INotificationPreferencesRepository _preferencesRepository;
+    private readonly IUserRepository _userRepository;
+    private readonly IGameNightEventRepository _gameNightEventRepository;
+    private readonly IGameNightEmailService _emailService;
+    private readonly MeepleAiDbContext _dbContext;
+    private readonly ILogger<GameNightReminder24hNotificationHandler> _logger;
+
+    public GameNightReminder24hNotificationHandler(
+        INotificationRepository notificationRepository,
+        INotificationPreferencesRepository preferencesRepository,
+        IUserRepository userRepository,
+        IGameNightEventRepository gameNightEventRepository,
+        IGameNightEmailService emailService,
+        MeepleAiDbContext dbContext,
+        ILogger<GameNightReminder24hNotificationHandler> logger)
+    {
+        _notificationRepository = notificationRepository ?? throw new ArgumentNullException(nameof(notificationRepository));
+        _preferencesRepository = preferencesRepository ?? throw new ArgumentNullException(nameof(preferencesRepository));
+        _userRepository = userRepository ?? throw new ArgumentNullException(nameof(userRepository));
+        _gameNightEventRepository = gameNightEventRepository ?? throw new ArgumentNullException(nameof(gameNightEventRepository));
+        _emailService = emailService ?? throw new ArgumentNullException(nameof(emailService));
+        _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task Handle(GameNightReminder24hEvent notification, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var correlationId = Guid.NewGuid();
+
+            // Load the full event with RSVPs
+            var gameNightEvent = await _gameNightEventRepository.GetByIdAsync(notification.GameNightEventId, cancellationToken).ConfigureAwait(false);
+            if (gameNightEvent == null)
+            {
+                _logger.LogWarning("GameNightEvent {EventId} not found for 24h reminder", notification.GameNightEventId);
+                return;
+            }
+
+            var confirmedCount = gameNightEvent.AcceptedCount;
+
+            foreach (var rsvp in gameNightEvent.Rsvps)
+            {
+                // Only notify Accepted and Pending users
+                if (rsvp.Status == RsvpStatus.Declined)
+                    continue;
+
+                try
+                {
+                    var prefs = await _preferencesRepository.GetByUserIdAsync(rsvp.UserId, cancellationToken).ConfigureAwait(false);
+                    var isAccepted = rsvp.Status == RsvpStatus.Accepted;
+                    var isPending = rsvp.Status == RsvpStatus.Pending || rsvp.Status == RsvpStatus.Maybe;
+
+                    // In-app notification for accepted users
+                    if (isAccepted && (prefs == null || prefs.InAppOnGameNightInvitation))
+                    {
+                        var inAppNotification = new Notification(
+                            id: Guid.NewGuid(),
+                            userId: rsvp.UserId,
+                            type: NotificationType.GameNightReminder24h,
+                            severity: NotificationSeverity.Info,
+                            title: "Game Night Tomorrow!",
+                            message: $"\"{notification.Title}\" is happening tomorrow. {confirmedCount} player(s) confirmed.",
+                            link: $"/game-nights/{notification.GameNightEventId}",
+                            metadata: JsonSerializer.Serialize(new Dictionary<string, object>(StringComparer.Ordinal)
+                            {
+                                ["gameNightEventId"] = notification.GameNightEventId,
+                                ["confirmedCount"] = confirmedCount
+                            }),
+                            correlationId: correlationId);
+
+                        await _notificationRepository.AddAsync(inAppNotification, cancellationToken).ConfigureAwait(false);
+                    }
+
+                    // Email for both accepted and pending users
+                    if (prefs == null || prefs.EmailOnGameNightReminder)
+                    {
+                        var user = await _userRepository.GetByIdAsync(rsvp.UserId, cancellationToken).ConfigureAwait(false);
+                        if (user != null)
+                        {
+                            await _emailService.SendGameNightReminder24hEmailAsync(
+                                toEmail: user.Email,
+                                title: notification.Title,
+                                scheduledAt: notification.ScheduledAt,
+                                location: notification.Location,
+                                confirmedCount: confirmedCount,
+                                isPending: isPending,
+                                unsubscribeUrl: "/settings/notifications",
+                                ct: cancellationToken).ConfigureAwait(false);
+                        }
+                    }
+                }
+#pragma warning disable CA1031
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex,
+                        "Failed to send 24h reminder to user {UserId} for event {EventId}",
+                        rsvp.UserId, notification.GameNightEventId);
+                }
+#pragma warning restore CA1031
+            }
+
+            await _dbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+            _logger.LogInformation(
+                "24h reminder notifications sent for event {EventId} (correlationId: {CorrelationId})",
+                notification.GameNightEventId, correlationId);
+        }
+#pragma warning disable CA1031
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "Failed to handle GameNightReminder24hEvent for event {EventId}",
+                notification.GameNightEventId);
+        }
+#pragma warning restore CA1031
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Application/EventHandlers/GameNightRsvpReceivedNotificationHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Application/EventHandlers/GameNightRsvpReceivedNotificationHandler.cs
@@ -1,0 +1,86 @@
+using Api.BoundedContexts.Authentication.Infrastructure.Persistence;
+using Api.BoundedContexts.GameManagement.Domain.Events;
+using Api.BoundedContexts.UserNotifications.Domain.Aggregates;
+using Api.BoundedContexts.UserNotifications.Domain.Repositories;
+using Api.BoundedContexts.UserNotifications.Domain.ValueObjects;
+using Api.Infrastructure;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using System.Text.Json;
+
+namespace Api.BoundedContexts.UserNotifications.Application.EventHandlers;
+
+/// <summary>
+/// Handles GameNightRsvpReceivedEvent to notify the organizer of a new RSVP response.
+/// In-app notification only (no email for RSVP notifications).
+/// Issue #44/#47: Game night notification types.
+/// </summary>
+internal sealed class GameNightRsvpReceivedNotificationHandler : INotificationHandler<GameNightRsvpReceivedEvent>
+{
+    private readonly INotificationRepository _notificationRepository;
+    private readonly IUserRepository _userRepository;
+    private readonly MeepleAiDbContext _dbContext;
+    private readonly ILogger<GameNightRsvpReceivedNotificationHandler> _logger;
+
+    public GameNightRsvpReceivedNotificationHandler(
+        INotificationRepository notificationRepository,
+        IUserRepository userRepository,
+        MeepleAiDbContext dbContext,
+        ILogger<GameNightRsvpReceivedNotificationHandler> logger)
+    {
+        _notificationRepository = notificationRepository ?? throw new ArgumentNullException(nameof(notificationRepository));
+        _userRepository = userRepository ?? throw new ArgumentNullException(nameof(userRepository));
+        _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task Handle(GameNightRsvpReceivedEvent notification, CancellationToken cancellationToken)
+    {
+        try
+        {
+            // Resolve the responding user's name
+            var respondingUser = await _userRepository.GetByIdAsync(notification.UserId, cancellationToken).ConfigureAwait(false);
+            var respondingUserName = respondingUser?.DisplayName ?? "A user";
+
+            var statusText = notification.RsvpStatus switch
+            {
+                GameManagement.Domain.Enums.RsvpStatus.Accepted => "accepted",
+                GameManagement.Domain.Enums.RsvpStatus.Declined => "declined",
+                GameManagement.Domain.Enums.RsvpStatus.Maybe => "responded maybe to",
+                _ => "responded to"
+            };
+
+            // In-app notification to the organizer only
+            var organizerNotification = new Notification(
+                id: Guid.NewGuid(),
+                userId: notification.OrganizerId,
+                type: NotificationType.GameNightRsvpReceived,
+                severity: NotificationSeverity.Info,
+                title: "RSVP Received",
+                message: $"{respondingUserName} {statusText} your game night invitation",
+                link: $"/game-nights/{notification.GameNightEventId}",
+                metadata: JsonSerializer.Serialize(new Dictionary<string, object>(StringComparer.Ordinal)
+                {
+                    ["gameNightEventId"] = notification.GameNightEventId,
+                    ["respondingUserId"] = notification.UserId,
+                    ["rsvpStatus"] = notification.RsvpStatus.ToString()
+                }),
+                correlationId: Guid.NewGuid());
+
+            await _notificationRepository.AddAsync(organizerNotification, cancellationToken).ConfigureAwait(false);
+            await _dbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+            _logger.LogInformation(
+                "RSVP received notification created for organizer {OrganizerId} — user {UserId} {Status} event {EventId}",
+                notification.OrganizerId, notification.UserId, statusText, notification.GameNightEventId);
+        }
+#pragma warning disable CA1031
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "Failed to handle GameNightRsvpReceivedEvent for event {EventId}, user {UserId}",
+                notification.GameNightEventId, notification.UserId);
+        }
+#pragma warning restore CA1031
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Domain/Aggregates/NotificationPreferences.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Domain/Aggregates/NotificationPreferences.cs
@@ -30,6 +30,13 @@ internal sealed class NotificationPreferences : AggregateRoot<Guid>
     public bool InAppOnDocumentFailed { get; private set; } = true;
     public bool InAppOnRetryAvailable { get; private set; } = true;
 
+    // Game Night - Issue #44/#47
+    public bool InAppOnGameNightInvitation { get; private set; } = true;
+    public bool EmailOnGameNightInvitation { get; private set; } = true;
+    public bool PushOnGameNightInvitation { get; private set; } = true;
+    public bool EmailOnGameNightReminder { get; private set; } = true;
+    public bool PushOnGameNightReminder { get; private set; } = true;
+
 #pragma warning disable CS8618
     private NotificationPreferences() : base() { }
 #pragma warning restore CS8618
@@ -47,7 +54,10 @@ internal sealed class NotificationPreferences : AggregateRoot<Guid>
         bool emailReady, bool emailFailed, bool emailRetry,
         bool pushReady, bool pushFailed, bool pushRetry,
         bool inAppReady, bool inAppFailed, bool inAppRetry,
-        string? pushEndpoint = null, string? pushP256dhKey = null, string? pushAuthKey = null)
+        string? pushEndpoint = null, string? pushP256dhKey = null, string? pushAuthKey = null,
+        bool inAppOnGameNightInvitation = true, bool emailOnGameNightInvitation = true,
+        bool pushOnGameNightInvitation = true, bool emailOnGameNightReminder = true,
+        bool pushOnGameNightReminder = true)
     {
         return new NotificationPreferences
         {
@@ -64,7 +74,12 @@ internal sealed class NotificationPreferences : AggregateRoot<Guid>
             InAppOnRetryAvailable = inAppRetry,
             PushEndpoint = pushEndpoint,
             PushP256dhKey = pushP256dhKey,
-            PushAuthKey = pushAuthKey
+            PushAuthKey = pushAuthKey,
+            InAppOnGameNightInvitation = inAppOnGameNightInvitation,
+            EmailOnGameNightInvitation = emailOnGameNightInvitation,
+            PushOnGameNightInvitation = pushOnGameNightInvitation,
+            EmailOnGameNightReminder = emailOnGameNightReminder,
+            PushOnGameNightReminder = pushOnGameNightReminder
         };
     }
 
@@ -97,6 +112,17 @@ internal sealed class NotificationPreferences : AggregateRoot<Guid>
     }
 
     public bool HasPushSubscription => !string.IsNullOrEmpty(PushEndpoint);
+
+    public void UpdateGameNightPreferences(
+        bool inAppOnInvitation, bool emailOnInvitation, bool pushOnInvitation,
+        bool emailOnReminder, bool pushOnReminder)
+    {
+        InAppOnGameNightInvitation = inAppOnInvitation;
+        EmailOnGameNightInvitation = emailOnInvitation;
+        PushOnGameNightInvitation = pushOnInvitation;
+        EmailOnGameNightReminder = emailOnReminder;
+        PushOnGameNightReminder = pushOnReminder;
+    }
 
     public void UpdateInAppPreferences(bool onReady, bool onFailed, bool onRetry)
     {

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Domain/ValueObjects/NotificationType.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Domain/ValueObjects/NotificationType.cs
@@ -76,6 +76,13 @@ internal sealed class NotificationType : ValueObject
     // ISSUE-5501: Auto-fallback activated when model deprecated (admin)
     public static readonly NotificationType AdminModelAutoFallback = new("admin_model_auto_fallback");
 
+    // ISSUE-44/47: Game night notification types
+    public static readonly NotificationType GameNightInvitation = new("game_night_invitation");
+    public static readonly NotificationType GameNightRsvpReceived = new("game_night_rsvp_received");
+    public static readonly NotificationType GameNightReminder24h = new("game_night_reminder_24h");
+    public static readonly NotificationType GameNightReminder1h = new("game_night_reminder_1h");
+    public static readonly NotificationType GameNightCancelled = new("game_night_cancelled");
+
     // GDPR Art. 17: Account deletion confirmation
     public static readonly NotificationType GdprAccountDeleted = new("gdpr_account_deleted");
 
@@ -93,6 +100,11 @@ internal sealed class NotificationType : ValueObject
     public bool IsPdfUploadCompleted => string.Equals(Value, PdfUploadCompleted.Value, StringComparison.Ordinal);
     public bool IsRuleSpecGenerated => string.Equals(Value, RuleSpecGenerated.Value, StringComparison.Ordinal);
     public bool IsProcessingFailed => string.Equals(Value, ProcessingFailed.Value, StringComparison.Ordinal);
+    public bool IsGameNightInvitation => string.Equals(Value, GameNightInvitation.Value, StringComparison.Ordinal);
+    public bool IsGameNightRsvpReceived => string.Equals(Value, GameNightRsvpReceived.Value, StringComparison.Ordinal);
+    public bool IsGameNightReminder24h => string.Equals(Value, GameNightReminder24h.Value, StringComparison.Ordinal);
+    public bool IsGameNightReminder1h => string.Equals(Value, GameNightReminder1h.Value, StringComparison.Ordinal);
+    public bool IsGameNightCancelled => string.Equals(Value, GameNightCancelled.Value, StringComparison.Ordinal);
 
     protected override IEnumerable<object?> GetEqualityComponents()
     {
@@ -144,6 +156,11 @@ internal sealed class NotificationType : ValueObject
             "gdpr_account_deleted" => GdprAccountDeleted,
             "gdpr_data_export_ready" => GdprDataExportReady,
             "gdpr_ai_consent_updated" => GdprAiConsentUpdated,
+            "game_night_invitation" => GameNightInvitation,
+            "game_night_rsvp_received" => GameNightRsvpReceived,
+            "game_night_reminder_24h" => GameNightReminder24h,
+            "game_night_reminder_1h" => GameNightReminder1h,
+            "game_night_cancelled" => GameNightCancelled,
             _ => throw new ArgumentException($"Unknown notification type: {value}", nameof(value))
         };
     }

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Persistence/NotificationPreferencesRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Persistence/NotificationPreferencesRepository.cs
@@ -68,7 +68,10 @@ internal class NotificationPreferencesRepository : RepositoryBase, INotification
             entity.EmailOnDocumentReady, entity.EmailOnDocumentFailed, entity.EmailOnRetryAvailable,
             entity.PushOnDocumentReady, entity.PushOnDocumentFailed, entity.PushOnRetryAvailable,
             entity.InAppOnDocumentReady, entity.InAppOnDocumentFailed, entity.InAppOnRetryAvailable,
-            entity.PushEndpoint, entity.PushP256dhKey, entity.PushAuthKey
+            entity.PushEndpoint, entity.PushP256dhKey, entity.PushAuthKey,
+            entity.InAppOnGameNightInvitation, entity.EmailOnGameNightInvitation,
+            entity.PushOnGameNightInvitation, entity.EmailOnGameNightReminder,
+            entity.PushOnGameNightReminder
         );
     }
 
@@ -89,7 +92,12 @@ internal class NotificationPreferencesRepository : RepositoryBase, INotification
             InAppOnRetryAvailable = domain.InAppOnRetryAvailable,
             PushEndpoint = domain.PushEndpoint,
             PushP256dhKey = domain.PushP256dhKey,
-            PushAuthKey = domain.PushAuthKey
+            PushAuthKey = domain.PushAuthKey,
+            InAppOnGameNightInvitation = domain.InAppOnGameNightInvitation,
+            EmailOnGameNightInvitation = domain.EmailOnGameNightInvitation,
+            PushOnGameNightInvitation = domain.PushOnGameNightInvitation,
+            EmailOnGameNightReminder = domain.EmailOnGameNightReminder,
+            PushOnGameNightReminder = domain.PushOnGameNightReminder
         };
     }
 }

--- a/apps/api/src/Api/Infrastructure/Entities/GameManagement/GameNightEventEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/GameManagement/GameNightEventEntity.cs
@@ -1,0 +1,63 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Api.Infrastructure.Entities.GameManagement;
+
+/// <summary>
+/// EF Core persistence entity for game night events.
+/// Issue #42: GameNightEvent + GameNightRsvp domain entities.
+/// </summary>
+[Table("game_night_events")]
+public class GameNightEventEntity
+{
+    [Key]
+    [Column("id")]
+    public Guid Id { get; set; }
+
+    [Required]
+    [Column("organizer_id")]
+    public Guid OrganizerId { get; set; }
+
+    [Required]
+    [MaxLength(200)]
+    [Column("title")]
+    public string Title { get; set; } = string.Empty;
+
+    [Column("description")]
+    [MaxLength(2000)]
+    public string? Description { get; set; }
+
+    [Required]
+    [Column("scheduled_at")]
+    public DateTimeOffset ScheduledAt { get; set; }
+
+    [Column("location")]
+    [MaxLength(500)]
+    public string? Location { get; set; }
+
+    [Column("max_players")]
+    public int? MaxPlayers { get; set; }
+
+    [Column("game_ids")]
+    public string GameIdsJson { get; set; } = "[]";
+
+    [Required]
+    [Column("status")]
+    [MaxLength(20)]
+    public string Status { get; set; } = "Draft";
+
+    [Column("reminder_24h_sent_at")]
+    public DateTimeOffset? Reminder24hSentAt { get; set; }
+
+    [Column("reminder_1h_sent_at")]
+    public DateTimeOffset? Reminder1hSentAt { get; set; }
+
+    [Required]
+    [Column("created_at")]
+    public DateTimeOffset CreatedAt { get; set; }
+
+    [Column("updated_at")]
+    public DateTimeOffset? UpdatedAt { get; set; }
+
+    public List<GameNightRsvpEntity> Rsvps { get; set; } = [];
+}

--- a/apps/api/src/Api/Infrastructure/Entities/GameManagement/GameNightRsvpEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/GameManagement/GameNightRsvpEntity.cs
@@ -1,0 +1,38 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Api.Infrastructure.Entities.GameManagement;
+
+/// <summary>
+/// EF Core persistence entity for game night RSVPs.
+/// Issue #42: GameNightEvent + GameNightRsvp domain entities.
+/// </summary>
+[Table("game_night_rsvps")]
+public class GameNightRsvpEntity
+{
+    [Key]
+    [Column("id")]
+    public Guid Id { get; set; }
+
+    [Required]
+    [Column("event_id")]
+    public Guid EventId { get; set; }
+
+    [Required]
+    [Column("user_id")]
+    public Guid UserId { get; set; }
+
+    [Required]
+    [Column("status")]
+    [MaxLength(20)]
+    public string Status { get; set; } = "Pending";
+
+    [Column("responded_at")]
+    public DateTimeOffset? RespondedAt { get; set; }
+
+    [Required]
+    [Column("created_at")]
+    public DateTimeOffset CreatedAt { get; set; }
+
+    public GameNightEventEntity Event { get; set; } = null!;
+}

--- a/apps/api/src/Api/Infrastructure/Entities/UserNotifications/NotificationPreferencesEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/UserNotifications/NotificationPreferencesEntity.cs
@@ -16,4 +16,11 @@ public class NotificationPreferencesEntity
     public bool InAppOnDocumentReady { get; set; } = true;
     public bool InAppOnDocumentFailed { get; set; } = true;
     public bool InAppOnRetryAvailable { get; set; } = true;
+
+    // Game Night - Issue #44/#47
+    public bool InAppOnGameNightInvitation { get; set; } = true;
+    public bool EmailOnGameNightInvitation { get; set; } = true;
+    public bool PushOnGameNightInvitation { get; set; } = true;
+    public bool EmailOnGameNightReminder { get; set; } = true;
+    public bool PushOnGameNightReminder { get; set; } = true;
 }

--- a/apps/api/src/Api/Infrastructure/EntityConfigurations/GameManagement/GameNightEventEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/EntityConfigurations/GameManagement/GameNightEventEntityConfiguration.cs
@@ -1,0 +1,43 @@
+using Api.Infrastructure.Entities.GameManagement;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Api.Infrastructure.EntityConfigurations.GameManagement;
+
+/// <summary>
+/// EF Core configuration for GameNightEventEntity.
+/// Issue #42: GameNightEvent + GameNightRsvp domain entities.
+/// </summary>
+internal class GameNightEventEntityConfiguration : IEntityTypeConfiguration<GameNightEventEntity>
+{
+    public void Configure(EntityTypeBuilder<GameNightEventEntity> builder)
+    {
+        builder.ToTable("game_night_events");
+        builder.HasKey(e => e.Id);
+
+        builder.Property(e => e.Id).HasColumnName("id").ValueGeneratedOnAdd();
+        builder.Property(e => e.OrganizerId).HasColumnName("organizer_id").IsRequired();
+        builder.Property(e => e.Title).HasColumnName("title").HasMaxLength(200).IsRequired();
+        builder.Property(e => e.Description).HasColumnName("description").HasMaxLength(2000);
+        builder.Property(e => e.ScheduledAt).HasColumnName("scheduled_at").IsRequired();
+        builder.Property(e => e.Location).HasColumnName("location").HasMaxLength(500);
+        builder.Property(e => e.MaxPlayers).HasColumnName("max_players");
+        builder.Property(e => e.GameIdsJson).HasColumnName("game_ids").HasColumnType("jsonb").IsRequired();
+        builder.Property(e => e.Status).HasColumnName("status").HasMaxLength(20).IsRequired();
+        builder.Property(e => e.Reminder24hSentAt).HasColumnName("reminder_24h_sent_at");
+        builder.Property(e => e.Reminder1hSentAt).HasColumnName("reminder_1h_sent_at");
+        builder.Property(e => e.CreatedAt).HasColumnName("created_at").IsRequired();
+        builder.Property(e => e.UpdatedAt).HasColumnName("updated_at");
+
+        builder.HasIndex(e => new { e.OrganizerId, e.ScheduledAt })
+            .HasDatabaseName("IX_game_night_events_organizer_scheduled");
+
+        builder.HasIndex(e => new { e.Status, e.ScheduledAt })
+            .HasDatabaseName("IX_game_night_events_status_scheduled");
+
+        builder.HasMany(e => e.Rsvps)
+            .WithOne(r => r.Event)
+            .HasForeignKey(r => r.EventId)
+            .OnDelete(DeleteBehavior.Cascade);
+    }
+}

--- a/apps/api/src/Api/Infrastructure/EntityConfigurations/GameManagement/GameNightRsvpEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/EntityConfigurations/GameManagement/GameNightRsvpEntityConfiguration.cs
@@ -1,0 +1,32 @@
+using Api.Infrastructure.Entities.GameManagement;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Api.Infrastructure.EntityConfigurations.GameManagement;
+
+/// <summary>
+/// EF Core configuration for GameNightRsvpEntity.
+/// Issue #42: GameNightEvent + GameNightRsvp domain entities.
+/// </summary>
+internal class GameNightRsvpEntityConfiguration : IEntityTypeConfiguration<GameNightRsvpEntity>
+{
+    public void Configure(EntityTypeBuilder<GameNightRsvpEntity> builder)
+    {
+        builder.ToTable("game_night_rsvps");
+        builder.HasKey(r => r.Id);
+
+        builder.Property(r => r.Id).HasColumnName("id").ValueGeneratedOnAdd();
+        builder.Property(r => r.EventId).HasColumnName("event_id").IsRequired();
+        builder.Property(r => r.UserId).HasColumnName("user_id").IsRequired();
+        builder.Property(r => r.Status).HasColumnName("status").HasMaxLength(20).IsRequired();
+        builder.Property(r => r.RespondedAt).HasColumnName("responded_at");
+        builder.Property(r => r.CreatedAt).HasColumnName("created_at").IsRequired();
+
+        builder.HasIndex(r => new { r.EventId, r.UserId })
+            .HasDatabaseName("IX_game_night_rsvps_event_user")
+            .IsUnique();
+
+        builder.HasIndex(r => r.UserId)
+            .HasDatabaseName("IX_game_night_rsvps_user_id");
+    }
+}

--- a/apps/api/src/Api/Infrastructure/MeepleAiDbContext.cs
+++ b/apps/api/src/Api/Infrastructure/MeepleAiDbContext.cs
@@ -184,6 +184,8 @@ public class MeepleAiDbContext : DbContext
     public DbSet<Api.Infrastructure.Entities.SessionTracking.SessionMediaEntity> SessionMedia => Set<Api.Infrastructure.Entities.SessionTracking.SessionMediaEntity>(); // ISSUE-4760
     public DbSet<SessionAttachmentEntity> SessionAttachments => Set<SessionAttachmentEntity>(); // ISSUE-5360: Session photo attachments
     public DbSet<GameNightPlaylistEntity> GameNightPlaylists => Set<GameNightPlaylistEntity>(); // ISSUE-5582: Game Night Playlist
+    public DbSet<GameNightEventEntity> GameNightEvents => Set<GameNightEventEntity>(); // ISSUE-42: Game Night Event
+    public DbSet<GameNightRsvpEntity> GameNightRsvps => Set<GameNightRsvpEntity>(); // ISSUE-42: Game Night RSVP
     public DbSet<Api.Infrastructure.Entities.SessionTracking.SessionChatMessageEntity> SessionChatMessages => Set<Api.Infrastructure.Entities.SessionTracking.SessionChatMessageEntity>(); // ISSUE-4760
 
     // Issue #4220: Notification preferences

--- a/apps/api/src/Api/Infrastructure/Migrations/20260310133931_AddGameNightEntities.Designer.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260310133931_AddGameNightEntities.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Api.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -12,9 +13,11 @@ using Pgvector;
 namespace Api.Infrastructure.Migrations
 {
     [DbContext(typeof(MeepleAiDbContext))]
-    partial class MeepleAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260310133931_AddGameNightEntities")]
+    partial class AddGameNightEntities
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/Api/Infrastructure/Migrations/20260310133931_AddGameNightEntities.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260310133931_AddGameNightEntities.cs
@@ -1,0 +1,91 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddGameNightEntities : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "game_night_events",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    organizer_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    title = table.Column<string>(type: "character varying(200)", maxLength: 200, nullable: false),
+                    description = table.Column<string>(type: "character varying(2000)", maxLength: 2000, nullable: true),
+                    scheduled_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    location = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: true),
+                    max_players = table.Column<int>(type: "integer", nullable: true),
+                    game_ids = table.Column<string>(type: "jsonb", nullable: false),
+                    status = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: false),
+                    reminder_24h_sent_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    reminder_1h_sent_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    created_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false),
+                    updated_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_game_night_events", x => x.id);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "game_night_rsvps",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    event_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    user_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    status = table.Column<string>(type: "character varying(20)", maxLength: 20, nullable: false),
+                    responded_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: true),
+                    created_at = table.Column<DateTimeOffset>(type: "timestamp with time zone", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_game_night_rsvps", x => x.id);
+                    table.ForeignKey(
+                        name: "FK_game_night_rsvps_game_night_events_event_id",
+                        column: x => x.event_id,
+                        principalTable: "game_night_events",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_game_night_events_organizer_scheduled",
+                table: "game_night_events",
+                columns: new[] { "organizer_id", "scheduled_at" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_game_night_events_status_scheduled",
+                table: "game_night_events",
+                columns: new[] { "status", "scheduled_at" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_game_night_rsvps_event_user",
+                table: "game_night_rsvps",
+                columns: new[] { "event_id", "user_id" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_game_night_rsvps_user_id",
+                table: "game_night_rsvps",
+                column: "user_id");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "game_night_rsvps");
+
+            migrationBuilder.DropTable(
+                name: "game_night_events");
+        }
+    }
+}

--- a/apps/api/src/Api/Infrastructure/Migrations/20260310140724_AddGameNightNotificationPreferences.Designer.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260310140724_AddGameNightNotificationPreferences.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Api.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -12,9 +13,11 @@ using Pgvector;
 namespace Api.Infrastructure.Migrations
 {
     [DbContext(typeof(MeepleAiDbContext))]
-    partial class MeepleAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260310140724_AddGameNightNotificationPreferences")]
+    partial class AddGameNightNotificationPreferences
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/Api/Infrastructure/Migrations/20260310140724_AddGameNightNotificationPreferences.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260310140724_AddGameNightNotificationPreferences.cs
@@ -1,0 +1,73 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddGameNightNotificationPreferences : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<bool>(
+                name: "EmailOnGameNightInvitation",
+                table: "notification_preferences",
+                type: "boolean",
+                nullable: false,
+                defaultValue: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "EmailOnGameNightReminder",
+                table: "notification_preferences",
+                type: "boolean",
+                nullable: false,
+                defaultValue: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "InAppOnGameNightInvitation",
+                table: "notification_preferences",
+                type: "boolean",
+                nullable: false,
+                defaultValue: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "PushOnGameNightInvitation",
+                table: "notification_preferences",
+                type: "boolean",
+                nullable: false,
+                defaultValue: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "PushOnGameNightReminder",
+                table: "notification_preferences",
+                type: "boolean",
+                nullable: false,
+                defaultValue: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "EmailOnGameNightInvitation",
+                table: "notification_preferences");
+
+            migrationBuilder.DropColumn(
+                name: "EmailOnGameNightReminder",
+                table: "notification_preferences");
+
+            migrationBuilder.DropColumn(
+                name: "InAppOnGameNightInvitation",
+                table: "notification_preferences");
+
+            migrationBuilder.DropColumn(
+                name: "PushOnGameNightInvitation",
+                table: "notification_preferences");
+
+            migrationBuilder.DropColumn(
+                name: "PushOnGameNightReminder",
+                table: "notification_preferences");
+        }
+    }
+}

--- a/apps/api/src/Api/Program.cs
+++ b/apps/api/src/Api/Program.cs
@@ -490,6 +490,7 @@ v1Api.MapWhiteboardEndpoints(); // Issue #4971: Whiteboard base toolkit endpoint
 v1Api.MapSessionSnapshotEndpoints(); // Issue #4755: Session snapshot endpoints
 v1Api.MapGameManagementEndpoints(); // Issue #4273: Game search autocomplete
 v1Api.MapPlaylistEndpoints(); // Issue #5582: Game Night Playlist endpoints
+v1Api.MapGameNightEndpoints(); // Issue #46: Game Night Event endpoints
 v1Api.MapRuleConflictFaqEndpoints(); // ISSUE-3966: Rule conflict FAQ management
 v1Api.MapSessionTrackingEndpoints(); // GST-003: Session tracking real-time collaboration
 v1Api.MapSessionStatisticsEndpoints(); // P4: Session analytics dashboard

--- a/apps/api/src/Api/Routing/GameNightEndpoints.cs
+++ b/apps/api/src/Api/Routing/GameNightEndpoints.cs
@@ -1,0 +1,286 @@
+using Api.BoundedContexts.GameManagement.Application.Commands.GameNights;
+using Api.BoundedContexts.GameManagement.Application.DTOs.GameNights;
+using Api.BoundedContexts.GameManagement.Application.Queries.GameNights;
+using Api.BoundedContexts.GameManagement.Domain.Enums;
+using Api.Extensions;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Api.Routing;
+
+/// <summary>
+/// Game night event endpoints for creating, managing, and RSVPing to game nights.
+/// Issue #46: GameNight API endpoints.
+/// </summary>
+internal static class GameNightEndpoints
+{
+    public static RouteGroupBuilder MapGameNightEndpoints(this RouteGroupBuilder group)
+    {
+        var gameNights = group.MapGroup("/game-nights")
+            .WithTags("GameNights");
+
+        // Commands
+        gameNights.MapPost("/", HandleCreateGameNight)
+            .RequireAuthenticatedUser()
+            .Produces<Guid>(201)
+            .Produces(400)
+            .Produces(401)
+            .WithName("CreateGameNight")
+            .WithSummary("Create a new game night event")
+            .WithDescription("Creates a new game night event in Draft status.");
+
+        gameNights.MapGet("/", HandleGetUpcomingGameNights)
+            .RequireAuthenticatedUser()
+            .Produces<IReadOnlyList<GameNightDto>>(200)
+            .Produces(401)
+            .WithName("GetUpcomingGameNights")
+            .WithSummary("Get upcoming game nights")
+            .WithDescription("Retrieves upcoming published game nights ordered by scheduled date.");
+
+        gameNights.MapGet("/mine", HandleGetMyGameNights)
+            .RequireAuthenticatedUser()
+            .Produces<IReadOnlyList<GameNightDto>>(200)
+            .Produces(401)
+            .WithName("GetMyGameNights")
+            .WithSummary("Get my game nights")
+            .WithDescription("Retrieves game nights where the user is organizer or invited.");
+
+        gameNights.MapGet("/{id:guid}", HandleGetGameNightById)
+            .RequireAuthenticatedUser()
+            .Produces<GameNightDto>(200)
+            .Produces(404)
+            .Produces(401)
+            .WithName("GetGameNightById")
+            .WithSummary("Get a game night by ID")
+            .WithDescription("Retrieves full details of a game night event.");
+
+        gameNights.MapPut("/{id:guid}", HandleUpdateGameNight)
+            .RequireAuthenticatedUser()
+            .Produces(204)
+            .Produces(400)
+            .Produces(404)
+            .Produces(401)
+            .WithName("UpdateGameNight")
+            .WithSummary("Update a game night")
+            .WithDescription("Updates a game night event. Only the organizer can update.");
+
+        gameNights.MapPost("/{id:guid}/publish", HandlePublishGameNight)
+            .RequireAuthenticatedUser()
+            .Produces(204)
+            .Produces(404)
+            .Produces(409)
+            .Produces(401)
+            .WithName("PublishGameNight")
+            .WithSummary("Publish a game night")
+            .WithDescription("Publishes a draft game night, making it visible and sending invitations.");
+
+        gameNights.MapPost("/{id:guid}/cancel", HandleCancelGameNight)
+            .RequireAuthenticatedUser()
+            .Produces(204)
+            .Produces(404)
+            .Produces(409)
+            .Produces(401)
+            .WithName("CancelGameNight")
+            .WithSummary("Cancel a game night")
+            .WithDescription("Cancels a game night event. Only the organizer can cancel.");
+
+        gameNights.MapPost("/{id:guid}/invite", HandleInviteToGameNight)
+            .RequireAuthenticatedUser()
+            .Produces(204)
+            .Produces(404)
+            .Produces(409)
+            .Produces(401)
+            .WithName("InviteToGameNight")
+            .WithSummary("Invite users to a game night")
+            .WithDescription("Invites additional users to a published game night.");
+
+        gameNights.MapGet("/{id:guid}/rsvps", HandleGetGameNightRsvps)
+            .RequireAuthenticatedUser()
+            .Produces<IReadOnlyList<GameNightRsvpDto>>(200)
+            .Produces(404)
+            .Produces(401)
+            .WithName("GetGameNightRsvps")
+            .WithSummary("Get game night RSVPs")
+            .WithDescription("Retrieves all RSVPs for a game night.");
+
+        gameNights.MapPost("/{id:guid}/rsvp", HandleRespondToGameNight)
+            .RequireAuthenticatedUser()
+            .Produces(204)
+            .Produces(400)
+            .Produces(404)
+            .Produces(401)
+            .WithName("RespondToGameNight")
+            .WithSummary("Respond to a game night invitation")
+            .WithDescription("Submits an RSVP response (Accepted, Declined, Maybe) to a game night invitation.");
+
+        return group;
+    }
+
+    #region Command Handlers
+
+    private static async Task<IResult> HandleCreateGameNight(
+        [FromBody] CreateGameNightRequest request,
+        [FromServices] IMediator mediator,
+        HttpContext httpContext,
+        CancellationToken cancellationToken)
+    {
+        var userId = httpContext.User.GetUserId();
+
+        var command = new CreateGameNightCommand(
+            UserId: userId,
+            Title: request.Title,
+            ScheduledAt: request.ScheduledAt,
+            Description: request.Description,
+            Location: request.Location,
+            MaxPlayers: request.MaxPlayers,
+            GameIds: request.GameIds,
+            InvitedUserIds: request.InvitedUserIds);
+
+        var id = await mediator.Send(command, cancellationToken).ConfigureAwait(false);
+        return Results.Created($"/api/v1/game-nights/{id}", id);
+    }
+
+    private static async Task<IResult> HandleUpdateGameNight(
+        Guid id,
+        [FromBody] UpdateGameNightRequest request,
+        [FromServices] IMediator mediator,
+        HttpContext httpContext,
+        CancellationToken cancellationToken)
+    {
+        var userId = httpContext.User.GetUserId();
+
+        var command = new UpdateGameNightCommand(
+            GameNightId: id,
+            UserId: userId,
+            Title: request.Title,
+            ScheduledAt: request.ScheduledAt,
+            Description: request.Description,
+            Location: request.Location,
+            MaxPlayers: request.MaxPlayers,
+            GameIds: request.GameIds);
+
+        await mediator.Send(command, cancellationToken).ConfigureAwait(false);
+        return Results.NoContent();
+    }
+
+    private static async Task<IResult> HandlePublishGameNight(
+        Guid id,
+        [FromServices] IMediator mediator,
+        HttpContext httpContext,
+        CancellationToken cancellationToken)
+    {
+        var userId = httpContext.User.GetUserId();
+        var command = new PublishGameNightCommand(id, userId);
+        await mediator.Send(command, cancellationToken).ConfigureAwait(false);
+        return Results.NoContent();
+    }
+
+    private static async Task<IResult> HandleCancelGameNight(
+        Guid id,
+        [FromServices] IMediator mediator,
+        HttpContext httpContext,
+        CancellationToken cancellationToken)
+    {
+        var userId = httpContext.User.GetUserId();
+        var command = new CancelGameNightCommand(id, userId);
+        await mediator.Send(command, cancellationToken).ConfigureAwait(false);
+        return Results.NoContent();
+    }
+
+    private static async Task<IResult> HandleInviteToGameNight(
+        Guid id,
+        [FromBody] InviteToGameNightRequest request,
+        [FromServices] IMediator mediator,
+        HttpContext httpContext,
+        CancellationToken cancellationToken)
+    {
+        var userId = httpContext.User.GetUserId();
+        var command = new InviteToGameNightCommand(id, userId, request.UserIds);
+        await mediator.Send(command, cancellationToken).ConfigureAwait(false);
+        return Results.NoContent();
+    }
+
+    private static async Task<IResult> HandleRespondToGameNight(
+        Guid id,
+        [FromBody] RespondToGameNightRequest request,
+        [FromServices] IMediator mediator,
+        HttpContext httpContext,
+        CancellationToken cancellationToken)
+    {
+        var userId = httpContext.User.GetUserId();
+
+        if (!Enum.TryParse<RsvpStatus>(request.Response, true, out var rsvpStatus) || rsvpStatus == RsvpStatus.Pending)
+            return Results.BadRequest(new { error = "Invalid RSVP response. Must be Accepted, Declined, or Maybe." });
+
+        var command = new RespondToGameNightCommand(id, userId, rsvpStatus);
+        await mediator.Send(command, cancellationToken).ConfigureAwait(false);
+        return Results.NoContent();
+    }
+
+    #endregion
+
+    #region Query Handlers
+
+    private static async Task<IResult> HandleGetUpcomingGameNights(
+        [FromServices] IMediator mediator,
+        CancellationToken cancellationToken)
+    {
+        var result = await mediator.Send(new GetUpcomingGameNightsQuery(), cancellationToken).ConfigureAwait(false);
+        return Results.Ok(result);
+    }
+
+    private static async Task<IResult> HandleGetMyGameNights(
+        [FromServices] IMediator mediator,
+        HttpContext httpContext,
+        CancellationToken cancellationToken)
+    {
+        var userId = httpContext.User.GetUserId();
+        var result = await mediator.Send(new GetMyGameNightsQuery(userId), cancellationToken).ConfigureAwait(false);
+        return Results.Ok(result);
+    }
+
+    private static async Task<IResult> HandleGetGameNightById(
+        Guid id,
+        [FromServices] IMediator mediator,
+        CancellationToken cancellationToken)
+    {
+        var result = await mediator.Send(new GetGameNightByIdQuery(id), cancellationToken).ConfigureAwait(false);
+        return Results.Ok(result);
+    }
+
+    private static async Task<IResult> HandleGetGameNightRsvps(
+        Guid id,
+        [FromServices] IMediator mediator,
+        CancellationToken cancellationToken)
+    {
+        var result = await mediator.Send(new GetGameNightRsvpsQuery(id), cancellationToken).ConfigureAwait(false);
+        return Results.Ok(result);
+    }
+
+    #endregion
+
+    #region Request Records
+
+    private sealed record CreateGameNightRequest(
+        string Title,
+        DateTimeOffset ScheduledAt,
+        string? Description = null,
+        string? Location = null,
+        int? MaxPlayers = null,
+        List<Guid>? GameIds = null,
+        List<Guid>? InvitedUserIds = null);
+
+    private sealed record UpdateGameNightRequest(
+        string Title,
+        DateTimeOffset ScheduledAt,
+        string? Description = null,
+        string? Location = null,
+        int? MaxPlayers = null,
+        List<Guid>? GameIds = null);
+
+    private sealed record InviteToGameNightRequest(List<Guid> UserIds);
+
+    private sealed record RespondToGameNightRequest(string Response);
+
+    #endregion
+}


### PR DESCRIPTION
## Summary

Phase 2 of Epic #33 — Complete Game Night calendar backend with CQRS, domain events, notification handlers, Quartz scheduling, and email templates.

### Issues Resolved
- **#42**: GameNightEvent + GameNightRsvp domain aggregates (Draft→Published→Completed/Cancelled lifecycle)
- **#43**: 6 CRUD commands + 4 queries + 3 FluentValidation validators + 10 handlers
- **#44**: 5 new NotificationTypes + 5 MediatR event handlers (invitation, RSVP received, 24h/1h reminders, cancellation)
- **#45**: GameNightReminderJob (Quartz, every 15min, idempotent via SentAt flags)
- **#46**: 10 REST endpoints under /api/v1/game-nights with authentication
- **#47**: 4 responsive HTML email templates with MeepleAI branding

### Architecture
- **Domain**: GameNightEvent aggregate with RSVP collection, status machine, factory methods
- **CQRS**: All endpoints use IMediator.Send() — zero direct service injection
- **Notifications**: Cross-channel (in-app + email) with CorrelationId and user preference checks
- **Scheduling**: Quartz job with 30min windows (24h and 1h reminders), no duplicate sends
- **Email**: GameNightEmailService with inline-CSS responsive templates

### Changes
- 50+ new files (domain, application, infrastructure, routing layers)
- 8 modified files (DI registration, DbContext, Program.cs, notification preferences)
- EF Migration: AddGameNightEntities (2 tables + indexes)

Closes #42, #43, #44, #45, #46, #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>