### PR TITLE
feat(ai-usage): editor self-service AI usage page (#94)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/DTOs/AiUsageDistributionsDto.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/DTOs/AiUsageDistributionsDto.cs
@@ -1,0 +1,20 @@
+namespace Api.BoundedContexts.KnowledgeBase.Application.DTOs;
+
+/// <summary>
+/// Distribution breakdowns for AI usage (model, provider, operation).
+/// Issue #94: C3 Editor Self-Service AI Usage Page
+/// </summary>
+public record AiUsageDistributionsDto(
+    IReadOnlyList<DistributionItemDto> Models,
+    IReadOnlyList<DistributionItemDto> Providers,
+    IReadOnlyList<DistributionItemDto> Operations
+);
+
+/// <summary>
+/// A single distribution item (name + count + percentage).
+/// </summary>
+public record DistributionItemDto(
+    string Name,
+    int Count,
+    double Percentage
+);

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/DTOs/AiUsageRecentDto.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/DTOs/AiUsageRecentDto.cs
@@ -1,0 +1,28 @@
+namespace Api.BoundedContexts.KnowledgeBase.Application.DTOs;
+
+/// <summary>
+/// Paginated recent AI requests for the current user.
+/// Issue #94: C3 Editor Self-Service AI Usage Page
+/// </summary>
+public record AiUsageRecentDto(
+    IReadOnlyList<RecentAiRequestDto> Items,
+    int Total,
+    int Page,
+    int PageSize,
+    string Note
+);
+
+/// <summary>
+/// A single recent AI request (security-filtered: no ErrorMessage, IpAddress, UserAgent, SessionId).
+/// </summary>
+public record RecentAiRequestDto(
+    DateTime RequestedAt,
+    string Model,
+    string Provider,
+    string Operation,
+    int PromptTokens,
+    int CompletionTokens,
+    decimal CostUsd,
+    int LatencyMs,
+    bool Success
+);

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/DTOs/AiUsageSummaryDto.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/DTOs/AiUsageSummaryDto.cs
@@ -1,0 +1,23 @@
+namespace Api.BoundedContexts.KnowledgeBase.Application.DTOs;
+
+/// <summary>
+/// Multi-period AI usage summary (today, 7-day, 30-day).
+/// Issue #94: C3 Editor Self-Service AI Usage Page
+/// </summary>
+public record AiUsageSummaryDto(
+    AiUsagePeriodSummaryDto Today,
+    AiUsagePeriodSummaryDto Last7Days,
+    AiUsagePeriodSummaryDto Last30Days
+);
+
+/// <summary>
+/// Usage summary for a single period.
+/// </summary>
+public record AiUsagePeriodSummaryDto(
+    int RequestCount,
+    long PromptTokens,
+    long CompletionTokens,
+    long TotalTokens,
+    decimal CostUsd,
+    int AverageLatencyMs
+);

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Handlers/GetMyAiUsageDistributionsQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Handlers/GetMyAiUsageDistributionsQueryHandler.cs
@@ -1,0 +1,60 @@
+using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
+using Api.BoundedContexts.KnowledgeBase.Application.Queries;
+using Api.Infrastructure;
+using Api.SharedKernel.Application.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Handlers;
+
+/// <summary>
+/// Handler for GetMyAiUsageDistributionsQuery.
+/// Returns model, provider, and operation distribution breakdowns.
+/// Issue #94: C3 Editor Self-Service AI Usage Page
+/// </summary>
+internal class GetMyAiUsageDistributionsQueryHandler
+    : IQueryHandler<GetMyAiUsageDistributionsQuery, AiUsageDistributionsDto>
+{
+    private readonly MeepleAiDbContext _dbContext;
+
+    public GetMyAiUsageDistributionsQueryHandler(MeepleAiDbContext dbContext)
+    {
+        _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+    }
+
+    public async Task<AiUsageDistributionsDto> Handle(
+        GetMyAiUsageDistributionsQuery query, CancellationToken cancellationToken)
+    {
+        var cutoff = DateOnly.FromDateTime(DateTime.UtcNow).AddDays(-(query.Days - 1));
+
+        var logs = await _dbContext.LlmCostLogs
+            .AsNoTracking()
+            .Where(x => x.UserId == query.UserId && x.RequestDate >= cutoff)
+            .Select(x => new { x.ModelId, x.Provider, x.Endpoint })
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        var total = logs.Count;
+        if (total == 0)
+            return new AiUsageDistributionsDto([], [], []);
+
+        var models = logs
+            .GroupBy(x => x.ModelId, StringComparer.Ordinal)
+            .Select(g => new DistributionItemDto(g.Key, g.Count(), Math.Round(g.Count() * 100.0 / total, 1)))
+            .OrderByDescending(x => x.Count)
+            .ToList();
+
+        var providers = logs
+            .GroupBy(x => x.Provider, StringComparer.OrdinalIgnoreCase)
+            .Select(g => new DistributionItemDto(g.Key, g.Count(), Math.Round(g.Count() * 100.0 / total, 1)))
+            .OrderByDescending(x => x.Count)
+            .ToList();
+
+        var operations = logs
+            .GroupBy(x => x.Endpoint, StringComparer.OrdinalIgnoreCase)
+            .Select(g => new DistributionItemDto(g.Key, g.Count(), Math.Round(g.Count() * 100.0 / total, 1)))
+            .OrderByDescending(x => x.Count)
+            .ToList();
+
+        return new AiUsageDistributionsDto(models, providers, operations);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Handlers/GetMyAiUsageRecentQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Handlers/GetMyAiUsageRecentQueryHandler.cs
@@ -1,0 +1,64 @@
+using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
+using Api.BoundedContexts.KnowledgeBase.Application.Queries;
+using Api.Infrastructure;
+using Api.SharedKernel.Application.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Handlers;
+
+/// <summary>
+/// Handler for GetMyAiUsageRecentQuery.
+/// Returns paginated recent AI requests (last 7 days only).
+/// Security: excludes ErrorMessage, IpAddress, UserAgent, SessionId.
+/// Issue #94: C3 Editor Self-Service AI Usage Page
+/// </summary>
+internal class GetMyAiUsageRecentQueryHandler
+    : IQueryHandler<GetMyAiUsageRecentQuery, AiUsageRecentDto>
+{
+    private readonly MeepleAiDbContext _dbContext;
+
+    public GetMyAiUsageRecentQueryHandler(MeepleAiDbContext dbContext)
+    {
+        _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+    }
+
+    public async Task<AiUsageRecentDto> Handle(
+        GetMyAiUsageRecentQuery query, CancellationToken cancellationToken)
+    {
+        var sevenDaysAgo = DateTime.UtcNow.AddDays(-7);
+        var page = Math.Max(1, query.Page);
+        var pageSize = Math.Clamp(query.PageSize, 1, 50);
+
+        var baseQuery = _dbContext.LlmCostLogs
+            .AsNoTracking()
+            .Where(x => x.UserId == query.UserId && x.CreatedAt >= sevenDaysAgo)
+            .OrderByDescending(x => x.CreatedAt);
+
+        var total = await baseQuery.CountAsync(cancellationToken).ConfigureAwait(false);
+
+        var items = await baseQuery
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
+            .Select(x => new RecentAiRequestDto(
+                x.CreatedAt,
+                x.ModelId,
+                x.Provider,
+                x.Endpoint,
+                x.PromptTokens,
+                x.CompletionTokens,
+                x.TotalCost,
+                x.LatencyMs,
+                x.Success
+            ))
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return new AiUsageRecentDto(
+            items,
+            total,
+            page,
+            pageSize,
+            "Individual requests are available for the last 7 days only (GDPR compliance)."
+        );
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Handlers/GetMyAiUsageSummaryQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Handlers/GetMyAiUsageSummaryQueryHandler.cs
@@ -1,0 +1,77 @@
+using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
+using Api.BoundedContexts.KnowledgeBase.Application.Queries;
+using Api.Infrastructure;
+using Api.SharedKernel.Application.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Handlers;
+
+/// <summary>
+/// Handler for GetMyAiUsageSummaryQuery.
+/// Returns multi-period summary (today/7d/30d) from LlmCostLogs.
+/// Issue #94: C3 Editor Self-Service AI Usage Page
+/// </summary>
+internal class GetMyAiUsageSummaryQueryHandler : IQueryHandler<GetMyAiUsageSummaryQuery, AiUsageSummaryDto>
+{
+    private readonly MeepleAiDbContext _dbContext;
+
+    public GetMyAiUsageSummaryQueryHandler(MeepleAiDbContext dbContext)
+    {
+        _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+    }
+
+    public async Task<AiUsageSummaryDto> Handle(GetMyAiUsageSummaryQuery query, CancellationToken cancellationToken)
+    {
+        var today = DateOnly.FromDateTime(DateTime.UtcNow);
+        var sevenDaysAgo = today.AddDays(-6);
+        var thirtyDaysAgo = today.AddDays(-29);
+
+        var allLogs = await _dbContext.LlmCostLogs
+            .AsNoTracking()
+            .Where(x => x.UserId == query.UserId && x.RequestDate >= thirtyDaysAgo)
+            .Select(x => new CostLogProjection(
+                x.RequestDate, x.PromptTokens, x.CompletionTokens,
+                x.TotalTokens, x.TotalCost, x.LatencyMs))
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        var todaySummary = Aggregate(allLogs.Where(x => x.RequestDate == today));
+        var sevenDaySummary = Aggregate(allLogs.Where(x => x.RequestDate >= sevenDaysAgo));
+        var thirtyDaySummary = Aggregate(allLogs);
+
+        return new AiUsageSummaryDto(todaySummary, sevenDaySummary, thirtyDaySummary);
+    }
+
+    private static AiUsagePeriodSummaryDto Aggregate(IEnumerable<CostLogProjection> logs)
+    {
+        var items = logs.ToList();
+        if (items.Count == 0)
+            return new AiUsagePeriodSummaryDto(0, 0, 0, 0, 0m, 0);
+
+        long promptTokens = 0, completionTokens = 0, totalTokens = 0;
+        decimal costUsd = 0m;
+        long totalLatency = 0;
+
+        foreach (var item in items)
+        {
+            promptTokens += item.PromptTokens;
+            completionTokens += item.CompletionTokens;
+            totalTokens += item.TotalTokens;
+            costUsd += item.TotalCost;
+            totalLatency += item.LatencyMs;
+        }
+
+        return new AiUsagePeriodSummaryDto(
+            items.Count,
+            promptTokens,
+            completionTokens,
+            totalTokens,
+            costUsd,
+            (int)(totalLatency / items.Count)
+        );
+    }
+
+    private record CostLogProjection(
+        DateOnly RequestDate, int PromptTokens, int CompletionTokens,
+        int TotalTokens, decimal TotalCost, int LatencyMs);
+}

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetMyAiUsageDistributionsQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetMyAiUsageDistributionsQuery.cs
@@ -1,0 +1,10 @@
+using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries;
+
+/// <summary>
+/// Query to get model/provider/operation distribution breakdowns.
+/// Issue #94: C3 Editor Self-Service AI Usage Page
+/// </summary>
+internal record GetMyAiUsageDistributionsQuery(Guid UserId, int Days = 30) : IQuery<AiUsageDistributionsDto>;

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetMyAiUsageRecentQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetMyAiUsageRecentQuery.cs
@@ -1,0 +1,14 @@
+using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries;
+
+/// <summary>
+/// Query to get paginated recent AI requests (last 7 days only).
+/// Issue #94: C3 Editor Self-Service AI Usage Page
+/// </summary>
+internal record GetMyAiUsageRecentQuery(
+    Guid UserId,
+    int Page = 1,
+    int PageSize = 20
+) : IQuery<AiUsageRecentDto>;

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetMyAiUsageSummaryQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/GetMyAiUsageSummaryQuery.cs
@@ -1,0 +1,10 @@
+using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries;
+
+/// <summary>
+/// Query to get multi-period AI usage summary (today/7d/30d).
+/// Issue #94: C3 Editor Self-Service AI Usage Page
+/// </summary>
+internal record GetMyAiUsageSummaryQuery(Guid UserId) : IQuery<AiUsageSummaryDto>;

--- a/apps/api/src/Api/Routing/UserProfileEndpoints.cs
+++ b/apps/api/src/Api/Routing/UserProfileEndpoints.cs
@@ -425,6 +425,64 @@ internal static class UserProfileEndpoints
 **Response**: UserAiUsageDto with detailed usage breakdown.")
         .Produces<UserAiUsageDto>(200)
         .Produces(401);
+
+        // Issue #94: Multi-period usage summary (today/7d/30d)
+        group.MapGet("/users/me/ai-usage/summary", async (
+            HttpContext context,
+            IMediator mediator,
+            CancellationToken ct = default) =>
+        {
+            var session = (SessionStatusDto)context.Items[nameof(SessionStatusDto)]!;
+            var query = new GetMyAiUsageSummaryQuery(session!.User!.Id);
+            return Results.Ok(await mediator.Send(query, ct).ConfigureAwait(false));
+        })
+        .RequireSession()
+        .RequireAuthorization()
+        .WithName("GetMyAiUsageSummary")
+        .WithTags("AI Usage")
+        .WithSummary("Get multi-period AI usage summary (today/7d/30d)")
+        .Produces<AiUsageSummaryDto>(200)
+        .Produces(401);
+
+        // Issue #94: Usage distributions (model, provider, operation)
+        group.MapGet("/users/me/ai-usage/distributions", async (
+            HttpContext context,
+            IMediator mediator,
+            int days = 30,
+            CancellationToken ct = default) =>
+        {
+            var session = (SessionStatusDto)context.Items[nameof(SessionStatusDto)]!;
+            var clampedDays = Math.Clamp(days, 1, 90);
+            var query = new GetMyAiUsageDistributionsQuery(session!.User!.Id, clampedDays);
+            return Results.Ok(await mediator.Send(query, ct).ConfigureAwait(false));
+        })
+        .RequireSession()
+        .RequireAuthorization()
+        .WithName("GetMyAiUsageDistributions")
+        .WithTags("AI Usage")
+        .WithSummary("Get AI usage distribution breakdowns (model, provider, operation)")
+        .Produces<AiUsageDistributionsDto>(200)
+        .Produces(401);
+
+        // Issue #94: Recent individual requests (last 7 days, paginated)
+        group.MapGet("/users/me/ai-usage/recent", async (
+            HttpContext context,
+            IMediator mediator,
+            int page = 1,
+            int pageSize = 20,
+            CancellationToken ct = default) =>
+        {
+            var session = (SessionStatusDto)context.Items[nameof(SessionStatusDto)]!;
+            var query = new GetMyAiUsageRecentQuery(session!.User!.Id, page, pageSize);
+            return Results.Ok(await mediator.Send(query, ct).ConfigureAwait(false));
+        })
+        .RequireSession()
+        .RequireAuthorization()
+        .WithName("GetMyAiUsageRecent")
+        .WithTags("AI Usage")
+        .WithSummary("Get recent AI requests (last 7 days, paginated)")
+        .Produces<AiUsageRecentDto>(200)
+        .Produces(401);
     }
 
     private static void MapFeatureAccessEndpoints(RouteGroupBuilder group)

--- a/apps/web/src/app/(authenticated)/dashboard/my-ai-usage/__tests__/page.test.tsx
+++ b/apps/web/src/app/(authenticated)/dashboard/my-ai-usage/__tests__/page.test.tsx
@@ -1,20 +1,27 @@
 /**
- * My AI Usage Page Tests - Issue #5484
+ * My AI Usage Page Tests — Issue #94 (C3: Editor Self-Service AI Usage Page)
  *
  * Tests:
- * 1. Renders page with stats when data loads
+ * 1. Renders multi-period summary cards (today/7d/30d)
  * 2. Shows loading skeleton
  * 3. Shows error state
- * 4. Period selector changes data
- * 5. Empty state when no usage
- * 6. Requires Editor+ role
+ * 4. Renders distribution charts (model, provider)
+ * 5. Renders recent requests table with pagination
+ * 6. Shows info banner
+ * 7. Empty state when no usage
+ * 8. Requires Editor+ role
  */
 
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect, vi, beforeEach } from 'vitest';
 
-import type { UserAiUsageDto } from '@/lib/api/schemas/ai-usage.schemas';
+import type {
+  AiUsageSummaryDto,
+  AiUsageDistributionsDto,
+  AiUsageRecentDto,
+  UserAiUsageDto,
+} from '@/lib/api/schemas/ai-usage.schemas';
 
 // ─── Mocks ───────────────────────────────────────────────────────────────────
 
@@ -24,36 +31,110 @@ vi.mock('@/hooks/useAuth', () => ({
   useAuth: () => ({ user: mockUser, isLoading: false }),
 }));
 
-// Mock RequireRole to just render children
 vi.mock('@/components/auth/RequireRole', () => ({
   RequireRole: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }));
 
+const mockGetMyAiUsageSummary = vi.fn();
+const mockGetMyAiUsageDistributions = vi.fn();
+const mockGetMyAiUsageRecent = vi.fn();
 const mockGetMyAiUsage = vi.fn();
+
 vi.mock('@/lib/api/dashboard-client', () => ({
   dashboardClient: {
+    getMyAiUsageSummary: (...args: unknown[]) => mockGetMyAiUsageSummary(...args),
+    getMyAiUsageDistributions: (...args: unknown[]) => mockGetMyAiUsageDistributions(...args),
+    getMyAiUsageRecent: (...args: unknown[]) => mockGetMyAiUsageRecent(...args),
     getMyAiUsage: (...args: unknown[]) => mockGetMyAiUsage(...args),
   },
 }));
 
-const mockUsageData: UserAiUsageDto = {
+const mockSummary: AiUsageSummaryDto = {
+  today: {
+    requestCount: 12,
+    promptTokens: 8400,
+    completionTokens: 3200,
+    totalTokens: 11600,
+    costUsd: 0.0234,
+    averageLatencyMs: 1250,
+  },
+  last7Days: {
+    requestCount: 87,
+    promptTokens: 62000,
+    completionTokens: 24000,
+    totalTokens: 86000,
+    costUsd: 0.172,
+    averageLatencyMs: 1180,
+  },
+  last30Days: {
+    requestCount: 342,
+    promptTokens: 245000,
+    completionTokens: 98000,
+    totalTokens: 343000,
+    costUsd: 0.684,
+    averageLatencyMs: 1210,
+  },
+};
+
+const mockDistributions: AiUsageDistributionsDto = {
+  models: [
+    { name: 'llama3:8b', count: 180, percentage: 52.6 },
+    { name: 'gpt-4o-mini', count: 95, percentage: 27.8 },
+    { name: 'claude-3-haiku', count: 67, percentage: 19.6 },
+  ],
+  providers: [
+    { name: 'Ollama', count: 210, percentage: 61.4 },
+    { name: 'OpenRouter', count: 132, percentage: 38.6 },
+  ],
+  operations: [
+    { name: 'chat', count: 200, percentage: 58.5 },
+    { name: 'rag_query', count: 142, percentage: 41.5 },
+  ],
+};
+
+const mockRecent: AiUsageRecentDto = {
+  items: [
+    {
+      requestedAt: '2026-03-10T14:22:00Z',
+      model: 'llama3:8b',
+      provider: 'Ollama',
+      operation: 'chat',
+      promptTokens: 650,
+      completionTokens: 280,
+      costUsd: 0.0,
+      latencyMs: 890,
+      success: true,
+    },
+    {
+      requestedAt: '2026-03-10T14:10:00Z',
+      model: 'gpt-4o-mini',
+      provider: 'OpenRouter',
+      operation: 'rag_query',
+      promptTokens: 1100,
+      completionTokens: 320,
+      costUsd: 0.0012,
+      latencyMs: 1420,
+      success: true,
+    },
+  ],
+  total: 87,
+  page: 1,
+  pageSize: 20,
+  note: 'Individual requests are available for the last 7 days only (GDPR compliance).',
+};
+
+const mockDailyUsage: UserAiUsageDto = {
   userId: 'user-1',
-  period: { from: '2024-01-01', to: '2024-01-07' },
-  totalTokens: 12500,
-  totalCostUsd: 0.0142,
-  requestCount: 45,
-  byModel: [
-    { model: 'meta-llama/llama-3.3-70b-instruct:free', tokens: 8000, cost: 0.0 },
-    { model: 'llama3:8b', tokens: 4500, cost: 0.0142 },
-  ],
-  byOperation: [
-    { operation: 'chat', count: 30, tokens: 9000 },
-    { operation: 'rag_query', count: 15, tokens: 3500 },
-  ],
+  period: { from: '2026-02-08', to: '2026-03-10' },
+  totalTokens: 343000,
+  totalCostUsd: 0.684,
+  requestCount: 342,
+  byModel: [],
+  byOperation: [],
   dailyUsage: [
-    { date: '2024-01-01', tokens: 1200 },
-    { date: '2024-01-02', tokens: 2300 },
-    { date: '2024-01-03', tokens: 1800 },
+    { date: '2026-03-08', tokens: 5000 },
+    { date: '2026-03-09', tokens: 7200 },
+    { date: '2026-03-10', tokens: 3100 },
   ],
 };
 
@@ -62,26 +143,39 @@ const mockUsageData: UserAiUsageDto = {
 describe('MyAiUsagePage', () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockGetMyAiUsage.mockResolvedValue(mockUsageData);
+    mockGetMyAiUsageSummary.mockResolvedValue(mockSummary);
+    mockGetMyAiUsageDistributions.mockResolvedValue(mockDistributions);
+    mockGetMyAiUsageRecent.mockResolvedValue(mockRecent);
+    mockGetMyAiUsage.mockResolvedValue(mockDailyUsage);
   });
 
-  it('renders usage stats after loading', async () => {
+  it('renders multi-period summary cards', async () => {
     const { default: Page } = await import('../page');
     render(<Page />);
 
     await waitFor(() => {
-      expect(screen.getByTestId('usage-stats')).toBeInTheDocument();
+      expect(screen.getByTestId('usage-summary')).toBeInTheDocument();
     });
 
-    expect(screen.getByText('45')).toBeInTheDocument(); // requestCount
-    expect(screen.getByText('12.5K')).toBeInTheDocument(); // totalTokens
-    // Cost appears in stat card and model detail — just check at least one
-    expect(screen.getAllByText('$0.0142').length).toBeGreaterThanOrEqual(1);
-    expect(screen.getByText('2')).toBeInTheDocument(); // models count
+    // Today card
+    expect(screen.getByText('Oggi')).toBeInTheDocument();
+    expect(screen.getByText('12')).toBeInTheDocument();
+
+    // 7 day card
+    expect(screen.getByText('7 Giorni')).toBeInTheDocument();
+    expect(screen.getByText('87')).toBeInTheDocument();
+
+    // 30 day card
+    expect(screen.getByText('30 Giorni')).toBeInTheDocument();
+    expect(screen.getByText('342')).toBeInTheDocument();
   });
 
   it('shows loading skeleton initially', async () => {
-    mockGetMyAiUsage.mockReturnValue(new Promise(() => {})); // never resolves
+    mockGetMyAiUsageSummary.mockReturnValue(new Promise(() => {}));
+    mockGetMyAiUsageDistributions.mockReturnValue(new Promise(() => {}));
+    mockGetMyAiUsageRecent.mockReturnValue(new Promise(() => {}));
+    mockGetMyAiUsage.mockReturnValue(new Promise(() => {}));
+
     const { default: Page } = await import('../page');
     render(<Page />);
 
@@ -89,7 +183,7 @@ describe('MyAiUsagePage', () => {
   });
 
   it('shows error when API fails', async () => {
-    mockGetMyAiUsage.mockRejectedValue(new Error('Network error'));
+    mockGetMyAiUsageSummary.mockRejectedValue(new Error('Network error'));
     const { default: Page } = await import('../page');
     render(<Page />);
 
@@ -98,26 +192,7 @@ describe('MyAiUsagePage', () => {
     });
   });
 
-  it('changes period and refetches data', async () => {
-    const user = userEvent.setup();
-    const { default: Page } = await import('../page');
-    render(<Page />);
-
-    await waitFor(() => {
-      expect(screen.getByTestId('usage-stats')).toBeInTheDocument();
-    });
-
-    // Default is 7d
-    expect(mockGetMyAiUsage).toHaveBeenCalledWith(7);
-
-    // Switch to 30d
-    await user.click(screen.getByTestId('period-30d'));
-    await waitFor(() => {
-      expect(mockGetMyAiUsage).toHaveBeenCalledWith(30);
-    });
-  });
-
-  it('renders model distribution bars', async () => {
+  it('renders model distribution chart', async () => {
     const { default: Page } = await import('../page');
     render(<Page />);
 
@@ -125,21 +200,65 @@ describe('MyAiUsagePage', () => {
       expect(screen.getByText('Distribuzione modelli')).toBeInTheDocument();
     });
 
-    expect(screen.getByText('meta-llama/llama-3.3-70b-instruct:free')).toBeInTheDocument();
-    expect(screen.getByText('llama3:8b')).toBeInTheDocument();
+    expect(screen.getAllByText('llama3:8b').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('gpt-4o-mini').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getByText('52.6%')).toBeInTheDocument();
   });
 
-  it('renders operation breakdown', async () => {
+  it('renders provider distribution chart', async () => {
     const { default: Page } = await import('../page');
     render(<Page />);
 
     await waitFor(() => {
-      expect(screen.getByText('Distribuzione per tipo')).toBeInTheDocument();
+      expect(screen.getByText('Distribuzione provider')).toBeInTheDocument();
     });
 
-    expect(screen.getByText('chat')).toBeInTheDocument();
-    expect(screen.getByText('rag_query')).toBeInTheDocument();
-    expect(screen.getByText('30 richieste')).toBeInTheDocument();
+    expect(screen.getAllByText('Ollama').length).toBeGreaterThanOrEqual(1);
+    expect(screen.getAllByText('OpenRouter').length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('renders recent requests table', async () => {
+    const { default: Page } = await import('../page');
+    render(<Page />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('recent-requests-table')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Richieste recenti')).toBeInTheDocument();
+    expect(screen.getByText(/87 richieste totali/)).toBeInTheDocument();
+  });
+
+  it('paginates recent requests', async () => {
+    const user = userEvent.setup();
+    const { default: Page } = await import('../page');
+    render(<Page />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('recent-requests-table')).toBeInTheDocument();
+    });
+
+    // Page 1 of 5 (87 total / 20 per page)
+    expect(screen.getByText(/Pagina 1 di 5/)).toBeInTheDocument();
+
+    // Click next page
+    mockGetMyAiUsageRecent.mockResolvedValue({ ...mockRecent, page: 2 });
+    await user.click(screen.getByLabelText('Pagina successiva'));
+
+    await waitFor(() => {
+      expect(mockGetMyAiUsageRecent).toHaveBeenCalledWith(2, 20);
+    });
+  });
+
+  it('shows info banner about 7-day vs 30-day data', async () => {
+    const { default: Page } = await import('../page');
+    render(<Page />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('usage-info-banner')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText(/dettagli individuali.*7 giorni/i)).toBeInTheDocument();
   });
 
   it('renders daily usage chart', async () => {
@@ -152,13 +271,17 @@ describe('MyAiUsagePage', () => {
   });
 
   it('shows empty state when no requests', async () => {
+    mockGetMyAiUsageSummary.mockResolvedValue({
+      today: { requestCount: 0, promptTokens: 0, completionTokens: 0, totalTokens: 0, costUsd: 0, averageLatencyMs: 0 },
+      last7Days: { requestCount: 0, promptTokens: 0, completionTokens: 0, totalTokens: 0, costUsd: 0, averageLatencyMs: 0 },
+      last30Days: { requestCount: 0, promptTokens: 0, completionTokens: 0, totalTokens: 0, costUsd: 0, averageLatencyMs: 0 },
+    });
+    mockGetMyAiUsageDistributions.mockResolvedValue({ models: [], providers: [], operations: [] });
+    mockGetMyAiUsageRecent.mockResolvedValue({ items: [], total: 0, page: 1, pageSize: 20, note: '' });
     mockGetMyAiUsage.mockResolvedValue({
-      ...mockUsageData,
+      ...mockDailyUsage,
       requestCount: 0,
       totalTokens: 0,
-      totalCostUsd: 0,
-      byModel: [],
-      byOperation: [],
       dailyUsage: [],
     });
 
@@ -166,7 +289,7 @@ describe('MyAiUsagePage', () => {
     render(<Page />);
 
     await waitFor(() => {
-      expect(screen.getByText(/Nessun utilizzo AI/)).toBeInTheDocument();
+      expect(screen.getByText(/Non hai ancora utilizzato/)).toBeInTheDocument();
     });
   });
 });

--- a/apps/web/src/app/(authenticated)/dashboard/my-ai-usage/page.tsx
+++ b/apps/web/src/app/(authenticated)/dashboard/my-ai-usage/page.tsx
@@ -1,33 +1,39 @@
 'use client';
 
 /**
- * My AI Usage Page — Issue #5484
+ * My AI Usage Page — Issue #94 (C3: Editor Self-Service AI Usage Page)
  * Route: /dashboard/my-ai-usage
  * Self-service AI usage dashboard for Editor and Admin roles.
+ * Shows multi-period summary, distribution charts, and recent requests.
  */
 
 import { useEffect, useState, useCallback } from 'react';
 
-import { Brain, Cpu, Zap, DollarSign, BarChart3, RefreshCw } from 'lucide-react';
+import {
+  Brain,
+  Cpu,
+  Zap,
+  DollarSign,
+  Clock,
+  RefreshCw,
+  ChevronLeft,
+  ChevronRight,
+  Info,
+} from 'lucide-react';
 
 import { RequireRole } from '@/components/auth/RequireRole';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { useAuth } from '@/hooks/useAuth';
 import { dashboardClient } from '@/lib/api/dashboard-client';
 import type {
+  AiUsageSummaryDto,
+  AiUsagePeriodSummaryDto,
+  AiUsageDistributionsDto,
+  DistributionItemDto,
+  AiUsageRecentDto,
   UserAiUsageDto,
-  ModelUsageDto,
-  DailyUsageDto,
 } from '@/lib/api/schemas/ai-usage.schemas';
 import { cn } from '@/lib/utils';
-
-type Period = 1 | 7 | 30;
-
-const PERIOD_OPTIONS: { value: Period; label: string }[] = [
-  { value: 1, label: 'Oggi' },
-  { value: 7, label: '7 giorni' },
-  { value: 30, label: '30 giorni' },
-];
 
 export default function MyAiUsagePage() {
   return (
@@ -39,17 +45,29 @@ export default function MyAiUsagePage() {
 
 function MyAiUsageContent() {
   const { user } = useAuth();
-  const [usage, setUsage] = useState<UserAiUsageDto | null>(null);
+  const [summary, setSummary] = useState<AiUsageSummaryDto | null>(null);
+  const [distributions, setDistributions] = useState<AiUsageDistributionsDto | null>(null);
+  const [recent, setRecent] = useState<AiUsageRecentDto | null>(null);
+  const [dailyData, setDailyData] = useState<UserAiUsageDto | null>(null);
+  const [recentPage, setRecentPage] = useState(1);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
-  const [period, setPeriod] = useState<Period>(7);
 
-  const fetchUsage = useCallback(async (days: Period) => {
+  const fetchAll = useCallback(async () => {
     try {
       setLoading(true);
       setError(null);
-      const data = await dashboardClient.getMyAiUsage(days);
-      setUsage(data);
+      const [summaryData, distData, recentData, daily] = await Promise.all([
+        dashboardClient.getMyAiUsageSummary(),
+        dashboardClient.getMyAiUsageDistributions(30),
+        dashboardClient.getMyAiUsageRecent(1, 20),
+        dashboardClient.getMyAiUsage(30),
+      ]);
+      setSummary(summaryData);
+      setDistributions(distData);
+      setRecent(recentData);
+      setDailyData(daily);
+      setRecentPage(1);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Errore nel caricamento');
     } finally {
@@ -57,14 +75,20 @@ function MyAiUsageContent() {
     }
   }, []);
 
+  const fetchRecentPage = useCallback(async (page: number) => {
+    try {
+      const data = await dashboardClient.getMyAiUsageRecent(page, 20);
+      setRecent(data);
+      setRecentPage(page);
+    } catch {
+      // Keep existing data on pagination error
+    }
+  }, []);
+
   useEffect(() => {
     if (!user) return;
-    fetchUsage(period);
-  }, [user, period, fetchUsage]);
-
-  const handlePeriodChange = (p: Period) => {
-    setPeriod(p);
-  };
+    fetchAll();
+  }, [user, fetchAll]);
 
   return (
     <div className="container mx-auto py-8 space-y-6" data-testid="my-ai-usage-page">
@@ -76,40 +100,18 @@ function MyAiUsageContent() {
             Il mio utilizzo AI
           </h1>
           <p className="text-sm text-muted-foreground mt-1">
-            Statistiche personali di utilizzo dei modelli AI
+            Scopri come utilizzi le funzionalità AI di MeepleAI
           </p>
         </div>
-        <div className="flex items-center gap-2">
-          {/* Period selector */}
-          <div className="flex rounded-md border" data-testid="period-selector">
-            {PERIOD_OPTIONS.map(opt => (
-              <button
-                key={opt.value}
-                type="button"
-                onClick={() => handlePeriodChange(opt.value)}
-                className={cn(
-                  'px-3 py-1.5 text-xs font-medium transition-colors',
-                  'first:rounded-l-md last:rounded-r-md',
-                  period === opt.value
-                    ? 'bg-primary text-primary-foreground'
-                    : 'bg-background text-muted-foreground hover:bg-muted'
-                )}
-                data-testid={`period-${opt.value}d`}
-              >
-                {opt.label}
-              </button>
-            ))}
-          </div>
-          <button
-            type="button"
-            onClick={() => fetchUsage(period)}
-            disabled={loading}
-            className="p-2 rounded-md border hover:bg-muted transition-colors disabled:opacity-50"
-            aria-label="Aggiorna"
-          >
-            <RefreshCw className={cn('h-4 w-4', loading && 'animate-spin')} />
-          </button>
-        </div>
+        <button
+          type="button"
+          onClick={fetchAll}
+          disabled={loading}
+          className="p-2 rounded-md border hover:bg-muted transition-colors disabled:opacity-50"
+          aria-label="Aggiorna"
+        >
+          <RefreshCw className={cn('h-4 w-4', loading && 'animate-spin')} />
+        </button>
       </div>
 
       {/* Error */}
@@ -120,9 +122,9 @@ function MyAiUsageContent() {
       )}
 
       {/* Loading skeleton */}
-      {loading && !usage && (
-        <div className="grid gap-4 md:grid-cols-4" data-testid="usage-skeleton">
-          {[...Array(4)].map((_, i) => (
+      {loading && !summary && (
+        <div className="grid gap-4 md:grid-cols-3" data-testid="usage-skeleton">
+          {[...Array(3)].map((_, i) => (
             <Card key={i}>
               <CardContent className="py-6">
                 <div className="h-4 w-24 bg-muted animate-pulse rounded mb-2" />
@@ -133,75 +135,62 @@ function MyAiUsageContent() {
         </div>
       )}
 
-      {/* Stats cards */}
-      {usage && (
-        <>
-          <div className="grid gap-4 md:grid-cols-4" data-testid="usage-stats">
-            <StatCard
-              icon={Zap}
-              label="Richieste"
-              value={usage.requestCount.toLocaleString()}
-              description={`Ultimi ${period === 1 ? 'oggi' : `${period} giorni`}`}
-            />
-            <StatCard
-              icon={Cpu}
-              label="Token totali"
-              value={formatTokens(usage.totalTokens)}
-              description="Prompt + completamento"
-            />
-            <StatCard
-              icon={DollarSign}
-              label="Costo stimato"
-              value={`$${usage.totalCostUsd.toFixed(4)}`}
-              description="USD equivalente"
-            />
-            <StatCard
-              icon={BarChart3}
-              label="Modelli usati"
-              value={usage.byModel.length.toString()}
-              description="Modelli diversi"
-            />
-          </div>
-
-          {/* Model distribution + Daily chart */}
-          <div className="grid gap-4 md:grid-cols-2">
-            <ModelDistribution models={usage.byModel} totalTokens={usage.totalTokens} />
-            <DailyUsageChart dailyUsage={usage.dailyUsage} />
-          </div>
-
-          {/* Operation breakdown */}
-          {usage.byOperation.length > 0 && (
-            <Card>
-              <CardHeader>
-                <CardTitle className="text-base">Distribuzione per tipo</CardTitle>
-                <CardDescription>
-                  Ripartizione delle richieste per tipologia operazione
-                </CardDescription>
-              </CardHeader>
-              <CardContent>
-                <div className="space-y-2">
-                  {usage.byOperation.map(op => (
-                    <div key={op.operation} className="flex items-center justify-between text-sm">
-                      <span className="font-medium capitalize">{op.operation}</span>
-                      <div className="flex items-center gap-4 tabular-nums">
-                        <span className="text-muted-foreground">{op.count} richieste</span>
-                        <span>{formatTokens(op.tokens)} token</span>
-                      </div>
-                    </div>
-                  ))}
-                </div>
-              </CardContent>
-            </Card>
-          )}
-        </>
+      {/* Summary cards — today / 7d / 30d */}
+      {summary && (
+        <div className="grid gap-4 md:grid-cols-3" data-testid="usage-summary">
+          <SummaryCard label="Oggi" period={summary.today} />
+          <SummaryCard label="7 Giorni" period={summary.last7Days} />
+          <SummaryCard label="30 Giorni" period={summary.last30Days} />
+        </div>
       )}
 
+      {/* Daily chart + Distributions */}
+      {(dailyData || distributions) && (
+        <div className="grid gap-4 md:grid-cols-2">
+          {dailyData && <DailyUsageChart dailyUsage={dailyData.dailyUsage} />}
+          {distributions && distributions.models.length > 0 && (
+            <DistributionCard title="Distribuzione modelli" items={distributions.models} />
+          )}
+        </div>
+      )}
+
+      {distributions && distributions.providers.length > 0 && (
+        <div className="grid gap-4 md:grid-cols-2">
+          <DistributionCard title="Distribuzione provider" items={distributions.providers} />
+          {distributions.operations.length > 0 && (
+            <DistributionCard title="Distribuzione operazioni" items={distributions.operations} />
+          )}
+        </div>
+      )}
+
+      {/* Recent requests table */}
+      {recent && (
+        <RecentRequestsTable
+          data={recent}
+          currentPage={recentPage}
+          onPageChange={fetchRecentPage}
+        />
+      )}
+
+      {/* Info banner */}
+      <div
+        className="flex items-start gap-2 rounded-lg border border-blue-200 bg-blue-50 px-4 py-3 text-sm text-blue-800 dark:border-blue-800 dark:bg-blue-950/30 dark:text-blue-200"
+        data-testid="usage-info-banner"
+      >
+        <Info className="h-4 w-4 mt-0.5 flex-shrink-0" />
+        <p>
+          I dettagli individuali delle richieste sono disponibili per gli ultimi 7 giorni. I totali
+          aggregati coprono fino a 30 giorni.
+        </p>
+      </div>
+
       {/* Empty state */}
-      {!loading && usage && usage.requestCount === 0 && (
+      {!loading && summary && summary.last30Days.requestCount === 0 && (
         <Card>
           <CardContent className="py-12 text-center text-muted-foreground">
             <Brain className="h-12 w-12 mx-auto mb-3 opacity-30" />
-            <p>Nessun utilizzo AI nel periodo selezionato.</p>
+            <p>Non hai ancora utilizzato le funzionalità AI.</p>
+            <p className="text-xs mt-1">Prova a chattare con un agente!</p>
           </CardContent>
         </Card>
       )}
@@ -211,86 +200,40 @@ function MyAiUsageContent() {
 
 // ─── Sub-components ────────────────────────────────────────────────────────
 
-function StatCard({
-  icon: Icon,
-  label,
-  value,
-  description,
-}: {
-  icon: React.ComponentType<{ className?: string }>;
-  label: string;
-  value: string;
-  description: string;
-}) {
+function SummaryCard({ label, period }: { label: string; period: AiUsagePeriodSummaryDto }) {
   return (
-    <Card>
-      <CardContent className="py-4">
-        <div className="flex items-center gap-2 text-muted-foreground mb-1">
-          <Icon className="h-4 w-4" />
-          <span className="text-xs font-medium">{label}</span>
-        </div>
-        <div className="text-2xl font-bold tabular-nums">{value}</div>
-        <p className="text-xs text-muted-foreground mt-0.5">{description}</p>
-      </CardContent>
-    </Card>
-  );
-}
-
-function ModelDistribution({
-  models,
-  totalTokens,
-}: {
-  models: ModelUsageDto[];
-  totalTokens: number;
-}) {
-  if (models.length === 0) return null;
-
-  const sorted = [...models].sort((a, b) => b.tokens - a.tokens);
-  const colors = [
-    'bg-blue-500',
-    'bg-violet-500',
-    'bg-amber-500',
-    'bg-emerald-500',
-    'bg-rose-500',
-    'bg-cyan-500',
-  ];
-
-  return (
-    <Card>
-      <CardHeader>
-        <CardTitle className="text-base">Distribuzione modelli</CardTitle>
-        <CardDescription>Token per modello AI utilizzato</CardDescription>
+    <Card data-testid={`summary-card-${label.toLowerCase().replace(/\s/g, '-')}`}>
+      <CardHeader className="pb-2">
+        <CardTitle className="text-sm font-medium text-muted-foreground">{label}</CardTitle>
       </CardHeader>
-      <CardContent className="space-y-3">
-        {sorted.map((m, i) => {
-          const pct = totalTokens > 0 ? (m.tokens / totalTokens) * 100 : 0;
-          return (
-            <div key={m.model} className="space-y-1">
-              <div className="flex items-center justify-between text-xs">
-                <span className="font-mono truncate max-w-[200px]" title={m.model}>
-                  {m.model}
-                </span>
-                <span className="tabular-nums text-muted-foreground ml-2">{pct.toFixed(0)}%</span>
-              </div>
-              <div className="h-2 rounded-full bg-muted overflow-hidden">
-                <div
-                  className={cn('h-full rounded-full transition-all', colors[i % colors.length])}
-                  style={{ width: `${pct}%` }}
-                />
-              </div>
-              <div className="flex justify-between text-[10px] text-muted-foreground tabular-nums">
-                <span>{formatTokens(m.tokens)} token</span>
-                <span>${m.cost.toFixed(4)}</span>
-              </div>
-            </div>
-          );
-        })}
+      <CardContent className="space-y-2">
+        <div className="flex items-center gap-2">
+          <Zap className="h-4 w-4 text-amber-500" />
+          <span className="text-2xl font-bold tabular-nums">
+            {period.requestCount.toLocaleString()}
+          </span>
+          <span className="text-xs text-muted-foreground">richieste</span>
+        </div>
+        <div className="grid grid-cols-3 gap-2 text-xs">
+          <div className="flex items-center gap-1">
+            <Cpu className="h-3 w-3 text-muted-foreground" />
+            <span className="tabular-nums">{formatTokens(period.totalTokens)}</span>
+          </div>
+          <div className="flex items-center gap-1">
+            <DollarSign className="h-3 w-3 text-muted-foreground" />
+            <span className="tabular-nums">${period.costUsd.toFixed(4)}</span>
+          </div>
+          <div className="flex items-center gap-1">
+            <Clock className="h-3 w-3 text-muted-foreground" />
+            <span className="tabular-nums">{period.averageLatencyMs}ms</span>
+          </div>
+        </div>
       </CardContent>
     </Card>
   );
 }
 
-function DailyUsageChart({ dailyUsage }: { dailyUsage: DailyUsageDto[] }) {
+function DailyUsageChart({ dailyUsage }: { dailyUsage: { date: string; tokens: number }[] }) {
   if (dailyUsage.length === 0) return null;
 
   const maxTokens = Math.max(...dailyUsage.map(d => d.tokens), 1);
@@ -299,7 +242,7 @@ function DailyUsageChart({ dailyUsage }: { dailyUsage: DailyUsageDto[] }) {
     <Card>
       <CardHeader>
         <CardTitle className="text-base">Utilizzo giornaliero</CardTitle>
-        <CardDescription>Token consumati per giorno</CardDescription>
+        <CardDescription>Token consumati per giorno (30g)</CardDescription>
       </CardHeader>
       <CardContent>
         <div className="flex items-end gap-1 h-32" data-testid="daily-usage-chart">
@@ -324,6 +267,163 @@ function DailyUsageChart({ dailyUsage }: { dailyUsage: DailyUsageDto[] }) {
             );
           })}
         </div>
+      </CardContent>
+    </Card>
+  );
+}
+
+const DISTRIBUTION_COLORS = [
+  'bg-blue-500',
+  'bg-violet-500',
+  'bg-amber-500',
+  'bg-emerald-500',
+  'bg-rose-500',
+  'bg-cyan-500',
+  'bg-orange-500',
+  'bg-teal-500',
+];
+
+function DistributionCard({ title, items }: { title: string; items: DistributionItemDto[] }) {
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">{title}</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {items.map((item, i) => (
+          <div key={item.name} className="space-y-1">
+            <div className="flex items-center justify-between text-xs">
+              <span className="font-mono truncate max-w-[200px]" title={item.name}>
+                {item.name}
+              </span>
+              <span className="tabular-nums text-muted-foreground ml-2">
+                {item.percentage.toFixed(1)}%
+              </span>
+            </div>
+            <div className="h-2 rounded-full bg-muted overflow-hidden">
+              <div
+                className={cn(
+                  'h-full rounded-full transition-all',
+                  DISTRIBUTION_COLORS[i % DISTRIBUTION_COLORS.length]
+                )}
+                style={{ width: `${item.percentage}%` }}
+              />
+            </div>
+            <div className="text-[10px] text-muted-foreground tabular-nums">
+              {item.count} richieste
+            </div>
+          </div>
+        ))}
+      </CardContent>
+    </Card>
+  );
+}
+
+function RecentRequestsTable({
+  data,
+  currentPage,
+  onPageChange,
+}: {
+  data: AiUsageRecentDto;
+  currentPage: number;
+  onPageChange: (page: number) => void;
+}) {
+  if (data.items.length === 0 && currentPage === 1) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">Richieste recenti</CardTitle>
+          <CardDescription>Ultimi 7 giorni</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-muted-foreground text-center py-4">
+            Nessuna richiesta negli ultimi 7 giorni.
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  const totalPages = Math.ceil(data.total / data.pageSize);
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="text-base">Richieste recenti</CardTitle>
+        <CardDescription>
+          Ultimi 7 giorni — {data.total} richieste totali
+        </CardDescription>
+      </CardHeader>
+      <CardContent>
+        <div className="overflow-x-auto">
+          <table className="w-full text-xs" data-testid="recent-requests-table">
+            <thead>
+              <tr className="border-b text-left text-muted-foreground">
+                <th className="pb-2 pr-4">Data/Ora</th>
+                <th className="pb-2 pr-4">Modello</th>
+                <th className="pb-2 pr-4">Provider</th>
+                <th className="pb-2 pr-4">Operazione</th>
+                <th className="pb-2 pr-4 text-right">Token</th>
+                <th className="pb-2 pr-4 text-right">Costo</th>
+                <th className="pb-2 text-right">Latenza</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data.items.map((item, i) => (
+                <tr key={i} className="border-b last:border-0">
+                  <td className="py-2 pr-4 tabular-nums whitespace-nowrap">
+                    {new Date(item.requestedAt).toLocaleString('it-IT', {
+                      month: '2-digit',
+                      day: '2-digit',
+                      hour: '2-digit',
+                      minute: '2-digit',
+                    })}
+                  </td>
+                  <td className="py-2 pr-4 font-mono truncate max-w-[160px]" title={item.model}>
+                    {item.model}
+                  </td>
+                  <td className="py-2 pr-4">{item.provider}</td>
+                  <td className="py-2 pr-4 capitalize">{item.operation}</td>
+                  <td className="py-2 pr-4 tabular-nums text-right">
+                    {(item.promptTokens + item.completionTokens).toLocaleString()}
+                  </td>
+                  <td className="py-2 pr-4 tabular-nums text-right">
+                    ${item.costUsd.toFixed(4)}
+                  </td>
+                  <td className="py-2 tabular-nums text-right">{item.latencyMs}ms</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+
+        {totalPages > 1 && (
+          <div className="flex items-center justify-between mt-3 pt-3 border-t">
+            <span className="text-xs text-muted-foreground">
+              Pagina {currentPage} di {totalPages}
+            </span>
+            <div className="flex gap-1">
+              <button
+                type="button"
+                onClick={() => onPageChange(currentPage - 1)}
+                disabled={currentPage <= 1}
+                className="p-1 rounded hover:bg-muted disabled:opacity-30"
+                aria-label="Pagina precedente"
+              >
+                <ChevronLeft className="h-4 w-4" />
+              </button>
+              <button
+                type="button"
+                onClick={() => onPageChange(currentPage + 1)}
+                disabled={currentPage >= totalPages}
+                className="p-1 rounded hover:bg-muted disabled:opacity-30"
+                aria-label="Pagina successiva"
+              >
+                <ChevronRight className="h-4 w-4" />
+              </button>
+            </div>
+          </div>
+        )}
       </CardContent>
     </Card>
   );

--- a/apps/web/src/lib/api/dashboard-client.ts
+++ b/apps/web/src/lib/api/dashboard-client.ts
@@ -6,7 +6,16 @@
  */
 
 import { HttpClient } from './core/httpClient';
-import { UserAiUsageDtoSchema, type UserAiUsageDto } from './schemas/ai-usage.schemas';
+import {
+  UserAiUsageDtoSchema,
+  type UserAiUsageDto,
+  AiUsageSummaryDtoSchema,
+  type AiUsageSummaryDto,
+  AiUsageDistributionsDtoSchema,
+  type AiUsageDistributionsDto,
+  AiUsageRecentDtoSchema,
+  type AiUsageRecentDto,
+} from './schemas/ai-usage.schemas';
 
 const httpClient = new HttpClient();
 
@@ -137,6 +146,45 @@ export const dashboardClient = {
       UserAiUsageDtoSchema
     );
     if (!response) throw new Error('Failed to fetch AI usage');
+    return response;
+  },
+
+  /**
+   * Get multi-period AI usage summary (today/7d/30d)
+   * Issue #94: C3 Editor Self-Service AI Usage Page
+   */
+  async getMyAiUsageSummary(): Promise<AiUsageSummaryDto> {
+    const response = await httpClient.get<AiUsageSummaryDto>(
+      '/api/v1/users/me/ai-usage/summary',
+      AiUsageSummaryDtoSchema
+    );
+    if (!response) throw new Error('Failed to fetch AI usage summary');
+    return response;
+  },
+
+  /**
+   * Get AI usage distributions (model, provider, operation)
+   * Issue #94: C3 Editor Self-Service AI Usage Page
+   */
+  async getMyAiUsageDistributions(days = 30): Promise<AiUsageDistributionsDto> {
+    const response = await httpClient.get<AiUsageDistributionsDto>(
+      `/api/v1/users/me/ai-usage/distributions?days=${days}`,
+      AiUsageDistributionsDtoSchema
+    );
+    if (!response) throw new Error('Failed to fetch AI usage distributions');
+    return response;
+  },
+
+  /**
+   * Get recent AI requests (last 7 days, paginated)
+   * Issue #94: C3 Editor Self-Service AI Usage Page
+   */
+  async getMyAiUsageRecent(page = 1, pageSize = 20): Promise<AiUsageRecentDto> {
+    const response = await httpClient.get<AiUsageRecentDto>(
+      `/api/v1/users/me/ai-usage/recent?page=${page}&pageSize=${pageSize}`,
+      AiUsageRecentDtoSchema
+    );
+    if (!response) throw new Error('Failed to fetch recent AI requests');
     return response;
   },
 };

--- a/apps/web/src/lib/api/schemas/ai-usage.schemas.ts
+++ b/apps/web/src/lib/api/schemas/ai-usage.schemas.ts
@@ -59,3 +59,68 @@ export const UserAiUsageDtoSchema = z.object({
 });
 
 export type UserAiUsageDto = z.infer<typeof UserAiUsageDtoSchema>;
+
+// ========== Issue #94: C3 — Multi-period Summary ==========
+
+export const AiUsagePeriodSummaryDtoSchema = z.object({
+  requestCount: z.number().int().nonnegative(),
+  promptTokens: z.number().int().nonnegative(),
+  completionTokens: z.number().int().nonnegative(),
+  totalTokens: z.number().int().nonnegative(),
+  costUsd: z.number().nonnegative(),
+  averageLatencyMs: z.number().int().nonnegative(),
+});
+
+export type AiUsagePeriodSummaryDto = z.infer<typeof AiUsagePeriodSummaryDtoSchema>;
+
+export const AiUsageSummaryDtoSchema = z.object({
+  today: AiUsagePeriodSummaryDtoSchema,
+  last7Days: AiUsagePeriodSummaryDtoSchema,
+  last30Days: AiUsagePeriodSummaryDtoSchema,
+});
+
+export type AiUsageSummaryDto = z.infer<typeof AiUsageSummaryDtoSchema>;
+
+// ========== Issue #94: C3 — Distributions ==========
+
+export const DistributionItemDtoSchema = z.object({
+  name: z.string(),
+  count: z.number().int().nonnegative(),
+  percentage: z.number().nonnegative(),
+});
+
+export type DistributionItemDto = z.infer<typeof DistributionItemDtoSchema>;
+
+export const AiUsageDistributionsDtoSchema = z.object({
+  models: z.array(DistributionItemDtoSchema),
+  providers: z.array(DistributionItemDtoSchema),
+  operations: z.array(DistributionItemDtoSchema),
+});
+
+export type AiUsageDistributionsDto = z.infer<typeof AiUsageDistributionsDtoSchema>;
+
+// ========== Issue #94: C3 — Recent Requests ==========
+
+export const RecentAiRequestDtoSchema = z.object({
+  requestedAt: z.string(),
+  model: z.string(),
+  provider: z.string(),
+  operation: z.string(),
+  promptTokens: z.number().int().nonnegative(),
+  completionTokens: z.number().int().nonnegative(),
+  costUsd: z.number().nonnegative(),
+  latencyMs: z.number().int().nonnegative(),
+  success: z.boolean(),
+});
+
+export type RecentAiRequestDto = z.infer<typeof RecentAiRequestDtoSchema>;
+
+export const AiUsageRecentDtoSchema = z.object({
+  items: z.array(RecentAiRequestDtoSchema),
+  total: z.number().int().nonnegative(),
+  page: z.number().int().positive(),
+  pageSize: z.number().int().positive(),
+  note: z.string(),
+});
+
+export type AiUsageRecentDto = z.infer<typeof AiUsageRecentDtoSchema>;


### PR DESCRIPTION
## Summary
- **Backend**: 3 new CQRS endpoints for editor AI usage self-service (multi-period summary, model/provider/operation distributions, paginated recent requests)
- **Frontend**: Rewritten /dashboard/my-ai-usage page with multi-period cards (today/7d/30d), distribution charts, recent requests table with pagination, daily usage chart, and GDPR info banner
- **Schemas**: Added Zod validation schemas and dashboard client methods for all new endpoints

## Changes
### Backend (3 new queries + handlers + DTOs + routing)
- `GET /users/me/ai-usage/summary` — Today/7d/30d period summary (requests, tokens, cost, latency)
- `GET /users/me/ai-usage/distributions?days=30` — Model, provider, operation distributions
- `GET /users/me/ai-usage/recent?page=1&pageSize=20` — Paginated recent requests (7-day window, GDPR)

### Frontend
- Multi-period summary cards with token counts, costs, latency
- Distribution charts with colored progress bars
- Recent requests table with pagination
- Daily usage bar chart
- Info banner explaining 7-day detail vs 30-day aggregate
- Empty state when no AI usage

### Key decisions
- No aggregation table needed: LlmCostLogs are NOT pseudonymized (unlike LlmRequestLogs), so direct queries work for 30-day periods
- Operation distribution replaces strategy distribution (no strategy field exists in cost logs)

## Test plan
- [x] Frontend tests: 10/10 pass (summary cards, loading, error, distributions, recent table, pagination, info banner, daily chart, empty state)
- [x] TypeScript typecheck: clean
- [ ] Backend integration tests: handlers follow existing patterns from GetUserDetailedAiUsageQueryHandler

Closes #94

🤖 Generated with [Claude Code](https://claude.com/claude-code)