### PR TITLE
feat(email-templates): P4 Admin Template Editor (Issue #33)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Application/Commands/CreateEmailTemplateCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Application/Commands/CreateEmailTemplateCommand.cs
@@ -1,0 +1,15 @@
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.UserNotifications.Application.Commands;
+
+/// <summary>
+/// Command to create a new email template.
+/// Issue #53: CQRS commands for admin email template management.
+/// </summary>
+internal record CreateEmailTemplateCommand(
+    string Name,
+    string Locale,
+    string Subject,
+    string HtmlBody,
+    Guid CreatedBy
+) : ICommand<Guid>;

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Application/Commands/PreviewEmailTemplateCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Application/Commands/PreviewEmailTemplateCommand.cs
@@ -1,0 +1,13 @@
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.UserNotifications.Application.Commands;
+
+/// <summary>
+/// Command to preview a rendered email template with test placeholder data.
+/// Returns the rendered HTML with placeholders replaced by test values.
+/// Issue #53: CQRS commands for admin email template management.
+/// </summary>
+internal record PreviewEmailTemplateCommand(
+    Guid Id,
+    Dictionary<string, string>? TestData
+) : ICommand<string>;

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Application/Commands/PublishEmailTemplateCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Application/Commands/PublishEmailTemplateCommand.cs
@@ -1,0 +1,10 @@
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.UserNotifications.Application.Commands;
+
+/// <summary>
+/// Command to publish (activate) a specific email template version.
+/// Deactivates all other versions of the same (name, locale) pair.
+/// Issue #53: CQRS commands for admin email template management.
+/// </summary>
+internal record PublishEmailTemplateCommand(Guid Id) : ICommand<bool>;

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Application/Commands/UpdateEmailTemplateCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Application/Commands/UpdateEmailTemplateCommand.cs
@@ -1,0 +1,14 @@
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.UserNotifications.Application.Commands;
+
+/// <summary>
+/// Command to update an existing email template's content.
+/// Issue #53: CQRS commands for admin email template management.
+/// </summary>
+internal record UpdateEmailTemplateCommand(
+    Guid Id,
+    string Subject,
+    string HtmlBody,
+    Guid ModifiedBy
+) : ICommand<bool>;

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Application/DTOs/EmailTemplateDto.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Application/DTOs/EmailTemplateDto.cs
@@ -1,0 +1,18 @@
+namespace Api.BoundedContexts.UserNotifications.Application.DTOs;
+
+/// <summary>
+/// Data transfer object for email template.
+/// Issue #52: P4.1 Admin email template management.
+/// </summary>
+public record EmailTemplateDto(
+    Guid Id,
+    string Name,
+    string Locale,
+    string Subject,
+    string HtmlBody,
+    int Version,
+    bool IsActive,
+    Guid? LastModifiedBy,
+    DateTime CreatedAt,
+    DateTime? UpdatedAt
+);

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Application/Handlers/CreateEmailTemplateCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Application/Handlers/CreateEmailTemplateCommandHandler.cs
@@ -1,0 +1,51 @@
+using Api.BoundedContexts.UserNotifications.Application.Commands;
+using Api.BoundedContexts.UserNotifications.Domain.Aggregates;
+using Api.BoundedContexts.UserNotifications.Domain.Repositories;
+using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.UserNotifications.Application.Handlers;
+
+/// <summary>
+/// Handler for CreateEmailTemplateCommand.
+/// Creates a new email template with auto-assigned version number.
+/// Issue #53: CQRS handlers for admin email template management.
+/// </summary>
+internal class CreateEmailTemplateCommandHandler : ICommandHandler<CreateEmailTemplateCommand, Guid>
+{
+    private readonly IEmailTemplateRepository _repository;
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly ILogger<CreateEmailTemplateCommandHandler> _logger;
+
+    public CreateEmailTemplateCommandHandler(
+        IEmailTemplateRepository repository,
+        IUnitOfWork unitOfWork,
+        ILogger<CreateEmailTemplateCommandHandler> logger)
+    {
+        _repository = repository;
+        _unitOfWork = unitOfWork;
+        _logger = logger;
+    }
+
+    public async Task<Guid> Handle(CreateEmailTemplateCommand command, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        var template = EmailTemplate.Create(
+            command.Name,
+            command.Locale,
+            command.Subject,
+            command.HtmlBody,
+            command.CreatedBy);
+
+        await _repository.AddAsync(template, cancellationToken).ConfigureAwait(false);
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        _logger.LogInformation(
+            "Created email template '{Name}' locale '{Locale}' version {Version} with ID {Id}",
+            template.Name, template.Locale, template.Version, template.Id);
+
+        return template.Id;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Application/Handlers/GetEmailTemplateByIdQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Application/Handlers/GetEmailTemplateByIdQueryHandler.cs
@@ -1,0 +1,42 @@
+using Api.BoundedContexts.UserNotifications.Application.DTOs;
+using Api.BoundedContexts.UserNotifications.Application.Queries;
+using Api.BoundedContexts.UserNotifications.Domain.Repositories;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.UserNotifications.Application.Handlers;
+
+/// <summary>
+/// Handler for GetEmailTemplateByIdQuery.
+/// Returns a single email template by ID, or null if not found.
+/// Issue #54: CQRS queries for admin email template management.
+/// </summary>
+internal class GetEmailTemplateByIdQueryHandler : IQueryHandler<GetEmailTemplateByIdQuery, EmailTemplateDto?>
+{
+    private readonly IEmailTemplateRepository _repository;
+
+    public GetEmailTemplateByIdQueryHandler(IEmailTemplateRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task<EmailTemplateDto?> Handle(GetEmailTemplateByIdQuery query, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        var template = await _repository.GetByIdAsync(query.Id, cancellationToken).ConfigureAwait(false);
+
+        return template != null
+            ? new EmailTemplateDto(
+                template.Id,
+                template.Name,
+                template.Locale,
+                template.Subject,
+                template.HtmlBody,
+                template.Version,
+                template.IsActive,
+                template.LastModifiedBy,
+                template.CreatedAt,
+                template.UpdatedAt)
+            : null;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Application/Handlers/GetEmailTemplateVersionsQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Application/Handlers/GetEmailTemplateVersionsQueryHandler.cs
@@ -1,0 +1,46 @@
+using Api.BoundedContexts.UserNotifications.Application.DTOs;
+using Api.BoundedContexts.UserNotifications.Application.Queries;
+using Api.BoundedContexts.UserNotifications.Domain.Repositories;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.UserNotifications.Application.Handlers;
+
+/// <summary>
+/// Handler for GetEmailTemplateVersionsQuery.
+/// Returns all versions of a template by name, optionally filtered by locale.
+/// Issue #54: CQRS queries for admin email template management.
+/// </summary>
+internal class GetEmailTemplateVersionsQueryHandler : IQueryHandler<GetEmailTemplateVersionsQuery, List<EmailTemplateDto>>
+{
+    private readonly IEmailTemplateRepository _repository;
+
+    public GetEmailTemplateVersionsQueryHandler(IEmailTemplateRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task<List<EmailTemplateDto>> Handle(GetEmailTemplateVersionsQuery query, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        var templates = await _repository.GetByNameAsync(query.Name, cancellationToken).ConfigureAwait(false);
+
+        if (!string.IsNullOrWhiteSpace(query.Locale))
+        {
+            var normalizedLocale = query.Locale.Trim().ToLowerInvariant();
+            templates = templates.Where(t => string.Equals(t.Locale, normalizedLocale, StringComparison.Ordinal)).ToList();
+        }
+
+        return templates.Select(t => new EmailTemplateDto(
+            t.Id,
+            t.Name,
+            t.Locale,
+            t.Subject,
+            t.HtmlBody,
+            t.Version,
+            t.IsActive,
+            t.LastModifiedBy,
+            t.CreatedAt,
+            t.UpdatedAt)).ToList();
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Application/Handlers/GetEmailTemplatesQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Application/Handlers/GetEmailTemplatesQueryHandler.cs
@@ -1,0 +1,40 @@
+using Api.BoundedContexts.UserNotifications.Application.DTOs;
+using Api.BoundedContexts.UserNotifications.Application.Queries;
+using Api.BoundedContexts.UserNotifications.Domain.Repositories;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.UserNotifications.Application.Handlers;
+
+/// <summary>
+/// Handler for GetEmailTemplatesQuery.
+/// Returns all templates with optional type and locale filtering.
+/// Issue #54: CQRS queries for admin email template management.
+/// </summary>
+internal class GetEmailTemplatesQueryHandler : IQueryHandler<GetEmailTemplatesQuery, List<EmailTemplateDto>>
+{
+    private readonly IEmailTemplateRepository _repository;
+
+    public GetEmailTemplatesQueryHandler(IEmailTemplateRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task<List<EmailTemplateDto>> Handle(GetEmailTemplatesQuery query, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        var templates = await _repository.GetAllAsync(query.Type, query.Locale, cancellationToken).ConfigureAwait(false);
+
+        return templates.Select(t => new EmailTemplateDto(
+            t.Id,
+            t.Name,
+            t.Locale,
+            t.Subject,
+            t.HtmlBody,
+            t.Version,
+            t.IsActive,
+            t.LastModifiedBy,
+            t.CreatedAt,
+            t.UpdatedAt)).ToList();
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Application/Handlers/PreviewEmailTemplateCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Application/Handlers/PreviewEmailTemplateCommandHandler.cs
@@ -1,0 +1,57 @@
+using System.Net;
+using Api.BoundedContexts.UserNotifications.Application.Commands;
+using Api.BoundedContexts.UserNotifications.Domain.Repositories;
+using Api.SharedKernel.Application.Interfaces;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.UserNotifications.Application.Handlers;
+
+/// <summary>
+/// Handler for PreviewEmailTemplateCommand.
+/// Renders an email template by replacing {{placeholders}} with test data values.
+/// Values are HTML-encoded to prevent XSS in the preview.
+/// Issue #53: CQRS handlers for admin email template management.
+/// </summary>
+internal class PreviewEmailTemplateCommandHandler : ICommandHandler<PreviewEmailTemplateCommand, string>
+{
+    private readonly IEmailTemplateRepository _repository;
+    private readonly ILogger<PreviewEmailTemplateCommandHandler> _logger;
+
+    public PreviewEmailTemplateCommandHandler(
+        IEmailTemplateRepository repository,
+        ILogger<PreviewEmailTemplateCommandHandler> logger)
+    {
+        _repository = repository;
+        _logger = logger;
+    }
+
+    public async Task<string> Handle(PreviewEmailTemplateCommand command, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        var template = await _repository.GetByIdAsync(command.Id, cancellationToken).ConfigureAwait(false);
+        if (template == null)
+        {
+            _logger.LogWarning("Email template {Id} not found for preview", command.Id);
+            return string.Empty;
+        }
+
+        var rendered = template.HtmlBody;
+
+        if (command.TestData != null)
+        {
+            foreach (var kvp in command.TestData)
+            {
+                var placeholder = $"{{{{{kvp.Key}}}}}";
+                var encodedValue = WebUtility.HtmlEncode(kvp.Value);
+                rendered = rendered.Replace(placeholder, encodedValue, StringComparison.OrdinalIgnoreCase);
+            }
+        }
+
+        _logger.LogInformation(
+            "Generated preview for email template '{Name}' locale '{Locale}' version {Version} (ID: {Id})",
+            template.Name, template.Locale, template.Version, template.Id);
+
+        return rendered;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Application/Handlers/PublishEmailTemplateCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Application/Handlers/PublishEmailTemplateCommandHandler.cs
@@ -1,0 +1,72 @@
+using Api.BoundedContexts.UserNotifications.Application.Commands;
+using Api.BoundedContexts.UserNotifications.Domain.Repositories;
+using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.UserNotifications.Application.Handlers;
+
+/// <summary>
+/// Handler for PublishEmailTemplateCommand.
+/// Activates the target template version and deactivates all other versions
+/// of the same (name, locale) pair within a single transaction.
+/// Issue #53: CQRS handlers for admin email template management.
+/// </summary>
+internal class PublishEmailTemplateCommandHandler : ICommandHandler<PublishEmailTemplateCommand, bool>
+{
+    private readonly IEmailTemplateRepository _repository;
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly ILogger<PublishEmailTemplateCommandHandler> _logger;
+
+    public PublishEmailTemplateCommandHandler(
+        IEmailTemplateRepository repository,
+        IUnitOfWork unitOfWork,
+        ILogger<PublishEmailTemplateCommandHandler> logger)
+    {
+        _repository = repository;
+        _unitOfWork = unitOfWork;
+        _logger = logger;
+    }
+
+    public async Task<bool> Handle(PublishEmailTemplateCommand command, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        var template = await _repository.GetByIdAsync(command.Id, cancellationToken).ConfigureAwait(false);
+        if (template == null)
+        {
+            _logger.LogWarning("Email template {Id} not found for publishing", command.Id);
+            return false;
+        }
+
+        await _unitOfWork.BeginTransactionAsync(cancellationToken).ConfigureAwait(false);
+        try
+        {
+            // Deactivate all other versions of the same (name, locale)
+            var allVersions = await _repository.GetByNameAsync(template.Name, cancellationToken).ConfigureAwait(false);
+            foreach (var version in allVersions.Where(v => string.Equals(v.Locale, template.Locale, StringComparison.Ordinal) && v.Id != template.Id && v.IsActive))
+            {
+                version.Deactivate();
+                await _repository.UpdateAsync(version, cancellationToken).ConfigureAwait(false);
+            }
+
+            // Activate the target version
+            template.Activate();
+            await _repository.UpdateAsync(template, cancellationToken).ConfigureAwait(false);
+
+            await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+            await _unitOfWork.CommitTransactionAsync(cancellationToken).ConfigureAwait(false);
+
+            _logger.LogInformation(
+                "Published email template '{Name}' locale '{Locale}' version {Version} (ID: {Id})",
+                template.Name, template.Locale, template.Version, template.Id);
+
+            return true;
+        }
+        catch
+        {
+            await _unitOfWork.RollbackTransactionAsync(cancellationToken).ConfigureAwait(false);
+            throw;
+        }
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Application/Handlers/UpdateEmailTemplateCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Application/Handlers/UpdateEmailTemplateCommandHandler.cs
@@ -1,0 +1,52 @@
+using Api.BoundedContexts.UserNotifications.Application.Commands;
+using Api.BoundedContexts.UserNotifications.Domain.Repositories;
+using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.UserNotifications.Application.Handlers;
+
+/// <summary>
+/// Handler for UpdateEmailTemplateCommand.
+/// Updates subject and HTML body of an existing template.
+/// Issue #53: CQRS handlers for admin email template management.
+/// </summary>
+internal class UpdateEmailTemplateCommandHandler : ICommandHandler<UpdateEmailTemplateCommand, bool>
+{
+    private readonly IEmailTemplateRepository _repository;
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly ILogger<UpdateEmailTemplateCommandHandler> _logger;
+
+    public UpdateEmailTemplateCommandHandler(
+        IEmailTemplateRepository repository,
+        IUnitOfWork unitOfWork,
+        ILogger<UpdateEmailTemplateCommandHandler> logger)
+    {
+        _repository = repository;
+        _unitOfWork = unitOfWork;
+        _logger = logger;
+    }
+
+    public async Task<bool> Handle(UpdateEmailTemplateCommand command, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        var template = await _repository.GetByIdAsync(command.Id, cancellationToken).ConfigureAwait(false);
+        if (template == null)
+        {
+            _logger.LogWarning("Email template {Id} not found for update", command.Id);
+            return false;
+        }
+
+        template.UpdateContent(command.Subject, command.HtmlBody, command.ModifiedBy);
+
+        await _repository.UpdateAsync(template, cancellationToken).ConfigureAwait(false);
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        _logger.LogInformation(
+            "Updated email template '{Name}' locale '{Locale}' version {Version} (ID: {Id})",
+            template.Name, template.Locale, template.Version, template.Id);
+
+        return true;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Application/Queries/GetEmailTemplateByIdQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Application/Queries/GetEmailTemplateByIdQuery.cs
@@ -1,0 +1,10 @@
+using Api.BoundedContexts.UserNotifications.Application.DTOs;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.UserNotifications.Application.Queries;
+
+/// <summary>
+/// Query to get a single email template by ID.
+/// Issue #54: CQRS queries for admin email template management.
+/// </summary>
+internal record GetEmailTemplateByIdQuery(Guid Id) : IQuery<EmailTemplateDto?>;

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Application/Queries/GetEmailTemplateVersionsQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Application/Queries/GetEmailTemplateVersionsQuery.cs
@@ -1,0 +1,13 @@
+using Api.BoundedContexts.UserNotifications.Application.DTOs;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.UserNotifications.Application.Queries;
+
+/// <summary>
+/// Query to get all versions of a template by name, optionally filtered by locale.
+/// Issue #54: CQRS queries for admin email template management.
+/// </summary>
+internal record GetEmailTemplateVersionsQuery(
+    string Name,
+    string? Locale = null
+) : IQuery<List<EmailTemplateDto>>;

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Application/Queries/GetEmailTemplatesQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Application/Queries/GetEmailTemplatesQuery.cs
@@ -1,0 +1,13 @@
+using Api.BoundedContexts.UserNotifications.Application.DTOs;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.UserNotifications.Application.Queries;
+
+/// <summary>
+/// Query to list email templates with optional type and locale filtering.
+/// Issue #54: CQRS queries for admin email template management.
+/// </summary>
+internal record GetEmailTemplatesQuery(
+    string? Type = null,
+    string? Locale = null
+) : IQuery<List<EmailTemplateDto>>;

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Domain/Aggregates/EmailTemplate.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Domain/Aggregates/EmailTemplate.cs
@@ -1,0 +1,143 @@
+using Api.SharedKernel.Domain.Entities;
+
+namespace Api.BoundedContexts.UserNotifications.Domain.Aggregates;
+
+/// <summary>
+/// Aggregate root representing an email template with versioning.
+/// Supports multiple locales, placeholder substitution, and version management.
+/// Only one version per (name, locale) pair can be active at a time.
+/// Issue #52: P4.1 Domain entity for admin email template management.
+/// </summary>
+internal sealed class EmailTemplate : AggregateRoot<Guid>
+{
+    public string Name { get; private set; }
+    public string Locale { get; private set; }
+    public string Subject { get; private set; }
+    public string HtmlBody { get; private set; }
+    public int Version { get; private set; }
+    public bool IsActive { get; private set; }
+    public Guid? LastModifiedBy { get; private set; }
+    public DateTime CreatedAt { get; private set; }
+    public DateTime? UpdatedAt { get; private set; }
+
+#pragma warning disable CS8618
+    private EmailTemplate() : base() { }
+#pragma warning restore CS8618
+
+    private EmailTemplate(
+        Guid id,
+        string name,
+        string locale,
+        string subject,
+        string htmlBody,
+        int version,
+        bool isActive,
+        Guid? lastModifiedBy)
+        : base(id)
+    {
+        Name = !string.IsNullOrWhiteSpace(name) ? name.Trim().ToLowerInvariant() : throw new ArgumentException("Name cannot be empty", nameof(name));
+        Locale = !string.IsNullOrWhiteSpace(locale) ? locale.Trim().ToLowerInvariant() : throw new ArgumentException("Locale cannot be empty", nameof(locale));
+        Subject = !string.IsNullOrWhiteSpace(subject) ? subject : throw new ArgumentException("Subject cannot be empty", nameof(subject));
+        HtmlBody = !string.IsNullOrWhiteSpace(htmlBody) ? htmlBody : throw new ArgumentException("HtmlBody cannot be empty", nameof(htmlBody));
+        Version = version;
+        IsActive = isActive;
+        LastModifiedBy = lastModifiedBy;
+        CreatedAt = DateTime.UtcNow;
+        UpdatedAt = null;
+    }
+
+    /// <summary>
+    /// Factory method to create a new email template (version 1, active by default).
+    /// </summary>
+    public static EmailTemplate Create(string name, string locale, string subject, string htmlBody, Guid createdBy)
+    {
+        return new EmailTemplate(
+            Guid.NewGuid(),
+            name,
+            locale,
+            subject,
+            htmlBody,
+            version: 1,
+            isActive: true,
+            lastModifiedBy: createdBy);
+    }
+
+    /// <summary>
+    /// Creates a new version of this template with updated content.
+    /// The new version starts as inactive until explicitly published.
+    /// </summary>
+    public EmailTemplate CreateNewVersion(string subject, string htmlBody, Guid modifiedBy)
+    {
+        if (string.IsNullOrWhiteSpace(subject))
+            throw new ArgumentException("Subject cannot be empty", nameof(subject));
+        if (string.IsNullOrWhiteSpace(htmlBody))
+            throw new ArgumentException("HtmlBody cannot be empty", nameof(htmlBody));
+
+        return new EmailTemplate(
+            Guid.NewGuid(),
+            Name,
+            Locale,
+            subject,
+            htmlBody,
+            version: Version + 1,
+            isActive: false,
+            lastModifiedBy: modifiedBy);
+    }
+
+    /// <summary>
+    /// Activates this template version.
+    /// Caller must ensure all other versions of the same (name, locale) are deactivated first.
+    /// </summary>
+    public void Activate()
+    {
+        IsActive = true;
+        UpdatedAt = DateTime.UtcNow;
+    }
+
+    /// <summary>
+    /// Deactivates this template version.
+    /// </summary>
+    public void Deactivate()
+    {
+        IsActive = false;
+        UpdatedAt = DateTime.UtcNow;
+    }
+
+    /// <summary>
+    /// Updates the content of this template in-place.
+    /// </summary>
+    public void UpdateContent(string subject, string htmlBody, Guid modifiedBy)
+    {
+        if (string.IsNullOrWhiteSpace(subject))
+            throw new ArgumentException("Subject cannot be empty", nameof(subject));
+        if (string.IsNullOrWhiteSpace(htmlBody))
+            throw new ArgumentException("HtmlBody cannot be empty", nameof(htmlBody));
+
+        Subject = subject;
+        HtmlBody = htmlBody;
+        LastModifiedBy = modifiedBy;
+        UpdatedAt = DateTime.UtcNow;
+    }
+
+    /// <summary>
+    /// Reconstitutes the aggregate from persistence.
+    /// Used by repository when mapping from database entity.
+    /// </summary>
+    internal static EmailTemplate Reconstitute(
+        Guid id,
+        string name,
+        string locale,
+        string subject,
+        string htmlBody,
+        int version,
+        bool isActive,
+        Guid? lastModifiedBy,
+        DateTime createdAt,
+        DateTime? updatedAt)
+    {
+        var template = new EmailTemplate(id, name, locale, subject, htmlBody, version, isActive, lastModifiedBy);
+        template.CreatedAt = createdAt;
+        template.UpdatedAt = updatedAt;
+        return template;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Domain/EmailTemplatePlaceholders.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Domain/EmailTemplatePlaceholders.cs
@@ -1,0 +1,33 @@
+namespace Api.BoundedContexts.UserNotifications.Domain;
+
+/// <summary>
+/// Constants for well-known email template placeholder tokens.
+/// Use these in template HTML bodies: e.g. "Hello {{userName}}, your file {{fileName}} is ready."
+/// Issue #52: P4.1 Domain entity for admin email template management.
+/// </summary>
+internal static class EmailTemplatePlaceholders
+{
+    // Common
+    public const string UserName = "{{userName}}";
+    public const string AppUrl = "{{appUrl}}";
+    public const string UnsubscribeUrl = "{{unsubscribeUrl}}";
+
+    // PDF
+    public const string FileName = "{{fileName}}";
+    public const string DocumentUrl = "{{documentUrl}}";
+
+    // Game Night
+    public const string EventTitle = "{{eventTitle}}";
+    public const string EventDate = "{{eventDate}}";
+    public const string OrganizerName = "{{organizerName}}";
+    public const string EventLocation = "{{eventLocation}}";
+    public const string RsvpUrl = "{{rsvpUrl}}";
+
+    // Admin
+    public const string AlertType = "{{alertType}}";
+    public const string AlertMessage = "{{alertMessage}}";
+
+    // Share Request
+    public const string GameTitle = "{{gameTitle}}";
+    public const string RequestStatus = "{{requestStatus}}";
+}

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Domain/Repositories/IEmailTemplateRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Domain/Repositories/IEmailTemplateRepository.cs
@@ -1,0 +1,19 @@
+using Api.BoundedContexts.UserNotifications.Domain.Aggregates;
+
+namespace Api.BoundedContexts.UserNotifications.Domain.Repositories;
+
+/// <summary>
+/// Repository interface for EmailTemplate aggregate persistence.
+/// Issue #52: P4.1 Domain entity for admin email template management.
+/// </summary>
+internal interface IEmailTemplateRepository
+{
+    Task<EmailTemplate?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default);
+    Task<EmailTemplate?> GetActiveAsync(string name, string locale, CancellationToken cancellationToken = default);
+    Task<List<EmailTemplate>> GetAllActiveAsync(CancellationToken cancellationToken = default);
+    Task<List<EmailTemplate>> GetByNameAsync(string name, CancellationToken cancellationToken = default);
+    Task<List<EmailTemplate>> GetAllAsync(string? type, string? locale, CancellationToken cancellationToken = default);
+    Task<int> GetNextVersionAsync(string name, string locale, CancellationToken cancellationToken = default);
+    Task AddAsync(EmailTemplate template, CancellationToken cancellationToken = default);
+    Task UpdateAsync(EmailTemplate template, CancellationToken cancellationToken = default);
+}

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/DependencyInjection/UserNotificationsServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/DependencyInjection/UserNotificationsServiceExtensions.cs
@@ -26,6 +26,7 @@ internal static class UserNotificationsServiceExtensions
         services.AddScoped<INotificationRepository, NotificationRepository>();
         services.AddScoped<INotificationPreferencesRepository, NotificationPreferencesRepository>();
         services.AddScoped<IEmailQueueRepository, EmailQueueRepository>(); // Issue #4417
+        services.AddScoped<IEmailTemplateRepository, EmailTemplateRepository>(); // Issue #52: Email template admin management
 
         // Register services
         services.AddSingleton<IEmailTemplateService, EmailTemplateService>(); // Issue #4417

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Persistence/EmailTemplateRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Infrastructure/Persistence/EmailTemplateRepository.cs
@@ -1,0 +1,168 @@
+using Api.BoundedContexts.UserNotifications.Domain.Aggregates;
+using Api.BoundedContexts.UserNotifications.Domain.Repositories;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.UserNotifications;
+using Api.SharedKernel.Application.Services;
+using Api.SharedKernel.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.UserNotifications.Infrastructure.Persistence;
+
+/// <summary>
+/// EF Core implementation of EmailTemplate repository.
+/// Maps between domain EmailTemplate aggregate and EmailTemplateEntity persistence model.
+/// Issue #52: P4.1 Domain entity for admin email template management.
+/// </summary>
+internal class EmailTemplateRepository : RepositoryBase, IEmailTemplateRepository
+{
+    public EmailTemplateRepository(MeepleAiDbContext dbContext, IDomainEventCollector eventCollector)
+        : base(dbContext, eventCollector)
+    {
+    }
+
+    public async Task<EmailTemplate?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        var entity = await DbContext.Set<EmailTemplateEntity>()
+            .AsNoTracking()
+            .FirstOrDefaultAsync(e => e.Id == id, cancellationToken).ConfigureAwait(false);
+
+        return entity != null ? MapToDomain(entity) : null;
+    }
+
+    public async Task<EmailTemplate?> GetActiveAsync(string name, string locale, CancellationToken cancellationToken = default)
+    {
+        var normalizedName = name.Trim().ToLowerInvariant();
+        var normalizedLocale = locale.Trim().ToLowerInvariant();
+
+        var entity = await DbContext.Set<EmailTemplateEntity>()
+            .AsNoTracking()
+            .FirstOrDefaultAsync(e => e.IsActive && e.Name == normalizedName && e.Locale == normalizedLocale, cancellationToken).ConfigureAwait(false);
+
+        return entity != null ? MapToDomain(entity) : null;
+    }
+
+    public async Task<List<EmailTemplate>> GetAllActiveAsync(CancellationToken cancellationToken = default)
+    {
+        var entities = await DbContext.Set<EmailTemplateEntity>()
+            .AsNoTracking()
+            .Where(e => e.IsActive)
+            .OrderBy(e => e.Name)
+            .ThenBy(e => e.Locale)
+            .ToListAsync(cancellationToken).ConfigureAwait(false);
+
+        return entities.Select(MapToDomain).ToList();
+    }
+
+    public async Task<List<EmailTemplate>> GetByNameAsync(string name, CancellationToken cancellationToken = default)
+    {
+        var normalizedName = name.Trim().ToLowerInvariant();
+
+        var entities = await DbContext.Set<EmailTemplateEntity>()
+            .AsNoTracking()
+            .Where(e => e.Name == normalizedName)
+            .OrderByDescending(e => e.Version)
+            .ToListAsync(cancellationToken).ConfigureAwait(false);
+
+        return entities.Select(MapToDomain).ToList();
+    }
+
+    public async Task<List<EmailTemplate>> GetAllAsync(string? type, string? locale, CancellationToken cancellationToken = default)
+    {
+        var query = DbContext.Set<EmailTemplateEntity>()
+            .AsNoTracking()
+            .AsQueryable();
+
+        if (!string.IsNullOrWhiteSpace(type))
+        {
+            var normalizedType = type.Trim().ToLowerInvariant();
+            query = query.Where(e => e.Name == normalizedType);
+        }
+
+        if (!string.IsNullOrWhiteSpace(locale))
+        {
+            var normalizedLocale = locale.Trim().ToLowerInvariant();
+            query = query.Where(e => e.Locale == normalizedLocale);
+        }
+
+        var entities = await query
+            .OrderBy(e => e.Name)
+            .ThenBy(e => e.Locale)
+            .ThenByDescending(e => e.Version)
+            .ToListAsync(cancellationToken).ConfigureAwait(false);
+
+        return entities.Select(MapToDomain).ToList();
+    }
+
+    public async Task<int> GetNextVersionAsync(string name, string locale, CancellationToken cancellationToken = default)
+    {
+        var normalizedName = name.Trim().ToLowerInvariant();
+        var normalizedLocale = locale.Trim().ToLowerInvariant();
+
+        var maxVersion = await DbContext.Set<EmailTemplateEntity>()
+            .AsNoTracking()
+            .Where(e => e.Name == normalizedName && e.Locale == normalizedLocale)
+            .MaxAsync(e => (int?)e.Version, cancellationToken).ConfigureAwait(false);
+
+        return (maxVersion ?? 0) + 1;
+    }
+
+    public async Task AddAsync(EmailTemplate template, CancellationToken cancellationToken = default)
+    {
+        CollectDomainEvents(template);
+        var entity = MapToPersistence(template);
+        await DbContext.Set<EmailTemplateEntity>().AddAsync(entity, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task UpdateAsync(EmailTemplate template, CancellationToken cancellationToken = default)
+    {
+        CollectDomainEvents(template);
+        var entity = MapToPersistence(template);
+
+        var tracked = DbContext.ChangeTracker.Entries<EmailTemplateEntity>()
+            .FirstOrDefault(e => e.Entity.Id == entity.Id);
+
+        if (tracked != null)
+        {
+            tracked.CurrentValues.SetValues(entity);
+            tracked.State = EntityState.Modified;
+        }
+        else
+        {
+            DbContext.Set<EmailTemplateEntity>().Update(entity);
+        }
+
+        await Task.CompletedTask.ConfigureAwait(false);
+    }
+
+    private static EmailTemplateEntity MapToPersistence(EmailTemplate template)
+    {
+        return new EmailTemplateEntity
+        {
+            Id = template.Id,
+            Name = template.Name,
+            Locale = template.Locale,
+            Subject = template.Subject,
+            HtmlBody = template.HtmlBody,
+            Version = template.Version,
+            IsActive = template.IsActive,
+            LastModifiedBy = template.LastModifiedBy,
+            CreatedAt = template.CreatedAt,
+            UpdatedAt = template.UpdatedAt
+        };
+    }
+
+    private static EmailTemplate MapToDomain(EmailTemplateEntity entity)
+    {
+        return EmailTemplate.Reconstitute(
+            id: entity.Id,
+            name: entity.Name,
+            locale: entity.Locale,
+            subject: entity.Subject,
+            htmlBody: entity.HtmlBody,
+            version: entity.Version,
+            isActive: entity.IsActive,
+            lastModifiedBy: entity.LastModifiedBy,
+            createdAt: entity.CreatedAt,
+            updatedAt: entity.UpdatedAt);
+    }
+}

--- a/apps/api/src/Api/Infrastructure/Entities/UserNotifications/EmailTemplateEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/UserNotifications/EmailTemplateEntity.cs
@@ -1,0 +1,54 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Api.Infrastructure.Entities.UserNotifications;
+
+/// <summary>
+/// EF Core entity for email templates with versioning support.
+/// Persistence model for EmailTemplate aggregate.
+/// Issue #52: P4.1 Domain entity for admin email template management.
+/// </summary>
+[Table("email_templates")]
+public class EmailTemplateEntity
+{
+    [Key]
+    [Column("id")]
+    public Guid Id { get; set; } = Guid.NewGuid();
+
+    [Required]
+    [MaxLength(100)]
+    [Column("name")]
+    public string Name { get; set; } = string.Empty;
+
+    [Required]
+    [MaxLength(10)]
+    [Column("locale")]
+    public string Locale { get; set; } = string.Empty;
+
+    [Required]
+    [MaxLength(500)]
+    [Column("subject")]
+    public string Subject { get; set; } = string.Empty;
+
+    [Required]
+    [Column("html_body", TypeName = "text")]
+    public string HtmlBody { get; set; } = string.Empty;
+
+    [Required]
+    [Column("version")]
+    public int Version { get; set; } = 1;
+
+    [Required]
+    [Column("is_active")]
+    public bool IsActive { get; set; } = true;
+
+    [Column("last_modified_by")]
+    public Guid? LastModifiedBy { get; set; }
+
+    [Required]
+    [Column("created_at")]
+    public DateTime CreatedAt { get; set; } = DateTime.UtcNow;
+
+    [Column("updated_at")]
+    public DateTime? UpdatedAt { get; set; }
+}

--- a/apps/api/src/Api/Infrastructure/MeepleAiDbContext.cs
+++ b/apps/api/src/Api/Infrastructure/MeepleAiDbContext.cs
@@ -194,6 +194,9 @@ public class MeepleAiDbContext : DbContext
     // Issue #4417: Email notification queue
     public DbSet<Api.Infrastructure.Entities.UserNotifications.EmailQueueEntity> EmailQueueItems => Set<Api.Infrastructure.Entities.UserNotifications.EmailQueueEntity>();
 
+    // Issue #52: Email template admin management
+    public DbSet<Api.Infrastructure.Entities.UserNotifications.EmailTemplateEntity> EmailTemplates => Set<Api.Infrastructure.Entities.UserNotifications.EmailTemplateEntity>();
+
     protected override void OnConfiguring(DbContextOptionsBuilder optionsBuilder)
     {
         ArgumentNullException.ThrowIfNull(optionsBuilder);

--- a/apps/api/src/Api/Program.cs
+++ b/apps/api/src/Api/Program.cs
@@ -534,6 +534,7 @@ v1Api.MapAdminPdfManagementEndpoints(); // PDF Storage Management Hub: Bulk ops,
 v1Api.MapAdminQueueEndpoints();         // Issue #4731: Processing queue management
 v1Api.MapAdminStorageMigrationEndpoints(); // S3 storage migration (local → S3)
 v1Api.MapAdminEmailEndpoints();        // Issue #4430: Email queue dashboard monitoring
+v1Api.MapAdminEmailTemplateEndpoints(); // Issue #52: Admin email template management
 v1Api.MapAdminBusinessStatsEndpoints(); // Issue #4562: App Usage Stats (Epic #3688)
 v1Api.MapAdminAgentDefinitionEndpoints(); // Issue #3809: Agent Definition management (AI Lab)
 v1Api.MapAgentPlaygroundEndpoints();    // Issue #3810: Agent Playground with SSE streaming

--- a/apps/api/src/Api/Routing/AdminEmailTemplateEndpoints.cs
+++ b/apps/api/src/Api/Routing/AdminEmailTemplateEndpoints.cs
@@ -1,3 +1,4 @@
+using Api.BoundedContexts.Authentication.Application.DTOs;
 using Api.BoundedContexts.UserNotifications.Application.Commands;
 using Api.BoundedContexts.UserNotifications.Application.Queries;
 using Api.Filters;
@@ -67,11 +68,15 @@ internal static class AdminEmailTemplateEndpoints
 
     private static async Task<IResult> CreateEmailTemplate(
         CreateEmailTemplateRequest request,
+        HttpContext context,
         IMediator mediator,
         CancellationToken cancellationToken = default)
     {
+        var session = context.Items[nameof(SessionStatusDto)] as SessionStatusDto;
+        var userId = session!.User!.Id;
+
         var id = await mediator.Send(
-            new CreateEmailTemplateCommand(request.Name, request.Locale, request.Subject, request.HtmlBody, request.CreatedBy),
+            new CreateEmailTemplateCommand(request.Name, request.Locale, request.Subject, request.HtmlBody, userId),
             cancellationToken).ConfigureAwait(false);
 
         return Results.Created($"/admin/email-templates/{id}", new { id });
@@ -80,11 +85,15 @@ internal static class AdminEmailTemplateEndpoints
     private static async Task<IResult> UpdateEmailTemplate(
         Guid id,
         UpdateEmailTemplateRequest request,
+        HttpContext context,
         IMediator mediator,
         CancellationToken cancellationToken = default)
     {
+        var session = context.Items[nameof(SessionStatusDto)] as SessionStatusDto;
+        var userId = session!.User!.Id;
+
         var result = await mediator.Send(
-            new UpdateEmailTemplateCommand(id, request.Subject, request.HtmlBody, request.ModifiedBy),
+            new UpdateEmailTemplateCommand(id, request.Subject, request.HtmlBody, userId),
             cancellationToken).ConfigureAwait(false);
 
         return result ? Results.Ok(new { success = true }) : Results.NotFound();
@@ -110,7 +119,7 @@ internal static class AdminEmailTemplateEndpoints
             cancellationToken).ConfigureAwait(false);
 
         return !string.IsNullOrEmpty(result)
-            ? Results.Content(result, "text/html")
+            ? Results.Ok(new { html = result })
             : Results.NotFound();
     }
 
@@ -128,6 +137,6 @@ internal static class AdminEmailTemplateEndpoints
     }
 }
 
-internal record CreateEmailTemplateRequest(string Name, string Locale, string Subject, string HtmlBody, Guid CreatedBy);
-internal record UpdateEmailTemplateRequest(string Subject, string HtmlBody, Guid ModifiedBy);
+internal record CreateEmailTemplateRequest(string Name, string Locale, string Subject, string HtmlBody);
+internal record UpdateEmailTemplateRequest(string Subject, string HtmlBody);
 internal record PreviewEmailTemplateRequest(Dictionary<string, string>? TestData);

--- a/apps/api/src/Api/Routing/AdminEmailTemplateEndpoints.cs
+++ b/apps/api/src/Api/Routing/AdminEmailTemplateEndpoints.cs
@@ -1,0 +1,133 @@
+using Api.BoundedContexts.UserNotifications.Application.Commands;
+using Api.BoundedContexts.UserNotifications.Application.Queries;
+using Api.Filters;
+using MediatR;
+
+namespace Api.Routing;
+
+/// <summary>
+/// Admin endpoints for email template management (CRUD, versioning, preview).
+/// Issue #56: Admin endpoints for email template management.
+/// </summary>
+internal static class AdminEmailTemplateEndpoints
+{
+    public static void MapAdminEmailTemplateEndpoints(this IEndpointRouteBuilder app)
+    {
+        var group = app.MapGroup("/admin/email-templates")
+            .WithTags("Admin - Email Templates")
+            .AddEndpointFilter<RequireAdminSessionFilter>();
+
+        group.MapGet("/", GetEmailTemplates)
+            .WithName("GetEmailTemplates")
+            .WithSummary("List email templates with optional type and locale filtering");
+
+        group.MapGet("/{id:guid}", GetEmailTemplate)
+            .WithName("GetEmailTemplateById")
+            .WithSummary("Get a single email template by ID");
+
+        group.MapPost("/", CreateEmailTemplate)
+            .WithName("CreateEmailTemplate")
+            .WithSummary("Create a new email template");
+
+        group.MapPut("/{id:guid}", UpdateEmailTemplate)
+            .WithName("UpdateEmailTemplate")
+            .WithSummary("Update an existing email template's content");
+
+        group.MapPost("/{id:guid}/publish", PublishEmailTemplate)
+            .WithName("PublishEmailTemplate")
+            .WithSummary("Publish (activate) a template version, deactivating others");
+
+        group.MapPost("/{id:guid}/preview", PreviewEmailTemplate)
+            .WithName("PreviewEmailTemplate")
+            .WithSummary("Preview a rendered template with test placeholder data");
+
+        group.MapGet("/{name}/versions", GetEmailTemplateVersions)
+            .WithName("GetEmailTemplateVersions")
+            .WithSummary("Get all versions of a template by name");
+    }
+
+    private static async Task<IResult> GetEmailTemplates(
+        IMediator mediator,
+        string? type = null,
+        string? locale = null,
+        CancellationToken cancellationToken = default)
+    {
+        var result = await mediator.Send(new GetEmailTemplatesQuery(type, locale), cancellationToken).ConfigureAwait(false);
+        return Results.Ok(result);
+    }
+
+    private static async Task<IResult> GetEmailTemplate(
+        Guid id,
+        IMediator mediator,
+        CancellationToken cancellationToken = default)
+    {
+        var result = await mediator.Send(new GetEmailTemplateByIdQuery(id), cancellationToken).ConfigureAwait(false);
+        return result != null ? Results.Ok(result) : Results.NotFound();
+    }
+
+    private static async Task<IResult> CreateEmailTemplate(
+        CreateEmailTemplateRequest request,
+        IMediator mediator,
+        CancellationToken cancellationToken = default)
+    {
+        var id = await mediator.Send(
+            new CreateEmailTemplateCommand(request.Name, request.Locale, request.Subject, request.HtmlBody, request.CreatedBy),
+            cancellationToken).ConfigureAwait(false);
+
+        return Results.Created($"/admin/email-templates/{id}", new { id });
+    }
+
+    private static async Task<IResult> UpdateEmailTemplate(
+        Guid id,
+        UpdateEmailTemplateRequest request,
+        IMediator mediator,
+        CancellationToken cancellationToken = default)
+    {
+        var result = await mediator.Send(
+            new UpdateEmailTemplateCommand(id, request.Subject, request.HtmlBody, request.ModifiedBy),
+            cancellationToken).ConfigureAwait(false);
+
+        return result ? Results.Ok(new { success = true }) : Results.NotFound();
+    }
+
+    private static async Task<IResult> PublishEmailTemplate(
+        Guid id,
+        IMediator mediator,
+        CancellationToken cancellationToken = default)
+    {
+        var result = await mediator.Send(new PublishEmailTemplateCommand(id), cancellationToken).ConfigureAwait(false);
+        return result ? Results.Ok(new { success = true }) : Results.NotFound();
+    }
+
+    private static async Task<IResult> PreviewEmailTemplate(
+        Guid id,
+        PreviewEmailTemplateRequest? request,
+        IMediator mediator,
+        CancellationToken cancellationToken = default)
+    {
+        var result = await mediator.Send(
+            new PreviewEmailTemplateCommand(id, request?.TestData),
+            cancellationToken).ConfigureAwait(false);
+
+        return !string.IsNullOrEmpty(result)
+            ? Results.Content(result, "text/html")
+            : Results.NotFound();
+    }
+
+    private static async Task<IResult> GetEmailTemplateVersions(
+        string name,
+        IMediator mediator,
+        string? locale = null,
+        CancellationToken cancellationToken = default)
+    {
+        var result = await mediator.Send(
+            new GetEmailTemplateVersionsQuery(name, locale),
+            cancellationToken).ConfigureAwait(false);
+
+        return Results.Ok(result);
+    }
+}
+
+internal record CreateEmailTemplateRequest(string Name, string Locale, string Subject, string HtmlBody, Guid CreatedBy);
+internal record UpdateEmailTemplateRequest(string Subject, string HtmlBody, Guid ModifiedBy);
+internal record PreviewEmailTemplateRequest(Dictionary<string, string>? TestData);

--- a/apps/web/src/app/admin/(dashboard)/content/email-templates/_content.tsx
+++ b/apps/web/src/app/admin/(dashboard)/content/email-templates/_content.tsx
@@ -1,0 +1,631 @@
+'use client';
+
+import * as React from 'react';
+
+import {
+  Copy,
+  Eye,
+  Globe,
+  History,
+  Monitor,
+  Plus,
+  Save,
+  Search,
+  Send,
+  Smartphone,
+} from 'lucide-react';
+
+import {
+  Badge,
+  Button,
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+  Input,
+  Label,
+} from '@/components/ui';
+import { Skeleton } from '@/components/ui/feedback/skeleton';
+import {
+  Dialog,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/overlays/dialog';
+import { ScrollArea } from '@/components/ui/primitives/scroll-area';
+import { Textarea } from '@/components/ui/primitives/textarea';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import {
+  useCreateEmailTemplate,
+  useEmailTemplates,
+  useEmailTemplateVersions,
+  usePreviewEmailTemplate,
+  usePublishEmailTemplate,
+  useUpdateEmailTemplate,
+} from '@/hooks/queries/useEmailTemplates';
+import { useToast } from '@/hooks/use-toast';
+import type { EmailTemplateDto } from '@/lib/api';
+
+import { getPlaceholdersForType, getDefaultTestData } from './_placeholders';
+
+// ─── Locale Helpers ──────────────────────────────────────────────────────────
+
+const LOCALE_OPTIONS = [
+  { value: 'all', label: 'Tutte le lingue' },
+  { value: 'it', label: 'Italiano' },
+  { value: 'en', label: 'English' },
+] as const;
+
+function localeFlag(locale: string): string {
+  switch (locale.toLowerCase()) {
+    case 'it':
+      return '\u{1F1EE}\u{1F1F9}';
+    case 'en':
+      return '\u{1F1EC}\u{1F1E7}';
+    default:
+      return '\u{1F310}';
+  }
+}
+
+// ─── Main Content ────────────────────────────────────────────────────────────
+
+export function EmailTemplatesContent() {
+  const { toast } = useToast();
+
+  // Filters
+  const [search, setSearch] = React.useState('');
+  const [localeFilter, setLocaleFilter] = React.useState('all');
+
+  // Selection
+  const [selectedId, setSelectedId] = React.useState<string | null>(null);
+
+  // Editor state
+  const [editSubject, setEditSubject] = React.useState('');
+  const [editHtmlBody, setEditHtmlBody] = React.useState('');
+  const textareaRef = React.useRef<HTMLTextAreaElement>(null);
+
+  // Preview
+  const [previewOpen, setPreviewOpen] = React.useState(false);
+  const [previewHtml, setPreviewHtml] = React.useState('');
+  const [previewWidth, setPreviewWidth] = React.useState<'desktop' | 'mobile'>('desktop');
+  const [testData, setTestData] = React.useState<Record<string, string>>({});
+
+  // Create dialog
+  const [createOpen, setCreateOpen] = React.useState(false);
+  const [newName, setNewName] = React.useState('');
+  const [newLocale, setNewLocale] = React.useState('it');
+  const [newSubject, setNewSubject] = React.useState('');
+  const [newHtmlBody, setNewHtmlBody] = React.useState('');
+
+  // Version history
+  const [versionsOpen, setVersionsOpen] = React.useState(false);
+
+  // Queries
+  const queryParams = localeFilter === 'all' ? undefined : { locale: localeFilter };
+  const { data: templates, isLoading } = useEmailTemplates(queryParams);
+
+  const selected = React.useMemo(
+    () => templates?.find(t => t.id === selectedId) ?? null,
+    [templates, selectedId]
+  );
+
+  const { data: versions } = useEmailTemplateVersions(selected?.name ?? '', selected?.locale);
+
+  // Mutations
+  const updateMutation = useUpdateEmailTemplate();
+  const publishMutation = usePublishEmailTemplate();
+  const previewMutation = usePreviewEmailTemplate();
+  const createMutation = useCreateEmailTemplate();
+
+  // Sync editor state when selection changes
+  React.useEffect(() => {
+    if (selected) {
+      setEditSubject(selected.subject);
+      setEditHtmlBody(selected.htmlBody);
+      setTestData(getDefaultTestData(selected.name));
+    }
+  }, [selected]);
+
+  // Filter templates
+  const filtered = React.useMemo(() => {
+    if (!templates) return [];
+    const q = search.toLowerCase().trim();
+    if (!q) return templates;
+    return templates.filter(
+      t => t.name.toLowerCase().includes(q) || t.subject.toLowerCase().includes(q)
+    );
+  }, [templates, search]);
+
+  // ── Handlers ─────────────────────────────────────────────────────────────
+
+  const handleSaveDraft = React.useCallback(async () => {
+    if (!selectedId) return;
+    try {
+      await updateMutation.mutateAsync({
+        id: selectedId,
+        data: { subject: editSubject, htmlBody: editHtmlBody },
+      });
+      toast({ title: 'Bozza salvata', description: 'Nuova versione creata con successo.' });
+    } catch {
+      toast({
+        title: 'Errore',
+        description: 'Impossibile salvare la bozza.',
+        variant: 'destructive',
+      });
+    }
+  }, [selectedId, editSubject, editHtmlBody, updateMutation, toast]);
+
+  const handlePublish = React.useCallback(async () => {
+    if (!selectedId) return;
+    try {
+      await publishMutation.mutateAsync(selectedId);
+      toast({ title: 'Pubblicato', description: 'Il template è ora attivo.' });
+    } catch {
+      toast({
+        title: 'Errore',
+        description: 'Impossibile pubblicare il template.',
+        variant: 'destructive',
+      });
+    }
+  }, [selectedId, publishMutation, toast]);
+
+  const handlePreview = React.useCallback(async () => {
+    if (!selectedId) return;
+    try {
+      const html = await previewMutation.mutateAsync({ id: selectedId, testData });
+      setPreviewHtml(html);
+      setPreviewOpen(true);
+    } catch {
+      toast({
+        title: 'Errore',
+        description: "Impossibile generare l'anteprima.",
+        variant: 'destructive',
+      });
+    }
+  }, [selectedId, testData, previewMutation, toast]);
+
+  const handleCreate = React.useCallback(async () => {
+    try {
+      const result = await createMutation.mutateAsync({
+        name: newName,
+        locale: newLocale,
+        subject: newSubject,
+        htmlBody: newHtmlBody,
+      });
+      setCreateOpen(false);
+      setNewName('');
+      setNewSubject('');
+      setNewHtmlBody('');
+      setSelectedId(result.id);
+      toast({ title: 'Template creato', description: `"${newName}" creato con successo.` });
+    } catch {
+      toast({
+        title: 'Errore',
+        description: 'Impossibile creare il template.',
+        variant: 'destructive',
+      });
+    }
+  }, [newName, newLocale, newSubject, newHtmlBody, createMutation, toast]);
+
+  const handleInsertPlaceholder = React.useCallback(
+    (placeholder: string) => {
+      const tag = `{{${placeholder}}}`;
+      const textarea = textareaRef.current;
+      if (textarea) {
+        const start = textarea.selectionStart;
+        const end = textarea.selectionEnd;
+        const before = editHtmlBody.slice(0, start);
+        const after = editHtmlBody.slice(end);
+        const newValue = before + tag + after;
+        setEditHtmlBody(newValue);
+        // Restore cursor position after React re-render
+        requestAnimationFrame(() => {
+          textarea.focus();
+          const pos = start + tag.length;
+          textarea.setSelectionRange(pos, pos);
+        });
+      } else {
+        setEditHtmlBody(prev => prev + tag);
+      }
+    },
+    [editHtmlBody]
+  );
+
+  const handleLoadVersion = React.useCallback(
+    (version: EmailTemplateDto) => {
+      setEditSubject(version.subject);
+      setEditHtmlBody(version.htmlBody);
+      setVersionsOpen(false);
+      toast({
+        title: 'Versione caricata',
+        description: `Versione ${version.version} caricata nell'editor.`,
+      });
+    },
+    [toast]
+  );
+
+  // ── Placeholders for selected template ───────────────────────────────────
+
+  const placeholders = React.useMemo(
+    () => (selected ? getPlaceholdersForType(selected.name) : []),
+    [selected]
+  );
+
+  // ── Render ───────────────────────────────────────────────────────────────
+
+  return (
+    <div className="flex h-[calc(100vh-12rem)] gap-4 p-6">
+      {/* ─── Left Panel: Template List ─── */}
+      <div className="flex w-80 shrink-0 flex-col gap-3">
+        <div className="flex items-center justify-between">
+          <h1 className="font-quicksand text-lg font-bold tracking-tight text-foreground">
+            Template Email
+          </h1>
+          <Button size="sm" variant="outline" onClick={() => setCreateOpen(true)}>
+            <Plus className="mr-1 h-4 w-4" />
+            Nuovo
+          </Button>
+        </div>
+
+        {/* Search */}
+        <div className="relative">
+          <Search className="absolute left-3 top-1/2 h-4 w-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            placeholder="Cerca template..."
+            value={search}
+            onChange={(e: React.ChangeEvent<HTMLInputElement>) => setSearch(e.target.value)}
+            className="pl-9"
+          />
+        </div>
+
+        {/* Locale filter */}
+        <Select value={localeFilter} onValueChange={setLocaleFilter}>
+          <SelectTrigger className="w-full">
+            <Globe className="mr-2 h-4 w-4 text-muted-foreground" />
+            <SelectValue placeholder="Lingua" />
+          </SelectTrigger>
+          <SelectContent>
+            {LOCALE_OPTIONS.map(opt => (
+              <SelectItem key={opt.value} value={opt.value}>
+                {opt.label}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        {/* Template list */}
+        <ScrollArea className="flex-1">
+          {isLoading ? (
+            <div className="space-y-2">
+              {Array.from({ length: 5 }).map((_, i) => (
+                <Skeleton key={i} className="h-16 w-full rounded-lg" />
+              ))}
+            </div>
+          ) : filtered.length === 0 ? (
+            <p className="py-8 text-center text-sm text-muted-foreground">
+              Nessun template trovato.
+            </p>
+          ) : (
+            <div className="space-y-1.5 pr-2">
+              {filtered.map(t => (
+                <button
+                  key={t.id}
+                  type="button"
+                  onClick={() => setSelectedId(t.id)}
+                  className={`w-full rounded-lg border p-3 text-left transition-colors hover:bg-accent/50 ${
+                    selectedId === t.id ? 'border-primary bg-primary/5' : 'border-border bg-card'
+                  }`}
+                >
+                  <div className="flex items-center justify-between">
+                    <span className="text-sm font-medium truncate">{t.name}</span>
+                    <Badge
+                      variant={t.isActive ? 'default' : 'secondary'}
+                      className="ml-2 shrink-0 text-xs"
+                    >
+                      {t.isActive ? 'Attivo' : 'Bozza'}
+                    </Badge>
+                  </div>
+                  <div className="mt-1 flex items-center gap-2 text-xs text-muted-foreground">
+                    <span>
+                      {localeFlag(t.locale)} {t.locale.toUpperCase()}
+                    </span>
+                    <span>v{t.version}</span>
+                  </div>
+                </button>
+              ))}
+            </div>
+          )}
+        </ScrollArea>
+      </div>
+
+      {/* ─── Right Panel: Editor ─── */}
+      <div className="flex flex-1 flex-col gap-4 overflow-hidden">
+        {!selected ? (
+          <div className="flex flex-1 items-center justify-center">
+            <p className="text-sm text-muted-foreground">
+              Seleziona un template dalla lista per iniziare a modificarlo.
+            </p>
+          </div>
+        ) : (
+          <>
+            {/* Header */}
+            <div className="flex items-center justify-between">
+              <div className="flex items-center gap-3">
+                <h2 className="font-quicksand text-xl font-bold">{selected.name}</h2>
+                <Badge variant="outline">
+                  {localeFlag(selected.locale)} {selected.locale.toUpperCase()}
+                </Badge>
+                <Badge variant="secondary">v{selected.version}</Badge>
+                <Badge variant={selected.isActive ? 'default' : 'secondary'}>
+                  {selected.isActive ? 'Attivo' : 'Bozza'}
+                </Badge>
+              </div>
+              <Button size="sm" variant="ghost" onClick={() => setVersionsOpen(true)}>
+                <History className="mr-1 h-4 w-4" />
+                Cronologia
+              </Button>
+            </div>
+
+            {/* Subject */}
+            <div className="space-y-1.5">
+              <Label htmlFor="template-subject">Oggetto</Label>
+              <Input
+                id="template-subject"
+                value={editSubject}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                  setEditSubject(e.target.value)
+                }
+                placeholder="Oggetto dell'email..."
+              />
+            </div>
+
+            {/* HTML Body */}
+            <div className="flex flex-1 flex-col gap-1.5 overflow-hidden">
+              <Label htmlFor="template-body">Corpo HTML</Label>
+              <Textarea
+                ref={textareaRef}
+                id="template-body"
+                value={editHtmlBody}
+                onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
+                  setEditHtmlBody(e.target.value)
+                }
+                className="flex-1 resize-none font-mono text-sm"
+                style={{ minHeight: '300px' }}
+                placeholder="<html>...</html>"
+              />
+            </div>
+
+            {/* Placeholders */}
+            {placeholders.length > 0 && (
+              <Card className="shrink-0">
+                <CardHeader className="py-2 px-3">
+                  <CardTitle className="text-xs font-medium text-muted-foreground">
+                    Placeholder disponibili
+                  </CardTitle>
+                </CardHeader>
+                <CardContent className="flex flex-wrap gap-1.5 px-3 pb-3 pt-0">
+                  {placeholders.map(p => (
+                    <button
+                      key={p}
+                      type="button"
+                      onClick={() => handleInsertPlaceholder(p)}
+                      className="inline-flex items-center gap-1 rounded-md border border-dashed border-border bg-muted/50 px-2 py-1 text-xs font-mono text-muted-foreground transition-colors hover:bg-accent hover:text-accent-foreground"
+                      title={`Inserisci {{${p}}}`}
+                    >
+                      <Copy className="h-3 w-3" />
+                      {`{{${p}}}`}
+                    </button>
+                  ))}
+                </CardContent>
+              </Card>
+            )}
+
+            {/* Test Data for Preview */}
+            <Card className="shrink-0">
+              <CardHeader className="py-2 px-3">
+                <CardTitle className="text-xs font-medium text-muted-foreground">
+                  Dati di test (per anteprima)
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="px-3 pb-3 pt-0">
+                <div className="grid grid-cols-2 gap-2 lg:grid-cols-3">
+                  {placeholders.map(p => (
+                    <div key={p} className="space-y-1">
+                      <Label className="text-xs">{p}</Label>
+                      <Input
+                        value={testData[p] ?? ''}
+                        onChange={(e: React.ChangeEvent<HTMLInputElement>) =>
+                          setTestData(prev => ({ ...prev, [p]: e.target.value }))
+                        }
+                        className="h-8 text-xs"
+                        placeholder={p}
+                      />
+                    </div>
+                  ))}
+                </div>
+              </CardContent>
+            </Card>
+
+            {/* Action Buttons */}
+            <div className="flex shrink-0 items-center gap-2 border-t pt-3">
+              <Button
+                onClick={handleSaveDraft}
+                disabled={updateMutation.isPending}
+                variant="outline"
+              >
+                <Save className="mr-1 h-4 w-4" />
+                {updateMutation.isPending ? 'Salvataggio...' : 'Salva bozza'}
+              </Button>
+              <Button onClick={handlePublish} disabled={publishMutation.isPending}>
+                <Send className="mr-1 h-4 w-4" />
+                {publishMutation.isPending ? 'Pubblicazione...' : 'Pubblica'}
+              </Button>
+              <Button
+                onClick={handlePreview}
+                disabled={previewMutation.isPending}
+                variant="secondary"
+              >
+                <Eye className="mr-1 h-4 w-4" />
+                {previewMutation.isPending ? 'Generazione...' : 'Anteprima'}
+              </Button>
+            </div>
+          </>
+        )}
+      </div>
+
+      {/* ─── Preview Dialog ─── */}
+      <Dialog open={previewOpen} onOpenChange={setPreviewOpen}>
+        <DialogContent className="max-w-4xl max-h-[90vh] flex flex-col">
+          <DialogHeader>
+            <DialogTitle className="flex items-center justify-between">
+              <span>Anteprima Email</span>
+              <div className="flex items-center gap-1">
+                <Button
+                  size="sm"
+                  variant={previewWidth === 'desktop' ? 'default' : 'outline'}
+                  onClick={() => setPreviewWidth('desktop')}
+                >
+                  <Monitor className="h-4 w-4" />
+                </Button>
+                <Button
+                  size="sm"
+                  variant={previewWidth === 'mobile' ? 'default' : 'outline'}
+                  onClick={() => setPreviewWidth('mobile')}
+                >
+                  <Smartphone className="h-4 w-4" />
+                </Button>
+              </div>
+            </DialogTitle>
+          </DialogHeader>
+          <div className="flex-1 overflow-auto flex justify-center bg-muted/30 rounded-lg p-4">
+            <iframe
+              title="Anteprima email"
+              srcDoc={previewHtml}
+              sandbox="allow-same-origin"
+              className="border rounded-lg bg-white"
+              style={{
+                width: previewWidth === 'desktop' ? '100%' : '375px',
+                maxWidth: '100%',
+                height: '600px',
+              }}
+            />
+          </div>
+        </DialogContent>
+      </Dialog>
+
+      {/* ─── Create Dialog ─── */}
+      <Dialog open={createOpen} onOpenChange={setCreateOpen}>
+        <DialogContent className="max-w-lg">
+          <DialogHeader>
+            <DialogTitle>Nuovo Template Email</DialogTitle>
+          </DialogHeader>
+          <div className="space-y-4">
+            <div className="space-y-1.5">
+              <Label htmlFor="new-name">Nome template</Label>
+              <Input
+                id="new-name"
+                value={newName}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) => setNewName(e.target.value)}
+                placeholder="es. game_night_invitation"
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="new-locale">Lingua</Label>
+              <Select value={newLocale} onValueChange={setNewLocale}>
+                <SelectTrigger id="new-locale" className="w-full">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="it">Italiano</SelectItem>
+                  <SelectItem value="en">English</SelectItem>
+                </SelectContent>
+              </Select>
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="new-subject">Oggetto</Label>
+              <Input
+                id="new-subject"
+                value={newSubject}
+                onChange={(e: React.ChangeEvent<HTMLInputElement>) => setNewSubject(e.target.value)}
+                placeholder="Oggetto dell'email..."
+              />
+            </div>
+            <div className="space-y-1.5">
+              <Label htmlFor="new-body">Corpo HTML</Label>
+              <Textarea
+                id="new-body"
+                value={newHtmlBody}
+                onChange={(e: React.ChangeEvent<HTMLTextAreaElement>) =>
+                  setNewHtmlBody(e.target.value)
+                }
+                className="font-mono text-sm"
+                rows={8}
+                placeholder="<html>...</html>"
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setCreateOpen(false)}>
+              Annulla
+            </Button>
+            <Button
+              onClick={handleCreate}
+              disabled={createMutation.isPending || !newName || !newSubject || !newHtmlBody}
+            >
+              {createMutation.isPending ? 'Creazione...' : 'Crea template'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      {/* ─── Version History Dialog ─── */}
+      <Dialog open={versionsOpen} onOpenChange={setVersionsOpen}>
+        <DialogContent className="max-w-lg">
+          <DialogHeader>
+            <DialogTitle>Cronologia versioni &mdash; {selected?.name}</DialogTitle>
+          </DialogHeader>
+          <ScrollArea className="max-h-[400px]">
+            {!versions || versions.length === 0 ? (
+              <p className="py-8 text-center text-sm text-muted-foreground">
+                Nessuna versione precedente.
+              </p>
+            ) : (
+              <div className="space-y-2 pr-2">
+                {versions.map(v => (
+                  <Card key={v.id} className="cursor-pointer hover:bg-accent/50 transition-colors">
+                    <CardContent className="flex items-center justify-between p-3">
+                      <div>
+                        <div className="flex items-center gap-2">
+                          <span className="font-medium text-sm">v{v.version}</span>
+                          <Badge variant={v.isActive ? 'default' : 'secondary'} className="text-xs">
+                            {v.isActive ? 'Attivo' : 'Bozza'}
+                          </Badge>
+                        </div>
+                        <p className="text-xs text-muted-foreground mt-0.5">
+                          {new Date(v.createdAt).toLocaleString('it-IT')}
+                        </p>
+                        <p className="text-xs text-muted-foreground truncate max-w-[280px]">
+                          {v.subject}
+                        </p>
+                      </div>
+                      <Button size="sm" variant="ghost" onClick={() => handleLoadVersion(v)}>
+                        Carica
+                      </Button>
+                    </CardContent>
+                  </Card>
+                ))}
+              </div>
+            )}
+          </ScrollArea>
+        </DialogContent>
+      </Dialog>
+    </div>
+  );
+}

--- a/apps/web/src/app/admin/(dashboard)/content/email-templates/_placeholders.ts
+++ b/apps/web/src/app/admin/(dashboard)/content/email-templates/_placeholders.ts
@@ -1,0 +1,63 @@
+/**
+ * Email Template Placeholders Configuration
+ *
+ * Maps template names to their available placeholders
+ * and provides default test data for preview rendering.
+ */
+
+export const TEMPLATE_PLACEHOLDERS: Record<string, string[]> = {
+  // Common (available for all templates)
+  _common: ['userName', 'appUrl', 'unsubscribeUrl'],
+  // PDF
+  pdf_ready: ['fileName', 'documentUrl'],
+  document_failed: ['fileName', 'errorMessage'],
+  retry_available: ['fileName', 'retryCount'],
+  // Game Night
+  game_night_invitation: ['eventTitle', 'eventDate', 'organizerName', 'eventLocation', 'rsvpUrl'],
+  game_night_reminder: ['eventTitle', 'eventDate', 'eventLocation'],
+  game_night_cancelled: ['eventTitle', 'organizerName'],
+  // Share Request
+  share_request_created: ['gameTitle', 'requestStatus'],
+  share_request_approved: ['gameTitle'],
+  share_request_rejected: ['gameTitle'],
+  // Admin
+  admin_digest: ['alertType', 'alertMessage'],
+  // Badge
+  badge_earned: ['badgeName', 'badgeDescription'],
+};
+
+export const DEFAULT_TEST_DATA: Record<string, Record<string, string>> = {
+  _common: {
+    userName: 'Mario Rossi',
+    appUrl: 'https://meepleai.app',
+    unsubscribeUrl: '#',
+  },
+  pdf_ready: { fileName: 'catan-rules.pdf', documentUrl: '#' },
+  game_night_invitation: {
+    eventTitle: 'Serata Catan',
+    eventDate: 'Sabato 15 Mar, 20:00',
+    organizerName: 'Mario',
+    eventLocation: 'Casa di Mario',
+    rsvpUrl: '#',
+  },
+};
+
+/**
+ * Get all placeholders applicable to a template by name.
+ * Returns common placeholders + template-specific ones.
+ */
+export function getPlaceholdersForType(templateName: string): string[] {
+  const common = TEMPLATE_PLACEHOLDERS._common ?? [];
+  const specific = TEMPLATE_PLACEHOLDERS[templateName] ?? [];
+  return [...common, ...specific];
+}
+
+/**
+ * Get default test data for a template (for preview rendering).
+ */
+export function getDefaultTestData(templateName: string): Record<string, string> {
+  return {
+    ...(DEFAULT_TEST_DATA._common ?? {}),
+    ...(DEFAULT_TEST_DATA[templateName] ?? {}),
+  };
+}

--- a/apps/web/src/app/admin/(dashboard)/content/email-templates/_skeleton.tsx
+++ b/apps/web/src/app/admin/(dashboard)/content/email-templates/_skeleton.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+import { Skeleton } from '@/components/ui/feedback/skeleton';
+
+export function EmailTemplatesSkeleton() {
+  return (
+    <div className="flex h-[calc(100vh-12rem)] gap-4 p-6">
+      {/* Left panel skeleton */}
+      <div className="w-80 shrink-0 space-y-3">
+        <Skeleton className="h-10 w-full rounded-lg" />
+        <Skeleton className="h-10 w-full rounded-lg" />
+        <div className="space-y-2 pt-2">
+          {Array.from({ length: 6 }).map((_, i) => (
+            <Skeleton key={i} className="h-16 w-full rounded-lg" />
+          ))}
+        </div>
+      </div>
+      {/* Right panel skeleton */}
+      <div className="flex-1 space-y-4">
+        <Skeleton className="h-8 w-64 rounded-lg" />
+        <Skeleton className="h-10 w-full rounded-lg" />
+        <Skeleton className="h-[400px] w-full rounded-lg" />
+        <div className="flex gap-2">
+          <Skeleton className="h-10 w-32 rounded-lg" />
+          <Skeleton className="h-10 w-32 rounded-lg" />
+          <Skeleton className="h-10 w-32 rounded-lg" />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/admin/(dashboard)/content/email-templates/page.tsx
+++ b/apps/web/src/app/admin/(dashboard)/content/email-templates/page.tsx
@@ -1,0 +1,18 @@
+/**
+ * Admin Email Templates Page (Issue #52-#56)
+ *
+ * Server component wrapper with Suspense boundary.
+ */
+
+import { Suspense } from 'react';
+
+import { EmailTemplatesContent } from './_content';
+import { EmailTemplatesSkeleton } from './_skeleton';
+
+export default function EmailTemplatesPage() {
+  return (
+    <Suspense fallback={<EmailTemplatesSkeleton />}>
+      <EmailTemplatesContent />
+    </Suspense>
+  );
+}

--- a/apps/web/src/config/admin-dashboard-navigation.ts
+++ b/apps/web/src/config/admin-dashboard-navigation.ts
@@ -118,7 +118,12 @@ export const DASHBOARD_SECTIONS: DashboardSection[] = [
     label: 'Content',
     icon: FileTextIcon,
     baseRoute: '/admin/shared-games',
-    additionalRoutes: ['/admin/content', '/admin/knowledge-base', '/admin/games'],
+    additionalRoutes: [
+      '/admin/content',
+      '/admin/knowledge-base',
+      '/admin/games',
+      '/admin/content/email-templates',
+    ],
     description: 'Games, documents, vectors, and RAG pipeline',
     group: 'core',
     sidebarItems: [
@@ -170,6 +175,12 @@ export const DASHBOARD_SECTIONS: DashboardSection[] = [
         href: '/admin/knowledge-base/upload',
         label: 'Upload & Process',
         icon: UploadIcon,
+      },
+      // Email Templates (Issue #52)
+      {
+        href: '/admin/content/email-templates',
+        label: 'Email Templates',
+        icon: MailIcon,
       },
     ],
   },

--- a/apps/web/src/hooks/queries/index.ts
+++ b/apps/web/src/hooks/queries/index.ts
@@ -193,6 +193,18 @@ export { useRulebookAnalysis, rulebookAnalysisKeys } from './useRulebookAnalysis
 // Game Setup Wizard queries (Issue #5583)
 export { useGameAnalysis, useGameExpansions, gameSetupKeys } from './useGameSetup';
 
+// Email Templates queries and mutations (Issue #52-#56)
+export {
+  useEmailTemplates,
+  useEmailTemplate,
+  useEmailTemplateVersions,
+  useCreateEmailTemplate,
+  useUpdateEmailTemplate,
+  usePublishEmailTemplate,
+  usePreviewEmailTemplate,
+  emailTemplateKeys,
+} from './useEmailTemplates';
+
 // Re-export from @tanstack/react-query for convenience
 export {
   useQuery,

--- a/apps/web/src/hooks/queries/useEmailTemplates.ts
+++ b/apps/web/src/hooks/queries/useEmailTemplates.ts
@@ -1,0 +1,87 @@
+/**
+ * Email Templates Query Hooks (Issue #52-#56)
+ *
+ * TanStack Query hooks for admin email template CRUD,
+ * preview, publish, and version history.
+ */
+
+import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { api } from '@/lib/api';
+import type { CreateEmailTemplateInput, UpdateEmailTemplateInput } from '@/lib/api';
+
+// ─── Query Keys ──────────────────────────────────────────────────────────────
+
+export const emailTemplateKeys = {
+  all: ['email-templates'] as const,
+  list: (params?: { type?: string; locale?: string }) =>
+    [...emailTemplateKeys.all, 'list', params] as const,
+  detail: (id: string) => [...emailTemplateKeys.all, 'detail', id] as const,
+  versions: (name: string, locale?: string) =>
+    [...emailTemplateKeys.all, 'versions', name, locale] as const,
+};
+
+// ─── Queries ─────────────────────────────────────────────────────────────────
+
+export function useEmailTemplates(params?: { type?: string; locale?: string }) {
+  return useQuery({
+    queryKey: emailTemplateKeys.list(params),
+    queryFn: () => api.admin.getEmailTemplates(params),
+  });
+}
+
+export function useEmailTemplate(id: string) {
+  return useQuery({
+    queryKey: emailTemplateKeys.detail(id),
+    queryFn: () => api.admin.getEmailTemplate(id),
+    enabled: !!id,
+  });
+}
+
+export function useEmailTemplateVersions(name: string, locale?: string) {
+  return useQuery({
+    queryKey: emailTemplateKeys.versions(name, locale),
+    queryFn: () => api.admin.getEmailTemplateVersions(name, locale),
+    enabled: !!name,
+  });
+}
+
+// ─── Mutations ───────────────────────────────────────────────────────────────
+
+export function useCreateEmailTemplate() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (data: CreateEmailTemplateInput) => api.admin.createEmailTemplate(data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: emailTemplateKeys.all });
+    },
+  });
+}
+
+export function useUpdateEmailTemplate() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, data }: { id: string; data: UpdateEmailTemplateInput }) =>
+      api.admin.updateEmailTemplate(id, data),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: emailTemplateKeys.all });
+    },
+  });
+}
+
+export function usePublishEmailTemplate() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (id: string) => api.admin.publishEmailTemplate(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: emailTemplateKeys.all });
+    },
+  });
+}
+
+export function usePreviewEmailTemplate() {
+  return useMutation({
+    mutationFn: ({ id, testData }: { id: string; testData?: Record<string, string> }) =>
+      api.admin.previewEmailTemplate(id, testData),
+  });
+}

--- a/apps/web/src/lib/api/clients/adminClient.ts
+++ b/apps/web/src/lib/api/clients/adminClient.ts
@@ -125,6 +125,11 @@ import {
   type AbTestSessionRevealedDto,
   AbTestAnalyticsDtoSchema,
   type AbTestAnalyticsDto,
+  EmailTemplateDtoSchema,
+  GetEmailTemplatesResponseSchema,
+  type EmailTemplateDto,
+  type CreateEmailTemplateInput,
+  type UpdateEmailTemplateInput,
 } from '../schemas';
 import {
   BulkDeleteResultSchema,
@@ -2825,6 +2830,101 @@ export function createAdminClient({ httpClient }: CreateAdminClientParams) {
         z.object({ success: z.boolean() })
       );
       return result?.success ?? false;
+    },
+
+    // ========== Email Templates (Issue #52-#56) ==========
+
+    /**
+     * List email templates with optional filters.
+     * GET /api/v1/admin/email-templates
+     */
+    async getEmailTemplates(params?: {
+      type?: string;
+      locale?: string;
+    }): Promise<EmailTemplateDto[]> {
+      const searchParams = new URLSearchParams();
+      if (params?.type) searchParams.set('type', params.type);
+      if (params?.locale) searchParams.set('locale', params.locale);
+      const query = searchParams.toString();
+      const result = await httpClient.get(
+        `/api/v1/admin/email-templates${query ? `?${query}` : ''}`,
+        GetEmailTemplatesResponseSchema
+      );
+      return result ?? [];
+    },
+
+    /**
+     * Get a single email template by ID.
+     * GET /api/v1/admin/email-templates/:id
+     */
+    async getEmailTemplate(id: string): Promise<EmailTemplateDto> {
+      const result = await httpClient.get(
+        `/api/v1/admin/email-templates/${id}`,
+        EmailTemplateDtoSchema
+      );
+      if (!result) throw new Error(`Email template ${id} not found`);
+      return result;
+    },
+
+    /**
+     * Create a new email template.
+     * POST /api/v1/admin/email-templates
+     */
+    async createEmailTemplate(data: CreateEmailTemplateInput): Promise<{ id: string }> {
+      return httpClient.post<{ id: string }>(
+        '/api/v1/admin/email-templates',
+        data,
+        z.object({ id: z.string().uuid() })
+      );
+    },
+
+    /**
+     * Update an existing email template (creates new version).
+     * PUT /api/v1/admin/email-templates/:id
+     */
+    async updateEmailTemplate(
+      id: string,
+      data: UpdateEmailTemplateInput
+    ): Promise<{ success: boolean }> {
+      return httpClient.put<{ success: boolean }>(
+        `/api/v1/admin/email-templates/${id}`,
+        data,
+        z.object({ success: z.boolean() })
+      );
+    },
+
+    /**
+     * Publish (activate) an email template version.
+     * POST /api/v1/admin/email-templates/:id/publish
+     */
+    async publishEmailTemplate(id: string): Promise<void> {
+      await httpClient.post('/api/v1/admin/email-templates/' + id + '/publish', {});
+    },
+
+    /**
+     * Preview rendered email template with test data.
+     * POST /api/v1/admin/email-templates/:id/preview
+     */
+    async previewEmailTemplate(id: string, testData?: Record<string, string>): Promise<string> {
+      const result = await httpClient.post<{ html: string }>(
+        `/api/v1/admin/email-templates/${id}/preview`,
+        { testData },
+        z.object({ html: z.string() })
+      );
+      return result.html;
+    },
+
+    /**
+     * Get version history for a template by name.
+     * GET /api/v1/admin/email-templates/:name/versions
+     */
+    async getEmailTemplateVersions(name: string, locale?: string): Promise<EmailTemplateDto[]> {
+      const params = locale ? `?locale=${locale}` : '';
+      const result = await httpClient.get(
+        `/api/v1/admin/email-templates/${name}/versions${params}`,
+        GetEmailTemplatesResponseSchema
+      );
+      return result ?? [];
     },
   };
 }

--- a/apps/web/src/lib/api/schemas/email-templates.schemas.ts
+++ b/apps/web/src/lib/api/schemas/email-templates.schemas.ts
@@ -1,0 +1,47 @@
+/**
+ * Email Templates Schemas (Issue #52-#56)
+ *
+ * Zod validation schemas for admin email template management.
+ */
+
+import { z } from 'zod';
+
+// ─── DTOs ────────────────────────────────────────────────────────────────────
+
+export const EmailTemplateDtoSchema = z.object({
+  id: z.string().uuid(),
+  name: z.string(),
+  locale: z.string(),
+  subject: z.string(),
+  htmlBody: z.string(),
+  version: z.number().int(),
+  isActive: z.boolean(),
+  lastModifiedBy: z.string().uuid().nullable().optional(),
+  createdAt: z.string().datetime(),
+  updatedAt: z.string().datetime().nullable().optional(),
+});
+export type EmailTemplateDto = z.infer<typeof EmailTemplateDtoSchema>;
+
+export const GetEmailTemplatesResponseSchema = z.array(EmailTemplateDtoSchema);
+export type GetEmailTemplatesResponse = z.infer<typeof GetEmailTemplatesResponseSchema>;
+
+// ─── Input Schemas ───────────────────────────────────────────────────────────
+
+export const CreateEmailTemplateInputSchema = z.object({
+  name: z.string().min(1).max(100),
+  locale: z.string().min(2).max(10),
+  subject: z.string().min(1).max(500),
+  htmlBody: z.string().min(1),
+});
+export type CreateEmailTemplateInput = z.infer<typeof CreateEmailTemplateInputSchema>;
+
+export const UpdateEmailTemplateInputSchema = z.object({
+  subject: z.string().min(1).max(500),
+  htmlBody: z.string().min(1),
+});
+export type UpdateEmailTemplateInput = z.infer<typeof UpdateEmailTemplateInputSchema>;
+
+export const PreviewEmailTemplateInputSchema = z.object({
+  testData: z.record(z.string(), z.string()).optional(),
+});
+export type PreviewEmailTemplateInput = z.infer<typeof PreviewEmailTemplateInputSchema>;

--- a/apps/web/src/lib/api/schemas/index.ts
+++ b/apps/web/src/lib/api/schemas/index.ts
@@ -116,3 +116,6 @@ export * from './ab-test.schemas';
 
 // Game Nights schemas (Issue #33)
 export * from './game-nights.schemas';
+
+// Email Templates schemas (Issue #52-#56)
+export * from './email-templates.schemas';


### PR DESCRIPTION
## Summary
- **P4.1** (#52): EmailTemplate domain entity with versioning, locale, active/draft lifecycle
- **P4.2** (#53): Admin UI at `/admin/content/email-templates` — two-panel editor with search, locale filter, placeholder insertion, version history
- **P4.3** (#54): Preview modal with desktop/mobile toggle, sandboxed iframe, customizable test data
- **P4.4** (#55): Backend CQRS commands/queries/handlers for create, update, publish, preview, list, versions
- **P4.5** (#56): i18n support (IT/EN locale), placeholder configuration per template type

## Changes
- **Backend** (16 new files): EmailTemplate aggregate, EF entity, repository, 4 commands + 3 queries with handlers, admin REST endpoints, placeholder constants
- **Frontend** (6 new files): Zod schemas, React Query hooks, admin page with editor/preview/version dialogs, placeholder config
- **Modified**: adminClient (+7 methods), navigation config, DI registration, DbContext, Program.cs routing

## Test plan
- [ ] Backend compiles with 0 errors (verified)
- [ ] Frontend builds with 0 errors (verified)
- [ ] TypeScript check passes (verified)
- [ ] Navigate to `/admin/content/email-templates` — page loads
- [ ] Create new template (name + locale + subject + HTML body)
- [ ] Edit template subject and HTML body
- [ ] Publish template (activates it, deactivates other versions)
- [ ] Preview with test data in sandboxed iframe
- [ ] Toggle desktop/mobile preview width
- [ ] Click placeholder chips to insert at cursor
- [ ] View version history for a template
- [ ] Filter templates by locale (IT/EN)
- [ ] Search templates by name

Closes #52, #53, #54, #55, #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)