### PR TITLE
fix(transparency): add cost field + fix debug link visibility (#93, #95)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Handlers/SendAgentMessageCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Handlers/SendAgentMessageCommandHandler.cs
@@ -754,7 +754,7 @@ internal sealed class SendAgentMessageCommandHandler : IStreamingQueryHandler<Se
         var fullResponse = llmResult.Response;
         var tokenCount = llmResult.Usage.TotalTokens;
 
-        // Debug: emit cost/token update (Issue #4916)
+        // Debug: emit cost/token update (Issue #4916, #93)
         yield return CreateEvent(
             StreamingEventType.DebugCostUpdate,
             new
@@ -763,6 +763,7 @@ internal sealed class SendAgentMessageCommandHandler : IStreamingQueryHandler<Se
                 promptTokens = llmResult.Usage.PromptTokens,
                 completionTokens = llmResult.Usage.CompletionTokens,
                 totalTokens = tokenCount,
+                costUsd = (double)llmResult.Cost.TotalCost,
                 confidence = retrievalConfidence,
                 typology = profile.Name
             });

--- a/apps/web/src/components/chat-unified/ChatThreadView.tsx
+++ b/apps/web/src/components/chat-unified/ChatThreadView.tsx
@@ -621,6 +621,7 @@ export function ChatThreadView({ threadId }: ChatThreadViewProps) {
                         <TechnicalDetailsPanel
                           debugSteps={streamState.debugSteps}
                           executionId={streamState.executionId}
+                          showDebugLink={isAdmin}
                         />
                       )}
                     </div>

--- a/apps/web/src/components/chat-unified/TechnicalDetailsPanel.tsx
+++ b/apps/web/src/components/chat-unified/TechnicalDetailsPanel.tsx
@@ -11,6 +11,8 @@ interface TechnicalDetailsPanelProps {
   debugSteps: DebugStep[];
   /** Execution ID for deep link to Debug Console (Issue #5486) */
   executionId?: string | null;
+  /** Show "View in Debug Console" link (requires Admin access to /admin/agents/debug-chat) */
+  showDebugLink?: boolean;
   className?: string;
 }
 
