### PR TITLE
fix(notifications): 3 critical bugs in Phase 1 unsubscribe and email retry

### DIFF
--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Application/Handlers/UnsubscribeEmailCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Application/Handlers/UnsubscribeEmailCommandHandler.cs
@@ -42,13 +42,66 @@ internal class UnsubscribeEmailCommandHandler : ICommandHandler<UnsubscribeEmail
             return false;
         }
 
-        // Disable email for the specific notification type
-        // Currently preferences are grouped by PDF processing events
-        // For now, disable all email preferences as a simple implementation
-        preferences.UpdateEmailPreferences(
-            onReady: false,
-            onFailed: false,
-            onRetry: false);
+        // Disable email for the specific notification type (GDPR: granular opt-out)
+        switch (command.NotificationType)
+        {
+            case "pdf_upload_completed":
+            case "document_ready":
+                preferences.UpdateEmailPreferences(
+                    onReady: false,
+                    onFailed: preferences.EmailOnDocumentFailed,
+                    onRetry: preferences.EmailOnRetryAvailable);
+                break;
+
+            case "processing_failed":
+            case "document_failed":
+                preferences.UpdateEmailPreferences(
+                    onReady: preferences.EmailOnDocumentReady,
+                    onFailed: false,
+                    onRetry: preferences.EmailOnRetryAvailable);
+                break;
+
+            case "retry_available":
+                preferences.UpdateEmailPreferences(
+                    onReady: preferences.EmailOnDocumentReady,
+                    onFailed: preferences.EmailOnDocumentFailed,
+                    onRetry: false);
+                break;
+
+            case "game_night_invitation":
+                preferences.UpdateGameNightPreferences(
+                    inAppOnInvitation: preferences.InAppOnGameNightInvitation,
+                    emailOnInvitation: false,
+                    pushOnInvitation: preferences.PushOnGameNightInvitation,
+                    emailOnReminder: preferences.EmailOnGameNightReminder,
+                    pushOnReminder: preferences.PushOnGameNightReminder);
+                break;
+
+            case "game_night_reminder_24h":
+            case "game_night_reminder_1h":
+            case "game_night_reminder":
+                preferences.UpdateGameNightPreferences(
+                    inAppOnInvitation: preferences.InAppOnGameNightInvitation,
+                    emailOnInvitation: preferences.EmailOnGameNightInvitation,
+                    pushOnInvitation: preferences.PushOnGameNightInvitation,
+                    emailOnReminder: false,
+                    pushOnReminder: preferences.PushOnGameNightReminder);
+                break;
+
+            default:
+                // "all" or unknown type: disable all email preferences
+                preferences.UpdateEmailPreferences(
+                    onReady: false,
+                    onFailed: false,
+                    onRetry: false);
+                preferences.UpdateGameNightPreferences(
+                    inAppOnInvitation: preferences.InAppOnGameNightInvitation,
+                    emailOnInvitation: false,
+                    pushOnInvitation: preferences.PushOnGameNightInvitation,
+                    emailOnReminder: false,
+                    pushOnReminder: preferences.PushOnGameNightReminder);
+                break;
+        }
 
         await _preferencesRepository.UpdateAsync(preferences, cancellationToken).ConfigureAwait(false);
         await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Domain/Aggregates/EmailQueueItem.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Domain/Aggregates/EmailQueueItem.cs
@@ -136,6 +136,7 @@ internal sealed class EmailQueueItem : AggregateRoot<Guid>
             throw new InvalidOperationException($"Cannot reset email in status '{Status.Value}'");
 
         Status = EmailQueueStatus.Pending;
+        RetryCount = 0;
         NextRetryAt = null;
         ErrorMessage = null;
     }

--- a/apps/api/src/Api/Routing/UnsubscribeEndpoints.cs
+++ b/apps/api/src/Api/Routing/UnsubscribeEndpoints.cs
@@ -54,6 +54,11 @@ internal static class UnsubscribeEndpoints
                 ClockSkew = TimeSpan.FromMinutes(5)
             }, out _);
 
+            // Validate purpose claim to prevent cross-token attacks (e.g., auth JWT used as unsubscribe token)
+            var purposeClaim = principal.FindFirst("purpose")?.Value;
+            if (!string.Equals(purposeClaim, "unsubscribe", StringComparison.Ordinal))
+                return Results.Content(GenerateHtmlPage("Invalid Token", "The unsubscribe link is invalid."), "text/html");
+
             var userIdClaim = principal.FindFirst("userId")?.Value ?? principal.FindFirst(ClaimTypes.NameIdentifier)?.Value;
             var notificationTypeClaim = principal.FindFirst("notificationType")?.Value;
 


### PR DESCRIPTION
## Summary
Fixes 3 critical bugs found during spec panel review of Epic #33 Phase 1:

- **ResetToPending() no-op bug**: Admin "Retry" button did nothing because `RetryCount` wasn't reset to 0 — dead-letter emails immediately re-entered dead letter on next processor run
- **Unsubscribe overbroad**: Handler ignored `notificationType` and disabled ALL email types. Now correctly does granular GDPR opt-out per notification type (PDF ready, PDF failed, retry, game night invitation, game night reminder)
- **Cross-token attack**: Unsubscribe endpoint didn't validate JWT `purpose` claim — any app JWT could silently unsubscribe any user. Now requires `purpose == "unsubscribe"`

## Test plan
- [x] `dotnet build` — 0 errors, 0 warnings
- [x] 285 unit tests pass (`--filter "FullyQualifiedName~UserNotifications&Category=Unit"`)
- [ ] Manual: retry dead-letter email → verify it actually retries (not immediate dead letter)
- [ ] Manual: unsubscribe from `pdf_upload_completed` → verify only that type disabled
- [ ] Manual: send auth JWT to unsubscribe endpoint → verify rejection

Closes part of #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)