### PR TITLE
refactor: complete ProcessingState migration and handler cleanup

### DIFF
--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/UploadPdfCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/UploadPdfCommandHandler.cs
@@ -788,13 +788,15 @@ internal class UploadPdfCommandHandler : ICommandHandler<UploadPdfCommand, PdfUp
         _logger.LogInformation("✅ [PDF-DEBUG-VALIDATE] PDF found, current status: {Status}", pdfDoc.ProcessingStatus);
 
         // IDEMPOTENCY CHECK (#1742): Skip if already processing/processed
-        if (!string.Equals(pdfDoc.ProcessingStatus, "pending", StringComparison.Ordinal))
+        var pendingState = nameof(PdfProcessingState.Pending);
+        if (!string.Equals(pdfDoc.ProcessingState, pendingState, StringComparison.Ordinal))
         {
             _logger.LogInformation(
-                "⏭️ [PDF-DEBUG-VALIDATE] PDF {PdfId} already processed (status: {Status}), skipping duplicate background task",
-                pdfId, pdfDoc.ProcessingStatus);
+                "⏭️ [PDF-DEBUG-VALIDATE] PDF {PdfId} already processed (state: {State}), skipping duplicate background task",
+                pdfId, pdfDoc.ProcessingState);
 
-            if (string.Equals(pdfDoc.ProcessingStatus, "failed", StringComparison.Ordinal))
+            var failedState = nameof(PdfProcessingState.Failed);
+            if (string.Equals(pdfDoc.ProcessingState, failedState, StringComparison.Ordinal))
             {
                 await quotaService.ReleaseQuotaAsync(userId, pdfId, CancellationToken.None).ConfigureAwait(false);
             }

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Handlers/CancelPdfProcessingCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Handlers/CancelPdfProcessingCommandHandler.cs
@@ -1,4 +1,5 @@
 using Api.BoundedContexts.DocumentProcessing.Application.Commands;
+using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
 using Api.BoundedContexts.DocumentProcessing.Application.DTOs;
 using Api.BoundedContexts.DocumentProcessing.Application.Queries;
 using Api.Infrastructure.Entities;
@@ -66,8 +67,10 @@ internal class CancelPdfProcessingCommandHandler : ICommandHandler<CancelPdfProc
         }
 
         // Step 3: Check if processing is still in progress
-        if (string.Equals(pdf.ProcessingStatus, "completed", StringComparison.Ordinal) ||
-            string.Equals(pdf.ProcessingStatus, "failed", StringComparison.Ordinal))
+        var readyState = nameof(PdfProcessingState.Ready);
+        var failedState = nameof(PdfProcessingState.Failed);
+        if (string.Equals(pdf.ProcessingState, readyState, StringComparison.Ordinal) ||
+            string.Equals(pdf.ProcessingState, failedState, StringComparison.Ordinal))
         {
             _logger.LogInformation(
                 "PDF {PdfId} processing already completed/failed (status: {Status})",

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Handlers/GetPdfOwnershipQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Handlers/GetPdfOwnershipQueryHandler.cs
@@ -39,7 +39,8 @@ internal class GetPdfOwnershipQueryHandler : IQueryHandler<GetPdfOwnershipQuery,
                 Id: document.Id,
                 UploadedByUserId: document.UploadedByUserId,
                 GameId: document.GameId,
-                ProcessingStatus: document.ProcessingStatus
+                ProcessingStatus: document.ProcessingStatus,
+                ProcessingState: document.ProcessingState.ToString()
             );
         }
 #pragma warning disable CA1031 // Do not catch general exception types

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Handlers/IndexPdfCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Handlers/IndexPdfCommandHandler.cs
@@ -1,4 +1,5 @@
 using Api.BoundedContexts.DocumentProcessing.Application.Commands;
+using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
 using Api.BoundedContexts.DocumentProcessing.Application.DTOs;
 using Api.Configuration;
 using Api.Infrastructure;
@@ -142,10 +143,11 @@ internal class IndexPdfCommandHandler : ICommandHandler<IndexPdfCommand, Indexin
             return (false, pdf, null, "PDF text extraction required. Please extract text before indexing.", PdfIndexingErrorCode.TextExtractionRequired);
         }
 
