### PR TITLE
fix(shared-catalog): set Agent.GameId when linking to SharedGame (#97)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Entities/Agent.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Entities/Agent.cs
@@ -141,6 +141,27 @@ internal sealed class Agent : AggregateRoot<Guid>
     }
 
     /// <summary>
+    /// Sets the game this agent is associated with.
+    /// Issue #97: Set Agent.GameId when linking to SharedGame.
+    /// </summary>
+    public void SetGameId(Guid gameId)
+    {
+        if (gameId == Guid.Empty)
+            throw new ArgumentException("GameId cannot be empty", nameof(gameId));
+
+        GameId = gameId;
+    }
+
+    /// <summary>
+    /// Clears the game association for this agent.
+    /// Issue #97: Clear Agent.GameId when unlinking from SharedGame.
+    /// </summary>
+    public void ClearGameId()
+    {
+        GameId = null;
+    }
+
+    /// <summary>
     /// Updates the agent name.
     /// </summary>
     public void Rename(string newName)

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/LinkAgentToSharedGameCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/LinkAgentToSharedGameCommandHandler.cs
@@ -1,3 +1,4 @@
+using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
 using Api.Middleware.Exceptions;
 using Api.SharedKernel.Application.Interfaces;
@@ -9,19 +10,23 @@ namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands;
 /// <summary>
 /// Handler for linking an AI agent to a shared game.
 /// Issue #4228: SharedGame and PrivateGame → AgentDefinition relationship
