### PR TITLE
feat(admin): MAU-AI monitoring in admin overview (#113)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/Administration/Application/DTOs/AdminOverviewStatsDto.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/DTOs/AdminOverviewStatsDto.cs
@@ -3,12 +3,14 @@ namespace Api.BoundedContexts.Administration.Application.DTOs;
 /// <summary>
 /// Lightweight DTO for admin overview statistics.
 /// Issue #4198: Used by StatsOverview component.
+/// Issue #113: Added ActiveAiUsers for MAU-AI monitoring.
 /// </summary>
 internal record AdminOverviewStatsDto(
     int TotalGames,
     int PublishedGames,
     int TotalUsers,
     int ActiveUsers,
+    int ActiveAiUsers,
     double ApprovalRate,
     int PendingApprovals,
     int RecentSubmissions);

--- a/apps/api/src/Api/BoundedContexts/Administration/Application/Handlers/GetAdminOverviewStatsQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/Handlers/GetAdminOverviewStatsQueryHandler.cs
@@ -1,5 +1,6 @@
 using Api.BoundedContexts.Administration.Application.DTOs;
 using Api.BoundedContexts.Administration.Application.Queries;
+using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
 using Api.Infrastructure;
 using Api.Infrastructure.Entities.SharedGameCatalog;
 using Api.SharedKernel.Application.Interfaces;
@@ -11,21 +12,25 @@ namespace Api.BoundedContexts.Administration.Application.Handlers;
 /// <summary>
 /// Handler for GetAdminOverviewStatsQuery.
 /// Issue #4198: Lightweight overview stats for StatsOverview component.
+/// Issue #113: Added ActiveAiUsers for MAU-AI monitoring.
 /// </summary>
 internal class GetAdminOverviewStatsQueryHandler : IQueryHandler<GetAdminOverviewStatsQuery, AdminOverviewStatsDto>
 {
     private readonly MeepleAiDbContext _dbContext;
     private readonly HybridCache _cache;
     private readonly TimeProvider _timeProvider;
+    private readonly ILlmRequestLogRepository _llmRequestLogRepository;
     private static readonly TimeSpan CacheDuration = TimeSpan.FromMinutes(1);
 
     public GetAdminOverviewStatsQueryHandler(
         MeepleAiDbContext dbContext,
         HybridCache cache,
+        ILlmRequestLogRepository llmRequestLogRepository,
         TimeProvider? timeProvider = null)
     {
         _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
         _cache = cache ?? throw new ArgumentNullException(nameof(cache));
+        _llmRequestLogRepository = llmRequestLogRepository ?? throw new ArgumentNullException(nameof(llmRequestLogRepository));
         _timeProvider = timeProvider ?? TimeProvider.System;
     }
 
@@ -62,6 +67,10 @@ internal class GetAdminOverviewStatsQueryHandler : IQueryHandler<GetAdminOvervie
                     .Distinct()
                     .CountAsync(cancel).ConfigureAwait(false);
 
+                // Issue #113: Active AI users — distinct users with >=1 LLM request in last 30 days
+                var activeAiUsers = await _llmRequestLogRepository
+                    .GetActiveAiUserCountAsync(thirtyDaysAgo, cancel).ConfigureAwait(false);
+
                 // Share request / approval stats
                 var shareRequests = _dbContext.Set<ShareRequestEntity>();
 
@@ -93,6 +102,7 @@ internal class GetAdminOverviewStatsQueryHandler : IQueryHandler<GetAdminOvervie
                     PublishedGames: publishedGames,
                     TotalUsers: totalUsers,
                     ActiveUsers: activeUsers,
+                    ActiveAiUsers: activeAiUsers,
                     ApprovalRate: approvalRate,
                     PendingApprovals: pendingApprovals,
                     RecentSubmissions: recentSubmissions);

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Repositories/ILlmRequestLogRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Repositories/ILlmRequestLogRepository.cs
@@ -31,6 +31,13 @@ public interface ILlmRequestLogRepository
         CancellationToken cancellationToken = default);
 
     /// <summary>