-        if (!string.Equals(pdf.ProcessingStatus, "completed", StringComparison.OrdinalIgnoreCase))
+        var readyState = nameof(PdfProcessingState.Ready);
+        if (!string.Equals(pdf.ProcessingState, readyState, StringComparison.Ordinal))
         {
-            _logger.LogWarning("PDF {PdfId} processing status is {Status}, expected 'completed'",
-                pdfId, pdf.ProcessingStatus);
+            _logger.LogWarning("PDF {PdfId} processing state is {State}, expected '{Expected}'",
+                pdfId, pdf.ProcessingState, readyState);
             return (false, pdf, null, "PDF text extraction not completed", PdfIndexingErrorCode.TextExtractionRequired);
         }
 

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Queries/GetPdfOwnershipQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Queries/GetPdfOwnershipQuery.cs
@@ -19,5 +19,6 @@ internal record PdfOwnershipResult(
     Guid Id,
     Guid UploadedByUserId,
     Guid GameId,
-    string ProcessingStatus
+    string ProcessingStatus,
+    string ProcessingState = ""
 );

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineService.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Services/PdfProcessingPipelineService.cs
@@ -1,3 +1,4 @@
+using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
 using Api.BoundedContexts.DocumentProcessing.Infrastructure.External;
 using Api.Infrastructure;
 using Api.Infrastructure.Entities;
@@ -70,8 +71,10 @@ internal sealed class PdfProcessingPipelineService : IPdfProcessingPipelineServi
             }
 
             // Idempotency: skip if already completed or failed
