### PR TITLE
feat: SharedGame RAG wizard with batch upload and SSE progress

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/AddRagToSharedGame/AddRagToSharedGameCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/AddRagToSharedGame/AddRagToSharedGameCommand.cs
@@ -1,0 +1,32 @@
+using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
+using Api.SharedKernel.Application.Interfaces;
+using Microsoft.AspNetCore.Http;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands.AddRagToSharedGame;
+
+/// <summary>
+/// Orchestration command that uploads a PDF, links it to a SharedGame,
+/// optionally auto-approves for RAG processing (admin), and enqueues for indexing.
+/// Editors require separate approval before processing begins.
+/// </summary>
+internal record AddRagToSharedGameCommand(
+    Guid SharedGameId,
+    IFormFile File,
+    SharedGameDocumentType DocumentType,
+    string Version,
+    List<string>? Tags,
+    Guid UserId,
+    bool IsAdmin
+) : ICommand<AddRagToSharedGameResult>;
+
+/// <summary>
+/// Result of the RAG wizard saga.
+/// ProcessingJobId is null when: editor upload (pending approval) or enqueue failed (graceful degradation).
+/// </summary>
+internal record AddRagToSharedGameResult(
+    Guid PdfDocumentId,
+    Guid SharedGameDocumentId,
+    Guid? ProcessingJobId,
+    bool AutoApproved,
+    string StreamUrl
+);

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/AddRagToSharedGame/AddRagToSharedGameCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/AddRagToSharedGame/AddRagToSharedGameCommandHandler.cs
@@ -1,0 +1,142 @@
+using Api.BoundedContexts.DocumentProcessing.Application.Commands;
+using Api.BoundedContexts.DocumentProcessing.Application.Commands.Queue;
+using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Application.Interfaces;
+using MediatR;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands.AddRagToSharedGame;
+
+/// <summary>
+/// Saga handler that orchestrates the RAG wizard workflow:
+/// 1. Validate SharedGame exists
+/// 2. Upload PDF via UploadPdfCommand
+/// 3. Link document via AddDocumentToSharedGameCommand
+/// 4. (Admin only) Auto-approve + enqueue for processing
+/// </summary>
+internal sealed class AddRagToSharedGameCommandHandler : ICommandHandler<AddRagToSharedGameCommand, AddRagToSharedGameResult>
+{
+    private readonly IMediator _mediator;
+    private readonly ISharedGameRepository _sharedGameRepository;
+    private readonly ILogger<AddRagToSharedGameCommandHandler> _logger;
+
+    public AddRagToSharedGameCommandHandler(
+        IMediator mediator,
+        ISharedGameRepository sharedGameRepository,
+        ILogger<AddRagToSharedGameCommandHandler> logger)
+    {
+        _mediator = mediator ?? throw new ArgumentNullException(nameof(mediator));
+        _sharedGameRepository = sharedGameRepository ?? throw new ArgumentNullException(nameof(sharedGameRepository));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<AddRagToSharedGameResult> Handle(AddRagToSharedGameCommand command, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        _logger.LogInformation(
+            "Starting RAG wizard saga for SharedGame {SharedGameId}, User {UserId}, IsAdmin={IsAdmin}",
+            command.SharedGameId, command.UserId, command.IsAdmin);
+
+        // Step 1: Validate SharedGame exists
+        var sharedGame = await _sharedGameRepository.GetByIdAsync(command.SharedGameId, cancellationToken).ConfigureAwait(false);
+        if (sharedGame is null)
+        {
+            throw new NotFoundException("SharedGame", command.SharedGameId.ToString());
+        }
+
+        // Step 2: Upload PDF
+        var uploadResult = await _mediator.Send(
+            new UploadPdfCommand(
+                GameId: null,
+                Metadata: null,
+                PrivateGameId: null,
+                UserId: command.UserId,
+                File: command.File),
+            cancellationToken).ConfigureAwait(false);
+
+        if (!uploadResult.Success || uploadResult.Document is null)
+        {
+            throw new InvalidOperationException($"PDF upload failed: {uploadResult.Message}");
+        }
+
+        var pdfDocumentId = uploadResult.Document.Id;
+
+        _logger.LogInformation(
+            "PDF uploaded successfully: PdfDocumentId={PdfDocumentId}",
+            pdfDocumentId);
+
+        // Step 3: Link document to SharedGame
+        var sharedGameDocumentId = await _mediator.Send(
+            new AddDocumentToSharedGameCommand(
+                SharedGameId: command.SharedGameId,
+                PdfDocumentId: pdfDocumentId,
+                DocumentType: command.DocumentType,
+                Version: command.Version,
+                Tags: command.Tags,
+                SetAsActive: true,
+                CreatedBy: command.UserId),
+            cancellationToken).ConfigureAwait(false);
+
+        _logger.LogInformation(
+            "Document linked to SharedGame: SharedGameDocumentId={SharedGameDocumentId}",
+            sharedGameDocumentId);
+
+        // Step 4: Admin auto-approval and enqueue
+        if (!command.IsAdmin)
+        {
+            _logger.LogInformation(
+                "Editor upload complete — pending approval. SharedGameDocumentId={SharedGameDocumentId}",
+                sharedGameDocumentId);
+
+            return new AddRagToSharedGameResult(
+                PdfDocumentId: pdfDocumentId,
+                SharedGameDocumentId: sharedGameDocumentId,
+                ProcessingJobId: null,
+                AutoApproved: false,
+                StreamUrl: $"/api/v1/pdf/{pdfDocumentId}/status/stream");
+        }
+
+        // Admin path: auto-approve
+        await _mediator.Send(
+            new ApproveDocumentForRagProcessingCommand(
+                DocumentId: sharedGameDocumentId,
+                ApprovedBy: command.UserId,
+                Notes: "Auto-approved via RAG wizard (admin)"),
+            cancellationToken).ConfigureAwait(false);
+
+        _logger.LogInformation(
+            "Document auto-approved for RAG processing: SharedGameDocumentId={SharedGameDocumentId}",
+            sharedGameDocumentId);
+
+        // Admin path: enqueue (graceful degradation on failure)
+        Guid? processingJobId = null;
+        try
+        {
+            processingJobId = await _mediator.Send(
+                new EnqueuePdfCommand(
+                    PdfDocumentId: pdfDocumentId,
+                    UserId: command.UserId,
+                    Priority: (int)ProcessingPriority.High),
+                cancellationToken).ConfigureAwait(false);
+
+            _logger.LogInformation(
+                "PDF enqueued for processing: ProcessingJobId={ProcessingJobId}",
+                processingJobId);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "Failed to enqueue PDF for processing (graceful degradation): PdfDocumentId={PdfDocumentId}",
+                pdfDocumentId);
+        }
+
+        return new AddRagToSharedGameResult(
+            PdfDocumentId: pdfDocumentId,
+            SharedGameDocumentId: sharedGameDocumentId,
+            ProcessingJobId: processingJobId,
+            AutoApproved: true,
+            StreamUrl: $"/api/v1/pdf/{pdfDocumentId}/status/stream");
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/AddRagToSharedGame/AddRagToSharedGameCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/AddRagToSharedGame/AddRagToSharedGameCommandHandler.cs
@@ -125,6 +125,10 @@ internal sealed class AddRagToSharedGameCommandHandler : ICommandHandler<AddRagT
                 "PDF enqueued for processing: ProcessingJobId={ProcessingJobId}",
                 processingJobId);
         }
