### PR TITLE
fix(kb): migrate ProcessingStatus to ProcessingState enum (#96)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/ProcessPendingPdfs/ProcessPendingPdfsCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/ProcessPendingPdfs/ProcessPendingPdfsCommandHandler.cs
@@ -33,12 +33,15 @@ internal sealed class ProcessPendingPdfsCommandHandler : ICommandHandler<Process
     {
         ArgumentNullException.ThrowIfNull(command);
 
-        // Find all PDFs in pending or processing status, ordered by priority (Admin first)
+        // Find all PDFs not in terminal states (Ready/Failed), ordered by priority (Admin first)
+        var readyState = nameof(Api.BoundedContexts.DocumentProcessing.Domain.Enums.PdfProcessingState.Ready);
+        var failedState = nameof(Api.BoundedContexts.DocumentProcessing.Domain.Enums.PdfProcessingState.Failed);
+
         var pendingPdfs = await _dbContext.PdfDocuments
-            .Where(p => p.ProcessingStatus == "pending" || p.ProcessingStatus == "processing")
+            .Where(p => p.ProcessingState != readyState && p.ProcessingState != failedState)
             .OrderByDescending(p => p.ProcessingPriority) // Admin > Normal
             .ThenBy(p => p.UploadedAt)
-            .Select(p => new { p.Id, p.FileName, p.ProcessingStatus })
+            .Select(p => new { p.Id, p.FileName, p.ProcessingState })
             .ToListAsync(cancellationToken)
             .ConfigureAwait(false);
 

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Handlers/Queue/GetDashboardMetricsQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Handlers/Queue/GetDashboardMetricsQueryHandler.cs
@@ -44,12 +44,15 @@ internal sealed class GetDashboardMetricsQueryHandler
         var docs = _db.Set<PdfDocumentEntity>()
             .Where(d => d.UploadedAt >= cutoff);
 
+        var readyState = nameof(Api.BoundedContexts.DocumentProcessing.Domain.Enums.PdfProcessingState.Ready);
+        var failedState = nameof(Api.BoundedContexts.DocumentProcessing.Domain.Enums.PdfProcessingState.Failed);
+
         var totalProcessed = await docs
-            .CountAsync(d => d.ProcessingStatus == "completed", cancellationToken)
+            .CountAsync(d => d.ProcessingState == readyState, cancellationToken)
             .ConfigureAwait(false);
 
         var totalFailed = await docs
-            .CountAsync(d => d.ProcessingStatus == "failed", cancellationToken)
+            .CountAsync(d => d.ProcessingState == failedState, cancellationToken)
             .ConfigureAwait(false);
 
         var total = totalProcessed + totalFailed;

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Queries/GetAllPdfsQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Queries/GetAllPdfsQueryHandler.cs
@@ -28,10 +28,32 @@ internal sealed class GetAllPdfsQueryHandler : IQueryHandler<GetAllPdfsQuery, Pd
             .Include(p => p.Game)
             .AsQueryable();
 
-        // Filter by legacy status
+        // Filter by legacy status — map to ProcessingState when possible
         if (!string.IsNullOrWhiteSpace(query.Status))
         {
-            pdfsQuery = pdfsQuery.Where(p => p.ProcessingStatus == query.Status);
+            var mappedState = query.Status switch
+            {
+                "pending" => nameof(Api.BoundedContexts.DocumentProcessing.Domain.Enums.PdfProcessingState.Pending),
+                "completed" => nameof(Api.BoundedContexts.DocumentProcessing.Domain.Enums.PdfProcessingState.Ready),
+                "failed" => nameof(Api.BoundedContexts.DocumentProcessing.Domain.Enums.PdfProcessingState.Failed),
+                _ => (string?)null
+            };
+
+            if (mappedState != null)
+            {
+                pdfsQuery = pdfsQuery.Where(p => p.ProcessingState == mappedState);
+            }
+            else
+            {
+                // "processing" maps to multiple states — filter out terminal states
+                var readyState = nameof(Api.BoundedContexts.DocumentProcessing.Domain.Enums.PdfProcessingState.Ready);
+                var failedState = nameof(Api.BoundedContexts.DocumentProcessing.Domain.Enums.PdfProcessingState.Failed);
+                var pendingState = nameof(Api.BoundedContexts.DocumentProcessing.Domain.Enums.PdfProcessingState.Pending);
+                pdfsQuery = pdfsQuery.Where(p =>
+                    p.ProcessingState != readyState &&
+                    p.ProcessingState != failedState &&
+                    p.ProcessingState != pendingState);
+            }
         }
 
         // Filter by 7-state processing state

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Domain/Repositories/IPdfDocumentRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Domain/Repositories/IPdfDocumentRepository.cs
@@ -1,4 +1,5 @@
 using Api.BoundedContexts.DocumentProcessing.Domain.Entities;
+using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
 using Api.SharedKernel.Infrastructure.Persistence;
 
 namespace Api.BoundedContexts.DocumentProcessing.Domain.Repositories;
@@ -7,7 +8,11 @@ internal interface IPdfDocumentRepository : IRepository<PdfDocument, Guid>
 {
     Task<IReadOnlyList<PdfDocument>> FindByGameIdAsync(Guid gameId, CancellationToken cancellationToken = default);
     Task<IReadOnlyList<PdfDocument>> FindByPrivateGameIdAsync(Guid privateGameId, CancellationToken cancellationToken = default); // Issue #3664
+#pragma warning disable S1133 // Deprecated code kept for backward compatibility during migration (Issue #96)
+    [Obsolete("Use FindByStateAsync(PdfProcessingState) instead. This method queries the deprecated ProcessingStatus column.")]
     Task<IReadOnlyList<PdfDocument>> FindByStatusAsync(string status, CancellationToken cancellationToken = default);
+#pragma warning restore S1133
+    Task<IReadOnlyList<PdfDocument>> FindByStateAsync(PdfProcessingState state, CancellationToken cancellationToken = default); // Issue #96
     Task<IReadOnlyList<PdfDocument>> GetByIdsAsync(IEnumerable<Guid> ids, CancellationToken cancellationToken = default);
     Task<IReadOnlyList<PdfDocument>> FindByUserIdAsync(Guid userId, CancellationToken cancellationToken = default); // Issue #2732: Quota queries
     Task<bool> ExistsByContentHashAsync(string contentHash, Guid? gameId, Guid? privateGameId, CancellationToken cancellationToken = default);

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/Persistence/PdfDocumentRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Infrastructure/Persistence/PdfDocumentRepository.cs
@@ -77,11 +77,26 @@ internal class PdfDocumentRepository : RepositoryBase, IPdfDocumentRepository
         return entities.Select(MapToDomain).ToList();
     }
 
+#pragma warning disable S1133 // Deprecated code kept for backward compatibility during migration (Issue #96)
+    [Obsolete("Use FindByStateAsync(PdfProcessingState) instead. This method queries the deprecated ProcessingStatus column.")]
+#pragma warning restore S1133
     public async Task<IReadOnlyList<PdfDocument>> FindByStatusAsync(string status, CancellationToken cancellationToken = default)
     {
         var entities = await DbContext.PdfDocuments
             .AsNoTracking()
             .Where(p => p.ProcessingStatus == status)
+            .OrderByDescending(p => p.UploadedAt)
+            .ToListAsync(cancellationToken).ConfigureAwait(false);
+
+        return entities.Select(MapToDomain).ToList();
+    }
+
+    public async Task<IReadOnlyList<PdfDocument>> FindByStateAsync(PdfProcessingState state, CancellationToken cancellationToken = default)
+    {
+        var stateString = state.ToString();
+        var entities = await DbContext.PdfDocuments
+            .AsNoTracking()
+            .Where(p => p.ProcessingState == stateString)
             .OrderByDescending(p => p.UploadedAt)
             .ToListAsync(cancellationToken).ConfigureAwait(false);
 

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/AskAgentQuestionCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/AskAgentQuestionCommandHandler.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics;
+using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
 using Api.BoundedContexts.DocumentProcessing.Domain.Repositories;
 using Api.BoundedContexts.GameManagement.Application.DTOs.GameSessionContext;
 using Api.BoundedContexts.GameManagement.Application.Services;
@@ -115,14 +116,20 @@ internal class AskAgentQuestionCommandHandler : IRequestHandler<AskAgentQuestion
             if (documents.Count > 0)
             {
                 var notCompleted = documents.Count(d =>
-                    !string.Equals(d.ProcessingStatus, "completed", StringComparison.OrdinalIgnoreCase));
+                    d.ProcessingState != PdfProcessingState.Ready);
                 if (notCompleted > 0)
                 {
+                    // Build state breakdown for better diagnostics
+                    var stateBreakdown = documents
+                        .GroupBy(d => d.ProcessingState)
+                        .Select(g => $"{g.Key}={g.Count()}")
+                        .ToList();
+
                     _logger.LogInformation(
-                        "Documents not ready for game {GameId}: {Processing}/{Total} still processing",
-                        request.GameId, notCompleted, documents.Count);
+                        "Documents not ready for game {GameId}: {NotReady}/{Total} not ready. States: {States}",
+                        request.GameId, notCompleted, documents.Count, string.Join(", ", stateBreakdown));
                     throw new InvalidOperationException(
-                        $"{notCompleted} of {documents.Count} documents are still being processed. Please wait for processing to complete before asking questions.");
+                        $"{notCompleted} of {documents.Count} documents are not ready (states: {string.Join(", ", stateBreakdown)}). Please wait for processing to complete before asking questions.");
                 }
             }
         }

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Handlers/AskQuestionQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Handlers/AskQuestionQueryHandler.cs
@@ -1,3 +1,4 @@
+using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
 using Api.BoundedContexts.DocumentProcessing.Domain.Repositories;
 using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
 using Api.BoundedContexts.KnowledgeBase.Application.Queries;