@@ -20,6 +22,7 @@ interface ExtractedMetadata {
   promptTokens: number | null;
   completionTokens: number | null;
   totalTokens: number | null;
+  costUsd: number | null;
   confidence: number | null;
   typology: string | null;
   searchStrategy: string | null;
@@ -35,6 +38,7 @@ function extractMetadata(steps: DebugStep[]): ExtractedMetadata {
     promptTokens: null,
     completionTokens: null,
     totalTokens: null,
+    costUsd: null,
     confidence: null,
     typology: null,
     searchStrategy: null,
@@ -55,6 +59,7 @@ function extractMetadata(steps: DebugStep[]): ExtractedMetadata {
         meta.promptTokens = (p.promptTokens as number) ?? meta.promptTokens;
         meta.completionTokens = (p.completionTokens as number) ?? meta.completionTokens;
         meta.totalTokens = (p.totalTokens as number) ?? meta.totalTokens;
+        meta.costUsd = (p.costUsd as number) ?? meta.costUsd;
         meta.confidence = (p.confidence as number) ?? meta.confidence;
         meta.typology = (p.typology as string) ?? meta.typology;
         break;
@@ -95,6 +100,7 @@ function extractMetadata(steps: DebugStep[]): ExtractedMetadata {
 export function TechnicalDetailsPanel({
   debugSteps,
   executionId,
+  showDebugLink = false,
   className,
 }: TechnicalDetailsPanelProps) {
   const [isOpen, setIsOpen] = useState(false);
@@ -111,6 +117,7 @@ export function TechnicalDetailsPanel({
       meta.promptTokens != null && `Prompt tokens: ${meta.promptTokens}`,
       meta.completionTokens != null && `Completion tokens: ${meta.completionTokens}`,
       meta.totalTokens != null && `Total tokens: ${meta.totalTokens}`,
+      meta.costUsd != null && `Cost: $${meta.costUsd.toFixed(4)}`,
       meta.latencyMs != null && `Latency: ${meta.latencyMs}ms`,
       meta.confidence != null && `Confidence: ${(meta.confidence * 100).toFixed(0)}%`,
       meta.typology && `Typology: ${meta.typology}`,
@@ -185,6 +192,12 @@ export function TechnicalDetailsPanel({
                   <dd className="tabular-nums font-medium">{meta.totalTokens}</dd>
                 </>
               )}
+              {meta.costUsd != null && (
+                <>
+                  <dt className="text-muted-foreground">Costo</dt>
+                  <dd className="tabular-nums">${meta.costUsd.toFixed(4)}</dd>
+                </>
+              )}
               {meta.latencyMs != null && (
                 <>
                   <dt className="text-muted-foreground">Latenza</dt>
@@ -249,7 +262,7 @@ export function TechnicalDetailsPanel({
             </div>
           )}
 
-          {executionId && (
+          {executionId && showDebugLink && (
             <div className="pt-1 border-t border-border/20">
               <a
                 href={`/admin/agents/debug-chat?executionId=${executionId}`}

--- a/apps/web/src/components/chat-unified/__tests__/TechnicalDetailsPanel.test.tsx
+++ b/apps/web/src/components/chat-unified/__tests__/TechnicalDetailsPanel.test.tsx
@@ -40,6 +40,7 @@ const mockDebugSteps: DebugStep[] = [
       promptTokens: 450,
       completionTokens: 230,
       totalTokens: 680,
+      costUsd: 0.0042,
       confidence: 0.87,
       typology: 'Tutor',
     },
@@ -128,9 +129,11 @@ describe('TechnicalDetailsPanel', () => {
     expect(copied).toContain('Typology: Tutor');
   });
 
-  it('shows debug console deep link when executionId provided', async () => {
+  it('shows debug console deep link when executionId and showDebugLink are provided', async () => {
     const user = userEvent.setup();
-    render(<TechnicalDetailsPanel debugSteps={mockDebugSteps} executionId="abc-123-def" />);
+    render(
+      <TechnicalDetailsPanel debugSteps={mockDebugSteps} executionId="abc-123-def" showDebugLink />,
+    );
 
     await user.click(screen.getByTestId('technical-details-toggle'));
 
@@ -140,13 +143,67 @@ describe('TechnicalDetailsPanel', () => {
     expect(link).toHaveTextContent('Vedi in Debug Console');
   });
 
+  it('hides debug console link when showDebugLink is false even with executionId', async () => {
+    const user = userEvent.setup();
+    render(<TechnicalDetailsPanel debugSteps={mockDebugSteps} executionId="abc-123-def" />);
+
+    await user.click(screen.getByTestId('technical-details-toggle'));
+
+    expect(screen.queryByTestId('debug-console-link')).not.toBeInTheDocument();
+  });
+
   it('hides debug console link when no executionId', async () => {
+    const user = userEvent.setup();
+    render(<TechnicalDetailsPanel debugSteps={mockDebugSteps} showDebugLink />);
+
+    await user.click(screen.getByTestId('technical-details-toggle'));
+
+    expect(screen.queryByTestId('debug-console-link')).not.toBeInTheDocument();
+  });
+
+  it('displays cost when costUsd is present in debug steps', async () => {
     const user = userEvent.setup();
     render(<TechnicalDetailsPanel debugSteps={mockDebugSteps} />);
 
     await user.click(screen.getByTestId('technical-details-toggle'));
 
-    expect(screen.queryByTestId('debug-console-link')).not.toBeInTheDocument();
+    expect(screen.getByText('Costo')).toBeInTheDocument();
+    expect(screen.getByText('$0.0042')).toBeInTheDocument();
+  });
+
+  it('includes cost in clipboard text', async () => {
+    const user = userEvent.setup();
+    const mockWriteText = vi.fn().mockResolvedValue(undefined);
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText: mockWriteText },
+      writable: true,
+      configurable: true,
+    });
+
+    render(<TechnicalDetailsPanel debugSteps={mockDebugSteps} />);
+
+    await user.click(screen.getByTestId('technical-details-toggle'));
+    await user.click(screen.getByTestId('technical-details-copy'));
+
+    const copied = mockWriteText.mock.calls[0][0] as string;
+    expect(copied).toContain('Cost: $0.0042');
+  });
+
+  it('hides cost row when costUsd is not in debug steps', async () => {
+    const noCostSteps: DebugStep[] = [
+      {
+        type: 17,
+        name: 'Cost Update',
+        payload: { model: 'llama3:8b', totalTokens: 100 },
+        timestamp: '2024-01-01T00:00:00Z',
+      },
+    ];
+    const user = userEvent.setup();
+    render(<TechnicalDetailsPanel debugSteps={noCostSteps} />);
+
+    await user.click(screen.getByTestId('technical-details-toggle'));
+
+    expect(screen.queryByText('Costo')).not.toBeInTheDocument();
   });
 
   it('detects Ollama provider from model name', () => {

--- a/docs/architecture/adr/adr-017-usage-aggregation-gdpr.md
+++ b/docs/architecture/adr/adr-017-usage-aggregation-gdpr.md
@@ -1,0 +1,86 @@
+# ADR-017: User AI Usage Aggregation vs GDPR Pseudonymization
+
+**Date**: 2026-03-10
+**Status**: Proposed
+**Deciders**: Spec Panel (Nygard, Fowler, Wiegers, Crispin)
+**Context**: Epic #25 (C3) vs Epic F (F5)
+
+## Context
+
+Two requirements conflict:
+
+1. **Epic F, F5**: GDPR compliance requires pseudonymizing `UserId` in `llm_request_logs` after 7 days (replace with SHA-256 hash). This is implemented via `LlmRequestLogPseudonymizationJob` running daily at 2:00 AM UTC.
+
+2. **Epic #25, C3**: Editors need a self-service page showing their personal AI usage for the last 30 days — requiring per-user queries on data older than 7 days.
+
+After pseudonymization, `UserId` becomes an irreversible hash. The editor's real UUID cannot match against hashed records. **Result**: Only 7 of 30 days would be queryable by user.
+
+## Decision
+
+**Introduce a pre-aggregated `UserAiUsageDailySummary` table** that stores daily per-user totals, computed from raw logs BEFORE pseudonymization runs.
+
+### Two-Table Architecture
+
+```
+                    1:30 AM              2:00 AM              4:00 AM
+                   Aggregation      Pseudonymization         Cleanup
+                       │                   │                    │
+Raw Logs ─────────────►├──► Summaries      │                    │
+(llm_request_logs)     │   (aggregated)    ├──► Hash UserId     ├──► Delete expired
+                       │                   │                    │
+```
+
+| Aspect | Raw Logs | Usage Summaries |
+|--------|----------|-----------------|
+| **Purpose** | Audit trail, admin debug | Editor self-service analytics |
+| **Granularity** | Per-request (full detail) | Per-user per-day (aggregated) |
+| **PII content** | Yes (UserId, prompt context via session) | Minimal (UserId + counts only) |
+| **Pseudonymization** | After 7 days (GDPR F5) | Not needed (see rationale) |
+| **Retention** | 30 days (hard delete) | 90 days |
+| **Query pattern** | Admin: filter by source/model/date | Editor: filter by own UserId + date range |
+
+### GDPR Compliance Rationale
+
+Aggregated daily summaries containing only:
+- `UserId` (identifier)
+- `Date` (day)
+- `RequestCount`, `TotalTokens`, `CostUsd` (numeric aggregates)
+- `ModelDistribution`, `StrategyDistribution` (categorical counts)
+
+...do **not** reveal the content of communications or enable profiling of individual behavior beyond basic usage metrics. Under GDPR Art. 5(1)(e) (storage limitation), retention of aggregate usage metrics for 90 days is proportionate to the legitimate interest of providing usage visibility to data subjects themselves (Art. 6(1)(f)).
+
+However, as a precaution:
+- Summaries are deleted after 90 days (not retained indefinitely)
+- The `DeleteUserLlmDataCommand` (F3) must also delete usage summaries for the user
+- Users can request deletion of their usage summaries via standard GDPR erasure flow
+
+## Consequences
+
+### Positive
+- Editors get 30-day usage visibility without compromising GDPR pseudonymization
+- Clear separation: raw logs for audit, summaries for analytics
+- Aggregation job is idempotent (UPSERT) — safe to re-run
+- No changes to existing pseudonymization or cleanup jobs
+
+### Negative
+- New table + migration + background job to maintain
+- Small window of data loss risk: if aggregation job fails, that day's data is lost after pseudonymization (mitigation: alerting on job failure + catch-up logic)
+- `DeleteUserLlmDataCommand` must be extended to include the new table
+
+### Neutral
+- Existing admin analytics continue to work unchanged (they query raw logs)
+- No impact on SSE streaming or real-time features
+
+## Alternatives Considered
+
+### A: Extend pseudonymization to 30 days
+**Rejected**: Weakens GDPR compliance. 7-day pseudonymization was chosen based on data minimization principle.
+
+### B: Store usage counters in Redis
+**Rejected**: Redis is volatile (restart = data loss). Not suitable for 30-day historical data.
+
+### C: Maintain a separate "analytics UserId" not subject to pseudonymization
+**Rejected**: Defeats the purpose of pseudonymization. Two non-hashed copies = no real anonymization.
+
+### D: Let editors only see 7 days of detailed data
+**Rejected**: PRD explicitly requires 30-day visibility. Editors need monthly cost impact visibility.

--- a/docs/plans/epic-25-c3-editor-usage-spec.md
+++ b/docs/plans/epic-25-c3-editor-usage-spec.md
@@ -1,0 +1,436 @@
+# C3: Editor Self-Service Usage Page — Detailed Specification
+
+**Epic**: #25 — LLM Transparency & Editor Experience
+**Priority**: 🟡 Important
+**Status**: Draft
+**Date**: 2026-03-10
+
+## Problem Statement
+
+Editors use LLM features daily but have zero visibility into their personal usage, cost impact, or model distribution. All analytics are currently admin-only (`/admin/agents/analytics`). Editors need self-service access to understand their own AI consumption without admin involvement.
+
+## Design Decision
+
+New page at `/dashboard/my-ai-usage` (NOT under `/admin/`) accessible to **Editor and above** roles. Shows only the current user's data — never exposes other users' information.
+
+## Architecture: F5↔C3 Conflict Resolution
+
+### The Problem
+
+GDPR pseudonymization (Epic F, Issue F5) replaces `UserId` with SHA-256 hash in `llm_request_logs` after **7 days**. This makes per-user queries impossible for days 7-30. But C3 needs 30-day personal usage visibility.
+
+### The Solution: Aggregated Usage Summary Table
+
+Introduce a **pre-aggregated daily summary** entity separate from raw request logs:
+
+```
+Raw Logs (llm_request_logs)          Usage Summaries (user_ai_usage_summaries)
+├─ Full request detail               ├─ Daily aggregates per user
+├─ Pseudonymized after 7 days        ├─ NOT pseudonymized (aggregated = non-PII)
+├─ Deleted after 30 days             ├─ Retained 90 days (configurable)
+└─ Used for: audit, admin debug      └─ Used for: C3 "My AI Usage" page
+```
+
+GDPR compliance rationale: Aggregated counts (e.g., "User X made 47 requests on March 5") are not considered personal data under Art. 4(1) when they don't reveal the content of communications. The summary stores only counts, token sums, and cost totals — no prompt content, no conversation data.
+
+---
+
+## Domain Model
+
+### New Entity: `UserAiUsageDailySummary`
+
+**Bounded Context**: KnowledgeBase (co-located with LlmRequestLog)
+
+```csharp
+public sealed class UserAiUsageDailySummary : Entity<Guid>
+{
+    public Guid UserId { get; private set; }
+    public DateOnly Date { get; private set; }
+    public int RequestCount { get; private set; }
+    public int PromptTokens { get; private set; }
+    public int CompletionTokens { get; private set; }
+    public int TotalTokens { get; private set; }
+    public decimal CostUsd { get; private set; }
+    public int AverageLatencyMs { get; private set; }
+    public string ModelDistributionJson { get; private set; }    // {"gpt-4o": 12, "llama3:8b": 35}
+    public string StrategyDistributionJson { get; private set; } // {"Fast": 20, "Balanced": 15, "Premium": 12}
+    public string ProviderDistributionJson { get; private set; } // {"ollama": 30, "openrouter": 17}
+    public DateTime ComputedAt { get; private set; }
+
+    // Factory method
+    public static UserAiUsageDailySummary Create(
+        Guid userId, DateOnly date, int requestCount,
+        int promptTokens, int completionTokens, int totalTokens,
+        decimal costUsd, int averageLatencyMs,
+        Dictionary<string, int> modelDistribution,
+        Dictionary<string, int> strategyDistribution,
+        Dictionary<string, int> providerDistribution)
+    {
+        // validation: requestCount >= 0, date <= today, etc.
+    }
+}
+```
+
+### EF Configuration
+
+```csharp
+public class UserAiUsageDailySummaryConfiguration : IEntityTypeConfiguration<UserAiUsageDailySummary>
+{
+    public void Configure(EntityTypeBuilder<UserAiUsageDailySummary> builder)
+    {
+        builder.ToTable("user_ai_usage_summaries");
+        builder.HasKey(x => x.Id);
+
+        builder.Property(x => x.UserId).IsRequired();
+        builder.Property(x => x.Date).IsRequired();
+        builder.Property(x => x.CostUsd).HasPrecision(18, 6);
+        builder.Property(x => x.ModelDistributionJson).HasColumnType("jsonb");
+        builder.Property(x => x.StrategyDistributionJson).HasColumnType("jsonb");
+        builder.Property(x => x.ProviderDistributionJson).HasColumnType("jsonb");
+
+        // Unique constraint: one summary per user per day
+        builder.HasIndex(x => new { x.UserId, x.Date }).IsUnique();
+        // Query index for date-range queries
+        builder.HasIndex(x => new { x.UserId, x.Date })
+            .HasDatabaseName("ix_user_ai_usage_summaries_user_date");
+    }
+}
+```
+
+### Background Job: `UserAiUsageAggregationJob`
+
+- **Schedule**: Daily at 1:30 AM UTC (runs BEFORE pseudonymization at 2:00 AM)
+- **Logic**: Aggregate yesterday's `llm_request_logs` WHERE `UserId IS NOT NULL AND NOT IsAnonymized`
+- **Idempotent**: Uses UPSERT (ON CONFLICT (UserId, Date) DO UPDATE)
+- **Retention**: Deletes summaries older than 90 days
+- **Catch-up**: On first run or after downtime, processes all non-aggregated days in the 30-day window
+
+---
+
+## Backend API Contract
+
+### Endpoints
+
+All endpoints require `Editor` role or above. All return only the authenticated user's data.
+
+#### 1. GET `/api/v1/users/me/ai-usage/summary`
+
+Returns aggregated totals for configurable periods.
+
+**Query Parameters**:
+- None (returns all three periods)
+
+**Response** (200):
+```json
+{
+  "today": {
+    "requestCount": 12,
+    "promptTokens": 8400,
+    "completionTokens": 3200,
+    "totalTokens": 11600,
+    "costUsd": 0.0234,
+    "averageLatencyMs": 1250
+  },
+  "last7Days": {
+    "requestCount": 87,
+    "promptTokens": 62000,
+    "completionTokens": 24000,
+    "totalTokens": 86000,
+    "costUsd": 0.1720,
+    "averageLatencyMs": 1180
+  },
+  "last30Days": {
+    "requestCount": 342,
+    "promptTokens": 245000,
+    "completionTokens": 98000,
+    "totalTokens": 343000,
+    "costUsd": 0.6840,
+    "averageLatencyMs": 1210
+  }
+}
+```
+
+**Implementation**: CQRS Query `GetMyAiUsageSummaryQuery` → handler queries `UserAiUsageDailySummary` with SUM aggregation. Today's data comes from live `llm_request_logs` (not yet aggregated).
+
+#### 2. GET `/api/v1/users/me/ai-usage/daily`
+
+Returns daily breakdown for charts.
+
+**Query Parameters**:
+- `days` (int, default: 30, max: 90) — number of days to return
+
+**Response** (200):
+```json
+{
+  "days": [
+    {
+      "date": "2026-03-10",
+      "requestCount": 12,
+      "totalTokens": 11600,
+      "costUsd": 0.0234,
+      "isLive": true
+    },
+    {
+      "date": "2026-03-09",
+      "requestCount": 15,
+      "totalTokens": 14200,
+      "costUsd": 0.0312,
+      "isLive": false
+    }
+  ]
+}
+```
+
+`isLive: true` indicates today's data is from live query (may update on refresh).
+
+#### 3. GET `/api/v1/users/me/ai-usage/distributions`
+
+Returns model, strategy, and provider distribution for pie charts.
+
+**Query Parameters**:
+- `days` (int, default: 30, max: 90)
+
+**Response** (200):
+```json
+{
+  "models": [
+    { "name": "llama3:8b", "count": 180, "percentage": 52.6 },
+    { "name": "gpt-4o-mini", "count": 95, "percentage": 27.8 },
+    { "name": "claude-3-haiku", "count": 67, "percentage": 19.6 }
+  ],
+  "strategies": [
+    { "name": "Fast", "count": 150, "percentage": 43.9 },
+    { "name": "Balanced", "count": 120, "percentage": 35.1 },
+    { "name": "Premium", "count": 50, "percentage": 14.6 },
+    { "name": "HybridRAG", "count": 22, "percentage": 6.4 }
+  ],
+  "providers": [
+    { "name": "ollama", "count": 210, "percentage": 61.4 },
+    { "name": "openrouter", "count": 132, "percentage": 38.6 }
+  ]
+}
+```
+
+#### 4. GET `/api/v1/users/me/ai-usage/recent`
+
+Returns recent individual requests (only from the last 7 days — before pseudonymization).
+
+**Query Parameters**:
+- `page` (int, default: 1)
+- `pageSize` (int, default: 20, max: 50)
+
+**Response** (200):
+```json
+{
+  "items": [
+    {
+      "requestedAt": "2026-03-10T14:22:00Z",
+      "model": "llama3:8b",
+      "provider": "ollama",
+      "strategy": "Fast",
+      "promptTokens": 650,
+      "completionTokens": 280,
+      "costUsd": 0.0000,
+      "latencyMs": 890,
+      "success": true
+    }
+  ],
+  "total": 87,
+  "page": 1,
+  "pageSize": 20,
+  "note": "Individual requests are available for the last 7 days only (GDPR compliance)."
+}
+```
+
+**Implementation**: Queries `llm_request_logs` WHERE `UserId = currentUser AND NOT IsAnonymized AND RequestedAt >= 7 days ago`. Does NOT expose `SessionId`, `ErrorMessage`, or prompt content.
+
+---
+
+## Frontend Specification
+
+### Route: `/dashboard/my-ai-usage`
+
+**Access**: Editor role and above (`isEditorOrAbove(user)`)
+**Layout**: Dashboard layout (not admin layout)
+**Navigation**: Add "AI Usage" item to dashboard sidebar with 🤖 icon
+
+### Page Structure
+
+```
+┌─────────────────────────────────────────────────────────┐
+│  Il mio utilizzo AI                                     │
+│  Scopri come utilizzi le funzionalità AI di MeepleAI    │
+├──────────┬──────────┬──────────┬────────────────────────┤
+│  Oggi    │  7 Giorni│ 30 Giorni│                        │
+│  12 req  │  87 req  │  342 req │  ← Summary cards       │
+│  11.6K   │  86K     │  343K    │     (tokens)           │
+│  $0.02   │  $0.17   │  $0.68   │     (cost)             │
+├──────────┴──────────┴──────────┴────────────────────────┤
+│                                                         │
+│  ┌─ Richieste giornaliere (30g) ───────────────────┐   │
+│  │  [Bar chart: daily request count]                │   │
+│  └──────────────────────────────────────────────────┘   │
+│                                                         │
+│  ┌─ Distribuzione Modelli ─┐ ┌─ Distribuzione Strategie│
+│  │  [Donut chart]          │ │  [Donut chart]          │
+│  │  llama3:8b  52.6%       │ │  Fast      43.9%        │
+│  │  gpt-4o    27.8%        │ │  Balanced  35.1%        │
+│  │  claude    19.6%        │ │  Premium   14.6%        │
+│  └─────────────────────────┘ └──────────────────────────┘
+│                                                         │
+│  ┌─ Richieste recenti (ultimi 7 giorni) ───────────┐   │
+│  │  Timestamp  │ Modello │ Strategia │ Tokens │ Costo│  │
+│  │  14:22      │ llama3  │ Fast      │ 930    │ $0.00│  │
+│  │  14:10      │ gpt-4o  │ Balanced  │ 1420   │ $0.01│  │
+│  │  ...                                              │  │
+│  │  [1] [2] [3] ... pagination                       │  │
+│  └──────────────────────────────────────────────────┘   │
+│                                                         │
+│  ⓘ I dati individuali sono disponibili per gli ultimi   │
+│    7 giorni. I totali aggregati coprono 30 giorni.      │
+└─────────────────────────────────────────────────────────┘
+```
+
+### Component Breakdown
+
+| Component | Description | Data Source |
+|-----------|-------------|-------------|
+| `UsageSummaryCards` | 3 period cards (today/7d/30d) with req count, tokens, cost | `/me/ai-usage/summary` |
+| `DailyRequestChart` | Bar chart with daily request count | `/me/ai-usage/daily` |
+| `ModelDistributionChart` | Donut chart with model breakdown | `/me/ai-usage/distributions` |
+| `StrategyDistributionChart` | Donut chart with strategy breakdown | `/me/ai-usage/distributions` |
+| `RecentRequestsTable` | Paginated table of recent individual requests | `/me/ai-usage/recent` |
+| `UsageInfoBanner` | Info notice about 7-day detail vs 30-day aggregate | Static |
+
+### Charting Library
+
+Use **recharts** (already in `apps/web/package.json` as dependency of existing admin analytics pages). If not present, use a lightweight alternative compatible with Next.js App Router.
+
+### Empty State
+
+When user has no AI usage:
+- Summary cards show 0 for all values
+- Charts show "Nessun dato disponibile" placeholder
+- Recent requests table shows "Non hai ancora utilizzato le funzionalità AI. Prova a chattare con un agente!"
+- No error state — empty is a valid state
+
+### Loading State
+
+- Skeleton loaders for summary cards (3 rectangles)
+- Skeleton loaders for charts (circular placeholder)
+- Skeleton rows for table
+
+### Error State
+
+- Toast notification on API error
+- Retry button per section (not full page reload)
+- Stale data display with "Ultimo aggiornamento: X minuti fa" label
+
+---
+
+## Acceptance Criteria
+
+### Functional
+
+- [ ] **AC-1**: Editor navigates to `/dashboard/my-ai-usage` and sees summary cards for today, 7-day, and 30-day periods
+- [ ] **AC-2**: Summary cards display request count, total tokens, and cost estimate for each period
+- [ ] **AC-3**: Daily request bar chart shows 30 days of data with correct counts
+- [ ] **AC-4**: Model distribution donut chart shows breakdown with percentages
+- [ ] **AC-5**: Strategy distribution donut chart shows Fast/Balanced/Premium/HybridRAG breakdown
+- [ ] **AC-6**: Recent requests table shows individual requests from last 7 days only
+- [ ] **AC-7**: Recent requests table is paginated (20 items per page)
+- [ ] **AC-8**: All data is scoped to the authenticated user only — no other users' data visible
+- [ ] **AC-9**: Users with "User" role cannot access the page (redirect to dashboard)
+- [ ] **AC-10**: Empty state displays correctly when user has no AI usage history
+- [ ] **AC-11**: Info banner explains the 7-day detail vs 30-day aggregate distinction
+
+### Non-Functional
+
+- [ ] **NFR-1**: Page loads in < 2 seconds for users with up to 10K requests in 30 days
+- [ ] **NFR-2**: API responses are cached for 5 minutes (stale-while-revalidate pattern)
+- [ ] **NFR-3**: Page is mobile responsive (single-column layout on mobile, charts stack vertically)
+- [ ] **NFR-4**: Charts render without JavaScript errors on Chrome, Firefox, Safari, Edge
+- [ ] **NFR-5**: Background aggregation job completes within 60 seconds for up to 100K daily records
+
+### Security
+
+- [ ] **SEC-1**: API endpoints enforce Editor role minimum via middleware
+- [ ] **SEC-2**: Backend filters by `UserId = currentUser` — no parameter allows querying other users
+- [ ] **SEC-3**: Recent requests endpoint does not expose `SessionId`, `ErrorMessage`, or prompt content
+- [ ] **SEC-4**: Cost data shows actual values (not estimates) — same data visible in admin analytics
+
+---
+
+## Specification by Example (Given/When/Then)
+
+### Scenario 1: Editor views usage summary
+```
+Given: Editor "alice" has made 12 AI requests today, 87 in last 7 days, 342 in last 30 days
+When: Alice navigates to /dashboard/my-ai-usage
+Then: She sees three summary cards with correct counts
+And: Token totals and cost estimates match her actual usage
+```
+
+### Scenario 2: Editor with no usage history
+```
+Given: Editor "bob" was just promoted to Editor role and has never used AI features
+When: Bob navigates to /dashboard/my-ai-usage
+Then: Summary cards show 0 for all values
+And: Charts show "Nessun dato disponibile" placeholder
+And: Recent requests table shows empty state message
+And: No error is displayed
+```
+
+### Scenario 3: User role denied access
+```
+Given: "charlie" has "User" role (not Editor)
+When: Charlie tries to navigate to /dashboard/my-ai-usage
+Then: He is redirected to /dashboard with "Accesso non autorizzato" message
+```
+
+### Scenario 4: Recent requests limited to 7 days
+```
+Given: Editor "alice" has requests from today and from 10 days ago
+When: She views the recent requests table
+Then: Only today's requests appear (not the 10-day-old ones)
+And: Info banner explains "I dettagli individuali sono disponibili per gli ultimi 7 giorni"
+And: 30-day summary cards still include ALL 30 days of aggregated data
+```
+
+### Scenario 5: Data isolation between users
+```
+Given: Editor "alice" and Editor "bob" both use AI features
+When: Alice views /dashboard/my-ai-usage
+Then: She sees ONLY her own request counts, costs, and history
+And: Bob's usage is not visible in any widget
+```
+
+### Scenario 6: Today's live data
+```
+Given: Editor "alice" sends an AI request at 14:22
+When: She refreshes /dashboard/my-ai-usage at 14:23
+Then: Today's summary card reflects the new request (live query, not cached)
+And: Daily chart shows today's bar updated
+And: Recent requests table shows the 14:22 request
+```
+
+---
+
+## Dependencies
+
+- **Aggregation job** must run BEFORE pseudonymization job (1:30 AM < 2:00 AM)
+- **recharts** or equivalent charting library in `apps/web/`
+- **UserAiUsageDailySummary** migration must be applied before aggregation job starts
+- No dependency on Epic F completion — aggregation table is independent
+
+## Estimated Effort
+
+| Component | Effort |
+|-----------|--------|
+| Domain entity + migration | 2h |
+| Aggregation background job | 4h |
+| 4 CQRS queries + handlers | 6h |
+| 4 API endpoints + routing | 3h |
+| Frontend page + 5 components | 8h |
+| Tests (unit + integration) | 6h |
+| **Total** | **~29h** |


### PR DESCRIPTION
## Summary

Fixes two gaps identified by the Epic #25 spec panel review:

- **#93 — Missing cost field**: `TechnicalDetailsPanel` now extracts `costUsd` from `DebugCostUpdate` SSE event (type 17) and displays it in the metadata panel + includes it in copy-to-clipboard text
- **#95 — Debug Console link visibility**: Added `showDebugLink` prop to `TechnicalDetailsPanel` (defaults to `false`). Only Admins see the "View in Debug Console" link since the debug-chat route is admin-protected. Editors still see all technical metadata.

Also includes:
- `docs/plans/epic-25-c3-editor-usage-spec.md` — Detailed spec for C3 (Editor Self-Service Usage Page)
- `docs/architecture/adr/adr-017-usage-aggregation-gdpr.md` — Architecture decision for resolving GDPR pseudonymization vs 30-day usage visibility conflict

## Changes

- `TechnicalDetailsPanel.tsx`: Add `costUsd` to `ExtractedMetadata`, extract from type 17 payload, display in dl list, include in clipboard
- `ChatThreadView.tsx`: Pass `showDebugLink={isAdmin}` to `TechnicalDetailsPanel`
- New docs: C3 spec + ADR-017

## Test plan

- [ ] Verify TypeScript compiles without errors (`pnpm typecheck`)
- [ ] Verify TechnicalDetailsPanel displays cost when `costUsd` is present in DebugCostUpdate
- [ ] Verify copy-to-clipboard includes cost line
- [ ] Verify Editor sees TechnicalDetailsPanel but NOT "View in Debug Console" link
- [ ] Verify Admin sees TechnicalDetailsPanel WITH "View in Debug Console" link
- [ ] Verify graceful degradation when `costUsd` is null (no cost row shown)

Closes #93
Closes #95

🤖 Generated with [Claude Code](https://claude.com/claude-code)
