### PR TITLE
Issue #33 P3: Game Night frontend pages + notification integration

### DIFF
--- a/apps/web/src/app/(authenticated)/game-nights/NavConfig.tsx
+++ b/apps/web/src/app/(authenticated)/game-nights/NavConfig.tsx
@@ -1,0 +1,51 @@
+/**
+ * GameNightsNavConfig — MiniNav + ActionBar for /game-nights
+ * Issue #33 — P3 Game Night Frontend
+ *
+ * Tabs: Prossime · Le Mie
+ * ActionBar: Nuova Serata (primary)
+ */
+
+'use client';
+
+import { useEffect } from 'react';
+
+import { Calendar, Plus, User } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+
+import { useSetNavConfig } from '@/hooks/useSetNavConfig';
+
+export function GameNightsNavConfig() {
+  const setNavConfig = useSetNavConfig();
+  const router = useRouter();
+
+  useEffect(() => {
+    setNavConfig({
+      miniNav: [
+        {
+          id: 'upcoming',
+          label: 'Prossime',
+          href: '/game-nights',
+          icon: Calendar,
+        },
+        {
+          id: 'mine',
+          label: 'Le Mie',
+          href: '/game-nights?tab=mine',
+          icon: User,
+        },
+      ],
+      actionBar: [
+        {
+          id: 'new-game-night',
+          label: 'Nuova Serata',
+          icon: Plus,
+          variant: 'primary',
+          onClick: () => router.push('/game-nights/new'),
+        },
+      ],
+    });
+  }, [setNavConfig, router]);
+
+  return null;
+}

--- a/apps/web/src/app/(authenticated)/game-nights/[id]/edit/page.tsx
+++ b/apps/web/src/app/(authenticated)/game-nights/[id]/edit/page.tsx
@@ -1,0 +1,71 @@
+/**
+ * Edit Game Night Page
+ * Issue #33 — P3 Game Night Frontend
+ */
+
+'use client';
+
+import { use } from 'react';
+
+import { useRouter } from 'next/navigation';
+
+import { Skeleton } from '@/components/ui/feedback/skeleton';
+import { useGameNight, useUpdateGameNight } from '@/hooks/queries/useGameNights';
+import { useToast } from '@/hooks/use-toast';
+import type { CreateGameNightInput } from '@/lib/api/schemas/game-nights.schemas';
+
+import { GameNightForm } from '../../_components/GameNightForm';
+
+export default function EditGameNightPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = use(params);
+  const router = useRouter();
+  const { toast } = useToast();
+
+  const { data: event, isLoading } = useGameNight(id);
+  const updateMutation = useUpdateGameNight();
+
+  function handleSubmit(data: CreateGameNightInput) {
+    updateMutation.mutate(
+      { id, input: data },
+      {
+        onSuccess: () => {
+          toast({ title: 'Serata aggiornata' });
+          router.push(`/game-nights/${id}`);
+        },
+        onError: () => {
+          toast({
+            title: 'Errore',
+            description: 'Impossibile aggiornare la serata.',
+            variant: 'destructive',
+          });
+        },
+      }
+    );
+  }
+
+  if (isLoading || !event) {
+    return (
+      <div className="p-4 max-w-2xl mx-auto space-y-4">
+        <Skeleton className="h-8 w-3/4" />
+        <Skeleton className="h-64 w-full" />
+      </div>
+    );
+  }
+
+  return (
+    <div className="p-4">
+      <GameNightForm
+        defaultValues={{
+          title: event.title,
+          description: event.description ?? undefined,
+          scheduledAt: event.scheduledAt,
+          location: event.location ?? undefined,
+          maxPlayers: event.maxPlayers ?? undefined,
+        }}
+        onSubmit={handleSubmit}
+        isSubmitting={updateMutation.isPending}
+        submitLabel="Salva Modifiche"
+      />
+    </div>
+  );
+}