+/// Issue #97: Also sets Agent.GameId so RAG search works for SharedGame-linked agents.
 /// </summary>
 internal sealed class LinkAgentToSharedGameCommandHandler : ICommandHandler<LinkAgentToSharedGameCommand, Unit>
 {
     private readonly ISharedGameRepository _repository;
+    private readonly IAgentRepository _agentRepository;
     private readonly IUnitOfWork _unitOfWork;
     private readonly ILogger<LinkAgentToSharedGameCommandHandler> _logger;
 
     public LinkAgentToSharedGameCommandHandler(
         ISharedGameRepository repository,
+        IAgentRepository agentRepository,
         IUnitOfWork unitOfWork,
         ILogger<LinkAgentToSharedGameCommandHandler> logger)
     {
         _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _agentRepository = agentRepository ?? throw new ArgumentNullException(nameof(agentRepository));
         _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
@@ -39,6 +44,20 @@ internal sealed class LinkAgentToSharedGameCommandHandler : ICommandHandler<Link
 
         // Call domain method (validates not already linked and raises event)
         game.LinkAgent(command.AgentId);
+
+        // Issue #97: Also set Agent.GameId so RAG search can filter by game_id
+        var agent = await _agentRepository.GetByIdAsync(command.AgentId, cancellationToken).ConfigureAwait(false);
+        if (agent is not null)
+        {
+            agent.SetGameId(command.GameId);
+            await _agentRepository.UpdateAsync(agent, cancellationToken).ConfigureAwait(false);
+        }
+        else
+        {
+            _logger.LogWarning(
+                "Agent {AgentId} not found in KnowledgeBase when linking to shared game {GameId}. Agent.GameId not set.",
+                command.AgentId, command.GameId);
+        }
 
         _repository.Update(game);
         await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/UnlinkAgentFromSharedGameCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/UnlinkAgentFromSharedGameCommandHandler.cs
@@ -1,3 +1,4 @@
+using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
 using Api.Middleware.Exceptions;
 using Api.SharedKernel.Application.Interfaces;
@@ -9,19 +10,23 @@ namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands;
 /// <summary>
 /// Handler for unlinking an AI agent from a shared game.
 /// Issue #4228: SharedGame and PrivateGame → AgentDefinition relationship
+/// Issue #97: Also clears Agent.GameId so stale game associations are removed.
 /// </summary>
 internal sealed class UnlinkAgentFromSharedGameCommandHandler : ICommandHandler<UnlinkAgentFromSharedGameCommand, Unit>
 {
     private readonly ISharedGameRepository _repository;
+    private readonly IAgentRepository _agentRepository;
     private readonly IUnitOfWork _unitOfWork;
     private readonly ILogger<UnlinkAgentFromSharedGameCommandHandler> _logger;
 
     public UnlinkAgentFromSharedGameCommandHandler(
         ISharedGameRepository repository,
+        IAgentRepository agentRepository,
         IUnitOfWork unitOfWork,
         ILogger<UnlinkAgentFromSharedGameCommandHandler> logger)
     {
         _repository = repository ?? throw new ArgumentNullException(nameof(repository));
+        _agentRepository = agentRepository ?? throw new ArgumentNullException(nameof(agentRepository));
         _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
@@ -37,8 +42,28 @@ internal sealed class UnlinkAgentFromSharedGameCommandHandler : ICommandHandler<
         var game = await _repository.GetByIdAsync(command.GameId, cancellationToken).ConfigureAwait(false)
             ?? throw new NotFoundException("SharedGame", command.GameId.ToString());
 
+        // Capture agent ID before unlinking (domain method clears it)
+        var agentId = game.AgentDefinitionId;
+
         // Call domain method (validates agent is linked and raises event)
         game.UnlinkAgent();
+
+        // Issue #97: Clear Agent.GameId so stale game associations are removed
+        if (agentId.HasValue)
+        {
+            var agent = await _agentRepository.GetByIdAsync(agentId.Value, cancellationToken).ConfigureAwait(false);
+            if (agent is not null)
+            {
+                agent.ClearGameId();
+                await _agentRepository.UpdateAsync(agent, cancellationToken).ConfigureAwait(false);
+            }
+            else
+            {
+                _logger.LogWarning(
+                    "Agent {AgentId} not found in KnowledgeBase when unlinking from shared game {GameId}. Agent.GameId not cleared.",
+                    agentId.Value, command.GameId);
+            }
+        }
 
         _repository.Update(game);
         await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/UploadSharedGamePdfCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/UploadSharedGamePdfCommandHandler.cs
@@ -100,7 +100,7 @@ internal sealed class UploadSharedGamePdfCommandHandler
         {
             Id = pdfDocumentId,
             SharedGameId = command.SharedGameId,
-            GameId = Guid.Empty, // Required column — use sentinel; real game is via SharedGameId
+            GameId = command.SharedGameId, // Issue #97: Use SharedGameId so Qdrant indexes with correct game_id
             FileName = fileName,
             FilePath = storageResult.FilePath!,
             FileSizeBytes = storageResult.FileSizeBytes,


### PR DESCRIPTION
## Summary

- Fix Agent.GameId never being set when linking agent to SharedGame (was always null)
- Fix Qdrant game_id being Guid.Empty for SharedGame PDFs (RAG search returned 0 results)
- Add SetGameId/ClearGameId methods to Agent entity following DDD conventions

## Changes (4 files)

| File | Change |
|------|--------|
| `Agent.cs` | Add `SetGameId(Guid)` and `ClearGameId()` domain methods |
| `LinkAgentToSharedGameCommandHandler.cs` | Also set `Agent.GameId = SharedGameId` when linking |
| `UnlinkAgentFromSharedGameCommandHandler.cs` | Clear `Agent.GameId` when unlinking |
| `UploadSharedGamePdfCommandHandler.cs` | Use `SharedGameId` as `GameId` (not `Guid.Empty`) |

## Impact

Before: Agent linked to SharedGame → RAG search → 0 Qdrant results → empty response
After: Agent.GameId = SharedGameId → Qdrant game_id = SharedGameId → RAG finds chunks

## Test plan

- [ ] Verify `dotnet build` passes with 0 errors
- [ ] Run unit tests for SharedGameCatalog and KnowledgeBase
- [ ] Manual: Link agent to SharedGame → verify Agent.GameId is set
- [ ] Manual: Upload PDF for SharedGame → verify Qdrant game_id matches SharedGameId
- [ ] Manual: Chat with linked agent → verify RAG returns relevant chunks

Closes #97

🤖 Generated with [Claude Code](https://claude.com/claude-code)