+    /// Returns the count of distinct users with at least one LLM request since the specified date.
+    /// Excludes anonymized records and null UserIds (system/anonymous requests).
+    /// Issue #113: MAU-AI monitoring for ADR-045 scaling triggers.
+    /// </summary>
+    Task<int> GetActiveAiUserCountAsync(DateTime from, CancellationToken cancellationToken = default);
+
+    /// <summary>
     /// Returns the total number of LLM request log entries recorded on the specified UTC date.
     /// Used by the admin usage dashboard to display today's request count.
     /// </summary>

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/Persistence/LlmRequestLogRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/Persistence/LlmRequestLogRepository.cs
@@ -76,6 +76,17 @@ public sealed class LlmRequestLogRepository : ILlmRequestLogRepository
             provider, modelId, source, promptTokens + completionTokens, costUsd, latencyMs);
     }
 
+    public async Task<int> GetActiveAiUserCountAsync(DateTime from, CancellationToken cancellationToken = default)
+    {
+        return await _context.LlmRequestLogs
+            .AsNoTracking()
+            .Where(x => x.RequestedAt >= from && x.UserId != null && !x.IsAnonymized)
+            .Select(x => x.UserId)
+            .Distinct()
+            .CountAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+
     public async Task<int> GetTodayCountAsync(DateOnly utcDate, CancellationToken cancellationToken = default)
     {
         var startUtc = utcDate.ToDateTime(TimeOnly.MinValue, DateTimeKind.Utc);

--- a/apps/api/tests/Api.Tests/BoundedContexts/Administration/Handlers/GetAdminOverviewStatsQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/Administration/Handlers/GetAdminOverviewStatsQueryHandlerTests.cs
@@ -1,6 +1,7 @@
 using Api.BoundedContexts.Administration.Application.DTOs;
 using Api.BoundedContexts.Administration.Application.Handlers;
 using Api.BoundedContexts.Administration.Application.Queries;
+using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
 using Api.Infrastructure;
 using Api.Infrastructure.Entities;
 using Api.Infrastructure.Entities.SharedGameCatalog;
@@ -9,6 +10,7 @@ using Api.Tests.Services;
 using Api.Tests.TestHelpers;
 using FluentAssertions;
 using Microsoft.Extensions.Time.Testing;
+using Moq;
 using Xunit;
 
 namespace Api.Tests.BoundedContexts.Administration.Handlers;
@@ -23,6 +25,7 @@ public class GetAdminOverviewStatsQueryHandlerTests : IDisposable
     private readonly MeepleAiDbContext _dbContext;
     private readonly FakeHybridCache _cache;
     private readonly FakeTimeProvider _timeProvider;
+    private readonly Mock<ILlmRequestLogRepository> _mockLlmRequestLogRepository;
     private readonly GetAdminOverviewStatsQueryHandler _handler;
 
     public GetAdminOverviewStatsQueryHandlerTests()
@@ -31,8 +34,12 @@ public class GetAdminOverviewStatsQueryHandlerTests : IDisposable
         _cache = new FakeHybridCache();
         _timeProvider = new FakeTimeProvider();
         _timeProvider.SetUtcNow(new DateTimeOffset(2024, 6, 15, 12, 0, 0, TimeSpan.Zero));
+        _mockLlmRequestLogRepository = new Mock<ILlmRequestLogRepository>();
+        _mockLlmRequestLogRepository
+            .Setup(x => x.GetActiveAiUserCountAsync(It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(0);
 
-        _handler = new GetAdminOverviewStatsQueryHandler(_dbContext, _cache, _timeProvider);
+        _handler = new GetAdminOverviewStatsQueryHandler(_dbContext, _cache, _mockLlmRequestLogRepository.Object, _timeProvider);
     }
 
     public void Dispose()
@@ -58,6 +65,7 @@ public class GetAdminOverviewStatsQueryHandlerTests : IDisposable
         result.PublishedGames.Should().Be(0);
         result.TotalUsers.Should().Be(0);
         result.ActiveUsers.Should().Be(0);
+        result.ActiveAiUsers.Should().Be(0);
         result.ApprovalRate.Should().Be(0);
         result.PendingApprovals.Should().Be(0);
         result.RecentSubmissions.Should().Be(0);
@@ -145,6 +153,24 @@ public class GetAdminOverviewStatsQueryHandlerTests : IDisposable
 
         // Assert
         result.RecentSubmissions.Should().Be(2);
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsActiveAiUsersFromRepository()
+    {
+        // Arrange
+        _mockLlmRequestLogRepository
+            .Setup(x => x.GetActiveAiUserCountAsync(It.IsAny<DateTime>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(42);
+
+        // Act
+        var result = await _handler.Handle(new GetAdminOverviewStatsQuery(), CancellationToken.None);
+
+        // Assert
+        result.ActiveAiUsers.Should().Be(42);
+        _mockLlmRequestLogRepository.Verify(
+            x => x.GetActiveAiUserCountAsync(It.IsAny<DateTime>(), It.IsAny<CancellationToken>()),
+            Times.Once);
     }
 
     [Fact]

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Infrastructure/Persistence/LlmRequestLogRepositoryTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Infrastructure/Persistence/LlmRequestLogRepositoryTests.cs
@@ -216,4 +216,86 @@ public sealed class LlmRequestLogRepositoryTests : SharedDatabaseTestBase<LlmReq
         // Assert
         Assert.Equal(0, deleted);
     }
+
+    // ─── GetActiveAiUserCountAsync ────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetActiveAiUserCountAsync_ReturnsDistinctUserCount()
+    {
+        // Arrange
+        await ResetDatabaseAsync();
+        var userId1 = Guid.NewGuid();
+        var userId2 = Guid.NewGuid();
+
+        // User1: 2 requests, User2: 1 request, System: 1 request (null userId)
+        await Repository.LogRequestAsync("model", "openrouter", RequestSource.Manual,
+            userId1, "user", 100, 50, 0.01m, 200, true, null, false, false, null, TestCancellationToken);
+        await Repository.LogRequestAsync("model", "openrouter", RequestSource.RagPipeline,
+            userId1, "user", 200, 100, 0.02m, 300, true, null, false, false, null, TestCancellationToken);
+        await Repository.LogRequestAsync("model", "ollama", RequestSource.Manual,
+            userId2, "admin", 50, 25, 0m, 100, true, null, false, true, null, TestCancellationToken);
+        await Repository.LogRequestAsync("model", "ollama", RequestSource.AgentTask,
+            null, null, 50, 25, 0m, 100, true, null, false, true, null, TestCancellationToken);
+
+        // Act
+        var count = await Repository.GetActiveAiUserCountAsync(
+            DateTime.UtcNow.AddDays(-30), TestCancellationToken);
+
+        // Assert — 2 distinct users (null userId excluded)
+        Assert.Equal(2, count);
+    }
+
+    [Fact]
+    public async Task GetActiveAiUserCountAsync_ExcludesAnonymizedRecords()
+    {
+        // Arrange
+        await ResetDatabaseAsync();
+        var userId = Guid.NewGuid();
+
+        await Repository.LogRequestAsync("model", "openrouter", RequestSource.Manual,
+            userId, "user", 100, 50, 0.01m, 200, true, null, false, false, null, TestCancellationToken);
+
+        // Pseudonymize all records
+        await Repository.PseudonymizeOldLogsAsync(
+            DateTime.UtcNow.AddMinutes(1), "test-salt", TestCancellationToken);
+
+        // Act
+        var count = await Repository.GetActiveAiUserCountAsync(
+            DateTime.UtcNow.AddDays(-30), TestCancellationToken);
+
+        // Assert — anonymized records excluded
+        Assert.Equal(0, count);
+    }
+
+    [Fact]
+    public async Task GetActiveAiUserCountAsync_EmptyTable_ReturnsZero()
+    {
+        // Arrange
+        await ResetDatabaseAsync();
+
+        // Act
+        var count = await Repository.GetActiveAiUserCountAsync(
+            DateTime.UtcNow.AddDays(-30), TestCancellationToken);
+
+        // Assert
+        Assert.Equal(0, count);
+    }
+
+    [Fact]
+    public async Task GetActiveAiUserCountAsync_ExcludesOldRecords()
+    {
+        // Arrange
+        await ResetDatabaseAsync();
+        var userId = Guid.NewGuid();
+
+        await Repository.LogRequestAsync("model", "openrouter", RequestSource.Manual,
+            userId, "user", 100, 50, 0.01m, 200, true, null, false, false, null, TestCancellationToken);
+
+        // Act — query with future 'from' date (all records are "old")
+        var count = await Repository.GetActiveAiUserCountAsync(
+            DateTime.UtcNow.AddMinutes(1), TestCancellationToken);
+
+        // Assert
+        Assert.Equal(0, count);
+    }
 }

--- a/apps/web/src/app/admin/(dashboard)/overview/__tests__/page.test.tsx
+++ b/apps/web/src/app/admin/(dashboard)/overview/__tests__/page.test.tsx
@@ -1,0 +1,90 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+const mockGetOverviewStats = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/api', () => ({
+  createApiClient: () => ({
+    admin: {
+      getOverviewStats: mockGetOverviewStats,
+    },
+  }),
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({
+    push: vi.fn(),
+    back: vi.fn(),
+    forward: vi.fn(),
+    refresh: vi.fn(),
+    replace: vi.fn(),
+    prefetch: vi.fn(),
+  }),
+  usePathname: () => '/admin/overview',
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+// Must import after mock setup
+import OverviewPage from '../page';
+
+describe('OverviewPage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders heading and stat cards', () => {
+    mockGetOverviewStats.mockResolvedValue({
+      totalGames: 0,
+      publishedGames: 0,
+      totalUsers: 0,
+      activeUsers: 0,
+      activeAiUsers: 0,
+      approvalRate: 0,
+      pendingApprovals: 0,
+      recentSubmissions: 0,
+    });
+
+    render(<OverviewPage />);
+
+    expect(screen.getByText('Dashboard Overview')).toBeInTheDocument();
+    expect(screen.getByText('Utenti Totali')).toBeInTheDocument();
+    expect(screen.getByText('Utenti Attivi (30gg)')).toBeInTheDocument();
+    expect(screen.getByText('Utenti AI Attivi (30gg)')).toBeInTheDocument();
+    expect(screen.getByText('Giochi')).toBeInTheDocument();
+  });
+
+  it('displays fetched stats values', async () => {
+    mockGetOverviewStats.mockResolvedValue({
+      totalGames: 42,
+      publishedGames: 30,
+      totalUsers: 150,
+      activeUsers: 85,
+      activeAiUsers: 23,
+      approvalRate: 87.5,
+      pendingApprovals: 5,
+      recentSubmissions: 12,
+    });
+
+    render(<OverviewPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText('150')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('85')).toBeInTheDocument();
+    expect(screen.getByText('23')).toBeInTheDocument();
+    expect(screen.getByText('30 / 42')).toBeInTheDocument();
+    expect(screen.getByText('5')).toBeInTheDocument();
+    expect(screen.getByText('12')).toBeInTheDocument();
+  });
+
+  it('handles API failure gracefully', async () => {
+    mockGetOverviewStats.mockRejectedValue(new Error('Network error'));
+
+    render(<OverviewPage />);
+
+    // Should still render labels without values
+    expect(screen.getByText('Utenti AI Attivi (30gg)')).toBeInTheDocument();
+    expect(screen.getByText('Utenti con interazione AI')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/admin/(dashboard)/overview/layout.tsx
+++ b/apps/web/src/app/admin/(dashboard)/overview/layout.tsx
@@ -1,0 +1,10 @@
+import { type Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'Overview',
+  description: 'Admin dashboard overview with platform stats and quick actions',
+};
+
+export default function OverviewLayout({ children }: { children: React.ReactNode }) {
+  return <>{children}</>;
+}

--- a/apps/web/src/app/admin/(dashboard)/overview/page.tsx
+++ b/apps/web/src/app/admin/(dashboard)/overview/page.tsx
@@ -1,20 +1,22 @@
-import { BarChart3, Users, Gamepad2, BookOpen } from 'lucide-react';
-import { type Metadata } from 'next';
+'use client';
+
+import { useEffect, useState } from 'react';
+
+import { BarChart3, Users, Gamepad2, BookOpen, BrainCircuit, ClipboardCheck } from 'lucide-react';
 
 import { QuickActionsWidget } from '@/components/admin/overview/QuickActionsWidget';
 import { SystemHealthCard } from '@/components/admin/overview/SystemHealthCard';
-
-export const metadata: Metadata = {
-  title: 'Overview',
-  description: 'Admin dashboard overview with platform stats and quick actions',
-};
+import { createApiClient } from '@/lib/api';
+import type { AdminOverviewStats } from '@/lib/api/schemas/admin.schemas';
 
 function StatCard({
   label,
+  value,
   icon: Icon,
   description,
 }: {
   label: string;
+  value?: number | string;
   icon: React.ComponentType<{ className?: string }>;
   description: string;
 }) {
@@ -26,7 +28,13 @@ function StatCard({
         </div>
         <div>
           <p className="font-quicksand text-sm font-semibold text-foreground">{label}</p>
-          <p className="text-xs text-muted-foreground">{description}</p>
+          {value !== undefined ? (
+            <p className="font-nunito text-lg font-bold text-foreground">
+              {typeof value === 'number' ? value.toLocaleString() : value}
+            </p>
+          ) : (
+            <p className="text-xs text-muted-foreground">{description}</p>
+          )}
         </div>
       </div>
     </div>
@@ -34,6 +42,16 @@ function StatCard({
 }
 
 export default function OverviewPage() {
+  const [stats, setStats] = useState<AdminOverviewStats | null>(null);
+
+  useEffect(() => {
+    const api = createApiClient();
+    api.admin
+      .getOverviewStats()
+      .then(setStats)
+      .catch(() => {});
+  }, []);
+
   return (
     <div className="space-y-8">
       <div>
@@ -46,10 +64,45 @@ export default function OverviewPage() {
       </div>
 
       <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6">
-        <StatCard icon={BarChart3} label="Analytics" description="View usage statistics" />
-        <StatCard icon={Users} label="Users" description="Manage user accounts" />
-        <StatCard icon={Gamepad2} label="Games" description="Shared game catalog" />
-        <StatCard icon={BookOpen} label="Knowledge Base" description="Documents and vectors" />
+        <StatCard
+          icon={Users}
+          label="Utenti Totali"
+          value={stats?.totalUsers}
+          description="Utenti registrati"
+        />
+        <StatCard
+          icon={BarChart3}
+          label="Utenti Attivi (30gg)"
+          value={stats?.activeUsers}
+          description="Sessioni attive"
+        />
+        <StatCard
+          icon={BrainCircuit}
+          label="Utenti AI Attivi (30gg)"
+          value={stats?.activeAiUsers}
+          description="Utenti con interazione AI"
+        />
+        <StatCard
+          icon={Gamepad2}
+          label="Giochi"
+          value={stats ? `${stats.publishedGames} / ${stats.totalGames}` : undefined}
+          description="Pubblicati / Totali"
+        />
+      </div>
+
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
+        <StatCard
+          icon={ClipboardCheck}
+          label="Approvazioni in attesa"
+          value={stats?.pendingApprovals}
+          description="Da revisionare"
+        />
+        <StatCard
+          icon={BookOpen}
+          label="Invii recenti (7gg)"
+          value={stats?.recentSubmissions}
+          description="Nuove sottomissioni"
+        />
       </div>
 
       <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">

--- a/apps/web/src/lib/api/clients/adminClient.ts
+++ b/apps/web/src/lib/api/clients/adminClient.ts
@@ -20,6 +20,7 @@ import {
   PromptResponseSchema,
   ActivateVersionResponseSchema,
   AdminStatsSchema,
+  AdminOverviewStatsSchema,
   AiRequestsResponseSchema,
   PromptVersionsResponseSchema,
   PromptAuditLogsResponseSchema,
@@ -45,6 +46,7 @@ import {
   type PromptTemplate,
   type ActivateVersionResponse,
   type AdminStats,
+  type AdminOverviewStats,
   type AiRequest,
   type PromptVersion,
   type PromptAuditLog,
@@ -538,6 +540,22 @@ export function createAdminClient({ httpClient }: CreateAdminClientParams) {
       const result = await httpClient.get<AdminStats>('/api/v1/admin/stats', AdminStatsSchema);
       if (!result) {
         throw new Error('Failed to fetch admin stats');
+      }
+      return result;
+    },
+
+    /**
+     * Get admin overview statistics (admin only)
+     * Issue #113: Includes ActiveAiUsers for MAU-AI monitoring.
+     * GET /api/v1/admin/overview-stats
+     */
+    async getOverviewStats(): Promise<AdminOverviewStats> {
+      const result = await httpClient.get<AdminOverviewStats>(
+        '/api/v1/admin/overview-stats',
+        AdminOverviewStatsSchema
+      );
+      if (!result) {
+        throw new Error('Failed to fetch admin overview stats');
       }
       return result;
     },

--- a/apps/web/src/lib/api/schemas/admin.schemas.ts
+++ b/apps/web/src/lib/api/schemas/admin.schemas.ts
@@ -237,11 +237,13 @@ export const AdminStatsSchema = z.object({
 export type AdminStats = z.infer<typeof AdminStatsSchema>;
 
 // Issue #4198: Lightweight overview stats for StatsOverview component
+// Issue #113: Added activeAiUsers for MAU-AI monitoring
 export const AdminOverviewStatsSchema = z.object({
   totalGames: z.number(),
   publishedGames: z.number(),
   totalUsers: z.number(),
   activeUsers: z.number(),
+  activeAiUsers: z.number(),
   approvalRate: z.number(),
   pendingApprovals: z.number(),
   recentSubmissions: z.number(),


### PR DESCRIPTION
## Summary
- Add **ActiveAiUsers** metric to admin overview: count of distinct users with ≥1 LLM request in last 30 days
- Wire admin overview page to fetch real stats via `GET /api/v1/admin/overview-stats`
- Display 6 KPI cards: Total Users, Active Users, Active AI Users, Games, Pending Approvals, Recent Submissions

## Changes

### Backend
- `ILlmRequestLogRepository.GetActiveAiUserCountAsync()` — new method, `SELECT COUNT(DISTINCT UserId)` excluding anonymized/null
- `AdminOverviewStatsDto` — added `ActiveAiUsers` field
- `GetAdminOverviewStatsQueryHandler` — injects `ILlmRequestLogRepository`, computes MAU-AI

### Frontend
- `AdminOverviewStatsSchema` — added `activeAiUsers` field
- `adminClient.getOverviewStats()` — new method wiring to existing endpoint
- Overview page — now client component fetching real data, 6 stat cards with values
- `layout.tsx` — metadata moved here (client components can't export metadata)

### Tests
- 4 integration tests: distinct count, anonymized exclusion, empty table, old records exclusion
- 1 unit test: handler delegates to repository mock
- 3 frontend tests: renders cards, displays values, handles API failure

## Context
ADR-045 defines scaling triggers based on MAU-AI (`>5K MAU` → K8s, `>20K MAU` → multi-region). This metric was not being tracked — now it's visible in the admin dashboard.

Closes #113

## Test plan
- [ ] Backend builds (0 errors)
- [ ] `dotnet test --filter "GetAdminOverviewStatsQueryHandlerTests"` — 7 pass
- [ ] `vitest run overview/__tests__/page.test.tsx` — 3 pass
- [ ] Manual: `/admin/overview` shows real stats

🤖 Generated with [Claude Code](https://claude.com/claude-code)