--- a/apps/web/src/app/(authenticated)/game-nights/[id]/page.tsx
+++ b/apps/web/src/app/(authenticated)/game-nights/[id]/page.tsx
@@ -1,0 +1,252 @@
+/**
+ * Game Night Detail Page
+ * Issue #33 — P3 Game Night Frontend
+ *
+ * Shows game night info, RSVP buttons, and participant list.
+ */
+
+'use client';
+
+import { use } from 'react';
+
+import { Calendar, Check, Edit, HelpCircle, MapPin, Send, Users, X, XCircle } from 'lucide-react';
+import Link from 'next/link';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/feedback/skeleton';
+import {
+  useGameNight,
+  useGameNightRsvps,
+  usePublishGameNight,
+  useCancelGameNight,
+  useRsvpGameNight,
+} from '@/hooks/queries/useGameNights';
+import { useToast } from '@/hooks/use-toast';
+import type { RsvpStatus } from '@/lib/api/schemas/game-nights.schemas';
+
+export default function GameNightDetailPage({ params }: { params: Promise<{ id: string }> }) {
+  const { id } = use(params);
+  const { toast } = useToast();
+
+  const { data: event, isLoading, error } = useGameNight(id);
+  const { data: rsvps } = useGameNightRsvps(id);
+  const publishMutation = usePublishGameNight();
+  const cancelMutation = useCancelGameNight();
+  const rsvpMutation = useRsvpGameNight();
+
+  function handleRsvp(response: RsvpStatus) {
+    rsvpMutation.mutate(
+      { id, response },
+      {
+        onSuccess: () => {
+          const labels: Record<string, string> = {
+            Accepted: 'Partecipazione confermata',
+            Declined: 'Hai declinato',
+            Maybe: 'Risposta registrata',
+          };
+          toast({ title: labels[response] ?? 'Risposta inviata' });
+        },
+        onError: () => {
+          toast({
+            title: 'Errore',
+            description: 'Impossibile inviare la risposta.',
+            variant: 'destructive',
+          });
+        },
+      }
+    );
+  }
+
+  function handlePublish() {
+    publishMutation.mutate(id, {
+      onSuccess: () =>
+        toast({
+          title: 'Serata pubblicata',
+          description: 'Gli invitati riceveranno una notifica.',
+        }),
+      onError: () =>
+        toast({ title: 'Errore', description: 'Impossibile pubblicare.', variant: 'destructive' }),
+    });
+  }
+
+  function handleCancel() {
+    cancelMutation.mutate(id, {
+      onSuccess: () => toast({ title: 'Serata annullata' }),
+      onError: () =>
+        toast({ title: 'Errore', description: 'Impossibile annullare.', variant: 'destructive' }),
+    });
+  }
+
+  if (isLoading) {
+    return (
+      <div className="p-4 max-w-2xl mx-auto space-y-4">
+        <Skeleton className="h-8 w-3/4" />
+        <Skeleton className="h-4 w-1/2" />
+        <Skeleton className="h-32 w-full" />
+      </div>
+    );
+  }
+
+  if (error || !event) {
+    return (
+      <div className="text-center py-12 text-destructive font-nunito">
+        <p>Serata non trovata.</p>
+      </div>
+    );
+  }
+
+  const scheduledDate = new Date(event.scheduledAt);
+  const isDraft = event.status === 'Draft';
+  const isCancelled = event.status === 'Cancelled';
+
+  return (
+    <div className="p-4 max-w-2xl mx-auto space-y-6">
+      {/* Header */}
+      <div className="flex items-start justify-between gap-4">
+        <div>
+          <h1 className="text-2xl font-bold font-quicksand">{event.title}</h1>
+          <p className="text-muted-foreground font-nunito">Organizzata da {event.organizerName}</p>
+        </div>
+        <div className="flex gap-2">
+          {isDraft && (
+            <>
+              <Button size="sm" variant="outline" asChild>
+                <Link href={`/game-nights/${id}/edit`}>
+                  <Edit className="h-4 w-4 mr-1" />
+                  Modifica
+                </Link>
+              </Button>
+              <Button size="sm" onClick={handlePublish} disabled={publishMutation.isPending}>
+                <Send className="h-4 w-4 mr-1" />
+                Pubblica
+              </Button>
+            </>
+          )}
+          {!isCancelled && !isDraft && (
+            <Button
+              size="sm"
+              variant="destructive"
+              onClick={handleCancel}
+              disabled={cancelMutation.isPending}
+            >
+              <XCircle className="h-4 w-4 mr-1" />
+              Annulla
+            </Button>
+          )}
+        </div>
+      </div>
+
+      {/* Info Card */}
+      <Card>
+        <CardContent className="pt-6 space-y-3 font-nunito">
+          <div className="flex items-center gap-2">
+            <Calendar className="h-4 w-4 text-muted-foreground" />
+            <span>
+              {scheduledDate.toLocaleDateString('it-IT', {
+                weekday: 'long',
+                day: 'numeric',
+                month: 'long',
+                year: 'numeric',
+                hour: '2-digit',
+                minute: '2-digit',
+              })}
+            </span>
+          </div>
+          {event.location && (
+            <div className="flex items-center gap-2">
+              <MapPin className="h-4 w-4 text-muted-foreground" />
+              <span>{event.location}</span>
+            </div>
+          )}
+          <div className="flex items-center gap-2">
+            <Users className="h-4 w-4 text-muted-foreground" />
+            <span>
+              {event.acceptedCount} confermati
+              {event.pendingCount > 0 && ` · ${event.pendingCount} in attesa`}
+              {event.maxPlayers && ` / ${event.maxPlayers} max`}
+            </span>
+          </div>
+          {event.description && (
+            <p className="text-sm text-muted-foreground pt-2 border-t">{event.description}</p>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* RSVP Buttons */}
+      {!isDraft && !isCancelled && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base font-quicksand">La tua risposta</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="flex gap-2 flex-wrap">
+              <Button
+                variant="outline"
+                className="border-green-300 hover:bg-green-50"
+                onClick={() => handleRsvp('Accepted')}
+                disabled={rsvpMutation.isPending}
+              >
+                <Check className="h-4 w-4 mr-1 text-green-600" />
+                Partecipo
+              </Button>
+              <Button
+                variant="outline"
+                className="border-amber-300 hover:bg-amber-50"
+                onClick={() => handleRsvp('Maybe')}
+                disabled={rsvpMutation.isPending}
+              >
+                <HelpCircle className="h-4 w-4 mr-1 text-amber-600" />
+                Forse
+              </Button>
+              <Button
+                variant="outline"
+                className="border-red-300 hover:bg-red-50"
+                onClick={() => handleRsvp('Declined')}
+                disabled={rsvpMutation.isPending}
+              >
+                <X className="h-4 w-4 mr-1 text-red-600" />
+                Non partecipo
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {/* Participants */}
+      {rsvps && rsvps.length > 0 && (
+        <Card>
+          <CardHeader>
+            <CardTitle className="text-base font-quicksand">
+              Partecipanti ({rsvps.length})
+            </CardTitle>
+          </CardHeader>
+          <CardContent>
+            <ul className="space-y-2">
+              {rsvps.map(rsvp => (
+                <li key={rsvp.id} className="flex items-center justify-between text-sm font-nunito">
+                  <span>{rsvp.userName}</span>
+                  <RsvpBadge status={rsvp.status} />
+                </li>
+              ))}
+            </ul>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}
+
+function RsvpBadge({ status }: { status: string }) {
+  switch (status) {
+    case 'Accepted':
+      return <Badge className="bg-green-100 text-green-800 border-green-200">Confermato</Badge>;
+    case 'Declined':
+      return <Badge variant="destructive">Declinato</Badge>;
+    case 'Maybe':
+      return <Badge className="bg-amber-100 text-amber-800 border-amber-200">Forse</Badge>;
+    default:
+      return <Badge variant="secondary">In attesa</Badge>;
+  }
+}

--- a/apps/web/src/app/(authenticated)/game-nights/_components/GameNightForm.tsx
+++ b/apps/web/src/app/(authenticated)/game-nights/_components/GameNightForm.tsx
@@ -1,0 +1,133 @@
+/**
+ * GameNightForm — Shared create/edit form for game nights
+ * Issue #33 — P3 Game Night Frontend
+ */
+
+'use client';
+
+import { useState } from 'react';
+
+import { CalendarIcon, Loader2 } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/primitives/textarea';
+import type { CreateGameNightInput } from '@/lib/api/schemas/game-nights.schemas';
+
+interface GameNightFormProps {
+  defaultValues?: Partial<CreateGameNightInput>;
+  onSubmit: (data: CreateGameNightInput) => void;
+  isSubmitting?: boolean;
+  submitLabel?: string;
+}
+
+export function GameNightForm({
+  defaultValues,
+  onSubmit,
+  isSubmitting,
+  submitLabel = 'Crea Serata',
+}: GameNightFormProps) {
+  const [title, setTitle] = useState(defaultValues?.title ?? '');
+  const [description, setDescription] = useState(defaultValues?.description ?? '');
+  const [scheduledAt, setScheduledAt] = useState(
+    defaultValues?.scheduledAt ? new Date(defaultValues.scheduledAt).toISOString().slice(0, 16) : ''
+  );
+  const [location, setLocation] = useState(defaultValues?.location ?? '');
+  const [maxPlayers, setMaxPlayers] = useState<string>(defaultValues?.maxPlayers?.toString() ?? '');
+
+  function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const data: CreateGameNightInput = {
+      title: title.trim(),
+      scheduledAt: new Date(scheduledAt).toISOString(),
+      ...(description.trim() && { description: description.trim() }),
+      ...(location.trim() && { location: location.trim() }),
+      ...(maxPlayers && { maxPlayers: Number(maxPlayers) }),
+    };
+    onSubmit(data);
+  }
+
+  return (
+    <Card className="max-w-2xl mx-auto">
+      <CardHeader>
+        <CardTitle className="font-quicksand">{submitLabel}</CardTitle>
+      </CardHeader>
+      <CardContent>
+        <form onSubmit={handleSubmit} className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="title">Titolo *</Label>
+            <Input
+              id="title"
+              value={title}
+              onChange={e => setTitle(e.target.value)}
+              placeholder="Es. Serata Catan & Carcassonne"
+              required
+              minLength={3}
+              maxLength={200}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="description">Descrizione</Label>
+            <Textarea
+              id="description"
+              value={description}
+              onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
+                setDescription(e.target.value)
+              }
+              placeholder="Dettagli sulla serata, cosa portare..."
+              maxLength={2000}
+              rows={3}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="scheduledAt">Data e Ora *</Label>
+            <div className="relative">
+              <CalendarIcon className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-muted-foreground" />
+              <Input
+                id="scheduledAt"
+                type="datetime-local"
+                value={scheduledAt}
+                onChange={e => setScheduledAt(e.target.value)}
+                className="pl-10"
+                required
+              />
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="location">Luogo</Label>
+            <Input
+              id="location"
+              value={location}
+              onChange={e => setLocation(e.target.value)}
+              placeholder="Es. Casa di Marco, Via Roma 42"
+              maxLength={500}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="maxPlayers">Numero Massimo Giocatori</Label>
+            <Input
+              id="maxPlayers"
+              type="number"
+              value={maxPlayers}
+              onChange={e => setMaxPlayers(e.target.value)}
+              placeholder="Lascia vuoto per nessun limite"
+              min={2}
+              max={50}
+            />
+          </div>
+
+          <Button type="submit" disabled={isSubmitting} className="w-full">
+            {isSubmitting && <Loader2 className="mr-2 h-4 w-4 animate-spin" />}
+            {submitLabel}
+          </Button>
+        </form>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/app/(authenticated)/game-nights/_content.tsx
+++ b/apps/web/src/app/(authenticated)/game-nights/_content.tsx
@@ -1,0 +1,141 @@
+/**
+ * Game Nights Content (client component)
+ * Issue #33 — P3 Game Night Frontend
+ *
+ * Renders upcoming / my game nights based on ?tab query param.
+ */
+
+'use client';
+
+import { Calendar, MapPin, Users } from 'lucide-react';
+import Link from 'next/link';
+import { useSearchParams } from 'next/navigation';
+
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
+import { Skeleton } from '@/components/ui/feedback/skeleton';
+import { useMyGameNights, useUpcomingGameNights } from '@/hooks/queries/useGameNights';
+import type { GameNightDto } from '@/lib/api/schemas/game-nights.schemas';
+
+function GameNightCard({ event }: { event: GameNightDto }) {
+  const scheduledDate = new Date(event.scheduledAt);
+  const isPast = scheduledDate < new Date();
+
+  return (
+    <Link href={`/game-nights/${event.id}`}>
+      <Card className="hover:border-amber-300 transition-colors cursor-pointer">
+        <CardHeader className="pb-2">
+          <div className="flex items-start justify-between gap-2">
+            <CardTitle className="text-lg font-quicksand">{event.title}</CardTitle>
+            <StatusBadge status={event.status} isPast={isPast} />
+          </div>
+          <CardDescription className="font-nunito">
+            Organizzata da {event.organizerName}
+          </CardDescription>
+        </CardHeader>
+        <CardContent className="space-y-2 text-sm text-muted-foreground font-nunito">
+          <div className="flex items-center gap-2">
+            <Calendar className="h-4 w-4" />
+            <span>
+              {scheduledDate.toLocaleDateString('it-IT', {
+                weekday: 'long',
+                day: 'numeric',
+                month: 'long',
+                hour: '2-digit',
+                minute: '2-digit',
+              })}
+            </span>
+          </div>
+          {event.location && (
+            <div className="flex items-center gap-2">
+              <MapPin className="h-4 w-4" />
+              <span>{event.location}</span>
+            </div>
+          )}
+          <div className="flex items-center gap-2">
+            <Users className="h-4 w-4" />
+            <span>
+              {event.acceptedCount} confermati
+              {event.pendingCount > 0 && ` · ${event.pendingCount} in attesa`}
+              {event.maxPlayers && ` / ${event.maxPlayers} max`}
+            </span>
+          </div>
+        </CardContent>
+      </Card>
+    </Link>
+  );
+}
+
+function StatusBadge({ status, isPast }: { status: string; isPast: boolean }) {
+  if (status === 'Cancelled') return <Badge variant="destructive">Annullata</Badge>;
+  if (status === 'Draft') return <Badge variant="secondary">Bozza</Badge>;
+  if (isPast) return <Badge variant="outline">Conclusa</Badge>;
+  return <Badge className="bg-amber-100 text-amber-900 border-amber-200">Pubblicata</Badge>;
+}
+
+function EmptyState({ tab }: { tab: string }) {
+  return (
+    <div className="text-center py-12 text-muted-foreground font-nunito">
+      <Calendar className="h-12 w-12 mx-auto mb-4 opacity-40" />
+      <p className="text-lg font-medium">
+        {tab === 'mine' ? 'Non hai ancora organizzato serate' : 'Nessuna serata in programma'}
+      </p>
+      <p className="text-sm mt-1">
+        {tab === 'mine'
+          ? 'Crea la tua prima serata giochi!'
+          : 'Le prossime serate appariranno qui.'}
+      </p>
+    </div>
+  );
+}
+
+export function GameNightsContent() {
+  const searchParams = useSearchParams();
+  const tab = searchParams.get('tab') ?? 'upcoming';
+
+  const upcomingQuery = useUpcomingGameNights();
+  const mineQuery = useMyGameNights();
+
+  const isUpcoming = tab !== 'mine';
+  const { data, isLoading, error } = isUpcoming ? upcomingQuery : mineQuery;
+
+  if (isLoading) return <GameNightsLoadingSkeleton />;
+
+  if (error) {
+    return (
+      <div className="text-center py-12 text-destructive font-nunito">
+        <p>Errore nel caricamento delle serate.</p>
+      </div>
+    );
+  }
+
+  if (!data || data.length === 0) return <EmptyState tab={tab} />;
+
+  return (
+    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 p-4">
+      {data.map(event => (
+        <GameNightCard key={event.id} event={event} />
+      ))}
+    </div>
+  );
+}
+
+export function GameNightsLoadingSkeleton() {
+  return (
+    <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 p-4">
+      {Array.from({ length: 6 }).map((_, i) => (
+        <Card key={i}>
+          <CardHeader className="pb-2">
+            <Skeleton className="h-5 w-3/4" />
+            <Skeleton className="h-4 w-1/2 mt-1" />
+          </CardHeader>
+          <CardContent className="space-y-2">
+            <Skeleton className="h-4 w-full" />
+            <Skeleton className="h-4 w-2/3" />
+            <Skeleton className="h-4 w-1/2" />
+          </CardContent>
+        </Card>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/app/(authenticated)/game-nights/layout.tsx
+++ b/apps/web/src/app/(authenticated)/game-nights/layout.tsx
@@ -1,0 +1,21 @@
+/**
+ * Game Nights Section Layout
+ * Issue #33 — P3 Game Night Frontend
+ *
+ * Mounts GameNightsNavConfig for all /game-nights sub-routes.
+ */
+
+'use client';
+
+import { type ReactNode } from 'react';
+
+import { GameNightsNavConfig } from './NavConfig';
+
+export default function GameNightsLayout({ children }: { children: ReactNode }) {
+  return (
+    <>
+      <GameNightsNavConfig />
+      {children}
+    </>
+  );
+}

--- a/apps/web/src/app/(authenticated)/game-nights/new/page.tsx
+++ b/apps/web/src/app/(authenticated)/game-nights/new/page.tsx
@@ -1,0 +1,42 @@
+/**
+ * Create Game Night Page
+ * Issue #33 — P3 Game Night Frontend
+ */
+
+'use client';
+
+import { useRouter } from 'next/navigation';
+
+import { useCreateGameNight } from '@/hooks/queries/useGameNights';
+import { useToast } from '@/hooks/use-toast';
+import type { CreateGameNightInput } from '@/lib/api/schemas/game-nights.schemas';
+
+import { GameNightForm } from '../_components/GameNightForm';
+
+export default function NewGameNightPage() {
+  const router = useRouter();
+  const { toast } = useToast();
+  const createMutation = useCreateGameNight();
+
+  function handleSubmit(data: CreateGameNightInput) {
+    createMutation.mutate(data, {
+      onSuccess: id => {
+        toast({ title: 'Serata creata', description: 'La serata è stata creata come bozza.' });
+        router.push(`/game-nights/${id}`);
+      },
+      onError: () => {
+        toast({
+          title: 'Errore',
+          description: 'Impossibile creare la serata.',
+          variant: 'destructive',
+        });
+      },
+    });
+  }
+
+  return (
+    <div className="p-4">
+      <GameNightForm onSubmit={handleSubmit} isSubmitting={createMutation.isPending} />
+    </div>
+  );
+}

--- a/apps/web/src/app/(authenticated)/game-nights/page.tsx
+++ b/apps/web/src/app/(authenticated)/game-nights/page.tsx
@@ -1,0 +1,22 @@
+/**
+ * Game Nights Page
+ * Issue #33 — P3 Game Night Frontend
+ *
+ * Lists upcoming and user-organized game nights with tab navigation.
+ */
+
+import { Suspense } from 'react';
+
+import { RequireRole } from '@/components/auth/RequireRole';
+
+import { GameNightsContent, GameNightsLoadingSkeleton } from './_content';
+
+export default function GameNightsPage() {
+  return (
+    <RequireRole allowedRoles={['User', 'Editor', 'Admin']}>
+      <Suspense fallback={<GameNightsLoadingSkeleton />}>
+        <GameNightsContent />
+      </Suspense>
+    </RequireRole>
+  );
+}

--- a/apps/web/src/app/(authenticated)/settings/notifications/page.tsx
+++ b/apps/web/src/app/(authenticated)/settings/notifications/page.tsx
@@ -7,7 +7,18 @@
 
 import React, { useEffect, useState } from 'react';
 
-import { Bell, Mail, Smartphone, MessageSquare, Save, Loader2, BellRing, BellOff, SendHorizontal } from 'lucide-react';
+import {
+  Bell,
+  Calendar,
+  Mail,
+  Smartphone,
+  MessageSquare,
+  Save,
+  Loader2,
+  BellRing,
+  BellOff,
+  SendHorizontal,
+} from 'lucide-react';
 
 import { Switch } from '@/components/ui/forms/switch';
 import { Button } from '@/components/ui/primitives/button';
@@ -26,6 +37,12 @@ interface NotificationPreferences {
   inAppOnDocumentFailed: boolean;
   inAppOnRetryAvailable: boolean;
   hasPushSubscription: boolean;
+  // Game Night preferences (Issue #33)
+  inAppOnGameNightInvitation: boolean;
+  emailOnGameNightInvitation: boolean;
+  pushOnGameNightInvitation: boolean;
+  emailOnGameNightReminder: boolean;
+  pushOnGameNightReminder: boolean;
 }
 
 export default function NotificationSettingsPage() {
@@ -112,7 +129,10 @@ export default function NotificationSettingsPage() {
     }
   };
 
-  const updatePref = (key: keyof Omit<NotificationPreferences, 'userId' | 'hasPushSubscription'>, value: boolean) => {
+  const updatePref = (
+    key: keyof Omit<NotificationPreferences, 'userId' | 'hasPushSubscription'>,
+    value: boolean
+  ) => {
     if (!prefs) return;
     setPrefs({ ...prefs, [key]: value });
   };
@@ -166,7 +186,9 @@ export default function NotificationSettingsPage() {
         <div className="bg-card rounded-xl p-6 border border-border/50 mb-6">
           <div className="flex items-center justify-between">
             <div className="flex items-center gap-4">
-              <div className={`p-2 rounded-lg ${push.isSubscribed ? 'bg-green-100 dark:bg-green-900/20' : 'bg-muted'}`}>
+              <div
+                className={`p-2 rounded-lg ${push.isSubscribed ? 'bg-green-100 dark:bg-green-900/20' : 'bg-muted'}`}
+              >
                 {push.isSubscribed ? (
                   <BellRing className="h-6 w-6 text-green-600 dark:text-green-400" />
                 ) : (
@@ -237,12 +259,14 @@ export default function NotificationSettingsPage() {
               <Mail className="h-5 w-5 text-muted-foreground" />
               <div>
                 <p className="font-medium">Email Notification</p>
-                <p className="text-sm text-muted-foreground">Receive email when document is ready</p>
+                <p className="text-sm text-muted-foreground">
+                  Receive email when document is ready
+                </p>
               </div>
             </div>
             <Switch
               checked={prefs.emailOnDocumentReady}
-              onCheckedChange={(checked) => updatePref('emailOnDocumentReady', checked)}
+              onCheckedChange={checked => updatePref('emailOnDocumentReady', checked)}
             />
           </div>
 
@@ -252,13 +276,15 @@ export default function NotificationSettingsPage() {
               <div>
                 <p className="font-medium">Push Notification</p>
                 <p className="text-sm text-muted-foreground">
-                  {pushEnabled ? 'Browser push notification when document is ready' : 'Enable push notifications above to use this'}
+                  {pushEnabled
+                    ? 'Browser push notification when document is ready'
+                    : 'Enable push notifications above to use this'}
                 </p>
               </div>
             </div>
             <Switch
               checked={prefs.pushOnDocumentReady}
-              onCheckedChange={(checked) => updatePref('pushOnDocumentReady', checked)}
+              onCheckedChange={checked => updatePref('pushOnDocumentReady', checked)}
               disabled={!pushEnabled}
             />
           </div>
@@ -268,12 +294,14 @@ export default function NotificationSettingsPage() {
               <MessageSquare className="h-5 w-5 text-muted-foreground" />
               <div>
                 <p className="font-medium">In-App Notification</p>
-                <p className="text-sm text-muted-foreground">Show notification in notification center</p>
+                <p className="text-sm text-muted-foreground">
+                  Show notification in notification center
+                </p>
               </div>
             </div>
             <Switch
               checked={prefs.inAppOnDocumentReady}
-              onCheckedChange={(checked) => updatePref('inAppOnDocumentReady', checked)}
+              onCheckedChange={checked => updatePref('inAppOnDocumentReady', checked)}
             />
           </div>
         </div>
@@ -304,7 +332,7 @@ export default function NotificationSettingsPage() {
             </div>
             <Switch
               checked={prefs.emailOnDocumentFailed}
-              onCheckedChange={(checked) => updatePref('emailOnDocumentFailed', checked)}
+              onCheckedChange={checked => updatePref('emailOnDocumentFailed', checked)}
             />
           </div>
 
@@ -314,13 +342,15 @@ export default function NotificationSettingsPage() {
               <div>
                 <p className="font-medium">Push Notification</p>
                 <p className="text-sm text-muted-foreground">
-                  {pushEnabled ? 'Browser push notification on processing failure' : 'Enable push notifications above to use this'}
+                  {pushEnabled
+                    ? 'Browser push notification on processing failure'
+                    : 'Enable push notifications above to use this'}
                 </p>
               </div>
             </div>
             <Switch
               checked={prefs.pushOnDocumentFailed}
-              onCheckedChange={(checked) => updatePref('pushOnDocumentFailed', checked)}
+              onCheckedChange={checked => updatePref('pushOnDocumentFailed', checked)}
               disabled={!pushEnabled}
             />
           </div>
@@ -335,7 +365,115 @@ export default function NotificationSettingsPage() {
             </div>
             <Switch
               checked={prefs.inAppOnDocumentFailed}
-              onCheckedChange={(checked) => updatePref('inAppOnDocumentFailed', checked)}
+              onCheckedChange={checked => updatePref('inAppOnDocumentFailed', checked)}
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* Game Night Invitations (Issue #33) */}
+      <div className="bg-card rounded-xl p-6 border border-border/50 mb-6">
+        <div className="flex items-start gap-4 mb-6">
+          <div className="p-2 rounded-lg bg-amber-100 dark:bg-amber-900/20">
+            <Calendar className="h-6 w-6 text-amber-600 dark:text-amber-400" />
+          </div>
+          <div className="flex-1">
+            <h2 className="text-xl font-bold mb-1">Serate Giochi — Inviti</h2>
+            <p className="text-sm text-muted-foreground">
+              Notifiche quando vieni invitato a una serata giochi
+            </p>
+          </div>
+        </div>
+
+        <div className="space-y-4">
+          <div className="flex items-center justify-between py-2">
+            <div className="flex items-center gap-3">
+              <Mail className="h-5 w-5 text-muted-foreground" />
+              <div>
+                <p className="font-medium">Email</p>
+                <p className="text-sm text-muted-foreground">Ricevi email per nuovi inviti</p>
+              </div>
+            </div>
+            <Switch
+              checked={prefs.emailOnGameNightInvitation}
+              onCheckedChange={checked => updatePref('emailOnGameNightInvitation', checked)}
+            />
+          </div>
+
+          <div className="flex items-center justify-between py-2">
+            <div className="flex items-center gap-3">
+              <Smartphone className="h-5 w-5 text-muted-foreground" />
+              <div>
+                <p className="font-medium">Push</p>
+                <p className="text-sm text-muted-foreground">
+                  {pushEnabled ? 'Notifica push per nuovi inviti' : 'Abilita le push sopra'}
+                </p>
+              </div>
+            </div>
+            <Switch
+              checked={prefs.pushOnGameNightInvitation}
+              onCheckedChange={checked => updatePref('pushOnGameNightInvitation', checked)}
+              disabled={!pushEnabled}
+            />
+          </div>
+
+          <div className="flex items-center justify-between py-2">
+            <div className="flex items-center gap-3">
+              <MessageSquare className="h-5 w-5 text-muted-foreground" />
+              <div>
+                <p className="font-medium">In-App</p>
+                <p className="text-sm text-muted-foreground">Mostra nel centro notifiche</p>
+              </div>
+            </div>
+            <Switch
+              checked={prefs.inAppOnGameNightInvitation}
+              onCheckedChange={checked => updatePref('inAppOnGameNightInvitation', checked)}
+            />
+          </div>
+        </div>
+      </div>
+
+      {/* Game Night Reminders (Issue #33) */}
+      <div className="bg-card rounded-xl p-6 border border-border/50 mb-6">
+        <div className="flex items-start gap-4 mb-6">
+          <div className="p-2 rounded-lg bg-amber-100 dark:bg-amber-900/20">
+            <Calendar className="h-6 w-6 text-amber-600 dark:text-amber-400" />
+          </div>
+          <div className="flex-1">
+            <h2 className="text-xl font-bold mb-1">Serate Giochi — Promemoria</h2>
+            <p className="text-sm text-muted-foreground">Promemoria 24h e 1h prima della serata</p>
+          </div>
+        </div>
+
+        <div className="space-y-4">
+          <div className="flex items-center justify-between py-2">
+            <div className="flex items-center gap-3">
+              <Mail className="h-5 w-5 text-muted-foreground" />
+              <div>
+                <p className="font-medium">Email</p>
+                <p className="text-sm text-muted-foreground">Ricevi email di promemoria</p>
+              </div>
+            </div>
+            <Switch
+              checked={prefs.emailOnGameNightReminder}
+              onCheckedChange={checked => updatePref('emailOnGameNightReminder', checked)}
+            />
+          </div>
+
+          <div className="flex items-center justify-between py-2">
+            <div className="flex items-center gap-3">
+              <Smartphone className="h-5 w-5 text-muted-foreground" />
+              <div>
+                <p className="font-medium">Push</p>
+                <p className="text-sm text-muted-foreground">
+                  {pushEnabled ? 'Notifica push di promemoria' : 'Abilita le push sopra'}
+                </p>
+              </div>
+            </div>
+            <Switch
+              checked={prefs.pushOnGameNightReminder}
+              onCheckedChange={checked => updatePref('pushOnGameNightReminder', checked)}
+              disabled={!pushEnabled}
             />
           </div>
         </div>
@@ -366,7 +504,7 @@ export default function NotificationSettingsPage() {
             </div>
             <Switch
               checked={prefs.emailOnRetryAvailable}
-              onCheckedChange={(checked) => updatePref('emailOnRetryAvailable', checked)}
+              onCheckedChange={checked => updatePref('emailOnRetryAvailable', checked)}
             />
           </div>
 
@@ -376,13 +514,15 @@ export default function NotificationSettingsPage() {
               <div>
                 <p className="font-medium">Push Notification</p>
                 <p className="text-sm text-muted-foreground">
-                  {pushEnabled ? 'Browser push notification on retry' : 'Enable push notifications above to use this'}
+                  {pushEnabled
+                    ? 'Browser push notification on retry'
+                    : 'Enable push notifications above to use this'}
                 </p>
               </div>
             </div>
             <Switch
               checked={prefs.pushOnRetryAvailable}
-              onCheckedChange={(checked) => updatePref('pushOnRetryAvailable', checked)}
+              onCheckedChange={checked => updatePref('pushOnRetryAvailable', checked)}
               disabled={!pushEnabled}
             />
           </div>
@@ -392,12 +532,14 @@ export default function NotificationSettingsPage() {
               <MessageSquare className="h-5 w-5 text-muted-foreground" />
               <div>
                 <p className="font-medium">In-App Notification</p>
-                <p className="text-sm text-muted-foreground">Show retry status in notification center</p>
+                <p className="text-sm text-muted-foreground">
+                  Show retry status in notification center
+                </p>
               </div>
             </div>
             <Switch
               checked={prefs.inAppOnRetryAvailable}
-              onCheckedChange={(checked) => updatePref('inAppOnRetryAvailable', checked)}
+              onCheckedChange={checked => updatePref('inAppOnRetryAvailable', checked)}
             />
           </div>
         </div>

--- a/apps/web/src/components/notifications/NotificationItem.tsx
+++ b/apps/web/src/components/notifications/NotificationItem.tsx
@@ -16,6 +16,7 @@
 
 import {
   Bot,
+  Calendar,
   CheckCircle2,
   Info,
   AlertTriangle,
@@ -164,6 +165,12 @@ function getTypeIcon(type: string): React.ComponentType<{ className?: string }> 
       return XCircle;
     case 'processing_job_completed':
       return Bot;
+    case 'game_night_invitation':
+    case 'game_night_rsvp_received':
+    case 'game_night_published':
+    case 'game_night_cancelled':
+    case 'game_night_reminder':
+      return Calendar;
     default:
       return Info;
   }

--- a/apps/web/src/hooks/queries/useGameNights.ts
+++ b/apps/web/src/hooks/queries/useGameNights.ts
@@ -1,0 +1,106 @@
+/**
+ * useGameNights — React Query hooks for Game Nights
+ * Issue #33 — P3 Game Night Frontend
+ */
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+
+import { api } from '@/lib/api';
+import type {
+  CreateGameNightInput,
+  RsvpStatus,
+  UpdateGameNightInput,
+} from '@/lib/api/schemas/game-nights.schemas';
+
+export const gameNightKeys = {
+  all: ['game-nights'] as const,
+  upcoming: () => [...gameNightKeys.all, 'upcoming'] as const,
+  mine: () => [...gameNightKeys.all, 'mine'] as const,
+  detail: (id: string) => [...gameNightKeys.all, id] as const,
+  rsvps: (id: string) => [...gameNightKeys.all, id, 'rsvps'] as const,
+};
+
+export function useUpcomingGameNights() {
+  return useQuery({
+    queryKey: gameNightKeys.upcoming(),
+    queryFn: () => api.gameNights.getUpcoming(),
+  });
+}
+
+export function useMyGameNights() {
+  return useQuery({
+    queryKey: gameNightKeys.mine(),
+    queryFn: () => api.gameNights.getMine(),
+  });
+}
+
+export function useGameNight(id: string) {
+  return useQuery({
+    queryKey: gameNightKeys.detail(id),
+    queryFn: () => api.gameNights.getById(id),
+    enabled: !!id,
+  });
+}
+
+export function useGameNightRsvps(id: string) {
+  return useQuery({
+    queryKey: gameNightKeys.rsvps(id),
+    queryFn: () => api.gameNights.getRsvps(id),
+    enabled: !!id,
+  });
+}
+
+export function useCreateGameNight() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (input: CreateGameNightInput) => api.gameNights.create(input),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: gameNightKeys.all });
+    },
+  });
+}
+
+export function useUpdateGameNight() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, input }: { id: string; input: UpdateGameNightInput }) =>
+      api.gameNights.update(id, input),
+    onSuccess: (_data, { id }) => {
+      queryClient.invalidateQueries({ queryKey: gameNightKeys.detail(id) });
+      queryClient.invalidateQueries({ queryKey: gameNightKeys.all });
+    },
+  });
+}
+
+export function usePublishGameNight() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => api.gameNights.publish(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: gameNightKeys.all });
+    },
+  });
+}
+
+export function useCancelGameNight() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => api.gameNights.cancel(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: gameNightKeys.all });
+    },
+  });
+}
+
+export function useRsvpGameNight() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, response }: { id: string; response: RsvpStatus }) =>
+      api.gameNights.rsvp(id, response),
+    onSuccess: (_data, { id }) => {
+      queryClient.invalidateQueries({ queryKey: gameNightKeys.detail(id) });
+      queryClient.invalidateQueries({ queryKey: gameNightKeys.rsvps(id) });
+      queryClient.invalidateQueries({ queryKey: gameNightKeys.all });
+    },
+  });
+}