@@ -349,7 +350,7 @@ internal class AskQuestionQueryHandler : IQueryHandler<AskQuestionQuery, QaRespo
         if (documents is null or { Count: 0 }) return (true, 0, 0);
 
         var notCompleted = documents.Count(d =>
-            !string.Equals(d.ProcessingStatus, "completed", StringComparison.OrdinalIgnoreCase));
+            d.ProcessingState != PdfProcessingState.Ready);
         return (notCompleted == 0, notCompleted, documents.Count);
     }
 }

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Handlers/StreamDebugQaQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Handlers/StreamDebugQaQueryHandler.cs
@@ -1,3 +1,4 @@
+using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
 using Api.BoundedContexts.DocumentProcessing.Domain.Repositories;
 using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
 using Api.BoundedContexts.KnowledgeBase.Application.Queries;
@@ -494,7 +495,7 @@ internal class StreamDebugQaQueryHandler : IStreamingQueryHandler<StreamDebugQaQ
         if (documents is null or { Count: 0 }) return (true, 0, 0);
 
         var notCompleted = documents.Count(d =>
-            !string.Equals(d.ProcessingStatus, "completed", StringComparison.OrdinalIgnoreCase));
+            d.ProcessingState != PdfProcessingState.Ready);
         return (notCompleted == 0, notCompleted, documents.Count);
     }
 

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Handlers/StreamQaQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Handlers/StreamQaQueryHandler.cs
@@ -1,3 +1,4 @@
+using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
 using Api.BoundedContexts.DocumentProcessing.Domain.Repositories;
 using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
 using Api.BoundedContexts.KnowledgeBase.Application.Queries;