+        catch (OperationCanceledException)
+        {
+            throw; // propagate cancellation
+        }
         catch (Exception ex)
         {
             _logger.LogWarning(ex,

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/AddRagToSharedGame/AddRagToSharedGameCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/AddRagToSharedGame/AddRagToSharedGameCommandHandler.cs
@@ -58,7 +58,7 @@ internal sealed class AddRagToSharedGameCommandHandler : ICommandHandler<AddRagT
 
         if (!uploadResult.Success || uploadResult.Document is null)
         {
-            throw new InvalidOperationException($"PDF upload failed: {uploadResult.Message}");
+            throw new ConflictException($"PDF upload failed: {uploadResult.Message}");
         }
 
         var pdfDocumentId = uploadResult.Document.Id;

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/AddRagToSharedGame/AddRagToSharedGameCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/AddRagToSharedGame/AddRagToSharedGameCommandValidator.cs
@@ -1,0 +1,43 @@
+using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
+using FluentValidation;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands.AddRagToSharedGame;
+
+internal sealed class AddRagToSharedGameCommandValidator : AbstractValidator<AddRagToSharedGameCommand>
+{
+    private const long MaxFileSizeBytes = 50 * 1024 * 1024; // 50MB
+
+    public AddRagToSharedGameCommandValidator()
+    {
+        RuleFor(x => x.SharedGameId)
+            .NotEqual(Guid.Empty).WithMessage("SharedGameId is required");
+
+        RuleFor(x => x.UserId)
+            .NotEqual(Guid.Empty).WithMessage("UserId is required");
+
+        RuleFor(x => x.File)
+            .NotNull().WithMessage("PDF file is required");
+
+        RuleFor(x => x.File)
+            .Must(f => f == null || f.Length <= MaxFileSizeBytes)
+            .WithMessage("File size must not exceed 50MB");
+
+        RuleFor(x => x.DocumentType)
+            .IsInEnum().WithMessage("DocumentType must be valid (Rulebook, Errata, or Homerule)");
+
+        RuleFor(x => x.Version)
+            .NotEmpty().WithMessage("Version is required")
+            .Matches(@"^\d+\.\d+$").WithMessage("Version must be in format MAJOR.MINOR (e.g., 1.0, 2.1)")
+            .MaximumLength(20).WithMessage("Version cannot exceed 20 characters");
+
+        RuleFor(x => x.Tags)
+            .Must(tags => tags == null || tags.Count <= 10)
+            .WithMessage("Cannot have more than 10 tags")
+            .Must(tags => tags == null || tags.All(t => !string.IsNullOrWhiteSpace(t) && t.Length <= 50))
+            .WithMessage("Each tag must be non-empty and not exceed 50 characters");
+
+        RuleFor(x => x)
+            .Must(x => x.DocumentType == SharedGameDocumentType.Homerule || x.Tags == null || x.Tags.Count == 0)
+            .WithMessage("Tags are only allowed for Homerule documents");
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/AddRagToSharedGame/BatchAddRagToSharedGameCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/AddRagToSharedGame/BatchAddRagToSharedGameCommand.cs
@@ -1,0 +1,25 @@
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands.AddRagToSharedGame;
+
+/// <summary>
+/// Batch command to add RAG to multiple SharedGames.
+/// Processes items sequentially to avoid overwhelming the upload pipeline.
+/// Supports partial success — individual failures don't stop the batch.
+/// </summary>
+internal record BatchAddRagToSharedGameCommand(
+    List<AddRagToSharedGameCommand> Items
+) : ICommand<BatchAddRagToSharedGameResult>;
+
+internal record BatchAddRagToSharedGameResult(
+    List<BatchItemResult> Results,
+    int SuccessCount,
+    int FailureCount
+);
+
+internal record BatchItemResult(
+    Guid SharedGameId,
+    string FileName,
+    AddRagToSharedGameResult? Result,
+    string? Error
+);

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/AddRagToSharedGame/BatchAddRagToSharedGameCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/AddRagToSharedGame/BatchAddRagToSharedGameCommandHandler.cs
@@ -30,6 +30,10 @@ internal sealed class BatchAddRagToSharedGameCommandHandler
                 var result = await _mediator.Send(item, cancellationToken).ConfigureAwait(false);
                 results.Add(new BatchItemResult(item.SharedGameId, item.File.FileName, result, null));
             }
+            catch (OperationCanceledException)
+            {
+                throw; // propagate cancellation
+            }
             catch (Exception ex)
             {
                 _logger.LogWarning(ex,

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/AddRagToSharedGame/BatchAddRagToSharedGameCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/AddRagToSharedGame/BatchAddRagToSharedGameCommandHandler.cs
@@ -1,0 +1,48 @@
+using Api.SharedKernel.Application.Interfaces;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands.AddRagToSharedGame;
+
+internal sealed class BatchAddRagToSharedGameCommandHandler
+    : ICommandHandler<BatchAddRagToSharedGameCommand, BatchAddRagToSharedGameResult>
+{
+    private readonly IMediator _mediator;
+    private readonly ILogger<BatchAddRagToSharedGameCommandHandler> _logger;
+
+    public BatchAddRagToSharedGameCommandHandler(
+        IMediator mediator,
+        ILogger<BatchAddRagToSharedGameCommandHandler> logger)
+    {
+        _mediator = mediator;
+        _logger = logger;
+    }
+
+    public async Task<BatchAddRagToSharedGameResult> Handle(
+        BatchAddRagToSharedGameCommand request, CancellationToken cancellationToken)
+    {
+        var results = new List<BatchItemResult>();
+
+        foreach (var item in request.Items)
+        {
+            try
+            {
+                var result = await _mediator.Send(item, cancellationToken).ConfigureAwait(false);
+                results.Add(new BatchItemResult(item.SharedGameId, item.File.FileName, result, null));
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex,
+                    "Batch RAG: Failed for SharedGame {GameId}, file {FileName}",
+                    item.SharedGameId, item.File.FileName);
+                results.Add(new BatchItemResult(item.SharedGameId, item.File.FileName, null, ex.Message));
+            }
+        }
+
+        return new BatchAddRagToSharedGameResult(
+            Results: results,
+            SuccessCount: results.Count(r => r.Result != null),
+            FailureCount: results.Count(r => r.Error != null)
+        );
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/AddRagToSharedGame/BatchAddRagToSharedGameCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Commands/AddRagToSharedGame/BatchAddRagToSharedGameCommandValidator.cs
@@ -1,0 +1,21 @@
+using FluentValidation;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Commands.AddRagToSharedGame;
+
+/// <summary>
+/// Validator for BatchAddRagToSharedGameCommand.
+/// Enforces list constraints before individual items are processed.
+/// </summary>
+internal sealed class BatchAddRagToSharedGameCommandValidator : AbstractValidator<BatchAddRagToSharedGameCommand>
+{
+    private const int MaxBatchSize = 20;
+
+    public BatchAddRagToSharedGameCommandValidator()
+    {
+        RuleFor(x => x.Items)
+            .NotNull().WithMessage("Items list is required")
+            .NotEmpty().WithMessage("At least one item is required")
+            .Must(items => items.Count <= MaxBatchSize)
+            .WithMessage($"Batch size cannot exceed {MaxBatchSize} items");
+    }
+}

--- a/apps/api/src/Api/Routing/SharedGameCatalogEndpoints.cs
+++ b/apps/api/src/Api/Routing/SharedGameCatalogEndpoints.cs
@@ -1,5 +1,6 @@
 using Api.BoundedContexts.SharedGameCatalog.Application;
 using Api.BoundedContexts.SharedGameCatalog.Application.Commands;
+using Api.BoundedContexts.SharedGameCatalog.Application.Commands.AddRagToSharedGame;
 using Api.BoundedContexts.SharedGameCatalog.Application.Commands.RecordGameEvent;
 using Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
 using Api.BoundedContexts.SharedGameCatalog.Application.Queries.GetCatalogTrending;
@@ -2548,6 +2549,33 @@ internal static class SharedGameCatalogEndpoints
             .Produces(StatusCodes.Status401Unauthorized)
             .Produces(StatusCodes.Status403Forbidden)
             .Produces(StatusCodes.Status409Conflict);
+
+        // RAG Wizard: Single upload + process
+        group.MapPost("/admin/shared-games/{id:guid}/rag", HandleAddRagToSharedGame)
+            .DisableAntiforgery() // Required for multipart/form-data file uploads
+            .RequireAuthorization("AdminOrEditorPolicy")
+            .RequireRateLimiting("SharedGamesAdmin")
+            .WithName("AddRagToSharedGame")
+            .WithSummary("Upload PDF and start RAG processing for a shared game (Admin/Editor)")
+            .WithDescription("Uploads a PDF, links it as a document to the shared game, and enqueues for RAG processing. Admin uploads are auto-approved; Editor uploads require separate approval.")
+            .Produces<AddRagToSharedGameResult>(StatusCodes.Status202Accepted)
+            .Produces(StatusCodes.Status400BadRequest)
+            .Produces(StatusCodes.Status401Unauthorized)
+            .Produces(StatusCodes.Status403Forbidden)
+            .Produces(StatusCodes.Status404NotFound);
+
+        // RAG Wizard: Batch upload + process
+        group.MapPost("/admin/shared-games/batch-rag", HandleBatchAddRagToSharedGame)
+            .DisableAntiforgery() // Required for multipart/form-data file uploads
+            .RequireAuthorization("AdminOrEditorPolicy")
+            .RequireRateLimiting("SharedGamesAdmin")
+            .WithName("BatchAddRagToSharedGame")
+            .WithSummary("Batch upload PDFs and start RAG processing for multiple shared games (Admin/Editor)")
+            .WithDescription("Uploads PDFs for multiple shared games in a single request. Supports partial success — individual failures don't stop the batch.")
+            .Produces<BatchAddRagToSharedGameResult>(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status400BadRequest)
+            .Produces(StatusCodes.Status401Unauthorized)
+            .Produces(StatusCodes.Status403Forbidden);
     }
 
     private static async Task<IResult> HandleGetCatalogTrending(
@@ -2758,6 +2786,144 @@ internal static class SharedGameCatalogEndpoints
             logger.LogWarning(ex, "Wizard create game conflict: {Message}", ex.Message);
             return Results.Conflict(new { error = ex.Message });
         }
+    }
+
+    // ========================================
+    // RAG WIZARD HANDLERS
+    // ========================================
+
+    /// <summary>
+    /// Handler for single RAG upload + process endpoint.
+    /// Uploads PDF, links to SharedGame, and enqueues for RAG processing.
+    /// </summary>
+    private static async Task<IResult> HandleAddRagToSharedGame(
+        Guid id,
+        HttpContext context,
+        IMediator mediator,
+        ILogger<Program> logger,
+        CancellationToken ct)
+    {
+        var (authorized, session, error) = context.RequireAdminOrEditorSession();
+        if (!authorized) return error!;
+
+        var form = await context.Request.ReadFormAsync(ct).ConfigureAwait(false);
+
+        var file = form.Files.GetFile("file");
+        if (file == null || file.Length == 0)
+        {
+            return Results.BadRequest(new { error = "validation_failed", details = new Dictionary<string, string>(StringComparer.Ordinal) { ["file"] = "No file provided or file is empty" } });
+        }
+
+        var documentTypeStr = form["documentType"].ToString();
+        if (string.IsNullOrWhiteSpace(documentTypeStr) || !Enum.TryParse<SharedGameDocumentType>(documentTypeStr, ignoreCase: true, out var documentType))
+        {
+            return Results.BadRequest(new { error = "validation_failed", details = new Dictionary<string, string>(StringComparer.Ordinal) { ["documentType"] = "Invalid or missing document type" } });
+        }
+
+        var version = form["version"].ToString();
+        if (string.IsNullOrWhiteSpace(version))
+        {
+            return Results.BadRequest(new { error = "validation_failed", details = new Dictionary<string, string>(StringComparer.Ordinal) { ["version"] = "Version is required" } });
+        }
+
+        var tagsStr = form["tags"].ToString();
+        List<string>? tags = string.IsNullOrWhiteSpace(tagsStr)
+            ? null
+            : tagsStr.Split(',', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries).ToList();
+
+        var isAdmin = context.User.IsInRole("Admin");
+
+        var command = new AddRagToSharedGameCommand(
+            id,
+            file,
+            documentType,
+            version,
+            tags,
+            session!.User!.Id,
+            isAdmin);
+
+        logger.LogInformation(
+            "RAG wizard: SharedGameId={SharedGameId}, File={FileName}, DocType={DocType}, IsAdmin={IsAdmin}",
+            id, file.FileName, documentType, isAdmin);
+
+        var result = await mediator.Send(command, ct).ConfigureAwait(false);
+
+        logger.LogInformation(
+            "RAG wizard completed: PdfId={PdfId}, DocId={DocId}, AutoApproved={AutoApproved}",
+            result.PdfDocumentId, result.SharedGameDocumentId, result.AutoApproved);
+
+        return Results.Accepted($"/api/v1/admin/shared-games/{id}/rag", result);
+    }
+
+    /// <summary>
+    /// Handler for batch RAG upload + process endpoint.
+    /// Uploads PDFs for multiple shared games in a single request.
+    /// </summary>
+    private static async Task<IResult> HandleBatchAddRagToSharedGame(
+        HttpContext context,
+        IMediator mediator,
+        ILogger<Program> logger,
+        CancellationToken ct)
+    {
+        var (authorized, session, error) = context.RequireAdminOrEditorSession();
+        if (!authorized) return error!;
+
+        var form = await context.Request.ReadFormAsync(ct).ConfigureAwait(false);
+
+        var sharedGameIdStrings = form["sharedGameIds"].ToList();
+        var files = form.Files.GetFiles("files").ToList();
+        var documentTypes = form["documentTypes"].ToList();
+        var versions = form["versions"].ToList();
+
+        if (sharedGameIdStrings.Count == 0 || files.Count == 0)
+        {
+            return Results.BadRequest(new { error = "validation_failed", details = new Dictionary<string, string>(StringComparer.Ordinal) { ["items"] = "At least one shared game ID and file are required" } });
+        }
+
+        if (sharedGameIdStrings.Count != files.Count || sharedGameIdStrings.Count != documentTypes.Count || sharedGameIdStrings.Count != versions.Count)
+        {
+            return Results.BadRequest(new { error = "validation_failed", details = new Dictionary<string, string>(StringComparer.Ordinal) { ["items"] = "sharedGameIds, files, documentTypes, and versions must have the same count" } });
+        }
+
+        var isAdmin = context.User.IsInRole("Admin");
+        var userId = session!.User!.Id;
+        var items = new List<AddRagToSharedGameCommand>();
+
+        for (var i = 0; i < sharedGameIdStrings.Count; i++)
+        {
+            if (!Guid.TryParse(sharedGameIdStrings[i], out var sharedGameId))
+            {
+                return Results.BadRequest(new { error = "validation_failed", details = new Dictionary<string, string>(StringComparer.Ordinal) { [$"sharedGameIds[{i}]"] = "Invalid GUID" } });
+            }
+
+            if (!Enum.TryParse<SharedGameDocumentType>(documentTypes[i], ignoreCase: true, out var docType))
+            {
+                return Results.BadRequest(new { error = "validation_failed", details = new Dictionary<string, string>(StringComparer.Ordinal) { [$"documentTypes[{i}]"] = "Invalid document type" } });
+            }
+
+            items.Add(new AddRagToSharedGameCommand(
+                sharedGameId,
+                files[i],
+                docType,
+                versions[i] ?? "1.0",
+                null,
+                userId,
+                isAdmin));
+        }
+
+        var batchCommand = new BatchAddRagToSharedGameCommand(items);
+
+        logger.LogInformation(
+            "Batch RAG wizard: {Count} items, IsAdmin={IsAdmin}, UserId={UserId}",
+            items.Count, isAdmin, userId);
+
+        var result = await mediator.Send(batchCommand, ct).ConfigureAwait(false);
+
+        logger.LogInformation(
+            "Batch RAG wizard completed: Success={Success}, Failed={Failed}",
+            result.SuccessCount, result.FailureCount);
+
+        return Results.Ok(result);
     }
 }
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/AddRagToSharedGame/AddRagToSharedGameCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/AddRagToSharedGame/AddRagToSharedGameCommandHandlerTests.cs
@@ -231,7 +231,7 @@ public class AddRagToSharedGameCommandHandlerTests
     }
 
     [Fact]
-    public async Task Handle_PdfUploadFails_ThrowsInvalidOperationException()
+    public async Task Handle_PdfUploadFails_ThrowsConflictException()
     {
         // Arrange
         var sharedGameId = Guid.NewGuid();
@@ -244,7 +244,7 @@ public class AddRagToSharedGameCommandHandlerTests
             .ReturnsAsync(new PdfUploadResult(Success: false, Message: "Invalid file", Document: null));
 
         // Act & Assert
-        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+        var ex = await Assert.ThrowsAsync<ConflictException>(
             () => _handler.Handle(command, TestContext.Current.CancellationToken));
 
         Assert.Contains("PDF upload failed", ex.Message);

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/AddRagToSharedGame/AddRagToSharedGameCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/AddRagToSharedGame/AddRagToSharedGameCommandHandlerTests.cs
@@ -1,0 +1,277 @@
+using Api.BoundedContexts.DocumentProcessing.Application.Commands;
+using Api.BoundedContexts.DocumentProcessing.Application.Commands.Queue;
+using Api.BoundedContexts.DocumentProcessing.Application.DTOs;
+using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
+using Api.BoundedContexts.SharedGameCatalog.Application.Commands;
+using Api.BoundedContexts.SharedGameCatalog.Application.Commands.AddRagToSharedGame;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.Middleware.Exceptions;
+using Api.Tests.Constants;
+using MediatR;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Commands.AddRagToSharedGame;
+
+[Trait("Category", TestCategories.Unit)]
+public class AddRagToSharedGameCommandHandlerTests
+{
+    private readonly Mock<IMediator> _mediatorMock;
+    private readonly Mock<ISharedGameRepository> _sharedGameRepositoryMock;
+    private readonly Mock<ILogger<AddRagToSharedGameCommandHandler>> _loggerMock;
+    private readonly AddRagToSharedGameCommandHandler _handler;
+
+    public AddRagToSharedGameCommandHandlerTests()
+    {
+        _mediatorMock = new Mock<IMediator>();
+        _sharedGameRepositoryMock = new Mock<ISharedGameRepository>();
+        _loggerMock = new Mock<ILogger<AddRagToSharedGameCommandHandler>>();
+        _handler = new AddRagToSharedGameCommandHandler(
+            _mediatorMock.Object,
+            _sharedGameRepositoryMock.Object,
+            _loggerMock.Object);
+    }
+
+    private static AddRagToSharedGameCommand CreateCommand(
+        Guid? sharedGameId = null,
+        Guid? userId = null,
+        bool isAdmin = true)
+    {
+        var fileMock = new Mock<IFormFile>();
+        fileMock.Setup(f => f.Length).Returns(1024);
+        fileMock.Setup(f => f.FileName).Returns("rulebook.pdf");
+
+        return new AddRagToSharedGameCommand(
+            SharedGameId: sharedGameId ?? Guid.NewGuid(),
+            File: fileMock.Object,
+            DocumentType: SharedGameDocumentType.Rulebook,
+            Version: "1.0",
+            Tags: null,
+            UserId: userId ?? Guid.NewGuid(),
+            IsAdmin: isAdmin);
+    }
+
+    private void SetupSharedGameExists(Guid sharedGameId)
+    {
+        var sharedGame = SharedGame.Create(
+            title: "Test Game",
+            yearPublished: 2024,
+            description: "A test game",
+            minPlayers: 2,
+            maxPlayers: 4,
+            playingTimeMinutes: 60,
+            minAge: 10,
+            complexityRating: null,
+            averageRating: null,
+            imageUrl: "https://example.com/image.jpg",
+            thumbnailUrl: "https://example.com/thumb.jpg",
+            rules: null,
+            createdBy: Guid.NewGuid(),
+            bggId: null);
+
+        _sharedGameRepositoryMock
+            .Setup(r => r.GetByIdAsync(sharedGameId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(sharedGame);
+    }
+
+    private void SetupPdfUploadSuccess(Guid pdfDocumentId)
+    {
+        _mediatorMock
+            .Setup(m => m.Send(It.IsAny<UploadPdfCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PdfUploadResult(
+                Success: true,
+                Message: "Upload successful",
+                Document: new PdfDocumentDto(
+                    Id: pdfDocumentId,
+                    GameId: null,
+                    FileName: "rulebook.pdf",
+                    FilePath: "/uploads/rulebook.pdf",
+                    FileSizeBytes: 1024,
+                    ProcessingStatus: "Uploaded",
+                    UploadedAt: DateTime.UtcNow,
+                    ProcessedAt: null,
+                    PageCount: null)));
+    }
+
+    private void SetupAddDocumentSuccess(Guid sharedGameDocumentId)
+    {
+        _mediatorMock
+            .Setup(m => m.Send(It.IsAny<AddDocumentToSharedGameCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(sharedGameDocumentId);
+    }
+
+    private void SetupApproveSuccess()
+    {
+        _mediatorMock
+            .Setup(m => m.Send(It.IsAny<ApproveDocumentForRagProcessingCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(MediatR.Unit.Value);
+    }
+
+    private void SetupEnqueueSuccess(Guid processingJobId)
+    {
+        _mediatorMock
+            .Setup(m => m.Send(It.IsAny<EnqueuePdfCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(processingJobId);
+    }
+
+    [Fact]
+    public async Task Handle_SharedGameNotFound_ThrowsNotFoundException()
+    {
+        // Arrange
+        var sharedGameId = Guid.NewGuid();
+        var command = CreateCommand(sharedGameId: sharedGameId);
+
+        _sharedGameRepositoryMock
+            .Setup(r => r.GetByIdAsync(sharedGameId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SharedGame?)null);
+
+        // Act & Assert
+        var ex = await Assert.ThrowsAsync<NotFoundException>(
+            () => _handler.Handle(command, TestContext.Current.CancellationToken));
+
+        Assert.Equal("SharedGame", ex.ResourceType);
+        Assert.Equal(sharedGameId.ToString(), ex.ResourceId);
+    }
+
+    [Fact]
+    public async Task Handle_AdminUser_ExecutesAllFourSteps()
+    {
+        // Arrange
+        var sharedGameId = Guid.NewGuid();
+        var pdfDocumentId = Guid.NewGuid();
+        var sharedGameDocumentId = Guid.NewGuid();
+        var processingJobId = Guid.NewGuid();
+
+        var command = CreateCommand(sharedGameId: sharedGameId, isAdmin: true);
+
+        SetupSharedGameExists(sharedGameId);
+        SetupPdfUploadSuccess(pdfDocumentId);
+        SetupAddDocumentSuccess(sharedGameDocumentId);
+        SetupApproveSuccess();
+        SetupEnqueueSuccess(processingJobId);
+
+        // Act
+        var result = await _handler.Handle(command, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(pdfDocumentId, result.PdfDocumentId);
+        Assert.Equal(sharedGameDocumentId, result.SharedGameDocumentId);
+        Assert.Equal(processingJobId, result.ProcessingJobId);
+        Assert.True(result.AutoApproved);
+        Assert.Equal($"/api/v1/pdf/{pdfDocumentId}/status/stream", result.StreamUrl);
+
+        // Verify all 4 sub-commands were called
+        _mediatorMock.Verify(m => m.Send(It.IsAny<UploadPdfCommand>(), It.IsAny<CancellationToken>()), Times.Once);
+        _mediatorMock.Verify(m => m.Send(It.IsAny<AddDocumentToSharedGameCommand>(), It.IsAny<CancellationToken>()), Times.Once);
+        _mediatorMock.Verify(m => m.Send(It.IsAny<ApproveDocumentForRagProcessingCommand>(), It.IsAny<CancellationToken>()), Times.Once);
+        _mediatorMock.Verify(m => m.Send(It.IsAny<EnqueuePdfCommand>(), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_EditorUser_OnlyUploadsAndLinks()
+    {
+        // Arrange
+        var sharedGameId = Guid.NewGuid();
+        var pdfDocumentId = Guid.NewGuid();
+        var sharedGameDocumentId = Guid.NewGuid();
+
+        var command = CreateCommand(sharedGameId: sharedGameId, isAdmin: false);
+
+        SetupSharedGameExists(sharedGameId);
+        SetupPdfUploadSuccess(pdfDocumentId);
+        SetupAddDocumentSuccess(sharedGameDocumentId);
+
+        // Act
+        var result = await _handler.Handle(command, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(pdfDocumentId, result.PdfDocumentId);
+        Assert.Equal(sharedGameDocumentId, result.SharedGameDocumentId);
+        Assert.Null(result.ProcessingJobId);
+        Assert.False(result.AutoApproved);
+
+        // Verify only upload + link called (NOT approve or enqueue)
+        _mediatorMock.Verify(m => m.Send(It.IsAny<UploadPdfCommand>(), It.IsAny<CancellationToken>()), Times.Once);
+        _mediatorMock.Verify(m => m.Send(It.IsAny<AddDocumentToSharedGameCommand>(), It.IsAny<CancellationToken>()), Times.Once);
+        _mediatorMock.Verify(m => m.Send(It.IsAny<ApproveDocumentForRagProcessingCommand>(), It.IsAny<CancellationToken>()), Times.Never);
+        _mediatorMock.Verify(m => m.Send(It.IsAny<EnqueuePdfCommand>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_EnqueueFails_GracefulDegradation()
+    {
+        // Arrange
+        var sharedGameId = Guid.NewGuid();
+        var pdfDocumentId = Guid.NewGuid();
+        var sharedGameDocumentId = Guid.NewGuid();
+
+        var command = CreateCommand(sharedGameId: sharedGameId, isAdmin: true);
+
+        SetupSharedGameExists(sharedGameId);
+        SetupPdfUploadSuccess(pdfDocumentId);
+        SetupAddDocumentSuccess(sharedGameDocumentId);
+        SetupApproveSuccess();
+
+        _mediatorMock
+            .Setup(m => m.Send(It.IsAny<EnqueuePdfCommand>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("Queue is full"));
+
+        // Act
+        var result = await _handler.Handle(command, TestContext.Current.CancellationToken);
+
+        // Assert — approval happened but enqueue failed gracefully
+        Assert.Equal(pdfDocumentId, result.PdfDocumentId);
+        Assert.Equal(sharedGameDocumentId, result.SharedGameDocumentId);
+        Assert.Null(result.ProcessingJobId);
+        Assert.True(result.AutoApproved);
+    }
+
+    [Fact]
+    public async Task Handle_PdfUploadFails_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        var sharedGameId = Guid.NewGuid();
+        var command = CreateCommand(sharedGameId: sharedGameId, isAdmin: true);
+
+        SetupSharedGameExists(sharedGameId);
+
+        _mediatorMock
+            .Setup(m => m.Send(It.IsAny<UploadPdfCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new PdfUploadResult(Success: false, Message: "Invalid file", Document: null));
+
+        // Act & Assert
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _handler.Handle(command, TestContext.Current.CancellationToken));
+
+        Assert.Contains("PDF upload failed", ex.Message);
+    }
+
+    [Fact]
+    public async Task Handle_AdminUser_EnqueueUsesHighPriority()
+    {
+        // Arrange
+        var sharedGameId = Guid.NewGuid();
+        var pdfDocumentId = Guid.NewGuid();
+        var sharedGameDocumentId = Guid.NewGuid();
+
+        var command = CreateCommand(sharedGameId: sharedGameId, isAdmin: true);
+
+        SetupSharedGameExists(sharedGameId);
+        SetupPdfUploadSuccess(pdfDocumentId);
+        SetupAddDocumentSuccess(sharedGameDocumentId);
+        SetupApproveSuccess();
+        SetupEnqueueSuccess(Guid.NewGuid());
+
+        // Act
+        await _handler.Handle(command, TestContext.Current.CancellationToken);
+
+        // Assert — verify high priority was used
+        _mediatorMock.Verify(m => m.Send(
+            It.Is<EnqueuePdfCommand>(c => c.Priority == (int)ProcessingPriority.High),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/AddRagToSharedGame/AddRagToSharedGameCommandValidatorTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/AddRagToSharedGame/AddRagToSharedGameCommandValidatorTests.cs
@@ -1,0 +1,300 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Commands.AddRagToSharedGame;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
+using Api.Tests.Constants;
+using Microsoft.AspNetCore.Http;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Commands.AddRagToSharedGame;
+
+[Trait("Category", TestCategories.Unit)]
+public class AddRagToSharedGameCommandValidatorTests
+{
+    private readonly AddRagToSharedGameCommandValidator _validator;
+
+    public AddRagToSharedGameCommandValidatorTests()
+    {
+        _validator = new AddRagToSharedGameCommandValidator();
+    }
+
+    private static AddRagToSharedGameCommand CreateValidCommand(
+        Guid? sharedGameId = null,
+        Guid? userId = null,
+        IFormFile? file = null,
+        SharedGameDocumentType documentType = SharedGameDocumentType.Rulebook,
+        string version = "1.0",
+        List<string>? tags = null,
+        bool isAdmin = true)
+    {
+        var fileMock = new Mock<IFormFile>();
+        fileMock.Setup(f => f.Length).Returns(1024); // 1KB
+        fileMock.Setup(f => f.FileName).Returns("rulebook.pdf");
+
+        return new AddRagToSharedGameCommand(
+            SharedGameId: sharedGameId ?? Guid.NewGuid(),
+            File: file ?? fileMock.Object,
+            DocumentType: documentType,
+            Version: version,
+            Tags: tags,
+            UserId: userId ?? Guid.NewGuid(),
+            IsAdmin: isAdmin);
+    }
+
+    [Fact]
+    public async Task Validate_ValidCommand_Passes()
+    {
+        // Arrange
+        var command = CreateValidCommand();
+
+        // Act
+        var result = await _validator.ValidateAsync(command, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.True(result.IsValid);
+        Assert.Empty(result.Errors);
+    }
+
+    [Fact]
+    public async Task Validate_EmptySharedGameId_Fails()
+    {
+        // Arrange
+        var command = CreateValidCommand(sharedGameId: Guid.Empty);
+
+        // Act
+        var result = await _validator.ValidateAsync(command, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors, e => e.ErrorMessage == "SharedGameId is required");
+    }
+
+    [Fact]
+    public async Task Validate_EmptyUserId_Fails()
+    {
+        // Arrange
+        var command = CreateValidCommand(userId: Guid.Empty);
+
+        // Act
+        var result = await _validator.ValidateAsync(command, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors, e => e.ErrorMessage == "UserId is required");
+    }
+
+    [Fact]
+    public async Task Validate_NullFile_Fails()
+    {
+        // Arrange — must construct manually to pass null file
+        var command = new AddRagToSharedGameCommand(
+            SharedGameId: Guid.NewGuid(),
+            File: null!,
+            DocumentType: SharedGameDocumentType.Rulebook,
+            Version: "1.0",
+            Tags: null,
+            UserId: Guid.NewGuid(),
+            IsAdmin: true);
+
+        // Act
+        var result = await _validator.ValidateAsync(command, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors, e => e.ErrorMessage == "PDF file is required");
+    }
+
+    [Fact]
+    public async Task Validate_FileTooLarge_Fails()
+    {
+        // Arrange
+        var fileMock = new Mock<IFormFile>();
+        fileMock.Setup(f => f.Length).Returns(51L * 1024 * 1024); // 51MB
+        fileMock.Setup(f => f.FileName).Returns("huge.pdf");
+
+        var command = CreateValidCommand(file: fileMock.Object);
+
+        // Act
+        var result = await _validator.ValidateAsync(command, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors, e => e.ErrorMessage == "File size must not exceed 50MB");
+    }
+
+    [Fact]
+    public async Task Validate_FileExactly50MB_Passes()
+    {
+        // Arrange
+        var fileMock = new Mock<IFormFile>();
+        fileMock.Setup(f => f.Length).Returns(50L * 1024 * 1024); // Exactly 50MB
+        fileMock.Setup(f => f.FileName).Returns("exact.pdf");
+
+        var command = CreateValidCommand(file: fileMock.Object);
+
+        // Act
+        var result = await _validator.ValidateAsync(command, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.True(result.IsValid);
+    }
+
+    [Theory]
+    [InlineData("")]
+    [InlineData("   ")]
+    public async Task Validate_EmptyVersion_Fails(string version)
+    {
+        // Arrange
+        var command = CreateValidCommand(version: version);
+
+        // Act
+        var result = await _validator.ValidateAsync(command, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors, e => e.ErrorMessage == "Version is required");
+    }
+
+    [Theory]
+    [InlineData("abc")]
+    [InlineData("1")]
+    [InlineData("1.0.0")]
+    [InlineData("v1.0")]
+    [InlineData("1.")]
+    [InlineData(".1")]
+    public async Task Validate_InvalidVersionFormat_Fails(string version)
+    {
+        // Arrange
+        var command = CreateValidCommand(version: version);
+
+        // Act
+        var result = await _validator.ValidateAsync(command, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors, e => e.ErrorMessage == "Version must be in format MAJOR.MINOR (e.g., 1.0, 2.1)");
+    }
+
+    [Theory]
+    [InlineData("1.0")]
+    [InlineData("2.1")]
+    [InlineData("10.99")]
+    public async Task Validate_ValidVersionFormat_Passes(string version)
+    {
+        // Arrange
+        var command = CreateValidCommand(version: version);
+
+        // Act
+        var result = await _validator.ValidateAsync(command, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.True(result.IsValid);
+    }
+
+    [Fact]
+    public async Task Validate_InvalidDocumentType_Fails()
+    {
+        // Arrange
+        var command = CreateValidCommand(documentType: (SharedGameDocumentType)99);
+
+        // Act
+        var result = await _validator.ValidateAsync(command, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors, e => e.ErrorMessage == "DocumentType must be valid (Rulebook, Errata, or Homerule)");
+    }
+
+    [Fact]
+    public async Task Validate_TagsOnRulebook_Fails()
+    {
+        // Arrange
+        var command = CreateValidCommand(
+            documentType: SharedGameDocumentType.Rulebook,
+            tags: new List<string> { "tag1" });
+
+        // Act
+        var result = await _validator.ValidateAsync(command, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors, e => e.ErrorMessage == "Tags are only allowed for Homerule documents");
+    }
+
+    [Fact]
+    public async Task Validate_TagsOnHomerule_Passes()
+    {
+        // Arrange
+        var command = CreateValidCommand(
+            documentType: SharedGameDocumentType.Homerule,
+            tags: new List<string> { "variant", "solo" });
+
+        // Act
+        var result = await _validator.ValidateAsync(command, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.True(result.IsValid);
+    }
+
+    [Fact]
+    public async Task Validate_TooManyTags_Fails()
+    {
+        // Arrange
+        var tags = Enumerable.Range(1, 11).Select(i => $"tag{i}").ToList();
+        var command = CreateValidCommand(
+            documentType: SharedGameDocumentType.Homerule,
+            tags: tags);
+
+        // Act
+        var result = await _validator.ValidateAsync(command, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors, e => e.ErrorMessage == "Cannot have more than 10 tags");
+    }
+
+    [Fact]
+    public async Task Validate_EmptyTagInList_Fails()
+    {
+        // Arrange
+        var command = CreateValidCommand(
+            documentType: SharedGameDocumentType.Homerule,
+            tags: new List<string> { "valid", "", "also-valid" });
+
+        // Act
+        var result = await _validator.ValidateAsync(command, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors, e => e.ErrorMessage == "Each tag must be non-empty and not exceed 50 characters");
+    }
+
+    [Fact]
+    public async Task Validate_TagTooLong_Fails()
+    {
+        // Arrange
+        var longTag = new string('a', 51);
+        var command = CreateValidCommand(
+            documentType: SharedGameDocumentType.Homerule,
+            tags: new List<string> { longTag });
+
+        // Act
+        var result = await _validator.ValidateAsync(command, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors, e => e.ErrorMessage == "Each tag must be non-empty and not exceed 50 characters");
+    }
+
+    [Fact]
+    public async Task Validate_NullTags_Passes()
+    {
+        // Arrange
+        var command = CreateValidCommand(tags: null);
+
+        // Act
+        var result = await _validator.ValidateAsync(command, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.True(result.IsValid);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/AddRagToSharedGame/BatchAddRagToSharedGameCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Commands/AddRagToSharedGame/BatchAddRagToSharedGameCommandHandlerTests.cs
@@ -1,0 +1,182 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.Commands.AddRagToSharedGame;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
+using Api.Tests.Constants;
+using MediatR;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Commands.AddRagToSharedGame;
+
+[Trait("Category", TestCategories.Unit)]
+public class BatchAddRagToSharedGameCommandHandlerTests
+{
+    private readonly Mock<IMediator> _mediatorMock;
+    private readonly Mock<ILogger<BatchAddRagToSharedGameCommandHandler>> _loggerMock;
+    private readonly BatchAddRagToSharedGameCommandHandler _handler;
+
+    public BatchAddRagToSharedGameCommandHandlerTests()
+    {
+        _mediatorMock = new Mock<IMediator>();
+        _loggerMock = new Mock<ILogger<BatchAddRagToSharedGameCommandHandler>>();
+        _handler = new BatchAddRagToSharedGameCommandHandler(
+            _mediatorMock.Object,
+            _loggerMock.Object);
+    }
+
+    private static AddRagToSharedGameCommand CreateItem(Guid? sharedGameId = null, string fileName = "test.pdf")
+    {
+        var file = new FormFile(
+            baseStream: new MemoryStream(new byte[1024]),
+            baseStreamOffset: 0,
+            length: 1024,
+            name: "file",
+            fileName: fileName)
+        {
+            Headers = new HeaderDictionary(),
+            ContentType = "application/pdf"
+        };
+
+        return new AddRagToSharedGameCommand(
+            SharedGameId: sharedGameId ?? Guid.NewGuid(),
+            File: file,
+            DocumentType: SharedGameDocumentType.Rulebook,
+            Version: "1.0",
+            Tags: null,
+            UserId: Guid.NewGuid(),
+            IsAdmin: true);
+    }
+
+    private static AddRagToSharedGameResult CreateSuccessResult()
+    {
+        return new AddRagToSharedGameResult(
+            PdfDocumentId: Guid.NewGuid(),
+            SharedGameDocumentId: Guid.NewGuid(),
+            ProcessingJobId: Guid.NewGuid(),
+            AutoApproved: true,
+            StreamUrl: "/api/v1/pdf/test/status/stream");
+    }
+
+    [Fact]
+    public async Task Handle_AllItemsSucceed_ReturnsFullSuccess()
+    {
+        // Arrange
+        var items = new List<AddRagToSharedGameCommand>
+        {
+            CreateItem(fileName: "rulebook1.pdf"),
+            CreateItem(fileName: "rulebook2.pdf"),
+            CreateItem(fileName: "rulebook3.pdf")
+        };
+        var command = new BatchAddRagToSharedGameCommand(items);
+
+        _mediatorMock
+            .Setup(m => m.Send(It.IsAny<AddRagToSharedGameCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateSuccessResult());
+
+        // Act
+        var result = await _handler.Handle(command, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(3, result.SuccessCount);
+        Assert.Equal(0, result.FailureCount);
+        Assert.Equal(3, result.Results.Count);
+        Assert.All(result.Results, r =>
+        {
+            Assert.NotNull(r.Result);
+            Assert.Null(r.Error);
+        });
+    }
+
+    [Fact]
+    public async Task Handle_OneFailsOneSucceeds_ReturnsPartialSuccess()
+    {
+        // Arrange
+        var successId = Guid.NewGuid();
+        var failId = Guid.NewGuid();
+
+        var items = new List<AddRagToSharedGameCommand>
+        {
+            CreateItem(sharedGameId: successId, fileName: "good.pdf"),
+            CreateItem(sharedGameId: failId, fileName: "bad.pdf")
+        };
+        var command = new BatchAddRagToSharedGameCommand(items);
+
+        _mediatorMock
+            .Setup(m => m.Send(
+                It.Is<AddRagToSharedGameCommand>(c => c.SharedGameId == successId),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateSuccessResult());
+
+        _mediatorMock
+            .Setup(m => m.Send(
+                It.Is<AddRagToSharedGameCommand>(c => c.SharedGameId == failId),
+                It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("PDF upload failed"));
+
+        // Act
+        var result = await _handler.Handle(command, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(1, result.SuccessCount);
+        Assert.Equal(1, result.FailureCount);
+        Assert.Equal(2, result.Results.Count);
+
+        var successItem = result.Results.Single(r => r.SharedGameId == successId);
+        Assert.NotNull(successItem.Result);
+        Assert.Null(successItem.Error);
+
+        var failItem = result.Results.Single(r => r.SharedGameId == failId);
+        Assert.Null(failItem.Result);
+        Assert.Contains("PDF upload failed", failItem.Error);
+    }
+
+    [Fact]
+    public async Task Handle_EmptyList_ReturnsZeroCounts()
+    {
+        // Arrange
+        var command = new BatchAddRagToSharedGameCommand(new List<AddRagToSharedGameCommand>());
+
+        // Act
+        var result = await _handler.Handle(command, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(0, result.SuccessCount);
+        Assert.Equal(0, result.FailureCount);
+        Assert.Empty(result.Results);
+
+        _mediatorMock.Verify(
+            m => m.Send(It.IsAny<AddRagToSharedGameCommand>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_AllItemsFail_ReturnsFullFailure()
+    {
+        // Arrange
+        var items = new List<AddRagToSharedGameCommand>
+        {
+            CreateItem(fileName: "bad1.pdf"),
+            CreateItem(fileName: "bad2.pdf")
+        };
+        var command = new BatchAddRagToSharedGameCommand(items);
+
+        _mediatorMock
+            .Setup(m => m.Send(It.IsAny<AddRagToSharedGameCommand>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("Upload service unavailable"));
+
+        // Act
+        var result = await _handler.Handle(command, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.Equal(0, result.SuccessCount);
+        Assert.Equal(2, result.FailureCount);
+        Assert.Equal(2, result.Results.Count);
+        Assert.All(result.Results, r =>
+        {
+            Assert.Null(r.Result);
+            Assert.NotNull(r.Error);
+            Assert.Contains("Upload service unavailable", r.Error);
+        });
+    }
+}

--- a/apps/web/src/app/admin/(dashboard)/shared-games/[id]/client.tsx
+++ b/apps/web/src/app/admin/(dashboard)/shared-games/[id]/client.tsx
@@ -22,6 +22,7 @@ import {
   MoreHorizontal,
   Trash2,
   Unlink,
+  Wand2,
 } from 'lucide-react';
 import Image from 'next/image';
 import Link from 'next/link';
@@ -29,6 +30,7 @@ import { useRouter } from 'next/navigation';
 
 import { PdfIndexingStatus } from '@/components/admin/shared-games/PdfIndexingStatus';
 import { PdfUploadSection } from '@/components/admin/shared-games/PdfUploadSection';
+import { RagWizard } from './rag-wizard/components/rag-wizard';
 import { Badge } from '@/components/ui/data-display/badge';
 import {
   Card,
@@ -46,6 +48,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/navigation/dropdown-menu';
+import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/navigation/sheet';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/navigation/tabs';
 import { Button } from '@/components/ui/primitives/button';
 import {
@@ -181,6 +184,15 @@ export function GameDetailClient({ params }: GameDetailClientProps) {
       queryClient.invalidateQueries({ queryKey: ['admin', 'shared-games', gameId, 'documents'] });
     },
   });
+
+  // ── RAG Wizard state ────────────────────────────────────────────────────
+  const [showRagWizard, setShowRagWizard] = useState(false);
+
+  const handleRagWizardClose = useCallback(() => {
+    setShowRagWizard(false);
+    queryClient.invalidateQueries({ queryKey: ['admin', 'shared-games', gameId, 'documents'] });
+    queryClient.invalidateQueries({ queryKey: ['admin', 'shared-games', gameId, 'kb-cards'] });
+  }, [queryClient, gameId]);
 
   // ── Agent linking state ──────────────────────────────────────────────────
   const [selectedAgentId, setSelectedAgentId] = useState('');
@@ -621,6 +633,14 @@ export function GameDetailClient({ params }: GameDetailClientProps) {
 
         {/* ── Documents Tab ───────────────────────────────────────────────── */}
         <TabsContent value="documents" className="space-y-6 mt-6">
+          {/* RAG Wizard action */}
+          <div className="flex justify-end">
+            <Button size="sm" onClick={() => setShowRagWizard(true)}>
+              <Wand2 className="mr-1.5 h-3.5 w-3.5" />
+              Aggiungi RAG
+            </Button>
+          </div>
+
           {/* Upload */}
           <Card className="bg-white/70 dark:bg-zinc-800/70 backdrop-blur-md border-slate-200/50 dark:border-zinc-700/50">
             <CardHeader>
@@ -676,6 +696,18 @@ export function GameDetailClient({ params }: GameDetailClientProps) {
           </Card>
         </TabsContent>
       </Tabs>
+
+      {/* RAG Wizard Sheet */}
+      <Sheet open={showRagWizard} onOpenChange={setShowRagWizard}>
+        <SheetContent side="right" className="w-full sm:max-w-xl overflow-y-auto">
+          <SheetHeader>
+            <SheetTitle>Aggiungi RAG — {game.title}</SheetTitle>
+          </SheetHeader>
+          <div className="mt-6">
+            <RagWizard sharedGameId={gameId} onClose={handleRagWizardClose} />
+          </div>
+        </SheetContent>
+      </Sheet>
     </div>
   );
 }

--- a/apps/web/src/app/admin/(dashboard)/shared-games/[id]/client.tsx
+++ b/apps/web/src/app/admin/(dashboard)/shared-games/[id]/client.tsx
@@ -698,7 +698,7 @@ export function GameDetailClient({ params }: GameDetailClientProps) {
       </Tabs>
 
       {/* RAG Wizard Sheet */}
-      <Sheet open={showRagWizard} onOpenChange={setShowRagWizard}>
+      <Sheet open={showRagWizard} onOpenChange={(open) => { if (!open) handleRagWizardClose(); else setShowRagWizard(true); }}>
         <SheetContent side="right" className="w-full sm:max-w-xl overflow-y-auto">
           <SheetHeader>
             <SheetTitle>Aggiungi RAG — {game.title}</SheetTitle>

--- a/apps/web/src/app/admin/(dashboard)/shared-games/[id]/rag-wizard/components/rag-wizard.tsx
+++ b/apps/web/src/app/admin/(dashboard)/shared-games/[id]/rag-wizard/components/rag-wizard.tsx
@@ -1,0 +1,169 @@
+/**
+ * RAG Wizard — Main Shell
+ *
+ * 4-step wizard for uploading and processing PDFs for RAG indexing:
+ * 1. Upload — select PDF files
+ * 2. Configura — per-file document type & version
+ * 3. Processing — upload + SSE progress
+ * 4. Completo — success summary
+ */
+
+'use client';
+
+import { useState, useCallback } from 'react';
+
+import { CheckCircle2 } from 'lucide-react';
+
+import { cn } from '@/lib/utils';
+
+import type { AddRagResult, DocumentType } from '../lib/rag-api';
+
+import { StepComplete } from './step-complete';
+import { StepConfigure } from './step-configure';
+import { StepProgress } from './step-progress';
+import { StepUpload } from './step-upload';
+
+// ── Types ───────────────────────────────────────────────────────────────
+
+export interface FileConfig {
+  file: File;
+  documentType: DocumentType;
+  version: string;
+}
+
+export interface FileResult {
+  fileName: string;
+  result: AddRagResult | null;
+  error: string | null;
+}
+
+interface RagWizardProps {
+  sharedGameId: string;
+  onClose: () => void;
+}
+
+// ── Step Indicator ──────────────────────────────────────────────────────
+
+const STEPS = [
+  { label: 'Upload', step: 0 },
+  { label: 'Configura', step: 1 },
+  { label: 'Processing', step: 2 },
+  { label: 'Completo', step: 3 },
+] as const;
+
+function StepIndicator({ currentStep }: { currentStep: number }) {
+  return (
+    <div className="flex items-center justify-between mb-8">
+      {STEPS.map(({ label, step }, i) => (
+        <div key={step} className="flex items-center flex-1 last:flex-none">
+          <div className="flex items-center gap-2">
+            <div
+              className={cn(
+                'flex h-8 w-8 items-center justify-center rounded-full text-sm font-medium transition-colors',
+                currentStep > step
+                  ? 'bg-green-600 text-white'
+                  : currentStep === step
+                    ? 'bg-primary text-primary-foreground'
+                    : 'bg-muted text-muted-foreground'
+              )}
+            >
+              {currentStep > step ? (
+                <CheckCircle2 className="h-4 w-4" />
+              ) : (
+                step + 1
+              )}
+            </div>
+            <span
+              className={cn(
+                'text-sm font-medium hidden sm:inline',
+                currentStep >= step ? 'text-foreground' : 'text-muted-foreground'
+              )}
+            >
+              {label}
+            </span>
+          </div>
+          {i < STEPS.length - 1 && (
+            <div
+              className={cn(
+                'h-px flex-1 mx-3',
+                currentStep > step ? 'bg-green-600' : 'bg-muted'
+              )}
+            />
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+// ── Main Wizard ─────────────────────────────────────────────────────────
+
+export function RagWizard({ sharedGameId, onClose }: RagWizardProps) {
+  const [currentStep, setCurrentStep] = useState(0);
+  const [files, setFiles] = useState<File[]>([]);
+  const [configs, setConfigs] = useState<FileConfig[]>([]);
+  const [results, setResults] = useState<FileResult[]>([]);
+
+  const handleFilesSelected = useCallback((selectedFiles: File[]) => {
+    setFiles(selectedFiles);
+  }, []);
+
+  const handleGoToConfigure = useCallback(() => {
+    // Initialize configs from files
+    setConfigs(
+      files.map(file => ({
+        file,
+        documentType: 'Rulebook' as DocumentType,
+        version: '1.0',
+      }))
+    );
+    setCurrentStep(1);
+  }, [files]);
+
+  const handleStartProcessing = useCallback((updatedConfigs: FileConfig[]) => {
+    setConfigs(updatedConfigs);
+    setCurrentStep(2);
+  }, []);
+
+  const handleProcessingComplete = useCallback((fileResults: FileResult[]) => {
+    setResults(fileResults);
+    setCurrentStep(3);
+  }, []);
+
+  return (
+    <div className="space-y-4">
+      <StepIndicator currentStep={currentStep} />
+
+      {currentStep === 0 && (
+        <StepUpload
+          files={files}
+          onFilesChange={handleFilesSelected}
+          onNext={handleGoToConfigure}
+        />
+      )}
+
+      {currentStep === 1 && (
+        <StepConfigure
+          configs={configs}
+          onBack={() => setCurrentStep(0)}
+          onStartProcessing={handleStartProcessing}
+        />
+      )}
+
+      {currentStep === 2 && (
+        <StepProgress
+          sharedGameId={sharedGameId}
+          configs={configs}
+          onComplete={handleProcessingComplete}
+        />
+      )}
+
+      {currentStep === 3 && (
+        <StepComplete
+          results={results}
+          onClose={onClose}
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/admin/(dashboard)/shared-games/[id]/rag-wizard/components/step-complete.tsx
+++ b/apps/web/src/app/admin/(dashboard)/shared-games/[id]/rag-wizard/components/step-complete.tsx
@@ -1,0 +1,110 @@
+/**
+ * Step 4: Completo — Success summary
+ *
+ * Shows green checkmark, count of indexed vs pending documents, and close button.
+ */
+
+'use client';
+
+import { CheckCircle2, AlertCircle } from 'lucide-react';
+
+import { Button } from '@/components/ui/primitives/button';
+
+import type { FileResult } from './rag-wizard';
+
+// ── Props ───────────────────────────────────────────────────────────────
+
+interface StepCompleteProps {
+  results: FileResult[];
+  onClose: () => void;
+}
+
+// ── Component ───────────────────────────────────────────────────────────
+
+export function StepComplete({ results, onClose }: StepCompleteProps) {
+  const succeeded = results.filter(r => r.result && !r.error);
+  const failed = results.filter(r => r.error);
+  const autoApproved = succeeded.filter(r => r.result?.autoApproved);
+  const pendingApproval = succeeded.filter(r => r.result && !r.result.autoApproved);
+
+  return (
+    <div className="flex flex-col items-center text-center space-y-6 py-4">
+      {/* Main icon */}
+      {failed.length === 0 ? (
+        <div className="flex h-16 w-16 items-center justify-center rounded-full bg-green-100 dark:bg-green-900/30">
+          <CheckCircle2 className="h-8 w-8 text-green-600 dark:text-green-400" />
+        </div>
+      ) : (
+        <div className="flex h-16 w-16 items-center justify-center rounded-full bg-amber-100 dark:bg-amber-900/30">
+          <AlertCircle className="h-8 w-8 text-amber-600 dark:text-amber-400" />
+        </div>
+      )}
+
+      {/* Title */}
+      <div>
+        <h3 className="text-lg font-semibold">
+          {failed.length === 0 ? 'Elaborazione completata!' : 'Elaborazione completata con errori'}
+        </h3>
+        <p className="text-sm text-muted-foreground mt-1">
+          {results.length} file processati
+        </p>
+      </div>
+
+      {/* Stats */}
+      <div className="grid grid-cols-2 gap-4 w-full max-w-xs text-sm">
+        {autoApproved.length > 0 && (
+          <div className="rounded-lg border bg-green-50 dark:bg-green-900/20 p-3">
+            <p className="text-2xl font-bold text-green-700 dark:text-green-300">
+              {autoApproved.length}
+            </p>
+            <p className="text-xs text-green-600 dark:text-green-400">Indicizzati</p>
+          </div>
+        )}
+
+        {pendingApproval.length > 0 && (
+          <div className="rounded-lg border bg-amber-50 dark:bg-amber-900/20 p-3">
+            <p className="text-2xl font-bold text-amber-700 dark:text-amber-300">
+              {pendingApproval.length}
+            </p>
+            <p className="text-xs text-amber-600 dark:text-amber-400">In attesa approvazione</p>
+          </div>
+        )}
+
+        {failed.length > 0 && (
+          <div className="rounded-lg border bg-red-50 dark:bg-red-900/20 p-3">
+            <p className="text-2xl font-bold text-red-700 dark:text-red-300">
+              {failed.length}
+            </p>
+            <p className="text-xs text-red-600 dark:text-red-400">Errori</p>
+          </div>
+        )}
+      </div>
+
+      {/* Failed file details */}
+      {failed.length > 0 && (
+        <div className="w-full max-w-md space-y-2 text-left">
+          <p className="text-xs font-medium text-muted-foreground uppercase tracking-wider">
+            File con errori
+          </p>
+          {failed.map(r => (
+            <div
+              key={r.fileName}
+              className="flex items-start gap-2 rounded-lg border border-red-200 dark:border-red-800 bg-red-50 dark:bg-red-900/20 px-3 py-2 text-sm"
+            >
+              <AlertCircle className="h-4 w-4 text-red-500 shrink-0 mt-0.5" />
+              <div className="min-w-0">
+                <p className="font-medium truncate">{r.fileName}</p>
+                <p className="text-xs text-red-600 dark:text-red-400">{r.error}</p>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Close button */}
+      <Button onClick={onClose} className="mt-2">
+        Chiudi
+      </Button>
+    </div>
+  );
+}

--- a/apps/web/src/app/admin/(dashboard)/shared-games/[id]/rag-wizard/components/step-complete.tsx
+++ b/apps/web/src/app/admin/(dashboard)/shared-games/[id]/rag-wizard/components/step-complete.tsx
@@ -24,7 +24,8 @@ interface StepCompleteProps {
 export function StepComplete({ results, onClose }: StepCompleteProps) {
   const succeeded = results.filter(r => r.result && !r.error);
   const failed = results.filter(r => r.error);
-  const autoApproved = succeeded.filter(r => r.result?.autoApproved);
+  const autoApprovedWithJob = succeeded.filter(r => r.result?.autoApproved && r.result?.processingJobId);
+  const autoApprovedNoJob = succeeded.filter(r => r.result?.autoApproved && !r.result?.processingJobId);
   const pendingApproval = succeeded.filter(r => r.result && !r.result.autoApproved);
 
   return (
@@ -51,13 +52,22 @@ export function StepComplete({ results, onClose }: StepCompleteProps) {
       </div>
 
       {/* Stats */}
-      <div className="grid grid-cols-2 gap-4 w-full max-w-xs text-sm">
-        {autoApproved.length > 0 && (
+      <div className="grid grid-cols-2 gap-4 w-full max-w-sm text-sm">
+        {autoApprovedWithJob.length > 0 && (
           <div className="rounded-lg border bg-green-50 dark:bg-green-900/20 p-3">
             <p className="text-2xl font-bold text-green-700 dark:text-green-300">
-              {autoApproved.length}
+              {autoApprovedWithJob.length}
             </p>
             <p className="text-xs text-green-600 dark:text-green-400">Indicizzati</p>
+          </div>
+        )}
+
+        {autoApprovedNoJob.length > 0 && (
+          <div className="rounded-lg border bg-amber-50 dark:bg-amber-900/20 p-3">
+            <p className="text-2xl font-bold text-amber-700 dark:text-amber-300">
+              {autoApprovedNoJob.length}
+            </p>
+            <p className="text-xs text-amber-600 dark:text-amber-400">Approvato (coda non disponibile)</p>
           </div>
         )}
 

--- a/apps/web/src/app/admin/(dashboard)/shared-games/[id]/rag-wizard/components/step-configure.tsx
+++ b/apps/web/src/app/admin/(dashboard)/shared-games/[id]/rag-wizard/components/step-configure.tsx
@@ -1,0 +1,142 @@
+/**
+ * Step 2: Configura — Per-file configuration
+ *
+ * For each file: document type Select + version Input.
+ * Version validation: ^\d+\.\d+$
+ * "Avvia Processing" button disabled until all configs are valid.
+ */
+
+'use client';
+
+import { useCallback, useState } from 'react';
+
+import { FileText } from 'lucide-react';
+
+import { Input } from '@/components/ui/primitives/input';
+import { Label } from '@/components/ui/primitives/label';
+import { Button } from '@/components/ui/primitives/button';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+
+import type { FileConfig } from './rag-wizard';
+import type { DocumentType } from '../lib/rag-api';
+
+// ── Constants ───────────────────────────────────────────────────────────
+
+const VERSION_REGEX = /^\d+\.\d+$/;
+
+const DOCUMENT_TYPES: { value: DocumentType; label: string }[] = [
+  { value: 'Rulebook', label: 'Regolamento' },
+  { value: 'Errata', label: 'Errata' },
+  { value: 'Homerule', label: 'Regola casalinga' },
+];
+
+// ── Props ───────────────────────────────────────────────────────────────
+
+interface StepConfigureProps {
+  configs: FileConfig[];
+  onBack: () => void;
+  onStartProcessing: (configs: FileConfig[]) => void;
+}
+
+// ── Component ───────────────────────────────────────────────────────────
+
+export function StepConfigure({ configs: initialConfigs, onBack, onStartProcessing }: StepConfigureProps) {
+  const [configs, setConfigs] = useState<FileConfig[]>(initialConfigs);
+
+  const updateConfig = useCallback((index: number, updates: Partial<FileConfig>) => {
+    setConfigs(prev =>
+      prev.map((c, i) => (i === index ? { ...c, ...updates } : c))
+    );
+  }, []);
+
+  const allValid = configs.every(c => VERSION_REGEX.test(c.version));
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-muted-foreground">
+        Configura tipo documento e versione per ogni file.
+      </p>
+
+      <div className="space-y-4">
+        {configs.map((config, index) => {
+          const versionValid = VERSION_REGEX.test(config.version);
+
+          return (
+            <div
+              key={`${config.file.name}-${config.file.size}`}
+              className="rounded-lg border bg-white/60 dark:bg-zinc-800/60 p-4 space-y-3"
+            >
+              {/* File name */}
+              <div className="flex items-center gap-2">
+                <FileText className="h-4 w-4 text-muted-foreground" />
+                <span className="text-sm font-medium truncate">{config.file.name}</span>
+              </div>
+
+              {/* Config fields */}
+              <div className="grid grid-cols-1 sm:grid-cols-2 gap-3">
+                {/* Document Type */}
+                <div className="space-y-1.5">
+                  <Label htmlFor={`docType-${index}`} className="text-xs">
+                    Tipo documento
+                  </Label>
+                  <Select
+                    value={config.documentType}
+                    onValueChange={(value: DocumentType) =>
+                      updateConfig(index, { documentType: value })
+                    }
+                  >
+                    <SelectTrigger id={`docType-${index}`} className="h-9 text-sm">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {DOCUMENT_TYPES.map(dt => (
+                        <SelectItem key={dt.value} value={dt.value} className="text-sm">
+                          {dt.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                {/* Version */}
+                <div className="space-y-1.5">
+                  <Label htmlFor={`version-${index}`} className="text-xs">
+                    Versione
+                  </Label>
+                  <Input
+                    id={`version-${index}`}
+                    value={config.version}
+                    onChange={e => updateConfig(index, { version: e.target.value })}
+                    placeholder="1.0"
+                    className={`h-9 text-sm ${!versionValid && config.version ? 'border-destructive' : ''}`}
+                  />
+                  {!versionValid && config.version && (
+                    <p className="text-xs text-destructive">
+                      Formato: X.Y (es. 1.0, 2.1)
+                    </p>
+                  )}
+                </div>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+
+      {/* Navigation */}
+      <div className="flex justify-between pt-2">
+        <Button variant="outline" onClick={onBack}>
+          Indietro
+        </Button>
+        <Button onClick={() => onStartProcessing(configs)} disabled={!allValid}>
+          Avvia Processing
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/admin/(dashboard)/shared-games/[id]/rag-wizard/components/step-progress.tsx
+++ b/apps/web/src/app/admin/(dashboard)/shared-games/[id]/rag-wizard/components/step-progress.tsx
@@ -116,19 +116,20 @@ function JobTracker({
   const { connectionState } = useJobSSE(jobId);
   const { data: jobDetail } = useJobDetail(jobId, connectionState === 'connected');
   const notifiedRef = useRef(false);
-  const startTimeRef = useRef(Date.now());
+  const onTerminalRef = useRef(onTerminal);
+  onTerminalRef.current = onTerminal;
 
   // Terminal status from job detail
   useEffect(() => {
     if (!jobDetail || notifiedRef.current) return;
     if (jobDetail.status === 'Completed') {
       notifiedRef.current = true;
-      onTerminal('completed');
+      onTerminalRef.current('completed');
     } else if (jobDetail.status === 'Failed') {
       notifiedRef.current = true;
-      onTerminal('failed');
+      onTerminalRef.current('failed');
     }
-  }, [jobDetail, onTerminal]);
+  }, [jobDetail]);
 
   // Timeout: if processing exceeds 5 minutes, treat as failed
   useEffect(() => {
@@ -136,20 +137,20 @@ function JobTracker({
     const timer = setTimeout(() => {
       if (!notifiedRef.current) {
         notifiedRef.current = true;
-        onTerminal('failed');
+        onTerminalRef.current('failed');
       }
     }, PROCESSING_TIMEOUT_MS);
     return () => clearTimeout(timer);
-  }, [onTerminal]);
+  }, []);
 
   // SSE connection error: if connection is in 'error' state, treat as failed
   useEffect(() => {
     if (notifiedRef.current) return;
     if (connectionState === 'error') {
       notifiedRef.current = true;
-      onTerminal('failed');
+      onTerminalRef.current('failed');
     }
-  }, [connectionState, onTerminal]);
+  }, [connectionState]);
 
   // Show pipeline steps from job detail
   const currentStep = jobDetail?.currentStep;

--- a/apps/web/src/app/admin/(dashboard)/shared-games/[id]/rag-wizard/components/step-progress.tsx
+++ b/apps/web/src/app/admin/(dashboard)/shared-games/[id]/rag-wizard/components/step-progress.tsx
@@ -1,0 +1,325 @@
+/**
+ * Step 3: Processing — Upload files sequentially and track progress via SSE
+ *
+ * For each file:
+ * - Upload via addRagToSharedGame()
+ * - If processingJobId returned, track via useJobSSE
+ * - Show pipeline steps and status badges
+ *
+ * Transitions to step 4 when ALL files are done (completed or failed).
+ */
+
+'use client';
+
+import { useState, useEffect, useCallback, useRef } from 'react';
+
+import {
+  CheckCircle2,
+  AlertCircle,
+  Loader2,
+  Clock,
+  Upload,
+} from 'lucide-react';
+
+import { Badge } from '@/components/ui/data-display/badge';
+import { Progress } from '@/components/ui/feedback/progress';
+
+import { addRagToSharedGame, type AddRagResult } from '../lib/rag-api';
+import type { FileConfig } from './rag-wizard';
+import type { FileResult } from './rag-wizard';
+import { useJobSSE } from '@/app/admin/(dashboard)/knowledge-base/queue/hooks/use-job-sse';
+import { useJobDetail } from '@/app/admin/(dashboard)/knowledge-base/queue/lib/queue-api';
+
+// ── Types ───────────────────────────────────────────────────────────────
+
+type FileStatus = 'waiting' | 'uploading' | 'processing' | 'completed' | 'failed';
+
+interface FileState {
+  file: File;
+  status: FileStatus;
+  uploadProgress: number;
+  result: AddRagResult | null;
+  error: string | null;
+}
+
+// ── Pipeline step labels ────────────────────────────────────────────────
+
+const PIPELINE_STEPS = [
+  'Upload',
+  'Estrazione testo',
+  'Chunking',
+  'Generazione embeddings',
+  'Indicizzazione vettoriale',
+] as const;
+
+// ── Props ───────────────────────────────────────────────────────────────
+
+interface StepProgressProps {
+  sharedGameId: string;
+  configs: FileConfig[];
+  onComplete: (results: FileResult[]) => void;
+}
+
+// ── Status Badge ────────────────────────────────────────────────────────
+
+function StatusBadge({ status }: { status: FileStatus }) {
+  switch (status) {
+    case 'waiting':
+      return (
+        <Badge variant="secondary" className="text-xs gap-1">
+          <Clock className="h-3 w-3" />
+          In attesa
+        </Badge>
+      );
+    case 'uploading':
+      return (
+        <Badge variant="outline" className="text-xs gap-1 text-blue-600 border-blue-300">
+          <Upload className="h-3 w-3" />
+          Caricamento
+        </Badge>
+      );
+    case 'processing':
+      return (
+        <Badge variant="outline" className="text-xs gap-1 text-amber-600 border-amber-300">
+          <Loader2 className="h-3 w-3 animate-spin" />
+          In elaborazione
+        </Badge>
+      );
+    case 'completed':
+      return (
+        <Badge variant="default" className="text-xs gap-1 bg-green-600">
+          <CheckCircle2 className="h-3 w-3" />
+          Completato
+        </Badge>
+      );
+    case 'failed':
+      return (
+        <Badge variant="destructive" className="text-xs gap-1">
+          <AlertCircle className="h-3 w-3" />
+          Errore
+        </Badge>
+      );
+  }
+}
+
+// ── Job SSE Tracker (per file with a processingJobId) ───────────────────
+
+function JobTracker({
+  jobId,
+  onTerminal,
+}: {
+  jobId: string;
+  onTerminal: (status: 'completed' | 'failed') => void;
+}) {
+  const { connectionState } = useJobSSE(jobId);
+  const { data: jobDetail } = useJobDetail(jobId, connectionState === 'connected');
+  const notifiedRef = useRef(false);
+
+  useEffect(() => {
+    if (!jobDetail || notifiedRef.current) return;
+    if (jobDetail.status === 'Completed') {
+      notifiedRef.current = true;
+      onTerminal('completed');
+    } else if (jobDetail.status === 'Failed') {
+      notifiedRef.current = true;
+      onTerminal('failed');
+    }
+  }, [jobDetail, onTerminal]);
+
+  // Show pipeline steps from job detail
+  const currentStep = jobDetail?.currentStep;
+
+  return (
+    <div className="mt-2 space-y-1">
+      {/* SSE connection indicator */}
+      <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+        <div
+          className={`h-1.5 w-1.5 rounded-full ${
+            connectionState === 'connected'
+              ? 'bg-green-500'
+              : connectionState === 'connecting' || connectionState === 'reconnecting'
+                ? 'bg-amber-500 animate-pulse'
+                : 'bg-red-500'
+          }`}
+        />
+        SSE: {connectionState}
+      </div>
+
+      {/* Pipeline steps */}
+      <div className="flex flex-wrap gap-1.5">
+        {PIPELINE_STEPS.map(step => {
+          const isDone =
+            jobDetail?.steps?.some(
+              s => s.stepName === step && s.status === 'Completed'
+            ) ?? false;
+          const isCurrent = currentStep === step;
+
+          return (
+            <span
+              key={step}
+              className={`text-xs px-2 py-0.5 rounded-full border ${
+                isDone
+                  ? 'bg-green-50 border-green-300 text-green-700 dark:bg-green-900/30 dark:text-green-300'
+                  : isCurrent
+                    ? 'bg-amber-50 border-amber-300 text-amber-700 dark:bg-amber-900/30 dark:text-amber-300'
+                    : 'bg-muted border-transparent text-muted-foreground'
+              }`}
+            >
+              {isDone && <CheckCircle2 className="inline h-3 w-3 mr-0.5 -mt-0.5" />}
+              {isCurrent && <Loader2 className="inline h-3 w-3 mr-0.5 -mt-0.5 animate-spin" />}
+              {step}
+            </span>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+// ── Main Component ──────────────────────────────────────────────────────
+
+export function StepProgress({ sharedGameId, configs, onComplete }: StepProgressProps) {
+  const [fileStates, setFileStates] = useState<FileState[]>(() =>
+    configs.map(c => ({
+      file: c.file,
+      status: 'waiting' as FileStatus,
+      uploadProgress: 0,
+      result: null,
+      error: null,
+    }))
+  );
+
+  const processingStartedRef = useRef(false);
+
+  // Update a single file state immutably
+  const updateFileState = useCallback((index: number, updates: Partial<FileState>) => {
+    setFileStates(prev =>
+      prev.map((fs, i) => (i === index ? { ...fs, ...updates } : fs))
+    );
+  }, []);
+
+  // Process files sequentially
+  useEffect(() => {
+    if (processingStartedRef.current) return;
+    processingStartedRef.current = true;
+
+    const processAll = async () => {
+      for (let i = 0; i < configs.length; i++) {
+        const config = configs[i];
+        updateFileState(i, { status: 'uploading', uploadProgress: 0 });
+
+        try {
+          const result = await addRagToSharedGame(
+            sharedGameId,
+            config.file,
+            config.documentType,
+            config.version,
+            undefined,
+            (percent) => {
+              updateFileState(i, { uploadProgress: percent });
+            }
+          );
+
+          if (result.processingJobId) {
+            // Has a job — transition to processing (JobTracker will handle SSE)
+            updateFileState(i, {
+              status: 'processing',
+              uploadProgress: 100,
+              result,
+            });
+          } else {
+            // No job (editor pending approval) — mark as completed
+            updateFileState(i, {
+              status: 'completed',
+              uploadProgress: 100,
+              result,
+            });
+          }
+        } catch (err) {
+          const message = err instanceof Error ? err.message : 'Errore sconosciuto';
+          updateFileState(i, {
+            status: 'failed',
+            error: message,
+          });
+        }
+      }
+    };
+
+    void processAll();
+  }, [configs, sharedGameId, updateFileState]);
+
+  // Handle SSE terminal event for a processing file
+  const handleJobTerminal = useCallback(
+    (index: number, terminalStatus: 'completed' | 'failed') => {
+      updateFileState(index, { status: terminalStatus });
+    },
+    [updateFileState]
+  );
+
+  // Check if all files are done (no 'waiting', 'uploading', or 'processing')
+  const allDone = fileStates.every(
+    fs => fs.status === 'completed' || fs.status === 'failed'
+  );
+
+  // Transition to complete step
+  useEffect(() => {
+    if (!allDone) return;
+
+    const results: FileResult[] = fileStates.map(fs => ({
+      fileName: fs.file.name,
+      result: fs.result,
+      error: fs.error,
+    }));
+
+    // Small delay so user can see final state
+    const timer = setTimeout(() => onComplete(results), 1500);
+    return () => clearTimeout(timer);
+  }, [allDone, fileStates, onComplete]);
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-muted-foreground">
+        Upload e indicizzazione in corso...
+      </p>
+
+      {fileStates.map((fs, index) => (
+        <div
+          key={`${fs.file.name}-${fs.file.size}`}
+          className="rounded-lg border bg-white/60 dark:bg-zinc-800/60 p-4 space-y-2"
+        >
+          <div className="flex items-center justify-between">
+            <span className="text-sm font-medium truncate">{fs.file.name}</span>
+            <StatusBadge status={fs.status} />
+          </div>
+
+          {/* Upload progress bar */}
+          {fs.status === 'uploading' && (
+            <Progress value={fs.uploadProgress} className="h-1.5" />
+          )}
+
+          {/* Error message */}
+          {fs.status === 'failed' && fs.error && (
+            <p className="text-xs text-destructive">{fs.error}</p>
+          )}
+
+          {/* SSE job tracking */}
+          {fs.status === 'processing' && fs.result?.processingJobId && (
+            <JobTracker
+              jobId={fs.result.processingJobId}
+              onTerminal={status => handleJobTerminal(index, status)}
+            />
+          )}
+
+          {/* Completed — auto-approved info */}
+          {fs.status === 'completed' && fs.result && (
+            <p className="text-xs text-muted-foreground">
+              {fs.result.autoApproved
+                ? 'Auto-approvato per RAG'
+                : 'In attesa di approvazione'}
+            </p>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/app/admin/(dashboard)/shared-games/[id]/rag-wizard/components/step-progress.tsx
+++ b/apps/web/src/app/admin/(dashboard)/shared-games/[id]/rag-wizard/components/step-progress.tsx
@@ -104,6 +104,8 @@ function StatusBadge({ status }: { status: FileStatus }) {
 
 // ── Job SSE Tracker (per file with a processingJobId) ───────────────────
 
+const PROCESSING_TIMEOUT_MS = 300_000; // 5 minutes
+
 function JobTracker({
   jobId,
   onTerminal,
@@ -114,7 +116,9 @@ function JobTracker({
   const { connectionState } = useJobSSE(jobId);
   const { data: jobDetail } = useJobDetail(jobId, connectionState === 'connected');
   const notifiedRef = useRef(false);
+  const startTimeRef = useRef(Date.now());
 
+  // Terminal status from job detail
   useEffect(() => {
     if (!jobDetail || notifiedRef.current) return;
     if (jobDetail.status === 'Completed') {
@@ -125,6 +129,27 @@ function JobTracker({
       onTerminal('failed');
     }
   }, [jobDetail, onTerminal]);
+
+  // Timeout: if processing exceeds 5 minutes, treat as failed
+  useEffect(() => {
+    if (notifiedRef.current) return;
+    const timer = setTimeout(() => {
+      if (!notifiedRef.current) {
+        notifiedRef.current = true;
+        onTerminal('failed');
+      }
+    }, PROCESSING_TIMEOUT_MS);
+    return () => clearTimeout(timer);
+  }, [onTerminal]);
+
+  // SSE connection error: if connection is in 'error' state, treat as failed
+  useEffect(() => {
+    if (notifiedRef.current) return;
+    if (connectionState === 'error') {
+      notifiedRef.current = true;
+      onTerminal('failed');
+    }
+  }, [connectionState, onTerminal]);
 
   // Show pipeline steps from job detail
   const currentStep = jobDetail?.currentStep;

--- a/apps/web/src/app/admin/(dashboard)/shared-games/[id]/rag-wizard/components/step-upload.tsx
+++ b/apps/web/src/app/admin/(dashboard)/shared-games/[id]/rag-wizard/components/step-upload.tsx
@@ -18,6 +18,7 @@ import { Button } from '@/components/ui/primitives/button';
 // ── Constants ───────────────────────────────────────────────────────────
 
 const MAX_FILE_SIZE = 50 * 1024 * 1024; // 50MB
+const MAX_FILE_COUNT = 20;
 
 // ── Props ───────────────────────────────────────────────────────────────
 
@@ -44,8 +45,18 @@ export function StepUpload({ files, onFilesChange, onNext }: StepUploadProps) {
   const validateAndAddFiles = useCallback(
     (newFiles: FileList | File[]) => {
       const validFiles: File[] = [];
+      const remaining = MAX_FILE_COUNT - files.length;
+
+      if (remaining <= 0) {
+        toast.error(`Massimo ${MAX_FILE_COUNT} file consentiti`);
+        return;
+      }
 
       for (const file of Array.from(newFiles)) {
+        if (validFiles.length >= remaining) {
+          toast.error(`Massimo ${MAX_FILE_COUNT} file consentiti`);
+          break;
+        }
         if (file.type !== 'application/pdf') {
           toast.error(`"${file.name}" non e un PDF valido`);
           continue;

--- a/apps/web/src/app/admin/(dashboard)/shared-games/[id]/rag-wizard/components/step-upload.tsx
+++ b/apps/web/src/app/admin/(dashboard)/shared-games/[id]/rag-wizard/components/step-upload.tsx
@@ -1,0 +1,182 @@
+/**
+ * Step 1: Upload — Drag & drop + file input for PDFs
+ *
+ * Accept only application/pdf, max 50MB per file.
+ * Shows file list with remove button.
+ * "Avanti" button disabled until at least 1 file.
+ */
+
+'use client';
+
+import { useCallback, useRef, useState } from 'react';
+
+import { FileUp, FileText, X } from 'lucide-react';
+import { toast } from 'sonner';
+
+import { Button } from '@/components/ui/primitives/button';
+
+// ── Constants ───────────────────────────────────────────────────────────
+
+const MAX_FILE_SIZE = 50 * 1024 * 1024; // 50MB
+
+// ── Props ───────────────────────────────────────────────────────────────
+
+interface StepUploadProps {
+  files: File[];
+  onFilesChange: (files: File[]) => void;
+  onNext: () => void;
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────────
+
+function formatFileSize(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+// ── Component ───────────────────────────────────────────────────────────
+
+export function StepUpload({ files, onFilesChange, onNext }: StepUploadProps) {
+  const [dragActive, setDragActive] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const validateAndAddFiles = useCallback(
+    (newFiles: FileList | File[]) => {
+      const validFiles: File[] = [];
+
+      for (const file of Array.from(newFiles)) {
+        if (file.type !== 'application/pdf') {
+          toast.error(`"${file.name}" non e un PDF valido`);
+          continue;
+        }
+        if (file.size > MAX_FILE_SIZE) {
+          toast.error(`"${file.name}" supera il limite di 50MB`);
+          continue;
+        }
+        // Skip duplicates by name
+        if (files.some(f => f.name === file.name && f.size === file.size)) {
+          toast.info(`"${file.name}" gia aggiunto`);
+          continue;
+        }
+        validFiles.push(file);
+      }
+
+      if (validFiles.length > 0) {
+        onFilesChange([...files, ...validFiles]);
+      }
+    },
+    [files, onFilesChange]
+  );
+
+  const handleDrop = useCallback(
+    (e: React.DragEvent) => {
+      e.preventDefault();
+      setDragActive(false);
+      if (e.dataTransfer.files.length > 0) {
+        validateAndAddFiles(e.dataTransfer.files);
+      }
+    },
+    [validateAndAddFiles]
+  );
+
+  const handleDragOver = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    setDragActive(true);
+  }, []);
+
+  const handleDragLeave = useCallback((e: React.DragEvent) => {
+    e.preventDefault();
+    setDragActive(false);
+  }, []);
+
+  const handleInputChange = useCallback(
+    (e: React.ChangeEvent<HTMLInputElement>) => {
+      if (e.target.files && e.target.files.length > 0) {
+        validateAndAddFiles(e.target.files);
+      }
+      // Reset input so the same file can be selected again
+      e.target.value = '';
+    },
+    [validateAndAddFiles]
+  );
+
+  const removeFile = useCallback(
+    (index: number) => {
+      onFilesChange(files.filter((_, i) => i !== index));
+    },
+    [files, onFilesChange]
+  );
+
+  return (
+    <div className="space-y-4">
+      {/* Drop zone */}
+      <div
+        className={`border-2 border-dashed rounded-xl p-8 text-center transition-colors cursor-pointer ${
+          dragActive
+            ? 'border-primary bg-primary/5'
+            : 'border-muted-foreground/25 hover:border-primary/50 hover:bg-muted/50'
+        }`}
+        onDrop={handleDrop}
+        onDragOver={handleDragOver}
+        onDragLeave={handleDragLeave}
+        onClick={() => inputRef.current?.click()}
+      >
+        <input
+          ref={inputRef}
+          type="file"
+          accept="application/pdf"
+          multiple
+          className="hidden"
+          onChange={handleInputChange}
+        />
+        <FileUp className="h-12 w-12 mx-auto text-muted-foreground mb-3" />
+        <p className="font-medium">Trascina i PDF qui o clicca per selezionare</p>
+        <p className="text-sm text-muted-foreground mt-1">
+          Solo file PDF, massimo 50MB ciascuno
+        </p>
+      </div>
+
+      {/* File list */}
+      {files.length > 0 && (
+        <div className="space-y-2">
+          <p className="text-sm font-medium text-muted-foreground">
+            {files.length} file{files.length !== 1 ? '' : ''} selezionat{files.length !== 1 ? 'i' : 'o'}
+          </p>
+          {files.map((file, index) => (
+            <div
+              key={`${file.name}-${file.size}`}
+              className="flex items-center justify-between rounded-lg border bg-white/60 dark:bg-zinc-800/60 px-4 py-3"
+            >
+              <div className="flex items-center gap-3 min-w-0">
+                <FileText className="h-5 w-5 text-muted-foreground shrink-0" />
+                <div className="min-w-0">
+                  <p className="text-sm font-medium truncate">{file.name}</p>
+                  <p className="text-xs text-muted-foreground">{formatFileSize(file.size)}</p>
+                </div>
+              </div>
+              <Button
+                variant="ghost"
+                size="icon"
+                className="shrink-0 h-8 w-8"
+                onClick={e => {
+                  e.stopPropagation();
+                  removeFile(index);
+                }}
+              >
+                <X className="h-4 w-4" />
+              </Button>
+            </div>
+          ))}
+        </div>
+      )}
+
+      {/* Navigation */}
+      <div className="flex justify-end pt-2">
+        <Button onClick={onNext} disabled={files.length === 0}>
+          Avanti
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/admin/(dashboard)/shared-games/[id]/rag-wizard/lib/rag-api.ts
+++ b/apps/web/src/app/admin/(dashboard)/shared-games/[id]/rag-wizard/lib/rag-api.ts
@@ -1,0 +1,151 @@
+/**
+ * RAG Wizard API Client
+ *
+ * API functions for the SharedGame RAG wizard.
+ * Uses raw fetch with FormData for multipart/form-data file uploads
+ * (the HttpClient only supports JSON body).
+ *
+ * Endpoints:
+ * - POST /api/v1/admin/shared-games/{id}/rag — single upload + process
+ * - POST /api/v1/admin/shared-games/batch-rag — batch upload + process
+ */
+
+import { getApiBase } from '@/lib/api';
+
+// ── Types matching backend DTOs ────────────────────────────────────────
+
+export interface AddRagResult {
+  pdfDocumentId: string;
+  sharedGameDocumentId: string;
+  processingJobId: string | null;
+  autoApproved: boolean;
+  streamUrl: string;
+}
+
+export interface BatchItemResult {
+  sharedGameId: string;
+  fileName: string;
+  result: AddRagResult | null;
+  error: string | null;
+}
+
+export interface BatchRagResult {
+  results: BatchItemResult[];
+  successCount: number;
+  failureCount: number;
+}
+
+// ── Document type enum matching backend SharedGameDocumentType ──────────
+
+export type DocumentType = 'Rulebook' | 'Errata' | 'Homerule';
+
+// ── API Functions ───────────────────────────────────────────────────────
+
+/**
+ * Upload a PDF and start RAG processing for a shared game.
+ * Uses XHR for upload progress tracking.
+ *
+ * POST /api/v1/admin/shared-games/{sharedGameId}/rag (multipart/form-data)
+ */
+export async function addRagToSharedGame(
+  sharedGameId: string,
+  file: File,
+  documentType: DocumentType,
+  version: string,
+  tags?: string[],
+  onProgress?: (percent: number) => void
+): Promise<AddRagResult> {
+  const baseUrl = getApiBase();
+  const url = `${baseUrl}/api/v1/admin/shared-games/${sharedGameId}/rag`;
+
+  return new Promise<AddRagResult>((resolve, reject) => {
+    const xhr = new XMLHttpRequest();
+
+    if (onProgress) {
+      xhr.upload.addEventListener('progress', e => {
+        if (e.lengthComputable) {
+          onProgress(Math.round((e.loaded / e.total) * 100));
+        }
+      });
+    }
+
+    xhr.addEventListener('load', () => {
+      if (xhr.status >= 200 && xhr.status < 300) {
+        try {
+          const response = JSON.parse(xhr.responseText) as AddRagResult;
+          resolve(response);
+        } catch {
+          reject(new Error('Risposta server non valida'));
+        }
+      } else {
+        try {
+          const errorResponse = JSON.parse(xhr.responseText) as { error?: string; details?: Record<string, string> };
+          const message = errorResponse.details
+            ? Object.values(errorResponse.details).join(', ')
+            : errorResponse.error ?? 'Upload fallito';
+          reject(new Error(message));
+        } catch {
+          reject(new Error(`Upload fallito: ${xhr.statusText}`));
+        }
+      }
+    });
+
+    xhr.addEventListener('error', () => {
+      reject(new Error("Errore di rete durante l'upload"));
+    });
+
+    xhr.addEventListener('timeout', () => {
+      reject(new Error("Timeout durante l'upload"));
+    });
+
+    const formData = new FormData();
+    formData.append('file', file);
+    formData.append('documentType', documentType);
+    formData.append('version', version);
+    if (tags && tags.length > 0) {
+      formData.append('tags', tags.join(','));
+    }
+
+    xhr.open('POST', url);
+    xhr.withCredentials = true;
+    xhr.send(formData);
+  });
+}
+
+/**
+ * Batch upload PDFs and start RAG processing for multiple shared games.
+ *
+ * POST /api/v1/admin/shared-games/batch-rag (multipart/form-data)
+ */
+export async function batchAddRag(
+  items: Array<{
+    sharedGameId: string;
+    file: File;
+    documentType: DocumentType;
+    version: string;
+  }>
+): Promise<BatchRagResult> {
+  const baseUrl = getApiBase();
+  const url = `${baseUrl}/api/v1/admin/shared-games/batch-rag`;
+
+  const formData = new FormData();
+  for (const item of items) {
+    formData.append('sharedGameIds', item.sharedGameId);
+    formData.append('files', item.file);
+    formData.append('documentTypes', item.documentType);
+    formData.append('versions', item.version);
+  }
+
+  const response = await fetch(url, {
+    method: 'POST',
+    credentials: 'include',
+    body: formData,
+  });
+
+  if (!response.ok) {
+    const errorBody = await response.json().catch(() => null) as { error?: string } | null;
+    throw new Error(errorBody?.error ?? `Batch upload fallito: ${response.statusText}`);
+  }
+
+  return (await response.json()) as BatchRagResult;
+}


### PR DESCRIPTION
## Summary

- New orchestration command `AddRagToSharedGameCommand` wraps 4 existing sub-commands (Upload → Link → Approve → Enqueue) into a single saga
- Admin auto-approves with `ProcessingPriority.High`; editor requires manual approval gate
- Batch variant (`BatchAddRagToSharedGameCommand`) supports partial success
- Graceful degradation: if enqueue fails, document is still linked + approved
- 4-step frontend wizard (Upload → Configure → Progress → Complete) integrated as Sheet/drawer in SharedGame detail page
- Real-time processing progress via existing `useJobSSE` + `useJobDetail` SSE infrastructure
- 5-minute timeout + SSE error detection prevents wizard from getting stuck
- Query invalidation on all wizard close paths (including backdrop click / Escape)

## Changes

**Backend (5 files, ~460 LOC):**
- `AddRagToSharedGameCommand` + Validator + Handler (saga orchestrator)
- `BatchAddRagToSharedGameCommand` + Handler (sequential, partial success)
- 2 new endpoints in `SharedGameCatalogEndpoints`: `POST /{id}/rag` + `POST /batch-rag`

**Frontend (7 files, ~1145 LOC):**
- RAG wizard components: `rag-wizard.tsx`, `step-upload.tsx`, `step-configure.tsx`, `step-progress.tsx`, `step-complete.tsx`
- API client: `rag-api.ts`
- Integration: "Aggiungi RAG" button + Sheet in SharedGame detail page

**Tests (3 files, ~760 LOC):**
- 34 unit tests: validator (25), handler (5), batch handler (4)

## Test plan

- [x] 34 backend unit tests pass (`dotnet test --filter AddRagToSharedGame`)
- [x] Frontend TypeScript compilation passes (`tsc --noEmit`)
- [x] Backend build passes (`dotnet build`)
- [ ] Manual: Admin uploads PDF via wizard → sees real-time progress → receives notification
- [ ] Manual: Editor uploads PDF → sees "pending approval" status
- [ ] Manual: Batch upload of multiple PDFs → partial success handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)