--- a/apps/web/src/lib/api/clients/gameNightsClient.ts
+++ b/apps/web/src/lib/api/clients/gameNightsClient.ts
@@ -1,0 +1,83 @@
+/**
+ * Game Nights API Client
+ * Issue #33 — P3 Game Night Frontend
+ */
+
+import { z } from 'zod';
+
+import {
+  GameNightDtoSchema,
+  GameNightRsvpDtoSchema,
+  type GameNightDto,
+  type GameNightRsvpDto,
+  type CreateGameNightInput,
+  type UpdateGameNightInput,
+  type RsvpStatus,
+} from '../schemas/game-nights.schemas';
+
+import type { HttpClient } from '../core/httpClient';
+
+export interface GameNightsClient {
+  getUpcoming(): Promise<GameNightDto[]>;
+  getMine(): Promise<GameNightDto[]>;
+  getById(id: string): Promise<GameNightDto>;
+  getRsvps(id: string): Promise<GameNightRsvpDto[]>;
+  create(data: CreateGameNightInput): Promise<string>;
+  update(id: string, data: UpdateGameNightInput): Promise<void>;
+  publish(id: string): Promise<void>;
+  cancel(id: string): Promise<void>;
+  invite(id: string, userIds: string[]): Promise<void>;
+  rsvp(id: string, response: RsvpStatus): Promise<void>;
+}
+
+export function createGameNightsClient({
+  httpClient,
+}: {
+  httpClient: HttpClient;
+}): GameNightsClient {
+  return {
+    async getUpcoming() {
+      const data = await httpClient.get<GameNightDto[]>('/api/v1/game-nights');
+      return z.array(GameNightDtoSchema).parse(data ?? []);
+    },
+
+    async getMine() {
+      const data = await httpClient.get<GameNightDto[]>('/api/v1/game-nights/mine');
+      return z.array(GameNightDtoSchema).parse(data ?? []);
+    },
+
+    async getById(id) {
+      const data = await httpClient.get<GameNightDto>(`/api/v1/game-nights/${id}`);
+      return GameNightDtoSchema.parse(data);
+    },
+
+    async getRsvps(id) {
+      const data = await httpClient.get<GameNightRsvpDto[]>(`/api/v1/game-nights/${id}/rsvps`);
+      return z.array(GameNightRsvpDtoSchema).parse(data ?? []);
+    },
+
+    async create(input) {
+      return await httpClient.post<string>('/api/v1/game-nights', input);
+    },
+
+    async update(id, input) {
+      await httpClient.put(`/api/v1/game-nights/${id}`, input);
+    },
+
+    async publish(id) {
+      await httpClient.post(`/api/v1/game-nights/${id}/publish`, {});
+    },
+
+    async cancel(id) {
+      await httpClient.post(`/api/v1/game-nights/${id}/cancel`, {});
+    },
+
+    async invite(id, userIds) {
+      await httpClient.post(`/api/v1/game-nights/${id}/invite`, { invitedUserIds: userIds });
+    },
+
+    async rsvp(id, response) {
+      await httpClient.post(`/api/v1/game-nights/${id}/rsvp`, { response });
+    },
+  };
+}