-            if (string.Equals(pdfDoc.ProcessingStatus, "completed", StringComparison.Ordinal)
-                || string.Equals(pdfDoc.ProcessingStatus, "failed", StringComparison.Ordinal))
+            var readyState = nameof(PdfProcessingState.Ready);
+            var failedState = nameof(PdfProcessingState.Failed);
+            if (string.Equals(pdfDoc.ProcessingState, readyState, StringComparison.Ordinal)
+                || string.Equals(pdfDoc.ProcessingState, failedState, StringComparison.Ordinal))
             {
                 _logger.LogInformation(
                     "[PdfPipeline] PDF {PdfId} already in terminal state ({Status}), skipping",

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/EventHandlers/DocumentApprovedForRagEventHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/EventHandlers/DocumentApprovedForRagEventHandler.cs
@@ -1,6 +1,5 @@
-using Api.BoundedContexts.DocumentProcessing.Domain.Repositories;
+using Api.BoundedContexts.DocumentProcessing.Application.Commands;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Events;
-using Api.SharedKernel.Infrastructure.Persistence;
 using MediatR;
 using Microsoft.Extensions.Logging;
 
@@ -10,20 +9,19 @@ namespace Api.BoundedContexts.SharedGameCatalog.Application.EventHandlers;
 /// Event handler that sets IsActiveForRag=true on the associated PdfDocument
 /// when a SharedGame document is approved for RAG processing.
 /// Issue #98: DocumentApprovedForRagEvent was published but had no handler.
+/// Delegates to SetActiveForRagCommand in DocumentProcessing BC via MediatR,
+/// avoiding direct cross-BC repository coupling.
 /// </summary>
 internal sealed class DocumentApprovedForRagEventHandler : INotificationHandler<DocumentApprovedForRagEvent>
 {
-    private readonly IPdfDocumentRepository _pdfDocumentRepository;
-    private readonly IUnitOfWork _unitOfWork;
+    private readonly IMediator _mediator;
     private readonly ILogger<DocumentApprovedForRagEventHandler> _logger;
 
     public DocumentApprovedForRagEventHandler(
-        IPdfDocumentRepository pdfDocumentRepository,
-        IUnitOfWork unitOfWork,
+        IMediator mediator,
         ILogger<DocumentApprovedForRagEventHandler> logger)
     {
-        _pdfDocumentRepository = pdfDocumentRepository ?? throw new ArgumentNullException(nameof(pdfDocumentRepository));
-        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+        _mediator = mediator ?? throw new ArgumentNullException(nameof(mediator));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -35,34 +33,23 @@ internal sealed class DocumentApprovedForRagEventHandler : INotificationHandler<
 
         try
         {
-            var pdfDocument = await _pdfDocumentRepository.GetByIdAsync(
-                notification.PdfDocumentId, cancellationToken).ConfigureAwait(false);
+            var result = await _mediator.Send(
+                new SetActiveForRagCommand(notification.PdfDocumentId, true),
+                cancellationToken).ConfigureAwait(false);
 
-            if (pdfDocument is null)
-            {
-                _logger.LogWarning(
-                    "PdfDocument {PdfDocumentId} not found for DocumentApprovedForRagEvent. " +
-                    "The PDF may have been deleted after approval was initiated.",
-                    notification.PdfDocumentId);
-                return;
-            }
-
-            if (pdfDocument.IsActiveForRag)
+            if (result.Success)
             {
                 _logger.LogInformation(
-                    "PdfDocument {PdfDocumentId} is already active for RAG, skipping update",
-                    notification.PdfDocumentId);
-                return;
+                    "Successfully set IsActiveForRag=true on PdfDocument {PdfDocumentId} " +
+                    "for SharedGame {SharedGameId}, approved by {ApprovedBy}",
+                    notification.PdfDocumentId, notification.SharedGameId, notification.ApprovedBy);
             }
-
-            pdfDocument.SetActiveForRag(true);
-            await _pdfDocumentRepository.UpdateAsync(pdfDocument, cancellationToken).ConfigureAwait(false);
-            await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
-
-            _logger.LogInformation(
-                "Successfully set IsActiveForRag=true on PdfDocument {PdfDocumentId} " +
-                "for SharedGame {SharedGameId}, approved by {ApprovedBy}",
-                notification.PdfDocumentId, notification.SharedGameId, notification.ApprovedBy);
+            else
+            {
+                _logger.LogWarning(
+                    "SetActiveForRag returned failure for PdfDocument {PdfDocumentId}: {Message}",
+                    notification.PdfDocumentId, result.Message);
+            }
         }
         catch (Exception ex)
         {

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Domain/Entities/AgentTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Domain/Entities/AgentTests.cs
@@ -356,6 +356,76 @@ public class AgentTests
         Assert.Null(agent.CreatedByUserId);
     }
 
+    // ── Issue #97: SetGameId / ClearGameId domain methods ──
+
+    [Fact]
+    public void SetGameId_ValidId_SetsGameId()
+    {
+        // Arrange
+        var agent = CreateTestAgent();
+        var gameId = Guid.NewGuid();
+
+        // Act
+        agent.SetGameId(gameId);
+
+        // Assert
+        Assert.Equal(gameId, agent.GameId);
+    }
+
+    [Fact]
+    public void SetGameId_EmptyGuid_ThrowsArgumentException()
+    {
+        // Arrange
+        var agent = CreateTestAgent();
+
+        // Act & Assert
+        Assert.Throws<ArgumentException>(() => agent.SetGameId(Guid.Empty));
+    }
+
+    [Fact]
+    public void SetGameId_OverwritesExistingGameId()
+    {
+        // Arrange
+        var agent = CreateTestAgent();
+        var firstGameId = Guid.NewGuid();
+        var secondGameId = Guid.NewGuid();
+        agent.SetGameId(firstGameId);
+
+        // Act
+        agent.SetGameId(secondGameId);
+
+        // Assert
+        Assert.Equal(secondGameId, agent.GameId);
+    }
+
+    [Fact]
+    public void ClearGameId_WithExistingGameId_SetsNull()
+    {
+        // Arrange
+        var agent = CreateTestAgent();
+        agent.SetGameId(Guid.NewGuid());
+
+        // Act
+        agent.ClearGameId();
+
+        // Assert
+        Assert.Null(agent.GameId);
+    }
+
+    [Fact]
+    public void ClearGameId_WithNoGameId_RemainsNull()
+    {
+        // Arrange
+        var agent = CreateTestAgent();
+        Assert.Null(agent.GameId);
+
+        // Act
+        agent.ClearGameId();
+
+        // Assert
+        Assert.Null(agent.GameId);
+    }
+
     // Helper method
     private static Agent CreateTestAgent(
         string name = "Test Agent",


### PR DESCRIPTION
## Summary
- Migrate 7 remaining `ProcessingStatus` string comparisons to `ProcessingState` enum across DocumentProcessing BC (5 files)
- Refactor `DocumentApprovedForRagEventHandler` to use `IMediator.Send(SetActiveForRagCommand)` instead of direct cross-BC `IPdfDocumentRepository` injection
- Add 5 unit tests for `Agent.SetGameId`/`ClearGameId` domain methods

## Changes
Follow-up improvements identified during code review of PRs #99, #100, #101:

**Task 1 — ProcessingStatus → ProcessingState migration (5 files)**
- `PdfProcessingPipelineService`: terminal state check uses enum
- `IndexPdfCommandHandler`: completion check uses enum
- `CancelPdfProcessingCommandHandler`: terminal state check uses enum
- `UploadPdfCommandHandler`: pending/failed state checks use enum
- `PdfOwnershipResult` DTO: added `ProcessingState` field

**Task 2 — Handler refactoring (1 file)**
- `DocumentApprovedForRagEventHandler`: replaced `IPdfDocumentRepository` + `IUnitOfWork` with `IMediator` delegation to existing `SetActiveForRagCommand`

**Task 3 — Domain tests (1 file)**
- `AgentTests.cs`: 5 new tests covering `SetGameId` (valid, empty guid, overwrite) and `ClearGameId` (with/without existing value)

## Test plan
- [x] API builds with 0 errors, 0 warnings
- [x] All 5 new Agent domain tests pass
- [x] Existing test suite compiles

Refs: #96, #97, #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)