### PR TITLE
fix(ci): boolean input comparison in deploy-staging

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -33,7 +33,7 @@ jobs:
   # Run tests before deploy (unless skipped for emergency)
   test:
     name: Pre-deploy Tests
-    if: github.event_name == 'push' || inputs.skip_tests != 'true'
+    if: github.event_name == 'push' || inputs.skip_tests != true
     uses: ./.github/workflows/ci.yml
     secrets: inherit
 
@@ -42,7 +42,7 @@ jobs:
     name: Build Images
     runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
     needs: [test]
-    if: always() && (needs.test.result == 'success' || (github.event_name == 'workflow_dispatch' && inputs.skip_tests == 'true'))
+    if: always() && (needs.test.result == 'success' || (github.event_name == 'workflow_dispatch' && inputs.skip_tests == true))
     outputs:
       api_image: ${{ steps.meta-api.outputs.tags }}
       web_image: ${{ steps.meta-web.outputs.tags }}


### PR DESCRIPTION
## Summary
- Fix `skip_tests` boolean input comparison in deploy-staging workflow
- GitHub Actions `workflow_dispatch` boolean inputs are actual booleans, not strings
- `inputs.skip_tests == 'true'` always evaluates false — changed to `== true`

## Impact
Without this fix, `skip_tests=true` on workflow_dispatch never bypasses the test gate, causing Build Images to be skipped when tests fail.

## Test plan
- [x] Trigger workflow_dispatch with skip_tests=true and verify Build Images proceeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)