--- a/apps/web/src/lib/api/clients/index.ts
+++ b/apps/web/src/lib/api/clients/index.ts
@@ -36,3 +36,4 @@ export * from './liveSessionsClient'; // ISSUE-5041 — Sessions Redesign
 export * from './sessionTrackingClient'; // ISSUE-5041 — Sessions Redesign
 export * from './gameToolkitClient'; // AI Toolkit Generation
 export * from './sessionStatisticsClient'; // P4: Session Analytics
+export * from './gameNightsClient'; // Issue #33 — Game Nights

--- a/apps/web/src/lib/api/index.ts
+++ b/apps/web/src/lib/api/index.ts
@@ -52,6 +52,7 @@ import {
   createSessionTrackingClient,
   createGameToolkitClient,
   createSessionStatisticsClient,
+  createGameNightsClient,
   type AuthClient,
   type GamesClient,
   type SessionsClient,
@@ -84,6 +85,7 @@ import {
   type SessionTrackingClient,
   type GameToolkitClient,
   type SessionStatisticsClient,
+  type GameNightsClient,
 } from './clients';
 import { HttpClient, type HttpClientConfig } from './core/httpClient';
 
@@ -267,6 +269,9 @@ export interface ApiClient {
   /** Session Analytics Dashboard (P4) */
   sessionStatistics: SessionStatisticsClient;
 
+  /** Game Nights (Issue #33) */
+  gameNights: GameNightsClient;
+
   /** Generic DELETE helper (used in some legacy tests) */
   delete: (path: string) => Promise<void>;
 }
@@ -349,6 +354,7 @@ export function createApiClient(config?: ApiClientConfig): ApiClient {
     sessionTracking: createSessionTrackingClient({ httpClient }), // ISSUE-5041
     gameToolkit: createGameToolkitClient({ httpClient }), // AI Toolkit Generation
     sessionStatistics: createSessionStatisticsClient({ httpClient }), // P4: Session Analytics
+    gameNights: createGameNightsClient({ httpClient }), // Issue #33
     delete: (path: string) => httpClient.delete(path),
   };
 

--- a/apps/web/src/lib/api/schemas/game-nights.schemas.ts
+++ b/apps/web/src/lib/api/schemas/game-nights.schemas.ts
@@ -1,0 +1,61 @@
+/**
+ * Game Nights Zod Schemas
+ * Issue #33 — P3 Game Night Frontend
+ */
+
+import { z } from 'zod';
+
+export const GameNightStatusSchema = z.enum(['Draft', 'Published', 'Cancelled', 'Completed']);
+export type GameNightStatus = z.infer<typeof GameNightStatusSchema>;
+
+export const RsvpStatusSchema = z.enum(['Pending', 'Accepted', 'Declined', 'Maybe']);
+export type RsvpStatus = z.infer<typeof RsvpStatusSchema>;
+
+export const GameNightRsvpDtoSchema = z.object({
+  id: z.string().uuid(),
+  eventId: z.string().uuid(),
+  userId: z.string().uuid(),
+  userName: z.string(),
+  status: RsvpStatusSchema,
+  respondedAt: z.string().nullable(),
+  createdAt: z.string(),
+});
+export type GameNightRsvpDto = z.infer<typeof GameNightRsvpDtoSchema>;
+
+export const GameNightDtoSchema = z.object({
+  id: z.string().uuid(),
+  organizerId: z.string().uuid(),
+  organizerName: z.string(),
+  title: z.string(),
+  description: z.string().nullable(),
+  scheduledAt: z.string(),
+  location: z.string().nullable(),
+  maxPlayers: z.number().nullable(),
+  gameIds: z.array(z.string().uuid()),
+  status: GameNightStatusSchema,
+  acceptedCount: z.number(),
+  pendingCount: z.number(),
+  createdAt: z.string(),
+});
+export type GameNightDto = z.infer<typeof GameNightDtoSchema>;
+
+export const CreateGameNightInputSchema = z.object({
+  title: z.string().min(3).max(200),
+  description: z.string().max(2000).optional(),
+  scheduledAt: z.string(),
+  location: z.string().max(500).optional(),
+  maxPlayers: z.number().min(2).max(50).optional(),
+  gameIds: z.array(z.string().uuid()).max(20).optional(),
+  invitedUserIds: z.array(z.string().uuid()).max(49).optional(),
+});
+export type CreateGameNightInput = z.infer<typeof CreateGameNightInputSchema>;
+
+export const UpdateGameNightInputSchema = z.object({
+  title: z.string().min(3).max(200),
+  description: z.string().max(2000).optional(),
+  scheduledAt: z.string(),
+  location: z.string().max(500).optional(),
+  maxPlayers: z.number().min(2).max(50).optional(),
+  gameIds: z.array(z.string().uuid()).max(20).optional(),
+});
+export type UpdateGameNightInput = z.infer<typeof UpdateGameNightInputSchema>;

--- a/apps/web/src/lib/api/schemas/index.ts
+++ b/apps/web/src/lib/api/schemas/index.ts
@@ -113,3 +113,6 @@ export * from './llm-system-config.schemas';
 
 // A/B Test schemas (Issue #5500)
 export * from './ab-test.schemas';
+
+// Game Nights schemas (Issue #33)
+export * from './game-nights.schemas';

--- a/apps/web/src/lib/api/schemas/notifications.schemas.ts
+++ b/apps/web/src/lib/api/schemas/notifications.schemas.ts
@@ -35,6 +35,11 @@ export const KNOWN_NOTIFICATION_TYPES = [
   'game_proposal_kb_merged',
   'processing_job_failed',
   'agent_linked',
+  'game_night_invitation',
+  'game_night_rsvp_received',
+  'game_night_published',
+  'game_night_cancelled',
+  'game_night_reminder',
 ] as const;
 
 // Defensive schema — accepts any string to prevent API breaking on new backend types
@@ -84,6 +89,12 @@ export const NotificationPreferencesSchema = z.object({
   inAppOnDocumentFailed: z.boolean(),
   inAppOnRetryAvailable: z.boolean(),
   hasPushSubscription: z.boolean(),
+  // Game Night preferences (Issue #33 / #44 / #47)
+  inAppOnGameNightInvitation: z.boolean().optional().default(true),
+  emailOnGameNightInvitation: z.boolean().optional().default(true),
+  pushOnGameNightInvitation: z.boolean().optional().default(true),
+  emailOnGameNightReminder: z.boolean().optional().default(true),
+  pushOnGameNightReminder: z.boolean().optional().default(true),
 });
 export type NotificationPreferences = z.infer<typeof NotificationPreferencesSchema>;
 


### PR DESCRIPTION
## Summary
- Game Nights API client with 10 methods (getUpcoming, getMine, getById, getRsvps, create, update, publish, cancel, invite, rsvp)
- Zod schemas for GameNightDto, GameNightRsvpDto, CreateGameNightInput, UpdateGameNightInput
- React Query hooks for all game night operations
- Pages: listing with tabs (Prossime/Le Mie), detail with RSVP buttons, create form, edit form
- NavConfig with MiniNav tabs + "Nuova Serata" ActionBar button
- 5 new notification types for game night events (invitation, RSVP, published, cancelled, reminder)
- Notification preferences section in settings page (Inviti + Promemoria with email/push/in-app toggles)
- NotificationItem Calendar icon mapping for all game night notification types

## Test plan
- [ ] Navigate to /game-nights — verify listing page renders with tabs
- [ ] Click "Nuova Serata" — verify create form with title, description, date, location, maxPlayers
- [ ] Submit create form — verify redirect to detail page
- [ ] On detail page: verify RSVP buttons (Partecipo/Forse/Non partecipo) for published events
- [ ] On detail page: verify Pubblica/Modifica buttons for draft events
- [ ] Navigate to /settings/notifications — verify "Serate Giochi" sections appear
- [ ] Verify notification preferences toggles work for game night invitations and reminders

Closes #48, #49, #50, #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)