@@ -412,7 +413,7 @@ internal class StreamQaQueryHandler : IStreamingQueryHandler<StreamQaQuery, RagS
         if (documents is null or { Count: 0 }) return (true, 0, 0);
 
         var notCompleted = documents.Count(d =>
-            !string.Equals(d.ProcessingStatus, "completed", StringComparison.OrdinalIgnoreCase));
+            d.ProcessingState != PdfProcessingState.Ready);
         return (notCompleted == 0, notCompleted, documents.Count);
     }
 

--- a/apps/api/src/Api/BoundedContexts/UserLibrary/Application/Handlers/GetGameWizardPreviewQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/UserLibrary/Application/Handlers/GetGameWizardPreviewQueryHandler.cs
@@ -62,7 +62,7 @@ internal class GetGameWizardPreviewQueryHandler : IQueryHandler<GetGameWizardPre
                 Id: d.Id,
                 FileName: d.FileName.Value,
                 PageCount: d.PageCount,
-                Status: d.ProcessingStatus,
+                Status: d.ProcessingState.ToString(),
                 DocumentType: d.DocumentType?.Value ?? "base"
             ))
             .ToList();

--- a/apps/api/src/Api/Infrastructure/BackgroundServices/StalePdfRecoveryService.cs
+++ b/apps/api/src/Api/Infrastructure/BackgroundServices/StalePdfRecoveryService.cs
@@ -1,4 +1,5 @@
 using Api.BoundedContexts.DocumentProcessing.Application.Services;
