### PR TITLE
fix(shared-catalog): add handler for DocumentApprovedForRagEvent (#98)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/EventHandlers/DocumentApprovedForRagEventHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/EventHandlers/DocumentApprovedForRagEventHandler.cs
@@ -1,0 +1,77 @@
+using Api.BoundedContexts.DocumentProcessing.Domain.Repositories;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Events;
+using Api.SharedKernel.Infrastructure.Persistence;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.EventHandlers;
+
+/// <summary>
+/// Event handler that sets IsActiveForRag=true on the associated PdfDocument
+/// when a SharedGame document is approved for RAG processing.
+/// Issue #98: DocumentApprovedForRagEvent was published but had no handler.
+/// </summary>
+internal sealed class DocumentApprovedForRagEventHandler : INotificationHandler<DocumentApprovedForRagEvent>
+{
+    private readonly IPdfDocumentRepository _pdfDocumentRepository;
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly ILogger<DocumentApprovedForRagEventHandler> _logger;
+
+    public DocumentApprovedForRagEventHandler(
+        IPdfDocumentRepository pdfDocumentRepository,
+        IUnitOfWork unitOfWork,
+        ILogger<DocumentApprovedForRagEventHandler> logger)
+    {
+        _pdfDocumentRepository = pdfDocumentRepository ?? throw new ArgumentNullException(nameof(pdfDocumentRepository));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task Handle(DocumentApprovedForRagEvent notification, CancellationToken cancellationToken)
+    {
+        _logger.LogInformation(
+            "Processing DocumentApprovedForRagEvent: DocumentId={DocumentId}, PdfDocumentId={PdfDocumentId}, SharedGameId={SharedGameId}",
+            notification.DocumentId, notification.PdfDocumentId, notification.SharedGameId);
+
+        try
+        {
+            var pdfDocument = await _pdfDocumentRepository.GetByIdAsync(
+                notification.PdfDocumentId, cancellationToken).ConfigureAwait(false);
+
+            if (pdfDocument is null)
+            {
+                _logger.LogWarning(
+                    "PdfDocument {PdfDocumentId} not found for DocumentApprovedForRagEvent. " +
+                    "The PDF may have been deleted after approval was initiated.",
+                    notification.PdfDocumentId);
+                return;
+            }
+
+            if (pdfDocument.IsActiveForRag)
+            {
+                _logger.LogInformation(
+                    "PdfDocument {PdfDocumentId} is already active for RAG, skipping update",
+                    notification.PdfDocumentId);
+                return;
+            }
+
+            pdfDocument.SetActiveForRag(true);
+            await _pdfDocumentRepository.UpdateAsync(pdfDocument, cancellationToken).ConfigureAwait(false);
+            await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+            _logger.LogInformation(
+                "Successfully set IsActiveForRag=true on PdfDocument {PdfDocumentId} " +
+                "for SharedGame {SharedGameId}, approved by {ApprovedBy}",
+                notification.PdfDocumentId, notification.SharedGameId, notification.ApprovedBy);
+        }
+        catch (Exception ex)
+        {
+            // RAG activation failure should NOT fail the approval flow
+            _logger.LogError(
+                ex,
+                "Failed to set IsActiveForRag on PdfDocument {PdfDocumentId} for document approval {DocumentId}. " +
+                "Manual activation may be required.",
+                notification.PdfDocumentId, notification.DocumentId);
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Create `DocumentApprovedForRagEventHandler` for the orphaned `DocumentApprovedForRagEvent`
- Handler sets `IsActiveForRag = true` on the associated PdfDocument when approved
- Fail-safe pattern: catches exceptions and logs without breaking approval flow
- Idempotent: skips if already active

## Changes (1 file)

| File | Change |
|------|--------|
| `DocumentApprovedForRagEventHandler.cs` | **NEW**: Handler for `DocumentApprovedForRagEvent` |

## Behavior

1. `ApproveDocumentForRagProcessingCommand` publishes `DocumentApprovedForRagEvent`
2. New handler receives event, loads PdfDocument by PdfDocumentId
3. Sets `IsActiveForRag = true` and persists
4. Logs the action; errors are caught and logged (fail-safe)

## Test plan

- [ ] Verify `dotnet build` passes with 0 errors
- [ ] Run unit tests for SharedGameCatalog
- [ ] Manual: Approve shared game document → verify PdfDocument.IsActiveForRag = true

Closes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)