+using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
 using Api.Infrastructure.Entities;
 using Microsoft.EntityFrameworkCore;
 
@@ -130,16 +131,28 @@ internal sealed class StalePdfRecoveryService : BackgroundService
         var pendingCutoff = now - PendingStaleness;
         var processingCutoff = now - ProcessingStaleness;
 
+        // Use ProcessingState enum (stored as string) instead of deprecated ProcessingStatus
+        var pendingState = nameof(PdfProcessingState.Pending);
+        var uploadingState = nameof(PdfProcessingState.Uploading);
+        var extractingState = nameof(PdfProcessingState.Extracting);
+        var chunkingState = nameof(PdfProcessingState.Chunking);
+        var embeddingState = nameof(PdfProcessingState.Embedding);
+        var indexingState = nameof(PdfProcessingState.Indexing);
+
         return await db.PdfDocuments
             .Where(p =>
-                (p.ProcessingStatus == "pending" && p.UploadedAt < pendingCutoff) ||
-                (p.ProcessingStatus == "processing" && p.UploadedAt < processingCutoff))
+                (p.ProcessingState == pendingState && p.UploadedAt < pendingCutoff) ||
+                ((p.ProcessingState == uploadingState ||
+                  p.ProcessingState == extractingState ||
+                  p.ProcessingState == chunkingState ||
+                  p.ProcessingState == embeddingState ||
+                  p.ProcessingState == indexingState) && p.UploadedAt < processingCutoff))
             .Select(p => new StalePdfInfo
             {
                 Id = p.Id,
                 FilePath = p.FilePath,
                 UploadedByUserId = p.UploadedByUserId,
-                OriginalStatus = p.ProcessingStatus,
+                OriginalStatus = p.ProcessingState,
                 UploadedAt = p.UploadedAt
             })
             .OrderBy(p => p.UploadedAt)
@@ -156,9 +169,11 @@ internal sealed class StalePdfRecoveryService : BackgroundService
             .FindAsync(new object[] { pdfDocumentId }, cancellationToken)
             .ConfigureAwait(false);
 
-        if (pdfDoc != null && !string.Equals(pdfDoc.ProcessingStatus, "completed", StringComparison.Ordinal))
+        var readyState = nameof(PdfProcessingState.Ready);
+        if (pdfDoc != null && !string.Equals(pdfDoc.ProcessingState, readyState, StringComparison.Ordinal))
         {
-            pdfDoc.ProcessingStatus = "pending";
+            pdfDoc.ProcessingState = nameof(PdfProcessingState.Pending);
+            pdfDoc.ProcessingStatus = "pending"; // Keep deprecated field in sync
             pdfDoc.ProcessingError = null;
             await db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
         }


### PR DESCRIPTION
## Summary

- Migrate all 7 files from deprecated `ProcessingStatus` (4-state string) to authoritative `ProcessingState` (7-state enum)
- Critical fix in KB completeness check (`AskAgentQuestionCommandHandler`) with improved error messages showing state breakdown
- Add `FindByStateAsync(PdfProcessingState)` to repository with `[Obsolete]` on legacy method

## Changes (8 files)

| File | Change |
|------|--------|
| `AskAgentQuestionCommandHandler.cs` | **CRITICAL**: Use `ProcessingState != Ready` instead of `ProcessingStatus == "completed"` |
| `StalePdfRecoveryService.cs` | Enum-based stale detection for all intermediate states |
| `PdfDocumentRepository.cs` | New `FindByStateAsync()` + `[Obsolete]` on `FindByStatusAsync()` |
| `IPdfDocumentRepository.cs` | Interface update matching repository |
| `GetAllPdfsQueryHandler.cs` | Map legacy status filter to ProcessingState |
| `GetDashboardMetricsQueryHandler.cs` | Enum-based metric counting |
| `ProcessPendingPdfsCommandHandler.cs` | Exclude terminal states instead of string matching |
| `GetGameWizardPreviewQueryHandler.cs` | DTO uses ProcessingState.ToString() |

## Test plan

- [ ] Verify `dotnet build` passes with 0 errors
- [ ] Run `dotnet test --filter "Category=Unit"` for DocumentProcessing and KnowledgeBase
- [ ] Manual: Upload PDF → verify KB completeness check works with new enum
- [ ] Manual: Dashboard metrics show correct counts

Closes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)