### PR TITLE
feat(score-tracking): AI-mediated score parsing and recording (#121)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Services/IPlayerNameResolutionService.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Services/IPlayerNameResolutionService.cs
@@ -1,0 +1,30 @@
+namespace Api.BoundedContexts.GameManagement.Application.Services;
+
+/// <summary>
+/// Service for resolving player names from natural language input to session player IDs.
+/// Supports fuzzy matching with exact, first-name, and contains strategies.
+/// </summary>
+internal interface IPlayerNameResolutionService
+{
+    PlayerResolutionResult ResolvePlayer(string playerName, IReadOnlyDictionary<Guid, string> sessionPlayers);
+}
+
+/// <summary>
+/// Result of attempting to resolve a player name against session players.
+/// </summary>
+internal sealed record PlayerResolutionResult
+{
+    public bool IsResolved { get; init; }
+    public Guid? PlayerId { get; init; }
+    public string? ResolvedName { get; init; }
+    public bool IsAmbiguous { get; init; }
+    public IReadOnlyList<(Guid Id, string Name)> Candidates { get; init; } = [];
+
+    public static PlayerResolutionResult Resolved(Guid id, string name) =>
+        new() { IsResolved = true, PlayerId = id, ResolvedName = name };
+
+    public static PlayerResolutionResult Ambiguous(IReadOnlyList<(Guid, string)> candidates) =>
+        new() { IsAmbiguous = true, Candidates = candidates };
+
+    public static PlayerResolutionResult NotFound() => new();
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Services/PlayerNameResolutionService.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Services/PlayerNameResolutionService.cs
@@ -1,0 +1,63 @@
+namespace Api.BoundedContexts.GameManagement.Application.Services;
+
+/// <summary>
+/// Resolves player names using fuzzy matching strategies:
+/// 1. Exact full name match (case-insensitive)
+/// 2. First name match (first word of display name)
+/// 3. Contains match (substring)
+/// Returns Ambiguous if multiple matches found at any level, NotFound if none.
+/// </summary>
+internal sealed class PlayerNameResolutionService : IPlayerNameResolutionService
+{
+    public PlayerResolutionResult ResolvePlayer(string playerName, IReadOnlyDictionary<Guid, string> sessionPlayers)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(playerName);
+        ArgumentNullException.ThrowIfNull(sessionPlayers);
+
+        var trimmedName = playerName.Trim();
+
+        // Strategy 1: Exact full name match (case-insensitive)
+        var exactMatches = sessionPlayers
+            .Where(p => string.Equals(p.Value, trimmedName, StringComparison.OrdinalIgnoreCase))
+            .Select(p => (p.Key, p.Value))
+            .ToList();
+
+        if (exactMatches.Count == 1)
+            return PlayerResolutionResult.Resolved(exactMatches[0].Key, exactMatches[0].Value);
+
+        if (exactMatches.Count > 1)
+            return PlayerResolutionResult.Ambiguous(exactMatches);
+
+        // Strategy 2: First name match (first word of display name)
+        var firstNameMatches = sessionPlayers
+            .Where(p => GetFirstName(p.Value).Equals(trimmedName, StringComparison.OrdinalIgnoreCase))
+            .Select(p => (p.Key, p.Value))
+            .ToList();
+
+        if (firstNameMatches.Count == 1)
+            return PlayerResolutionResult.Resolved(firstNameMatches[0].Key, firstNameMatches[0].Value);
+
+        if (firstNameMatches.Count > 1)
+            return PlayerResolutionResult.Ambiguous(firstNameMatches);
+
+        // Strategy 3: Contains match (substring)
+        var containsMatches = sessionPlayers
+            .Where(p => p.Value.Contains(trimmedName, StringComparison.OrdinalIgnoreCase))
+            .Select(p => (p.Key, p.Value))
+            .ToList();
+
+        if (containsMatches.Count == 1)
+            return PlayerResolutionResult.Resolved(containsMatches[0].Key, containsMatches[0].Value);
+
+        if (containsMatches.Count > 1)
+            return PlayerResolutionResult.Ambiguous(containsMatches);
+
+        return PlayerResolutionResult.NotFound();
+    }
+
+    private static string GetFirstName(string displayName)
+    {
+        var spaceIndex = displayName.IndexOf(' ');
+        return spaceIndex > 0 ? displayName[..spaceIndex] : displayName;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/DependencyInjection/GameManagementServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/DependencyInjection/GameManagementServiceExtensions.cs
@@ -68,6 +68,9 @@ internal static class GameManagementServiceExtensions
         // Issue #5579: GameSessionContext cross-context orchestrator
         services.AddScoped<IGameSessionOrchestratorService, GameSessionOrchestratorService>();
 
+        // Game Night AI Assistant: Player name resolution for score parsing
+        services.AddScoped<IPlayerNameResolutionService, PlayerNameResolutionService>();
+
         // Issue #44/#47: Game night email templates
         services.AddScoped<IGameNightEmailService, GameNightEmailService>();
 

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/ConfirmScoreCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/ConfirmScoreCommand.cs
@@ -1,0 +1,35 @@
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Commands;
+
+/// <summary>
+/// Command to confirm and record a previously parsed score.
+/// Delegates to RecordLiveSessionScoreCommand via mediator.
+/// </summary>
+internal sealed record ConfirmScoreCommand : ICommand
+{
+    /// <summary>
+    /// The live session ID.
+    /// </summary>
+    public required Guid SessionId { get; init; }
+
+    /// <summary>
+    /// The resolved player ID.
+    /// </summary>
+    public required Guid PlayerId { get; init; }
+
+    /// <summary>
+    /// The scoring dimension (e.g., "points", "roads").
+    /// </summary>
+    public required string Dimension { get; init; }
+
+    /// <summary>
+    /// The score value to record.
+    /// </summary>
+    public required int Value { get; init; }
+
+    /// <summary>
+    /// The round number for the score.
+    /// </summary>
+    public required int Round { get; init; }
+}

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/ParseAndRecordScoreCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/ParseAndRecordScoreCommand.cs
@@ -1,0 +1,25 @@
+using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Commands;
+
+/// <summary>
+/// Command to parse a natural language message for score information and optionally record it.
+/// </summary>
+internal sealed record ParseAndRecordScoreCommand : ICommand<ScoreParseResultDto>
+{
+    /// <summary>
+    /// The live session ID to associate the score with.
+    /// </summary>
+    public required Guid SessionId { get; init; }
+
+    /// <summary>
+    /// The natural language message to parse (e.g., "Marco ha 5 punti").
+    /// </summary>
+    public required string Message { get; init; }
+
+    /// <summary>
+    /// If true and confidence is high enough, automatically record the score.
+    /// </summary>
+    public bool AutoRecord { get; init; }
+}

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/DTOs/ScoreParseResultDto.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/DTOs/ScoreParseResultDto.cs
@@ -1,0 +1,57 @@
+namespace Api.BoundedContexts.KnowledgeBase.Application.DTOs;
+
+/// <summary>
+/// DTO representing the result of parsing and optionally recording a score from natural language.
+/// </summary>
+internal sealed record ScoreParseResultDto
+{
+    /// <summary>
+    /// Status of the parse operation: "parsed", "recorded", "ambiguous", or "unrecognized".
+    /// </summary>
+    public required string Status { get; init; }
+
+    /// <summary>
+    /// The resolved player name, if identified.
+    /// </summary>
+    public string? PlayerName { get; init; }
+
+    /// <summary>
+    /// The resolved player ID, if identified.
+    /// </summary>
+    public Guid? PlayerId { get; init; }
+
+    /// <summary>
+    /// The scoring dimension extracted (e.g., "points", "roads").
+    /// </summary>
+    public string? Dimension { get; init; }
+
+    /// <summary>
+    /// The score value extracted.
+    /// </summary>
+    public int? Value { get; init; }
+
+    /// <summary>
+    /// The round number for the score.
+    /// </summary>
+    public int? Round { get; init; }
+
+    /// <summary>
+    /// Confidence level of the parse (0.0 to 1.0).
+    /// </summary>
+    public float Confidence { get; init; }
+
+    /// <summary>
+    /// Whether the user should confirm before the score is recorded.
+    /// </summary>
+    public bool RequiresConfirmation { get; init; }
+
+    /// <summary>
+    /// Human-readable message describing the result.
+    /// </summary>
+    public string? Message { get; init; }
+
+    /// <summary>
+    /// When status is "ambiguous", lists the candidate player names.
+    /// </summary>
+    public IReadOnlyList<string> AmbiguousCandidates { get; init; } = [];
+}

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/DTOs/ScoreParseResultDto.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/DTOs/ScoreParseResultDto.cs
@@ -3,7 +3,7 @@ namespace Api.BoundedContexts.KnowledgeBase.Application.DTOs;
 /// <summary>
 /// DTO representing the result of parsing and optionally recording a score from natural language.
 /// </summary>
-internal sealed record ScoreParseResultDto
+public sealed record ScoreParseResultDto
 {
     /// <summary>
     /// Status of the parse operation: "parsed", "recorded", "ambiguous", or "unrecognized".

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Handlers/ConfirmScoreCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Handlers/ConfirmScoreCommandHandler.cs
@@ -1,0 +1,29 @@
+using Api.BoundedContexts.GameManagement.Application.Commands.LiveSessions;
+using Api.BoundedContexts.KnowledgeBase.Application.Commands;
+using Api.SharedKernel.Application.Interfaces;
+using MediatR;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Handlers;
+
+/// <summary>
+/// Handles confirming a previously parsed score by delegating to RecordLiveSessionScoreCommand.
+/// </summary>
+internal sealed class ConfirmScoreCommandHandler : ICommandHandler<ConfirmScoreCommand>
+{
+    private readonly IMediator _mediator;
+
+    public ConfirmScoreCommandHandler(IMediator mediator)
+    {
+        _mediator = mediator ?? throw new ArgumentNullException(nameof(mediator));
+    }
+
+    public async Task Handle(ConfirmScoreCommand command, CancellationToken cancellationToken)
+    {
+        await _mediator.Send(new RecordLiveSessionScoreCommand(
+            command.SessionId,
+            command.PlayerId,
+            command.Round,
+            command.Dimension,
+            command.Value), cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Handlers/ParseAndRecordScoreCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Handlers/ParseAndRecordScoreCommandHandler.cs
@@ -1,0 +1,176 @@
+using Api.BoundedContexts.GameManagement.Application.Commands.LiveSessions;
+using Api.BoundedContexts.GameManagement.Application.DTOs.LiveSessions;
+using Api.BoundedContexts.GameManagement.Application.Queries.LiveSessions;
+using Api.BoundedContexts.GameManagement.Application.Services;
+using Api.BoundedContexts.KnowledgeBase.Application.Commands;
+using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
+using Api.BoundedContexts.KnowledgeBase.Domain.Services;
+using Api.BoundedContexts.KnowledgeBase.Domain.ValueObjects;
+using Api.SharedKernel.Application.Interfaces;
+using MediatR;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Handlers;
+
+/// <summary>
+/// Handles parsing natural language messages for score data and optionally recording scores.
+/// Flow: Parse → Resolve player → Auto-record if confidence is high enough.
+/// </summary>
+internal sealed class ParseAndRecordScoreCommandHandler
+    : ICommandHandler<ParseAndRecordScoreCommand, ScoreParseResultDto>
+{
+    private readonly IStateParser _stateParser;
+    private readonly IMediator _mediator;
+    private readonly IPlayerNameResolutionService _playerNameResolution;
+
+    public ParseAndRecordScoreCommandHandler(
+        IStateParser stateParser,
+        IMediator mediator,
+        IPlayerNameResolutionService playerNameResolution)
+    {
+        _stateParser = stateParser ?? throw new ArgumentNullException(nameof(stateParser));
+        _mediator = mediator ?? throw new ArgumentNullException(nameof(mediator));
+        _playerNameResolution = playerNameResolution ?? throw new ArgumentNullException(nameof(playerNameResolution));
+    }
+
+    public async Task<ScoreParseResultDto> Handle(
+        ParseAndRecordScoreCommand command,
+        CancellationToken cancellationToken)
+    {
+        // Step 1: Parse the message with the state parser
+        var extraction = await _stateParser.ParseAsync(command.Message, cancellationToken: cancellationToken)
+            .ConfigureAwait(false);
+
+        // Step 2: If no state change detected, return unrecognized
+        if (extraction.ChangeType == StateChangeType.NoChange)
+        {
+            return new ScoreParseResultDto
+            {
+                Status = "unrecognized",
+                Confidence = extraction.Confidence,
+                Message = "No score information detected in the message."
+            };
+        }
+
+        // Step 3: Extract score value and dimension from extracted state
+        var scoreValue = extraction.ExtractedState.TryGetValue("score", out var scoreObj)
+            ? Convert.ToInt32(scoreObj, System.Globalization.CultureInfo.InvariantCulture)
+            : (int?)null;
+
+        var dimension = extraction.ExtractedState.TryGetValue("dimension", out var dimObj)
+            ? dimObj?.ToString() ?? "points"
+            : "points";
+
+        // Step 4: Get session players and resolve the player name
+        var playerList = await _mediator.Send(new GetSessionPlayersQuery(command.SessionId), cancellationToken)
+            .ConfigureAwait(false);
+        var players = playerList
+            .Where(p => p.IsActive)
+            .ToDictionary(p => p.Id, p => p.DisplayName);
+
+        // Step 5: Determine current round
+        var currentRound = await GetCurrentRoundAsync(command.SessionId, cancellationToken)
+            .ConfigureAwait(false);
+
+        // Step 6: Resolve player
+        if (extraction.PlayerName is null or "")
+        {
+            return new ScoreParseResultDto
+            {
+                Status = "parsed",
+                Dimension = dimension,
+                Value = scoreValue,
+                Round = currentRound,
+                Confidence = extraction.Confidence,
+                RequiresConfirmation = true,
+                Message = "Score detected but no player name found in the message."
+            };
+        }
+
+        var resolution = _playerNameResolution.ResolvePlayer(extraction.PlayerName, players);
+
+        // Step 7: Handle ambiguous player
+        if (resolution.IsAmbiguous)
+        {
+            return new ScoreParseResultDto
+            {
+                Status = "ambiguous",
+                PlayerName = extraction.PlayerName,
+                Dimension = dimension,
+                Value = scoreValue,
+                Round = currentRound,
+                Confidence = extraction.Confidence,
+                RequiresConfirmation = true,
+                Message = $"Multiple players match '{extraction.PlayerName}'. Please specify.",
+                AmbiguousCandidates = resolution.Candidates.Select(c => c.Name).ToList()
+            };
+        }
+
+        // Step 8: Handle player not found
+        if (!resolution.IsResolved)
+        {
+            return new ScoreParseResultDto
+            {
+                Status = "parsed",
+                PlayerName = extraction.PlayerName,
+                Dimension = dimension,
+                Value = scoreValue,
+                Round = currentRound,
+                Confidence = extraction.Confidence,
+                RequiresConfirmation = true,
+                Message = $"Player '{extraction.PlayerName}' not found in this session."
+            };
+        }
+
+        // Step 9: Auto-record if conditions are met
+        if (command.AutoRecord && extraction.Confidence >= 0.8f && scoreValue.HasValue)
+        {
+            await _mediator.Send(new RecordLiveSessionScoreCommand(
+                command.SessionId,
+                resolution.PlayerId!.Value,
+                currentRound,
+                dimension,
+                scoreValue.Value), cancellationToken).ConfigureAwait(false);
+
+            return new ScoreParseResultDto
+            {
+                Status = "recorded",
+                PlayerName = resolution.ResolvedName,
+                PlayerId = resolution.PlayerId,
+                Dimension = dimension,
+                Value = scoreValue,
+                Round = currentRound,
+                Confidence = extraction.Confidence,
+                RequiresConfirmation = false,
+                Message = $"Score recorded: {resolution.ResolvedName} scored {scoreValue} {dimension} in round {currentRound}."
+            };
+        }
+
+        // Step 10: Return parsed result requiring confirmation
+        return new ScoreParseResultDto
+        {
+            Status = "parsed",
+            PlayerName = resolution.ResolvedName,
+            PlayerId = resolution.PlayerId,
+            Dimension = dimension,
+            Value = scoreValue,
+            Round = currentRound,
+            Confidence = extraction.Confidence,
+            RequiresConfirmation = true,
+            Message = $"Detected: {resolution.ResolvedName} scored {scoreValue} {dimension}. Please confirm."
+        };
+    }
+
+    private async Task<int> GetCurrentRoundAsync(Guid sessionId, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var session = await _mediator.Send(new GetLiveSessionQuery(sessionId), cancellationToken)
+                .ConfigureAwait(false);
+            return session.CurrentTurnIndex > 0 ? session.CurrentTurnIndex : 1;
+        }
+        catch
+        {
+            return 1;
+        }
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Handlers/ParseAndRecordScoreCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Handlers/ParseAndRecordScoreCommandHandler.cs
@@ -168,7 +168,11 @@ internal sealed class ParseAndRecordScoreCommandHandler
                 .ConfigureAwait(false);
             return session.CurrentTurnIndex > 0 ? session.CurrentTurnIndex : 1;
         }
-        catch
+        catch (OperationCanceledException)
+        {
+            throw;
+        }
+        catch (Exception)
         {
             return 1;
         }

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Validators/ConfirmScoreCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Validators/ConfirmScoreCommandValidator.cs
@@ -24,10 +24,6 @@ internal sealed class ConfirmScoreCommandValidator : AbstractValidator<ConfirmSc
             .MaximumLength(50)
             .WithMessage("Dimension must not exceed 50 characters");
 
-        RuleFor(x => x.Value)
-            .GreaterThanOrEqualTo(0)
-            .WithMessage("Value must be non-negative");
-
         RuleFor(x => x.Round)
             .GreaterThan(0)
             .WithMessage("Round must be at least 1");

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Validators/ConfirmScoreCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Validators/ConfirmScoreCommandValidator.cs
@@ -1,0 +1,35 @@
+using Api.BoundedContexts.KnowledgeBase.Application.Commands;
+using FluentValidation;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Validators;
+
+/// <summary>
+/// Validator for ConfirmScoreCommand.
+/// </summary>
+internal sealed class ConfirmScoreCommandValidator : AbstractValidator<ConfirmScoreCommand>
+{
+    public ConfirmScoreCommandValidator()
+    {
+        RuleFor(x => x.SessionId)
+            .NotEmpty()
+            .WithMessage("Session ID is required");
+
+        RuleFor(x => x.PlayerId)
+            .NotEmpty()
+            .WithMessage("Player ID is required");
+
+        RuleFor(x => x.Dimension)
+            .NotEmpty()
+            .WithMessage("Dimension is required")
+            .MaximumLength(50)
+            .WithMessage("Dimension must not exceed 50 characters");
+
+        RuleFor(x => x.Value)
+            .GreaterThanOrEqualTo(0)
+            .WithMessage("Value must be non-negative");
+
+        RuleFor(x => x.Round)
+            .GreaterThan(0)
+            .WithMessage("Round must be at least 1");
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Validators/ParseAndRecordScoreCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Validators/ParseAndRecordScoreCommandValidator.cs
@@ -1,0 +1,23 @@
+using Api.BoundedContexts.KnowledgeBase.Application.Commands;
+using FluentValidation;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Validators;
+
+/// <summary>
+/// Validator for ParseAndRecordScoreCommand.
+/// </summary>
+internal sealed class ParseAndRecordScoreCommandValidator : AbstractValidator<ParseAndRecordScoreCommand>
+{
+    public ParseAndRecordScoreCommandValidator()
+    {
+        RuleFor(x => x.SessionId)
+            .NotEmpty()
+            .WithMessage("Session ID is required");
+
+        RuleFor(x => x.Message)
+            .NotEmpty()
+            .WithMessage("Message is required")
+            .MaximumLength(500)
+            .WithMessage("Message must not exceed 500 characters");
+    }
+}

--- a/apps/api/src/Api/Routing/LiveSessionEndpoints.cs
+++ b/apps/api/src/Api/Routing/LiveSessionEndpoints.cs
@@ -8,6 +8,8 @@ using Api.BoundedContexts.GameManagement.Application.Queries.LiveSessions;
 using Api.BoundedContexts.GameManagement.Application.Queries.ToolState;
 using Api.BoundedContexts.GameManagement.Domain.Entities.SessionSnapshot;
 using Api.BoundedContexts.GameManagement.Domain.Enums;
+using Api.BoundedContexts.KnowledgeBase.Application.Commands;
+using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
 using Api.Extensions;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
@@ -173,6 +175,23 @@ internal static class LiveSessionEndpoints
             .Produces(404)
             .WithTags("LiveSessions")
             .WithSummary("Update session notes");
+
+        group.MapPost("/live-sessions/{sessionId}/scores/parse", HandleParseScore)
+            .RequireAuthenticatedUser()
+            .Produces<ScoreParseResultDto>(200)
+            .Produces(400)
+            .Produces(404)
+            .WithTags("LiveSessions")
+            .WithSummary("Parse a natural language message for score data")
+            .WithDescription("Parses a message and optionally auto-records the score if confidence is high enough.");
+
+        group.MapPost("/live-sessions/{sessionId}/scores/confirm", HandleConfirmScore)
+            .RequireAuthenticatedUser()
+            .Produces(204)
+            .Produces(400)
+            .Produces(404)
+            .WithTags("LiveSessions")
+            .WithSummary("Confirm and record a previously parsed score");
 
         // === Queries ===
         // NOTE: Literal-segment routes MUST be registered before parameterized {sessionId} route
@@ -455,6 +474,42 @@ internal static class LiveSessionEndpoints
         return Results.NoContent();
     }
 
+    private static async Task<IResult> HandleParseScore(
+        Guid sessionId,
+        [FromBody] ParseScoreRequest request,
+        [FromServices] IMediator mediator,
+        CancellationToken cancellationToken)
+    {
+        var command = new ParseAndRecordScoreCommand
+        {
+            SessionId = sessionId,
+            Message = request.Message,
+            AutoRecord = request.AutoRecord
+        };
+
+        var result = await mediator.Send(command, cancellationToken).ConfigureAwait(false);
+        return Results.Ok(result);
+    }
+
+    private static async Task<IResult> HandleConfirmScore(
+        Guid sessionId,
+        [FromBody] ConfirmScoreRequest request,
+        [FromServices] IMediator mediator,
+        CancellationToken cancellationToken)
+    {
+        var command = new ConfirmScoreCommand
+        {
+            SessionId = sessionId,
+            PlayerId = request.PlayerId,
+            Dimension = request.Dimension,
+            Value = request.Value,
+            Round = request.Round
+        };
+
+        await mediator.Send(command, cancellationToken).ConfigureAwait(false);
+        return Results.NoContent();
+    }
+
     #endregion
 
     #region Query Handlers
@@ -580,6 +635,10 @@ internal static class LiveSessionEndpoints
         SnapshotTrigger TriggerType,
         string? Description = null,
         Guid? CreatedByPlayerId = null);
+
+    private sealed record ParseScoreRequest(string Message, bool AutoRecord = true);
+
+    private sealed record ConfirmScoreRequest(Guid PlayerId, string Dimension, int Value, int Round);
 
     #endregion
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Services/PlayerNameResolutionServiceTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/Services/PlayerNameResolutionServiceTests.cs
@@ -1,0 +1,115 @@
+using Api.BoundedContexts.GameManagement.Application.Services;
+using Api.Tests.Constants;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameManagement.Application.Services;
+
+/// <summary>
+/// Tests for PlayerNameResolutionService fuzzy matching.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+public class PlayerNameResolutionServiceTests
+{
+    private readonly PlayerNameResolutionService _sut = new();
+
+    [Fact]
+    public void ResolvePlayer_ExactFullNameMatch_ReturnsResolved()
+    {
+        // Arrange
+        var playerId = Guid.NewGuid();
+        var players = new Dictionary<Guid, string>
+        {
+            { playerId, "Marco Rossi" },
+            { Guid.NewGuid(), "Luca Bianchi" }
+        }.AsReadOnly();
+
+        // Act
+        var result = _sut.ResolvePlayer("Marco Rossi", players);
+
+        // Assert
+        Assert.True(result.IsResolved);
+        Assert.Equal(playerId, result.PlayerId);
+        Assert.Equal("Marco Rossi", result.ResolvedName);
+        Assert.False(result.IsAmbiguous);
+    }
+
+    [Fact]
+    public void ResolvePlayer_FirstNameMatch_ReturnsResolved()
+    {
+        // Arrange
+        var playerId = Guid.NewGuid();
+        var players = new Dictionary<Guid, string>
+        {
+            { playerId, "Marco Rossi" },
+            { Guid.NewGuid(), "Luca Bianchi" }
+        }.AsReadOnly();
+
+        // Act
+        var result = _sut.ResolvePlayer("Marco", players);
+
+        // Assert
+        Assert.True(result.IsResolved);
+        Assert.Equal(playerId, result.PlayerId);
+        Assert.Equal("Marco Rossi", result.ResolvedName);
+    }
+
+    [Fact]
+    public void ResolvePlayer_CaseInsensitiveMatch_ReturnsResolved()
+    {
+        // Arrange
+        var playerId = Guid.NewGuid();
+        var players = new Dictionary<Guid, string>
+        {
+            { playerId, "Marco Rossi" },
+            { Guid.NewGuid(), "Luca Bianchi" }
+        }.AsReadOnly();
+
+        // Act
+        var result = _sut.ResolvePlayer("marco rossi", players);
+
+        // Assert
+        Assert.True(result.IsResolved);
+        Assert.Equal(playerId, result.PlayerId);
+        Assert.Equal("Marco Rossi", result.ResolvedName);
+    }
+
+    [Fact]
+    public void ResolvePlayer_AmbiguousFirstName_ReturnsAmbiguous()
+    {
+        // Arrange
+        var player1Id = Guid.NewGuid();
+        var player2Id = Guid.NewGuid();
+        var players = new Dictionary<Guid, string>
+        {
+            { player1Id, "Marco Rossi" },
+            { player2Id, "Marco Bianchi" }
+        }.AsReadOnly();
+
+        // Act
+        var result = _sut.ResolvePlayer("Marco", players);
+
+        // Assert
+        Assert.True(result.IsAmbiguous);
+        Assert.False(result.IsResolved);
+        Assert.Equal(2, result.Candidates.Count);
+    }
+
+    [Fact]
+    public void ResolvePlayer_NoMatch_ReturnsNotFound()
+    {
+        // Arrange
+        var players = new Dictionary<Guid, string>
+        {
+            { Guid.NewGuid(), "Marco Rossi" },
+            { Guid.NewGuid(), "Luca Bianchi" }
+        }.AsReadOnly();
+
+        // Act
+        var result = _sut.ResolvePlayer("Giovanni", players);
+
+        // Assert
+        Assert.False(result.IsResolved);
+        Assert.False(result.IsAmbiguous);
+        Assert.Null(result.PlayerId);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/ConfirmScoreCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/ConfirmScoreCommandHandlerTests.cs
@@ -1,0 +1,76 @@
+using Api.BoundedContexts.GameManagement.Application.Commands.LiveSessions;
+using Api.BoundedContexts.KnowledgeBase.Application.Commands;
+using Api.BoundedContexts.KnowledgeBase.Application.Handlers;
+using Api.Tests.Constants;
+using MediatR;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.KnowledgeBase.Application.Handlers;
+
+/// <summary>
+/// Tests for ConfirmScoreCommandHandler.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+public class ConfirmScoreCommandHandlerTests
+{
+    private readonly Mock<IMediator> _mockMediator;
+    private readonly ConfirmScoreCommandHandler _handler;
+
+    public ConfirmScoreCommandHandlerTests()
+    {
+        _mockMediator = new Mock<IMediator>();
+        _handler = new ConfirmScoreCommandHandler(_mockMediator.Object);
+    }
+
+    [Fact]
+    public async Task Handle_ValidCommand_DelegatesToRecordLiveSessionScoreCommand()
+    {
+        // Arrange
+        var sessionId = Guid.NewGuid();
+        var playerId = Guid.NewGuid();
+        var command = new ConfirmScoreCommand
+        {
+            SessionId = sessionId,
+            PlayerId = playerId,
+            Dimension = "points",
+            Value = 10,
+            Round = 2
+        };
+
+        // Act
+        await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        _mockMediator.Verify(m => m.Send(
+            It.Is<RecordLiveSessionScoreCommand>(c =>
+                c.SessionId == sessionId &&
+                c.PlayerId == playerId &&
+                c.Dimension == "points" &&
+                c.Value == 10 &&
+                c.Round == 2),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_MediatorThrows_PropagatesException()
+    {
+        // Arrange
+        var command = new ConfirmScoreCommand
+        {
+            SessionId = Guid.NewGuid(),
+            PlayerId = Guid.NewGuid(),
+            Dimension = "points",
+            Value = 5,
+            Round = 1
+        };
+
+        _mockMediator
+            .Setup(m => m.Send(It.IsAny<RecordLiveSessionScoreCommand>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("Session not found"));
+
+        // Act & Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _handler.Handle(command, CancellationToken.None));
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/ParseAndRecordScoreCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/ParseAndRecordScoreCommandHandlerTests.cs
@@ -1,0 +1,281 @@
+using Api.BoundedContexts.GameManagement.Application.Commands.LiveSessions;
+using Api.BoundedContexts.GameManagement.Application.DTOs.LiveSessions;
+using Api.BoundedContexts.GameManagement.Application.Queries.LiveSessions;
+using Api.BoundedContexts.GameManagement.Application.Services;
+using Api.BoundedContexts.GameManagement.Domain.Enums;
+using Api.BoundedContexts.KnowledgeBase.Application.Commands;
+using Api.BoundedContexts.KnowledgeBase.Application.Handlers;
+using Api.BoundedContexts.KnowledgeBase.Domain.Services;
+using Api.BoundedContexts.KnowledgeBase.Domain.ValueObjects;
+using Api.Tests.Constants;
+using MediatR;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.KnowledgeBase.Application.Handlers;
+
+/// <summary>
+/// Tests for ParseAndRecordScoreCommandHandler.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+public class ParseAndRecordScoreCommandHandlerTests
+{
+    private readonly Mock<IStateParser> _mockStateParser;
+    private readonly Mock<IMediator> _mockMediator;
+    private readonly Mock<IPlayerNameResolutionService> _mockPlayerResolution;
+    private readonly ParseAndRecordScoreCommandHandler _handler;
+
+    private readonly Guid _sessionId = Guid.NewGuid();
+    private readonly Guid _playerId = Guid.NewGuid();
+
+    public ParseAndRecordScoreCommandHandlerTests()
+    {
+        _mockStateParser = new Mock<IStateParser>();
+        _mockMediator = new Mock<IMediator>();
+        _mockPlayerResolution = new Mock<IPlayerNameResolutionService>();
+        _handler = new ParseAndRecordScoreCommandHandler(
+            _mockStateParser.Object,
+            _mockMediator.Object,
+            _mockPlayerResolution.Object);
+
+        // Default: return active players
+        var players = new List<LiveSessionPlayerDto>
+        {
+            new(_playerId, Guid.NewGuid(), "Marco Rossi", null, PlayerColor.Red, PlayerRole.Player,
+                null, 0, 1, DateTime.UtcNow, true)
+        };
+
+        _mockMediator
+            .Setup(m => m.Send(It.IsAny<GetSessionPlayersQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(players.AsReadOnly());
+
+        // Default: return session with turn index 1
+        var sessionDto = CreateLiveSessionDto(currentTurnIndex: 1);
+        _mockMediator
+            .Setup(m => m.Send(It.IsAny<GetLiveSessionQuery>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(sessionDto);
+    }
+
+    [Fact]
+    public async Task Handle_HighConfidenceAutoRecord_RecordsScoreAndReturnsRecorded()
+    {
+        // Arrange
+        var extraction = StateExtractionResult.Create(
+            changeType: StateChangeType.ScoreChange,
+            originalMessage: "Marco ha 5 punti",
+            confidence: 0.95f,
+            extractedState: new Dictionary<string, object> { { "score", 5 }, { "dimension", "points" } },
+            playerName: "Marco",
+            requiresConfirmation: false);
+
+        _mockStateParser
+            .Setup(p => p.ParseAsync(It.IsAny<string>(), null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(extraction);
+
+        _mockPlayerResolution
+            .Setup(r => r.ResolvePlayer("Marco", It.IsAny<IReadOnlyDictionary<Guid, string>>()))
+            .Returns(PlayerResolutionResult.Resolved(_playerId, "Marco Rossi"));
+
+        var command = new ParseAndRecordScoreCommand
+        {
+            SessionId = _sessionId,
+            Message = "Marco ha 5 punti",
+            AutoRecord = true
+        };
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.Equal("recorded", result.Status);
+        Assert.Equal("Marco Rossi", result.PlayerName);
+        Assert.Equal(_playerId, result.PlayerId);
+        Assert.Equal(5, result.Value);
+        Assert.Equal("points", result.Dimension);
+        Assert.False(result.RequiresConfirmation);
+
+        _mockMediator.Verify(m => m.Send(
+            It.Is<RecordLiveSessionScoreCommand>(c =>
+                c.SessionId == _sessionId &&
+                c.PlayerId == _playerId &&
+                c.Value == 5 &&
+                c.Dimension == "points"),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_LowConfidence_ReturnsParsedWithConfirmation()
+    {
+        // Arrange
+        var extraction = StateExtractionResult.Create(
+            changeType: StateChangeType.ScoreChange,
+            originalMessage: "Marco forse 5 punti",
+            confidence: 0.5f,
+            extractedState: new Dictionary<string, object> { { "score", 5 }, { "dimension", "points" } },
+            playerName: "Marco",
+            requiresConfirmation: true);
+
+        _mockStateParser
+            .Setup(p => p.ParseAsync(It.IsAny<string>(), null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(extraction);
+
+        _mockPlayerResolution
+            .Setup(r => r.ResolvePlayer("Marco", It.IsAny<IReadOnlyDictionary<Guid, string>>()))
+            .Returns(PlayerResolutionResult.Resolved(_playerId, "Marco Rossi"));
+
+        var command = new ParseAndRecordScoreCommand
+        {
+            SessionId = _sessionId,
+            Message = "Marco forse 5 punti",
+            AutoRecord = true
+        };
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.Equal("parsed", result.Status);
+        Assert.True(result.RequiresConfirmation);
+        Assert.Equal(_playerId, result.PlayerId);
+
+        _mockMediator.Verify(m => m.Send(
+            It.IsAny<RecordLiveSessionScoreCommand>(),
+            It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_NoScoreDetected_ReturnsUnrecognized()
+    {
+        // Arrange
+        var extraction = StateExtractionResult.NoChange("ciao come stai");
+
+        _mockStateParser
+            .Setup(p => p.ParseAsync(It.IsAny<string>(), null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(extraction);
+
+        var command = new ParseAndRecordScoreCommand
+        {
+            SessionId = _sessionId,
+            Message = "ciao come stai"
+        };
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.Equal("unrecognized", result.Status);
+        Assert.Contains("No score information", result.Message);
+    }
+
+    [Fact]
+    public async Task Handle_AmbiguousPlayer_ReturnsAmbiguousWithCandidates()
+    {
+        // Arrange
+        var extraction = StateExtractionResult.Create(
+            changeType: StateChangeType.ScoreChange,
+            originalMessage: "Marco ha 5 punti",
+            confidence: 0.9f,
+            extractedState: new Dictionary<string, object> { { "score", 5 }, { "dimension", "points" } },
+            playerName: "Marco",
+            requiresConfirmation: false);
+
+        _mockStateParser
+            .Setup(p => p.ParseAsync(It.IsAny<string>(), null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(extraction);
+
+        var candidates = new List<(Guid, string)>
+        {
+            (_playerId, "Marco Rossi"),
+            (Guid.NewGuid(), "Marco Bianchi")
+        };
+
+        _mockPlayerResolution
+            .Setup(r => r.ResolvePlayer("Marco", It.IsAny<IReadOnlyDictionary<Guid, string>>()))
+            .Returns(PlayerResolutionResult.Ambiguous(candidates));
+
+        var command = new ParseAndRecordScoreCommand
+        {
+            SessionId = _sessionId,
+            Message = "Marco ha 5 punti",
+            AutoRecord = true
+        };
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.Equal("ambiguous", result.Status);
+        Assert.True(result.RequiresConfirmation);
+        Assert.Equal(2, result.AmbiguousCandidates.Count);
+        Assert.Contains("Marco Rossi", result.AmbiguousCandidates);
+        Assert.Contains("Marco Bianchi", result.AmbiguousCandidates);
+    }
+
+    [Fact]
+    public async Task Handle_PlayerNotFound_ReturnsParsedWithMessage()
+    {
+        // Arrange
+        var extraction = StateExtractionResult.Create(
+            changeType: StateChangeType.ScoreChange,
+            originalMessage: "Giovanni ha 5 punti",
+            confidence: 0.9f,
+            extractedState: new Dictionary<string, object> { { "score", 5 }, { "dimension", "points" } },
+            playerName: "Giovanni",
+            requiresConfirmation: false);
+
+        _mockStateParser
+            .Setup(p => p.ParseAsync(It.IsAny<string>(), null, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(extraction);
+
+        _mockPlayerResolution
+            .Setup(r => r.ResolvePlayer("Giovanni", It.IsAny<IReadOnlyDictionary<Guid, string>>()))
+            .Returns(PlayerResolutionResult.NotFound());
+
+        var command = new ParseAndRecordScoreCommand
+        {
+            SessionId = _sessionId,
+            Message = "Giovanni ha 5 punti",
+            AutoRecord = true
+        };
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.Equal("parsed", result.Status);
+        Assert.True(result.RequiresConfirmation);
+        Assert.Contains("Giovanni", result.Message);
+        Assert.Contains("not found", result.Message);
+    }
+
+    private LiveSessionDto CreateLiveSessionDto(int currentTurnIndex = 1)
+    {
+        return new LiveSessionDto(
+            Id: _sessionId,
+            SessionCode: "ABC123",
+            GameId: null,
+            GameName: "Test Game",
+            CreatedByUserId: Guid.NewGuid(),
+            Status: LiveSessionStatus.InProgress,
+            Visibility: PlayRecordVisibility.Private,
+            GroupId: null,
+            CreatedAt: DateTime.UtcNow,
+            StartedAt: DateTime.UtcNow,
+            PausedAt: null,
+            CompletedAt: null,
+            UpdatedAt: DateTime.UtcNow,
+            LastSavedAt: null,
+            CurrentTurnIndex: currentTurnIndex,
+            CurrentTurnPlayerId: null,
+            AgentMode: AgentSessionMode.None,
+            ChatSessionId: null,
+            Notes: null,
+            Players: new List<LiveSessionPlayerDto>(),
+            Teams: new List<LiveSessionTeamDto>(),
+            RoundScores: new List<LiveSessionRoundScoreDto>(),
+            ScoringConfig: new LiveSessionScoringConfigDto(
+                new List<string> { "points" },
+                new Dictionary<string, string>())
+        );
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Infrastructure/Persistence/LlmRequestLogRepositoryTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Infrastructure/Persistence/LlmRequestLogRepositoryTests.cs
@@ -230,13 +230,13 @@ public sealed class LlmRequestLogRepositoryTests : SharedDatabaseTestBase<LlmReq
 
         // User1: 2 requests, User2: 1 request, System: 1 request (null userId)
         await Repository.LogRequestAsync("model", "openrouter", RequestSource.Manual,
-            userId1, "user", 100, 50, 0.01m, 200, true, null, false, false, null, TestCancellationToken);
+            userId1, "user", 100, 50, 0.01m, 200, true, null, false, false, null, null, TestCancellationToken);
         await Repository.LogRequestAsync("model", "openrouter", RequestSource.RagPipeline,
-            userId1, "user", 200, 100, 0.02m, 300, true, null, false, false, null, TestCancellationToken);
+            userId1, "user", 200, 100, 0.02m, 300, true, null, false, false, null, null, TestCancellationToken);
         await Repository.LogRequestAsync("model", "ollama", RequestSource.Manual,
-            userId2, "admin", 50, 25, 0m, 100, true, null, false, true, null, TestCancellationToken);
+            userId2, "admin", 50, 25, 0m, 100, true, null, false, true, null, null, TestCancellationToken);
         await Repository.LogRequestAsync("model", "ollama", RequestSource.AgentTask,
-            null, null, 50, 25, 0m, 100, true, null, false, true, null, TestCancellationToken);
+            null, null, 50, 25, 0m, 100, true, null, false, true, null, null, TestCancellationToken);
 
         // Act
         var count = await Repository.GetActiveAiUserCountAsync(
@@ -254,7 +254,7 @@ public sealed class LlmRequestLogRepositoryTests : SharedDatabaseTestBase<LlmReq
         var userId = Guid.NewGuid();
 
         await Repository.LogRequestAsync("model", "openrouter", RequestSource.Manual,
-            userId, "user", 100, 50, 0.01m, 200, true, null, false, false, null, TestCancellationToken);
+            userId, "user", 100, 50, 0.01m, 200, true, null, false, false, null, null, TestCancellationToken);
 
         // Pseudonymize all records
         await Repository.PseudonymizeOldLogsAsync(
@@ -290,7 +290,7 @@ public sealed class LlmRequestLogRepositoryTests : SharedDatabaseTestBase<LlmReq
         var userId = Guid.NewGuid();
 
         await Repository.LogRequestAsync("model", "openrouter", RequestSource.Manual,
-            userId, "user", 100, 50, 0.01m, 200, true, null, false, false, null, TestCancellationToken);
+            userId, "user", 100, 50, 0.01m, 200, true, null, false, false, null, null, TestCancellationToken);
 
         // Act — query with future 'from' date (all records are "old")
         var count = await Repository.GetActiveAiUserCountAsync(

--- a/apps/web/src/components/game-night/LiveSessionView.tsx
+++ b/apps/web/src/components/game-night/LiveSessionView.tsx
@@ -39,6 +39,7 @@ import { useSessionStore } from '@/lib/stores/sessionStore';
 
 import { LiveScoreboard, type LiveScoreboardPlayer } from './LiveScoreboard';
 import { QuickActions } from './QuickActions';
+import { ScoreAssistant } from './ScoreAssistant';
 import { SessionChatWidget, type ChatMessage } from './SessionChatWidget';
 import { SessionHeader } from './SessionHeader';
 
@@ -267,6 +268,9 @@ export function LiveSessionView({ sessionId }: LiveSessionViewProps) {
         <div className="flex-1 space-y-4 lg:max-w-[60%]">
           {/* Scoreboard */}
           <LiveScoreboard players={scoreboardPlayers} isRealTime={isConnected} />
+
+          {/* AI Score Assistant */}
+          <ScoreAssistant sessionId={sessionId} onScoreRecorded={loadScores} />
 
           {/* Quick Actions */}
           <QuickActions

--- a/apps/web/src/components/game-night/ScoreAssistant.tsx
+++ b/apps/web/src/components/game-night/ScoreAssistant.tsx
@@ -79,7 +79,7 @@ export function ScoreAssistant({ sessionId, onScoreRecorded, className }: ScoreA
   // ----- Confirm a parsed score -----
   const handleConfirm = useCallback(
     async (result: ScoreParseResult) => {
-      if (!result.playerId || !result.value || !result.round || !result.dimension) return;
+      if (!result.playerId || result.value == null || !result.round || !result.dimension) return;
 
       setState({ kind: 'loading' });
 

--- a/apps/web/src/components/game-night/ScoreAssistant.tsx
+++ b/apps/web/src/components/game-night/ScoreAssistant.tsx
@@ -1,0 +1,293 @@
+'use client';
+
+/**
+ * ScoreAssistant — AI-powered natural language score input for live sessions.
+ *
+ * Users type messages like "Marco ha 5 punti" and the AI parses, resolves
+ * players, and records scores. Handles ambiguous players, low confidence,
+ * and confirmation flow.
+ *
+ * Issue #121 — AI Score Tracking
+ */
+
+import { useState, useCallback, type FormEvent } from 'react';
+
+import { CheckCircle2, AlertTriangle, HelpCircle, Loader2, Send, Mic, XCircle } from 'lucide-react';
+
+import { Button } from '@/components/ui/primitives/button';
+import { Input } from '@/components/ui/primitives/input';
+import { api } from '@/lib/api';
+import type {
+  ScoreParseResult,
+  ConfirmScoreRequest,
+} from '@/lib/api/schemas/score-tracking.schemas';
+import { cn } from '@/lib/utils';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface ScoreAssistantProps {
+  sessionId: string;
+  /** Called after a score is successfully recorded */
+  onScoreRecorded?: () => void;
+  className?: string;
+}
+
+type AssistantState =
+  | { kind: 'idle' }
+  | { kind: 'loading' }
+  | { kind: 'result'; data: ScoreParseResult }
+  | { kind: 'error'; message: string };
+
+// ============================================================================
+// Component
+// ============================================================================
+
+export function ScoreAssistant({ sessionId, onScoreRecorded, className }: ScoreAssistantProps) {
+  const [input, setInput] = useState('');
+  const [state, setState] = useState<AssistantState>({ kind: 'idle' });
+
+  // ----- Parse message -----
+  const handleSubmit = useCallback(
+    async (e: FormEvent) => {
+      e.preventDefault();
+      const trimmed = input.trim();
+      if (!trimmed) return;
+
+      setState({ kind: 'loading' });
+
+      try {
+        const result = await api.liveSessions.parseScore(sessionId, {
+          message: trimmed,
+          autoRecord: true,
+        });
+
+        if (result.status === 'recorded') {
+          onScoreRecorded?.();
+        }
+
+        setState({ kind: 'result', data: result });
+        setInput('');
+      } catch {
+        setState({ kind: 'error', message: 'Errore nella comunicazione con il server.' });
+      }
+    },
+    [input, sessionId, onScoreRecorded]
+  );
+
+  // ----- Confirm a parsed score -----
+  const handleConfirm = useCallback(
+    async (result: ScoreParseResult) => {
+      if (!result.playerId || !result.value || !result.round || !result.dimension) return;
+
+      setState({ kind: 'loading' });
+
+      try {
+        const request: ConfirmScoreRequest = {
+          playerId: result.playerId,
+          dimension: result.dimension,
+          value: result.value,
+          round: result.round,
+        };
+        await api.liveSessions.confirmScore(sessionId, request);
+        onScoreRecorded?.();
+        setState({
+          kind: 'result',
+          data: {
+            ...result,
+            status: 'recorded',
+            requiresConfirmation: false,
+            message: `Punteggio registrato: ${result.playerName} ${result.value} ${result.dimension}.`,
+          },
+        });
+      } catch {
+        setState({ kind: 'error', message: 'Errore nella conferma del punteggio.' });
+      }
+    },
+    [sessionId, onScoreRecorded]
+  );
+
+  // ----- Dismiss result -----
+  const handleDismiss = useCallback(() => {
+    setState({ kind: 'idle' });
+  }, []);
+
+  return (
+    <section
+      className={cn(
+        'rounded-xl border border-slate-200 dark:border-slate-700',
+        'bg-white/80 dark:bg-slate-800/60 backdrop-blur-sm p-3',
+        className
+      )}
+      data-testid="score-assistant"
+    >
+      {/* Header */}
+      <div className="flex items-center gap-2 mb-2">
+        <Mic className="h-4 w-4 text-amber-600 dark:text-amber-400" aria-hidden="true" />
+        <span className="text-sm font-semibold text-slate-900 dark:text-slate-100">
+          Assistente punteggi
+        </span>
+      </div>
+
+      {/* Input form */}
+      <form onSubmit={handleSubmit} className="flex items-center gap-2">
+        <Input
+          value={input}
+          onChange={e => setInput(e.target.value)}
+          placeholder="Es: Marco ha 5 punti"
+          disabled={state.kind === 'loading'}
+          className="flex-1 h-9 text-sm"
+          data-testid="score-input"
+        />
+        <Button
+          type="submit"
+          size="icon"
+          disabled={state.kind === 'loading' || !input.trim()}
+          className={cn(
+            'h-9 w-9 flex-shrink-0',
+            'bg-amber-600 hover:bg-amber-700 text-white',
+            'active:scale-95 transition-all'
+          )}
+          data-testid="score-submit"
+        >
+          {state.kind === 'loading' ? (
+            <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+          ) : (
+            <Send className="h-4 w-4" aria-hidden="true" />
+          )}
+          <span className="sr-only">Invia</span>
+        </Button>
+      </form>
+
+      {/* Result display */}
+      {state.kind === 'result' && (
+        <ResultCard result={state.data} onConfirm={handleConfirm} onDismiss={handleDismiss} />
+      )}
+
+      {/* Error display */}
+      {state.kind === 'error' && (
+        <div
+          className="mt-2 flex items-center gap-2 text-sm text-red-600 dark:text-red-400"
+          data-testid="score-error"
+        >
+          <XCircle className="h-4 w-4 flex-shrink-0" aria-hidden="true" />
+          <span>{state.message}</span>
+          <Button variant="ghost" size="sm" onClick={handleDismiss} className="ml-auto h-7 text-xs">
+            OK
+          </Button>
+        </div>
+      )}
+    </section>
+  );
+}
+
+// ============================================================================
+// Result Card
+// ============================================================================
+
+interface ResultCardProps {
+  result: ScoreParseResult;
+  onConfirm: (result: ScoreParseResult) => void;
+  onDismiss: () => void;
+}
+
+function ResultCard({ result, onConfirm, onDismiss }: ResultCardProps) {
+  const statusConfig = {
+    recorded: {
+      icon: CheckCircle2,
+      color: 'text-emerald-600 dark:text-emerald-400',
+      bg: 'bg-emerald-50 dark:bg-emerald-900/20',
+    },
+    parsed: {
+      icon: HelpCircle,
+      color: 'text-amber-600 dark:text-amber-400',
+      bg: 'bg-amber-50 dark:bg-amber-900/20',
+    },
+    ambiguous: {
+      icon: AlertTriangle,
+      color: 'text-orange-600 dark:text-orange-400',
+      bg: 'bg-orange-50 dark:bg-orange-900/20',
+    },
+    unrecognized: {
+      icon: XCircle,
+      color: 'text-slate-500 dark:text-slate-400',
+      bg: 'bg-slate-50 dark:bg-slate-800/40',
+    },
+  };
+
+  const config = statusConfig[result.status];
+  const Icon = config.icon;
+
+  return (
+    <div
+      className={cn('mt-2 rounded-lg p-3', config.bg)}
+      data-testid="score-result"
+      data-status={result.status}
+    >
+      <div className="flex items-start gap-2">
+        <Icon className={cn('h-4 w-4 mt-0.5 flex-shrink-0', config.color)} aria-hidden="true" />
+        <div className="flex-1 min-w-0">
+          <p className="text-sm text-slate-800 dark:text-slate-200">{result.message}</p>
+
+          {/* Confidence indicator */}
+          <div className="flex items-center gap-1 mt-1">
+            <span className="text-xs text-slate-500">Confidenza:</span>
+            <span
+              className={cn(
+                'text-xs font-medium',
+                result.confidence >= 0.8
+                  ? 'text-emerald-600'
+                  : result.confidence >= 0.5
+                    ? 'text-amber-600'
+                    : 'text-red-600'
+              )}
+            >
+              {Math.round(result.confidence * 100)}%
+            </span>
+          </div>
+
+          {/* Ambiguous candidates */}
+          {result.status === 'ambiguous' && result.ambiguousCandidates && (
+            <div className="mt-1.5">
+              <span className="text-xs text-slate-500">Giocatori possibili:</span>
+              <div className="flex flex-wrap gap-1 mt-1">
+                {result.ambiguousCandidates.map(name => (
+                  <span
+                    key={name}
+                    className="inline-flex items-center rounded-full bg-white dark:bg-slate-700 px-2 py-0.5 text-xs font-medium text-slate-700 dark:text-slate-300 border border-slate-200 dark:border-slate-600"
+                  >
+                    {name}
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Action buttons */}
+          <div className="flex items-center gap-2 mt-2">
+            {result.requiresConfirmation && result.playerId && result.value != null && (
+              <Button
+                size="sm"
+                onClick={() => onConfirm(result)}
+                className="h-7 text-xs bg-emerald-600 hover:bg-emerald-700 text-white"
+                data-testid="score-confirm"
+              >
+                Conferma
+              </Button>
+            )}
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={onDismiss}
+              className="h-7 text-xs"
+              data-testid="score-dismiss"
+            >
+              {result.status === 'recorded' ? 'OK' : 'Annulla'}
+            </Button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/game-night/__tests__/ScoreAssistant.test.tsx
+++ b/apps/web/src/components/game-night/__tests__/ScoreAssistant.test.tsx
@@ -1,0 +1,198 @@
+/**
+ * ScoreAssistant Component Tests
+ * Issue #121 — AI Score Tracking
+ */
+
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { ScoreAssistant } from '../ScoreAssistant';
+
+// Mock the api module
+const mockParseScore = vi.fn();
+const mockConfirmScore = vi.fn();
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    liveSessions: {
+      parseScore: (...args: unknown[]) => mockParseScore(...args),
+      confirmScore: (...args: unknown[]) => mockConfirmScore(...args),
+    },
+  },
+}));
+
+describe('ScoreAssistant', () => {
+  const sessionId = '550e8400-e29b-41d4-a716-446655440000';
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('should render the input and submit button', () => {
+    render(<ScoreAssistant sessionId={sessionId} />);
+    expect(screen.getByTestId('score-assistant')).toBeInTheDocument();
+    expect(screen.getByTestId('score-input')).toBeInTheDocument();
+    expect(screen.getByTestId('score-submit')).toBeInTheDocument();
+    expect(screen.getByText('Assistente punteggi')).toBeInTheDocument();
+  });
+
+  it('should disable submit when input is empty', () => {
+    render(<ScoreAssistant sessionId={sessionId} />);
+    expect(screen.getByTestId('score-submit')).toBeDisabled();
+  });
+
+  it('should call parseScore on submit', async () => {
+    mockParseScore.mockResolvedValueOnce({
+      status: 'recorded',
+      playerName: 'Marco',
+      playerId: '11111111-1111-1111-1111-111111111111',
+      dimension: 'points',
+      value: 5,
+      round: 1,
+      confidence: 0.95,
+      requiresConfirmation: false,
+      message: 'Score recorded: Marco scored 5 points in round 1.',
+    });
+
+    const onScoreRecorded = vi.fn();
+    render(<ScoreAssistant sessionId={sessionId} onScoreRecorded={onScoreRecorded} />);
+
+    const input = screen.getByTestId('score-input');
+    fireEvent.change(input, { target: { value: 'Marco ha 5 punti' } });
+    fireEvent.submit(input.closest('form')!);
+
+    await waitFor(() => {
+      expect(mockParseScore).toHaveBeenCalledWith(sessionId, {
+        message: 'Marco ha 5 punti',
+        autoRecord: true,
+      });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByTestId('score-result')).toBeInTheDocument();
+      expect(onScoreRecorded).toHaveBeenCalled();
+    });
+  });
+
+  it('should show confirmation button when requiresConfirmation is true', async () => {
+    mockParseScore.mockResolvedValueOnce({
+      status: 'parsed',
+      playerName: 'Marco',
+      playerId: '11111111-1111-1111-1111-111111111111',
+      dimension: 'points',
+      value: 5,
+      round: 1,
+      confidence: 0.6,
+      requiresConfirmation: true,
+      message: 'Detected: Marco scored 5 points. Please confirm.',
+    });
+
+    render(<ScoreAssistant sessionId={sessionId} />);
+
+    fireEvent.change(screen.getByTestId('score-input'), {
+      target: { value: 'Marco forse 5 punti' },
+    });
+    fireEvent.submit(screen.getByTestId('score-input').closest('form')!);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('score-confirm')).toBeInTheDocument();
+    });
+  });
+
+  it('should call confirmScore when confirm button is clicked', async () => {
+    const parsedResult = {
+      status: 'parsed' as const,
+      playerName: 'Marco',
+      playerId: '11111111-1111-1111-1111-111111111111',
+      dimension: 'points',
+      value: 5,
+      round: 1,
+      confidence: 0.6,
+      requiresConfirmation: true,
+      message: 'Detected: Marco scored 5 points. Please confirm.',
+    };
+    mockParseScore.mockResolvedValueOnce(parsedResult);
+    mockConfirmScore.mockResolvedValueOnce(undefined);
+
+    const onScoreRecorded = vi.fn();
+    render(<ScoreAssistant sessionId={sessionId} onScoreRecorded={onScoreRecorded} />);
+
+    fireEvent.change(screen.getByTestId('score-input'), { target: { value: 'Marco 5' } });
+    fireEvent.submit(screen.getByTestId('score-input').closest('form')!);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('score-confirm')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('score-confirm'));
+
+    await waitFor(() => {
+      expect(mockConfirmScore).toHaveBeenCalledWith(sessionId, {
+        playerId: '11111111-1111-1111-1111-111111111111',
+        dimension: 'points',
+        value: 5,
+        round: 1,
+      });
+      expect(onScoreRecorded).toHaveBeenCalled();
+    });
+  });
+
+  it('should show ambiguous candidates when status is ambiguous', async () => {
+    mockParseScore.mockResolvedValueOnce({
+      status: 'ambiguous',
+      playerName: 'M',
+      dimension: 'points',
+      value: 5,
+      round: 1,
+      confidence: 0.7,
+      requiresConfirmation: true,
+      message: "Multiple players match 'M'. Please specify.",
+      ambiguousCandidates: ['Marco', 'Maria'],
+    });
+
+    render(<ScoreAssistant sessionId={sessionId} />);
+
+    fireEvent.change(screen.getByTestId('score-input'), { target: { value: 'M ha 5 punti' } });
+    fireEvent.submit(screen.getByTestId('score-input').closest('form')!);
+
+    await waitFor(() => {
+      expect(screen.getByText('Marco')).toBeInTheDocument();
+      expect(screen.getByText('Maria')).toBeInTheDocument();
+    });
+  });
+
+  it('should show error state on API failure', async () => {
+    mockParseScore.mockRejectedValueOnce(new Error('Network error'));
+
+    render(<ScoreAssistant sessionId={sessionId} />);
+
+    fireEvent.change(screen.getByTestId('score-input'), { target: { value: 'test' } });
+    fireEvent.submit(screen.getByTestId('score-input').closest('form')!);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('score-error')).toBeInTheDocument();
+    });
+  });
+
+  it('should dismiss result on dismiss button click', async () => {
+    mockParseScore.mockResolvedValueOnce({
+      status: 'unrecognized',
+      confidence: 0.1,
+      requiresConfirmation: false,
+      message: 'No score information detected.',
+    });
+
+    render(<ScoreAssistant sessionId={sessionId} />);
+
+    fireEvent.change(screen.getByTestId('score-input'), { target: { value: 'hello' } });
+    fireEvent.submit(screen.getByTestId('score-input').closest('form')!);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('score-result')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId('score-dismiss'));
+
+    expect(screen.queryByTestId('score-result')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/game-night/index.ts
+++ b/apps/web/src/components/game-night/index.ts
@@ -17,3 +17,4 @@ export { SessionChatWidget } from './SessionChatWidget';
 export type { SessionChatWidgetProps, ChatMessage } from './SessionChatWidget';
 export { LiveSessionView } from './LiveSessionView';
 export type { LiveSessionViewProps } from './LiveSessionView';
+export { ScoreAssistant } from './ScoreAssistant';

--- a/apps/web/src/lib/api/clients/liveSessionsClient.ts
+++ b/apps/web/src/lib/api/clients/liveSessionsClient.ts
@@ -33,6 +33,12 @@ import {
   type TriggerSnapshotRequest,
   type UpdateNotesRequest,
 } from '../schemas/live-sessions.schemas';
+import {
+  ScoreParseResultSchema,
+  type ScoreParseResult,
+  type ParseScoreRequest,
+  type ConfirmScoreRequest,
+} from '../schemas/score-tracking.schemas';
 
 import type { HttpClient } from '../core/httpClient';
 
@@ -132,6 +138,14 @@ export interface LiveSessionsClient {
 
   /** Update session notes */
   updateNotes(sessionId: string, request: UpdateNotesRequest): Promise<void>;
+
+  // ========== AI Score Tracking (Issue #121) ==========
+
+  /** Parse a natural language message for score data, optionally auto-record */
+  parseScore(sessionId: string, request: ParseScoreRequest): Promise<ScoreParseResult>;
+
+  /** Confirm and record a previously parsed score */
+  confirmScore(sessionId: string, request: ConfirmScoreRequest): Promise<void>;
 }
 
 export function createLiveSessionsClient({
@@ -296,6 +310,21 @@ export function createLiveSessionsClient({
 
     async updateNotes(sessionId, request) {
       await httpClient.put(`${BASE}/${encodeURIComponent(sessionId)}/notes`, request);
+    },
+
+    // ========== AI Score Tracking (Issue #121) ==========
+
+    async parseScore(sessionId, request) {
+      const response = await httpClient.post<ScoreParseResult>(
+        `${BASE}/${encodeURIComponent(sessionId)}/scores/parse`,
+        request
+      );
+      if (!response) throw new Error('Parse score failed');
+      return ScoreParseResultSchema.parse(response);
+    },
+
+    async confirmScore(sessionId, request) {
+      await httpClient.post(`${BASE}/${encodeURIComponent(sessionId)}/scores/confirm`, request);
     },
   };
 }

--- a/apps/web/src/lib/api/schemas/index.ts
+++ b/apps/web/src/lib/api/schemas/index.ts
@@ -108,6 +108,9 @@ export * from './live-sessions.schemas';
 // Session Tracking schemas (Issue #5041 — Sessions Redesign)
 export * from './session-tracking.schemas';
 
+// AI Score Tracking schemas (Issue #121)
+export * from './score-tracking.schemas';
+
 // LLM System Configuration schemas (Issue #5495)
 export * from './llm-system-config.schemas';
 

--- a/apps/web/src/lib/api/schemas/score-tracking.schemas.ts
+++ b/apps/web/src/lib/api/schemas/score-tracking.schemas.ts
@@ -1,0 +1,45 @@
+/**
+ * Score Tracking AI Schemas
+ *
+ * Zod schemas for AI-mediated score parsing and confirmation.
+ * Maps to ParseAndRecordScoreCommand / ConfirmScoreCommand in KnowledgeBase BC.
+ *
+ * Issue #121 — AI Score Tracking
+ */
+
+import { z } from 'zod';
+
+// ========== Request Schemas ==========
+
+export const ParseScoreRequestSchema = z.object({
+  message: z.string().min(1).max(500),
+  autoRecord: z.boolean().optional().default(true),
+});
+
+export type ParseScoreRequest = z.infer<typeof ParseScoreRequestSchema>;
+
+export const ConfirmScoreRequestSchema = z.object({
+  playerId: z.string().uuid(),
+  dimension: z.string().min(1),
+  value: z.number().int(),
+  round: z.number().int().min(1),
+});
+
+export type ConfirmScoreRequest = z.infer<typeof ConfirmScoreRequestSchema>;
+
+// ========== Response Schemas ==========
+
+export const ScoreParseResultSchema = z.object({
+  status: z.enum(['parsed', 'recorded', 'ambiguous', 'unrecognized']),
+  playerName: z.string().nullish(),
+  playerId: z.string().uuid().nullish(),
+  dimension: z.string().nullish(),
+  value: z.number().int().nullish(),
+  round: z.number().int().nullish(),
+  confidence: z.number().min(0).max(1),
+  requiresConfirmation: z.boolean(),
+  message: z.string(),
+  ambiguousCandidates: z.array(z.string()).nullish(),
+});
+
+export type ScoreParseResult = z.infer<typeof ScoreParseResultSchema>;

--- a/docs/plans/2026-03-11-game-night-ai-assistant.md
+++ b/docs/plans/2026-03-11-game-night-ai-assistant.md
@@ -1,0 +1,2004 @@
+# Game Night AI Assistant — Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Transform the AI agent from a passive rule consultant into an active "game master assistant" that tracks scores via natural language, orchestrates complete game state saves, provides recap on resume, and offers a frictionless quick-start wizard for improvised game nights.
+
+**Architecture:** Backend-first approach. Phase 1 creates a new `AgentScoreTrackingService` that bridges the existing `IStateParser` NLU to `LiveGameSession.RecordScore()`. Phase 2 adds a `SaveCompleteSessionStateCommand` saga that orchestrates snapshot + agent persist + recap generation. Phase 3 builds a frontend `GameNightWizard` that chains existing flows. All phases are independently deployable.
+
+**Tech Stack:** .NET 9 (MediatR, EF Core, FluentValidation) | Next.js 16 (React 19, Tailwind 4, shadcn/ui, Zustand) | Vitest + xUnit
+
+**Prerequisites:** These existing plans should be completed first (or in parallel):
+- `2026-03-09-game-night-implementation-plan.md` — GameSessionContext orchestrator, session-aware RAG (#5578)
+- `2026-03-10-game-night-journey-plan.md` — BGG discover tab, copyright disclaimer, scoreboard page
+
+**Branch Strategy:** `main-dev` → `game-night-ai-assistant` (umbrella) → `feature/issue-XXXX-*` per task
+
+**Single device model:** Host controls everything. No WebSocket/real-time sync needed.
+
+---
+
+## Dependency Graph
+
+```
+Phase 1: AI Score Tracking
+  #A1 PlayerNameResolver ──┐
+  #A2 ScoreIntentDetector ─┤──→ #A4 ParseAndRecordScore endpoint
+  #A3 ScoreConfirmation ───┘           │
+                                       ↓
+                              #A5 Frontend ScoreAssistant panel
+                              #A6 Tests (unit + integration)
+
+Phase 2: Enhanced Save/Resume (independent of Phase 1)
+  #B1 SaveCompleteState command ──→ #B2 ResumeContext query
+                                         │
+                                         ↓
+                                   #B3 Frontend Enhanced Pause/Resume
+                                   #B4 Tests
+
+Phase 3: Game Night Wizard (independent of Phase 1 & 2)
+  #C1 Frontend GameNightWizard ──→ #C2 Degraded Mode banner
+                                   #C3 Tests
+```
+
+---
+
+## Phase 1: AI Score Tracking
+
+### What exists (DO NOT rebuild)
+
+| Component | Path | What it does |
+|---|---|---|
+| `IStateParser` | `KnowledgeBase/Domain/Services/IStateParser.cs` | NLU: parses text → `StateExtractionResult` with `ScoreChange` type |
+| `StateExtractionResult` | `KnowledgeBase/Domain/ValueObjects/StateExtractionResult.cs` | Result: `ChangeType`, `PlayerName`, `ExtractedState`, `Confidence` |
+| `ParseLedgerMessageCommand` | `KnowledgeBase/Application/Commands/ParseLedgerMessageCommand.cs` | Existing bridge: message → `IStateParser` → `LedgerParseResultDto` |
+| `RecordLiveSessionScoreCommand` | `GameManagement/Application/Commands/LiveSessions/RecordLiveSessionScoreCommand.cs` | Records score: `SessionId, PlayerId, Round, Dimension, Value, Unit` |
+| `LiveGameSession.RecordScore()` | `GameManagement/Domain/Entities/LiveGameSession.cs:416` | Domain: validates, upserts score, recalculates ranks |
+| `GameSessionContextDto` | `GameManagement/Application/DTOs/GameSessionContext/GameSessionContextDto.cs` | Session context with players, phases, game IDs |
+| `LiveScoreSheet` | `apps/web/src/components/session/LiveScoreSheet.tsx` | Bottom sheet for manual score entry |
+| `VoiceMicButton` | `apps/web/src/components/chat-unified/VoiceMicButton.tsx` | Speech-to-text input |
+
+### Task A1: PlayerNameResolutionService
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/GameManagement/Application/Services/PlayerNameResolutionService.cs`
+- Create: `apps/api/src/Api/BoundedContexts/GameManagement/Application/Services/IPlayerNameResolutionService.cs`
+- Create: `apps/api/tests/Api.Tests/Unit/BoundedContexts/GameManagement/Application/Services/PlayerNameResolutionServiceTests.cs`
+
+**Purpose:** Maps fuzzy player names from NLU ("Marco", "marco", "M.") to actual `LiveSessionPlayer.Id` GUIDs in the session.
+
+- [ ] **Step 1: Write failing tests**
+
+```csharp
+// apps/api/tests/Api.Tests/Unit/BoundedContexts/GameManagement/Application/Services/PlayerNameResolutionServiceTests.cs
+using Api.BoundedContexts.GameManagement.Application.Services;
+
+namespace Api.Tests.Unit.BoundedContexts.GameManagement.Application.Services;
+
+public class PlayerNameResolutionServiceTests
+{
+    private readonly PlayerNameResolutionService _sut = new();
+
+    private static readonly Dictionary<Guid, string> Players = new()
+    {
+        [Guid.Parse("aaaaaaaa-0000-0000-0000-000000000001")] = "Marco Rossi",
+        [Guid.Parse("aaaaaaaa-0000-0000-0000-000000000002")] = "Sara Bianchi",
+        [Guid.Parse("aaaaaaaa-0000-0000-0000-000000000003")] = "Giulia Verdi",
+    };
+
+    [Theory]
+    [InlineData("Marco", "aaaaaaaa-0000-0000-0000-000000000001")]
+    [InlineData("marco", "aaaaaaaa-0000-0000-0000-000000000001")]
+    [InlineData("Marco Rossi", "aaaaaaaa-0000-0000-0000-000000000001")]
+    [InlineData("Sara", "aaaaaaaa-0000-0000-0000-000000000002")]
+    public void ResolvePlayer_ExactOrFirstName_ReturnsCorrectId(string input, string expectedId)
+    {
+        var result = _sut.ResolvePlayer(input, Players);
+        Assert.True(result.IsResolved);
+        Assert.Equal(Guid.Parse(expectedId), result.PlayerId);
+    }
+
+    [Fact]
+    public void ResolvePlayer_AmbiguousName_ReturnsAmbiguous()
+    {
+        var playersWithDuplicate = new Dictionary<Guid, string>(Players)
+        {
+            [Guid.Parse("aaaaaaaa-0000-0000-0000-000000000004")] = "Marco Neri"
+        };
+
+        var result = _sut.ResolvePlayer("Marco", playersWithDuplicate);
+        Assert.False(result.IsResolved);
+        Assert.True(result.IsAmbiguous);
+        Assert.Equal(2, result.Candidates.Count);
+    }
+
+    [Fact]
+    public void ResolvePlayer_UnknownName_ReturnsNotFound()
+    {
+        var result = _sut.ResolvePlayer("Roberto", Players);
+        Assert.False(result.IsResolved);
+        Assert.False(result.IsAmbiguous);
+    }
+}
+```
+
+- [ ] **Step 2: Run test — expect FAIL (class not found)**
+
+```bash
+cd apps/api && dotnet test --filter "FullyQualifiedName~PlayerNameResolutionServiceTests" --no-build 2>&1 | head -20
+```
+Expected: Build error — `PlayerNameResolutionService` not found
+
+- [ ] **Step 3: Implement PlayerNameResolutionService**
+
+```csharp
+// apps/api/src/Api/BoundedContexts/GameManagement/Application/Services/IPlayerNameResolutionService.cs
+namespace Api.BoundedContexts.GameManagement.Application.Services;
+
+internal interface IPlayerNameResolutionService
+{
+    PlayerResolutionResult ResolvePlayer(string playerName, IReadOnlyDictionary<Guid, string> sessionPlayers);
+}
+
+internal sealed record PlayerResolutionResult
+{
+    public bool IsResolved { get; init; }
+    public Guid? PlayerId { get; init; }
+    public string? ResolvedName { get; init; }
+    public bool IsAmbiguous { get; init; }
+    public IReadOnlyList<(Guid Id, string Name)> Candidates { get; init; } = [];
+
+    public static PlayerResolutionResult Resolved(Guid id, string name) =>
+        new() { IsResolved = true, PlayerId = id, ResolvedName = name };
+
+    public static PlayerResolutionResult Ambiguous(IReadOnlyList<(Guid, string)> candidates) =>
+        new() { IsAmbiguous = true, Candidates = candidates };
+
+    public static PlayerResolutionResult NotFound() => new();
+}
+```
+
+```csharp
+// apps/api/src/Api/BoundedContexts/GameManagement/Application/Services/PlayerNameResolutionService.cs
+namespace Api.BoundedContexts.GameManagement.Application.Services;
+
+internal sealed class PlayerNameResolutionService : IPlayerNameResolutionService
+{
+    public PlayerResolutionResult ResolvePlayer(
+        string playerName, IReadOnlyDictionary<Guid, string> sessionPlayers)
+    {
+        if (string.IsNullOrWhiteSpace(playerName))
+            return PlayerResolutionResult.NotFound();
+
+        var normalized = playerName.Trim();
+
+        // 1. Exact match (case-insensitive)
+        var exact = sessionPlayers
+            .Where(p => p.Value.Equals(normalized, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+        if (exact.Count == 1)
+            return PlayerResolutionResult.Resolved(exact[0].Key, exact[0].Value);
+
+        // 2. First name match
+        var firstNameMatches = sessionPlayers
+            .Where(p => p.Value.Split(' ')[0].Equals(normalized, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+        if (firstNameMatches.Count == 1)
+            return PlayerResolutionResult.Resolved(firstNameMatches[0].Key, firstNameMatches[0].Value);
+        if (firstNameMatches.Count > 1)
+            return PlayerResolutionResult.Ambiguous(
+                firstNameMatches.Select(p => (p.Key, p.Value)).ToList());
+
+        // 3. Contains match
+        var contains = sessionPlayers
+            .Where(p => p.Value.Contains(normalized, StringComparison.OrdinalIgnoreCase))
+            .ToList();
+        if (contains.Count == 1)
+            return PlayerResolutionResult.Resolved(contains[0].Key, contains[0].Value);
+        if (contains.Count > 1)
+            return PlayerResolutionResult.Ambiguous(
+                contains.Select(p => (p.Key, p.Value)).ToList());
+
+        return PlayerResolutionResult.NotFound();
+    }
+}
+```
+
+- [ ] **Step 4: Run tests — expect PASS**
+
+```bash
+cd apps/api && dotnet test --filter "FullyQualifiedName~PlayerNameResolutionServiceTests" --verbosity normal
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/GameManagement/Application/Services/PlayerNameResolutionService.cs \
+       apps/api/src/Api/BoundedContexts/GameManagement/Application/Services/IPlayerNameResolutionService.cs \
+       apps/api/tests/Api.Tests/Unit/BoundedContexts/GameManagement/Application/Services/PlayerNameResolutionServiceTests.cs
+git commit -m "feat(game-mgmt): add PlayerNameResolutionService for fuzzy player name matching"
+```
+
+---
+
+### Task A2: ParseAndRecordScoreCommand (Backend Bridge)
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/ParseAndRecordScoreCommand.cs`
+- Create: `apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Handlers/ParseAndRecordScoreCommandHandler.cs`
+- Create: `apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Validators/ParseAndRecordScoreCommandValidator.cs`
+- Create: `apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/DTOs/ScoreParseResultDto.cs`
+- Create: `apps/api/tests/Api.Tests/Unit/BoundedContexts/KnowledgeBase/Application/Handlers/ParseAndRecordScoreCommandHandlerTests.cs`
+
+**Purpose:** Takes natural language ("Marco 5 punti agricoltura"), parses via `IStateParser`, resolves player, and optionally records score on `LiveGameSession`.
+
+- [ ] **Step 1: Create DTOs**
+
+```csharp
+// apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/DTOs/ScoreParseResultDto.cs
+namespace Api.BoundedContexts.KnowledgeBase.Application.DTOs;
+
+public sealed record ScoreParseResultDto
+{
+    public required string Status { get; init; }  // "parsed", "recorded", "ambiguous", "unrecognized"
+    public string? PlayerName { get; init; }
+    public Guid? PlayerId { get; init; }
+    public string? Dimension { get; init; }
+    public int? Value { get; init; }
+    public int? Round { get; init; }
+    public float Confidence { get; init; }
+    public bool RequiresConfirmation { get; init; }
+    public string? Message { get; init; }
+    public IReadOnlyList<string> AmbiguousCandidates { get; init; } = [];
+}
+```
+
+- [ ] **Step 2: Create Command + Validator**
+
+```csharp
+// apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/ParseAndRecordScoreCommand.cs
+using MediatR;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Commands;
+
+public sealed record ParseAndRecordScoreCommand : IRequest<ScoreParseResultDto>
+{
+    public required Guid SessionId { get; init; }
+    public required string Message { get; init; }
+    public bool AutoRecord { get; init; } = false;  // true = record if confidence > 0.8
+}
+```
+
+```csharp
+// apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Validators/ParseAndRecordScoreCommandValidator.cs
+using FluentValidation;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Validators;
+
+internal sealed class ParseAndRecordScoreCommandValidator
+    : AbstractValidator<ParseAndRecordScoreCommand>
+{
+    public ParseAndRecordScoreCommandValidator()
+    {
+        RuleFor(x => x.SessionId).NotEmpty();
+        RuleFor(x => x.Message).NotEmpty().MaximumLength(500);
+    }
+}
+```
+
+- [ ] **Step 3: Write failing handler test**
+
+```csharp
+// apps/api/tests/Api.Tests/Unit/BoundedContexts/KnowledgeBase/Application/Handlers/ParseAndRecordScoreCommandHandlerTests.cs
+using Api.BoundedContexts.GameManagement.Application.Services;
+using Api.BoundedContexts.KnowledgeBase.Application.Commands;
+using Api.BoundedContexts.KnowledgeBase.Application.Handlers;
+using Api.BoundedContexts.KnowledgeBase.Domain.Services;
+using Api.BoundedContexts.KnowledgeBase.Domain.ValueObjects;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using NSubstitute;
+
+namespace Api.Tests.Unit.BoundedContexts.KnowledgeBase.Application.Handlers;
+
+public class ParseAndRecordScoreCommandHandlerTests
+{
+    private readonly IStateParser _stateParser = Substitute.For<IStateParser>();
+    private readonly IPlayerNameResolutionService _playerResolver = Substitute.For<IPlayerNameResolutionService>();
+    private readonly IMediator _mediator = Substitute.For<IMediator>();
+    private readonly ILogger<ParseAndRecordScoreCommandHandler> _logger =
+        Substitute.For<ILogger<ParseAndRecordScoreCommandHandler>>();
+
+    private ParseAndRecordScoreCommandHandler CreateSut() =>
+        new(_stateParser, _playerResolver, _mediator, _logger);
+
+    [Fact]
+    public async Task Handle_ScoreChange_HighConfidence_AutoRecord_RecordsScore()
+    {
+        // Arrange
+        var sessionId = Guid.NewGuid();
+        var playerId = Guid.NewGuid();
+        var command = new ParseAndRecordScoreCommand
+        {
+            SessionId = sessionId,
+            Message = "Marco 5 punti agricoltura",
+            AutoRecord = true,
+        };
+
+        _stateParser.ParseAsync("Marco 5 punti agricoltura", null, Arg.Any<CancellationToken>())
+            .Returns(StateExtractionResult.Create(
+                StateChangeType.ScoreChange, "Marco",
+                new Dictionary<string, object> { ["score"] = 5, ["dimension"] = "agricoltura" },
+                0.95f, "Marco 5 punti agricoltura"));
+
+        // Mock session players lookup via mediator
+        _mediator.Send(Arg.Any<GetSessionPlayersQuery>(), Arg.Any<CancellationToken>())
+            .Returns(new Dictionary<Guid, string> { [playerId] = "Marco Rossi" });
+
+        _playerResolver.ResolvePlayer("Marco", Arg.Any<IReadOnlyDictionary<Guid, string>>())
+            .Returns(PlayerResolutionResult.Resolved(playerId, "Marco Rossi"));
+
+        var sut = CreateSut();
+
+        // Act
+        var result = await sut.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.Equal("recorded", result.Status);
+        Assert.Equal(playerId, result.PlayerId);
+        Assert.Equal("agricoltura", result.Dimension);
+        Assert.Equal(5, result.Value);
+
+        await _mediator.Received(1).Send(
+            Arg.Is<RecordLiveSessionScoreCommand>(c =>
+                c.SessionId == sessionId &&
+                c.PlayerId == playerId &&
+                c.Dimension == "agricoltura" &&
+                c.Value == 5),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_ScoreChange_LowConfidence_ReturnsParsedNotRecorded()
+    {
+        var command = new ParseAndRecordScoreCommand
+        {
+            SessionId = Guid.NewGuid(),
+            Message = "forse Marco ha fatto dei punti",
+            AutoRecord = true,
+        };
+
+        _stateParser.ParseAsync(command.Message, null, Arg.Any<CancellationToken>())
+            .Returns(StateExtractionResult.Create(
+                StateChangeType.ScoreChange, "Marco",
+                new Dictionary<string, object> { ["score"] = 0 },
+                0.4f, command.Message));
+
+        var sut = CreateSut();
+        var result = await sut.Handle(command, CancellationToken.None);
+
+        Assert.Equal("parsed", result.Status);
+        Assert.True(result.RequiresConfirmation);
+    }
+
+    [Fact]
+    public async Task Handle_NoScoreDetected_ReturnsUnrecognized()
+    {
+        var command = new ParseAndRecordScoreCommand
+        {
+            SessionId = Guid.NewGuid(),
+            Message = "che bella giornata",
+            AutoRecord = true,
+        };
+
+        _stateParser.ParseAsync(command.Message, null, Arg.Any<CancellationToken>())
+            .Returns(StateExtractionResult.NoChange(command.Message));
+
+        var sut = CreateSut();
+        var result = await sut.Handle(command, CancellationToken.None);
+
+        Assert.Equal("unrecognized", result.Status);
+    }
+}
+```
+
+- [ ] **Step 4: Run test — expect FAIL (handler not found)**
+
+```bash
+cd apps/api && dotnet test --filter "FullyQualifiedName~ParseAndRecordScoreCommandHandlerTests" --no-build 2>&1 | head -10
+```
+
+- [ ] **Step 5: Implement handler**
+
+```csharp
+// apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Handlers/ParseAndRecordScoreCommandHandler.cs
+using Api.BoundedContexts.GameManagement.Application.Commands.LiveSessions;
+using Api.BoundedContexts.GameManagement.Application.Services;
+using Api.BoundedContexts.KnowledgeBase.Application.Commands;
+using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
+using Api.BoundedContexts.KnowledgeBase.Domain.Services;
+using Api.BoundedContexts.KnowledgeBase.Domain.ValueObjects;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Handlers;
+
+internal sealed class ParseAndRecordScoreCommandHandler
+    : IRequestHandler<ParseAndRecordScoreCommand, ScoreParseResultDto>
+{
+    private const float AutoRecordThreshold = 0.8f;
+
+    private readonly IStateParser _stateParser;
+    private readonly IPlayerNameResolutionService _playerResolver;
+    private readonly IMediator _mediator;
+    private readonly ILogger<ParseAndRecordScoreCommandHandler> _logger;
+
+    public ParseAndRecordScoreCommandHandler(
+        IStateParser stateParser,
+        IPlayerNameResolutionService playerResolver,
+        IMediator mediator,
+        ILogger<ParseAndRecordScoreCommandHandler> logger)
+    {
+        _stateParser = stateParser;
+        _playerResolver = playerResolver;
+        _mediator = mediator;
+        _logger = logger;
+    }
+
+    public async Task<ScoreParseResultDto> Handle(
+        ParseAndRecordScoreCommand command, CancellationToken ct)
+    {
+        // 1. Parse natural language
+        var extraction = await _stateParser.ParseAsync(command.Message, null, ct);
+
+        if (!extraction.HasStateChanges || extraction.ChangeType != StateChangeType.ScoreChange)
+        {
+            return new ScoreParseResultDto
+            {
+                Status = "unrecognized",
+                Confidence = extraction.Confidence,
+                Message = "Nessun punteggio rilevato nel messaggio.",
+            };
+        }
+
+        // 2. Extract score data
+        var scoreValue = extraction.ExtractedState.TryGetValue("score", out var sv)
+            ? Convert.ToInt32(sv) : 0;
+        var dimension = extraction.ExtractedState.TryGetValue("dimension", out var dim)
+            ? dim.ToString() ?? "default" : "default";
+
+        // 3. Resolve player
+        var players = await _mediator.Send(
+            new GetSessionPlayersQuery(command.SessionId), ct);
+
+        var resolution = _playerResolver.ResolvePlayer(
+            extraction.PlayerName ?? "", players);
+
+        if (resolution.IsAmbiguous)
+        {
+            return new ScoreParseResultDto
+            {
+                Status = "ambiguous",
+                PlayerName = extraction.PlayerName,
+                Dimension = dimension,
+                Value = scoreValue,
+                Confidence = extraction.Confidence,
+                RequiresConfirmation = true,
+                Message = $"Più giocatori corrispondono a \"{extraction.PlayerName}\". Quale intendi?",
+                AmbiguousCandidates = resolution.Candidates.Select(c => c.Name).ToList(),
+            };
+        }
+
+        if (!resolution.IsResolved)
+        {
+            return new ScoreParseResultDto
+            {
+                Status = "parsed",
+                PlayerName = extraction.PlayerName,
+                Dimension = dimension,
+                Value = scoreValue,
+                Confidence = extraction.Confidence,
+                RequiresConfirmation = true,
+                Message = $"Giocatore \"{extraction.PlayerName}\" non trovato nella sessione.",
+            };
+        }
+
+        // 4. Auto-record or require confirmation
+        var shouldAutoRecord = command.AutoRecord && extraction.Confidence >= AutoRecordThreshold;
+
+        if (shouldAutoRecord)
+        {
+            var currentRound = await GetCurrentRound(command.SessionId, ct);
+            await _mediator.Send(new RecordLiveSessionScoreCommand(
+                command.SessionId,
+                resolution.PlayerId!.Value,
+                currentRound,
+                dimension,
+                scoreValue), ct);
+
+            _logger.LogInformation(
+                "Auto-recorded score: {Player} +{Value} {Dimension} (confidence: {Confidence:F2})",
+                resolution.ResolvedName, scoreValue, dimension, extraction.Confidence);
+
+            return new ScoreParseResultDto
+            {
+                Status = "recorded",
+                PlayerName = resolution.ResolvedName,
+                PlayerId = resolution.PlayerId,
+                Dimension = dimension,
+                Value = scoreValue,
+                Round = currentRound,
+                Confidence = extraction.Confidence,
+                Message = $"{resolution.ResolvedName}: +{scoreValue} {dimension} registrato.",
+            };
+        }
+
+        return new ScoreParseResultDto
+        {
+            Status = "parsed",
+            PlayerName = resolution.ResolvedName,
+            PlayerId = resolution.PlayerId,
+            Dimension = dimension,
+            Value = scoreValue,
+            Confidence = extraction.Confidence,
+            RequiresConfirmation = true,
+            Message = $"Confermi: {resolution.ResolvedName} +{scoreValue} {dimension}?",
+        };
+    }
+
+    private async Task<int> GetCurrentRound(Guid sessionId, CancellationToken ct)
+    {
+        try
+        {
+            var session = await _mediator.Send(
+                new GetLiveSessionQuery(sessionId), ct);
+            return session?.CurrentTurnIndex ?? 1;
+        }
+        catch
+        {
+            return 1;
+        }
+    }
+}
+```
+
+**Note:** `GetSessionPlayersQuery` and `GetLiveSessionQuery` — if these don't exist as exact queries, create thin wrappers that query the `ILiveSessionRepository`. Check existing queries in `GameManagement/Application/Queries/LiveSessions/` first.
+
+- [ ] **Step 6: Run tests — expect PASS**
+
+```bash
+cd apps/api && dotnet test --filter "FullyQualifiedName~ParseAndRecordScoreCommandHandlerTests" --verbosity normal
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/ParseAndRecordScoreCommand.cs \
+       apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Handlers/ParseAndRecordScoreCommandHandler.cs \
+       apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Validators/ParseAndRecordScoreCommandValidator.cs \
+       apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/DTOs/ScoreParseResultDto.cs \
+       apps/api/tests/Api.Tests/Unit/BoundedContexts/KnowledgeBase/Application/Handlers/ParseAndRecordScoreCommandHandlerTests.cs
+git commit -m "feat(kb): add ParseAndRecordScoreCommand — NLU bridge to LiveGameSession scoring"
+```
+
+---
+
+### Task A3: ConfirmScoreCommand
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/ConfirmScoreCommand.cs`
+- Create: `apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Handlers/ConfirmScoreCommandHandler.cs`
+- Create: `apps/api/tests/Api.Tests/Unit/BoundedContexts/KnowledgeBase/Application/Handlers/ConfirmScoreCommandHandlerTests.cs`
+
+**Purpose:** When `ParseAndRecordScore` returns `"parsed"` with `RequiresConfirmation = true`, the frontend shows a confirm button. This command takes the pre-parsed data and records it.
+
+- [ ] **Step 1: Write failing test**
+
+```csharp
+// apps/api/tests/Api.Tests/Unit/BoundedContexts/KnowledgeBase/Application/Handlers/ConfirmScoreCommandHandlerTests.cs
+namespace Api.Tests.Unit.BoundedContexts.KnowledgeBase.Application.Handlers;
+
+public class ConfirmScoreCommandHandlerTests
+{
+    private readonly IMediator _mediator = Substitute.For<IMediator>();
+
+    [Fact]
+    public async Task Handle_ValidConfirmation_RecordsScore()
+    {
+        var playerId = Guid.NewGuid();
+        var sessionId = Guid.NewGuid();
+        var command = new ConfirmScoreCommand
+        {
+            SessionId = sessionId,
+            PlayerId = playerId,
+            Dimension = "agricoltura",
+            Value = 5,
+            Round = 3,
+        };
+
+        var handler = new ConfirmScoreCommandHandler(_mediator);
+        await handler.Handle(command, CancellationToken.None);
+
+        await _mediator.Received(1).Send(
+            Arg.Is<RecordLiveSessionScoreCommand>(c =>
+                c.SessionId == sessionId &&
+                c.PlayerId == playerId &&
+                c.Dimension == "agricoltura" &&
+                c.Value == 5 &&
+                c.Round == 3),
+            Arg.Any<CancellationToken>());
+    }
+}
+```
+
+- [ ] **Step 2: Implement command + handler**
+
+```csharp
+// apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/ConfirmScoreCommand.cs
+namespace Api.BoundedContexts.KnowledgeBase.Application.Commands;
+
+public sealed record ConfirmScoreCommand : IRequest
+{
+    public required Guid SessionId { get; init; }
+    public required Guid PlayerId { get; init; }
+    public required string Dimension { get; init; }
+    public required int Value { get; init; }
+    public required int Round { get; init; }
+}
+```
+
+```csharp
+// apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Handlers/ConfirmScoreCommandHandler.cs
+namespace Api.BoundedContexts.KnowledgeBase.Application.Handlers;
+
+internal sealed class ConfirmScoreCommandHandler : IRequestHandler<ConfirmScoreCommand>
+{
+    private readonly IMediator _mediator;
+
+    public ConfirmScoreCommandHandler(IMediator mediator) => _mediator = mediator;
+
+    public async Task Handle(ConfirmScoreCommand command, CancellationToken ct)
+    {
+        await _mediator.Send(new RecordLiveSessionScoreCommand(
+            command.SessionId, command.PlayerId, command.Round,
+            command.Dimension, command.Value), ct);
+    }
+}
+```
+
+- [ ] **Step 3: Run tests — expect PASS**
+- [ ] **Step 4: Commit**
+
+```bash
+git commit -m "feat(kb): add ConfirmScoreCommand for user-confirmed score recording"
+```
+
+---
+
+### Task A4: Score Tracking HTTP Endpoints
+
+**Files:**
+- Modify: `apps/api/src/Api/Routing/LiveSessionEndpoints.cs` (or create new `ScoreTrackingEndpoints.cs`)
+
+**Purpose:** Expose `ParseAndRecordScore` and `ConfirmScore` as REST endpoints.
+
+- [ ] **Step 1: Add endpoints**
+
+Add to the live session routing group:
+
+```csharp
+// POST /api/v1/live-sessions/{sessionId}/scores/parse
+// Body: { "message": "Marco 5 punti agricoltura", "autoRecord": true }
+// Returns: ScoreParseResultDto
+group.MapPost("/{sessionId:guid}/scores/parse", HandleParseScore)
+    .RequireSession()
+    .RequireAuthorization()
+    .WithName("ParseScore")
+    .WithDescription("Parse natural language score input and optionally auto-record");
+
+// POST /api/v1/live-sessions/{sessionId}/scores/confirm
+// Body: { "playerId": "...", "dimension": "agricoltura", "value": 5, "round": 3 }
+group.MapPost("/{sessionId:guid}/scores/confirm", HandleConfirmScore)
+    .RequireSession()
+    .RequireAuthorization()
+    .WithName("ConfirmScore")
+    .WithDescription("Confirm and record a parsed score");
+```
+
+```csharp
+private static async Task<IResult> HandleParseScore(
+    Guid sessionId, ParseScoreRequest request, IMediator mediator, CancellationToken ct)
+{
+    var result = await mediator.Send(new ParseAndRecordScoreCommand
+    {
+        SessionId = sessionId,
+        Message = request.Message,
+        AutoRecord = request.AutoRecord,
+    }, ct);
+    return Results.Ok(result);
+}
+
+private sealed record ParseScoreRequest(string Message, bool AutoRecord = true);
+
+private static async Task<IResult> HandleConfirmScore(
+    Guid sessionId, ConfirmScoreRequest request, IMediator mediator, CancellationToken ct)
+{
+    await mediator.Send(new ConfirmScoreCommand
+    {
+        SessionId = sessionId,
+        PlayerId = request.PlayerId,
+        Dimension = request.Dimension,
+        Value = request.Value,
+        Round = request.Round,
+    }, ct);
+    return Results.NoContent();
+}
+
+private sealed record ConfirmScoreRequest(Guid PlayerId, string Dimension, int Value, int Round);
+```
+
+- [ ] **Step 2: Register DI for PlayerNameResolutionService**
+
+In `GameManagementServiceExtensions.cs`:
+```csharp
+services.AddScoped<IPlayerNameResolutionService, PlayerNameResolutionService>();
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git commit -m "feat(routing): add /scores/parse and /scores/confirm endpoints for AI score tracking"
+```
+
+---
+
+### Task A5: Frontend — ScoreAssistant Panel
+
+**Files:**
+- Create: `apps/web/src/components/session/ScoreAssistant.tsx`
+- Create: `apps/web/src/components/session/ScoreConfirmationCard.tsx`
+- Create: `apps/web/src/components/session/__tests__/ScoreAssistant.test.tsx`
+- Create: `apps/web/src/lib/api/clients/scoreTrackingClient.ts`
+- Modify: `apps/web/src/lib/api/index.ts` (register client)
+- Modify: `apps/web/src/app/(authenticated)/sessions/[id]/page.tsx` (add panel)
+
+**Purpose:** A voice/text input panel in the session view where users can say "Marco 5 punti" and see it parsed → confirmed → recorded.
+
+- [ ] **Step 1: Create API client**
+
+```typescript
+// apps/web/src/lib/api/clients/scoreTrackingClient.ts
+import { httpClient } from '../http-client';
+
+export interface ScoreParseResult {
+  status: 'parsed' | 'recorded' | 'ambiguous' | 'unrecognized';
+  playerName?: string;
+  playerId?: string;
+  dimension?: string;
+  value?: number;
+  round?: number;
+  confidence: number;
+  requiresConfirmation: boolean;
+  message?: string;
+  ambiguousCandidates: string[];
+}
+
+export function createScoreTrackingClient() {
+  return {
+    async parseScore(sessionId: string, message: string, autoRecord = true) {
+      return httpClient.post<ScoreParseResult>(
+        `/api/v1/live-sessions/${sessionId}/scores/parse`,
+        { message, autoRecord }
+      );
+    },
+
+    async confirmScore(sessionId: string, data: {
+      playerId: string; dimension: string; value: number; round: number;
+    }) {
+      return httpClient.post<void>(
+        `/api/v1/live-sessions/${sessionId}/scores/confirm`,
+        data
+      );
+    },
+  };
+}
+```
+
+- [ ] **Step 2: Register in API client factory**
+
+In `apps/web/src/lib/api/index.ts`, add `scoreTracking: createScoreTrackingClient()` to the `createApiClient()` factory.
+
+- [ ] **Step 3: Write failing test for ScoreAssistant**
+
+```typescript
+// apps/web/src/components/session/__tests__/ScoreAssistant.test.tsx
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+const mockParseScore = vi.fn();
+const mockConfirmScore = vi.fn();
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    scoreTracking: {
+      parseScore: (...args: unknown[]) => mockParseScore(...args),
+      confirmScore: (...args: unknown[]) => mockConfirmScore(...args),
+    },
+  },
+}));
+
+import { ScoreAssistant } from '../ScoreAssistant';
+
+describe('ScoreAssistant', () => {
+  const sessionId = 'session-123';
+
+  beforeEach(() => vi.clearAllMocks());
+
+  it('renders input field and mic button', () => {
+    render(<ScoreAssistant sessionId={sessionId} />);
+    expect(screen.getByPlaceholderText(/segna un punteggio/i)).toBeInTheDocument();
+  });
+
+  it('parses score on submit and shows confirmation', async () => {
+    const user = userEvent.setup();
+    mockParseScore.mockResolvedValue({
+      status: 'parsed',
+      playerName: 'Marco Rossi',
+      playerId: 'player-1',
+      dimension: 'agricoltura',
+      value: 5,
+      round: 3,
+      confidence: 0.75,
+      requiresConfirmation: true,
+      message: 'Confermi: Marco Rossi +5 agricoltura?',
+      ambiguousCandidates: [],
+    });
+
+    render(<ScoreAssistant sessionId={sessionId} />);
+    const input = screen.getByPlaceholderText(/segna un punteggio/i);
+    await user.type(input, 'Marco 5 punti agricoltura');
+    await user.keyboard('{Enter}');
+
+    await waitFor(() => {
+      expect(mockParseScore).toHaveBeenCalledWith(sessionId, 'Marco 5 punti agricoltura', true);
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/confermi/i)).toBeInTheDocument();
+      expect(screen.getByRole('button', { name: /conferma/i })).toBeInTheDocument();
+    });
+  });
+
+  it('shows recorded status when auto-recorded', async () => {
+    const user = userEvent.setup();
+    mockParseScore.mockResolvedValue({
+      status: 'recorded',
+      playerName: 'Marco Rossi',
+      dimension: 'agricoltura',
+      value: 5,
+      confidence: 0.95,
+      requiresConfirmation: false,
+      message: 'Marco Rossi: +5 agricoltura registrato.',
+      ambiguousCandidates: [],
+    });
+
+    render(<ScoreAssistant sessionId={sessionId} />);
+    await user.type(screen.getByPlaceholderText(/segna un punteggio/i), 'Marco 5 agricoltura');
+    await user.keyboard('{Enter}');
+
+    await waitFor(() => {
+      expect(screen.getByText(/registrato/i)).toBeInTheDocument();
+    });
+  });
+});
+```
+
+- [ ] **Step 4: Implement ScoreAssistant component**
+
+```tsx
+// apps/web/src/components/session/ScoreAssistant.tsx
+'use client';
+
+import { useCallback, useState } from 'react';
+import { Check, Loader2, Mic, Send, X } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/primitives/input';
+import { api } from '@/lib/api';
+import type { ScoreParseResult } from '@/lib/api/clients/scoreTrackingClient';
+
+interface ScoreAssistantProps {
+  sessionId: string;
+  onScoreRecorded?: () => void; // trigger scoreboard refresh
+}
+
+export function ScoreAssistant({ sessionId, onScoreRecorded }: ScoreAssistantProps) {
+  const [input, setInput] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [result, setResult] = useState<ScoreParseResult | null>(null);
+  const [confirming, setConfirming] = useState(false);
+
+  const handleSubmit = useCallback(async () => {
+    if (!input.trim() || loading) return;
+    setLoading(true);
+    setResult(null);
+    try {
+      const parsed = await api.scoreTracking.parseScore(sessionId, input.trim(), true);
+      setResult(parsed);
+      if (parsed.status === 'recorded') {
+        setInput('');
+        onScoreRecorded?.();
+        // Auto-dismiss after 3s
+        setTimeout(() => setResult(null), 3000);
+      }
+    } catch {
+      setResult({
+        status: 'unrecognized',
+        confidence: 0,
+        requiresConfirmation: false,
+        message: 'Errore di connessione. Riprova.',
+        ambiguousCandidates: [],
+      });
+    } finally {
+      setLoading(false);
+    }
+  }, [input, loading, sessionId, onScoreRecorded]);
+
+  const handleConfirm = useCallback(async () => {
+    if (!result?.playerId || !result.dimension || result.value == null || result.round == null)
+      return;
+    setConfirming(true);
+    try {
+      await api.scoreTracking.confirmScore(sessionId, {
+        playerId: result.playerId,
+        dimension: result.dimension,
+        value: result.value,
+        round: result.round,
+      });
+      setResult({ ...result, status: 'recorded', message: `${result.playerName}: +${result.value} ${result.dimension} registrato.` });
+      setInput('');
+      onScoreRecorded?.();
+      setTimeout(() => setResult(null), 3000);
+    } catch {
+      setResult({ ...result, message: 'Errore nel salvataggio. Riprova.' });
+    } finally {
+      setConfirming(false);
+    }
+  }, [result, sessionId, onScoreRecorded]);
+
+  const handleDismiss = useCallback(() => {
+    setResult(null);
+    setInput('');
+  }, []);
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter') handleSubmit();
+    },
+    [handleSubmit]
+  );
+
+  return (
+    <div className="space-y-2">
+      {/* Input row */}
+      <div className="flex items-center gap-2">
+        <div className="relative flex-1">
+          <Input
+            value={input}
+            onChange={e => setInput(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder='Segna un punteggio... (es. "Marco 5 agricoltura")'
+            disabled={loading}
+            className="pr-10"
+          />
+        </div>
+        <Button
+          size="icon"
+          variant="ghost"
+          onClick={handleSubmit}
+          disabled={!input.trim() || loading}
+          aria-label="Invia punteggio"
+        >
+          {loading ? <Loader2 className="h-4 w-4 animate-spin" /> : <Send className="h-4 w-4" />}
+        </Button>
+      </div>
+
+      {/* Result card */}
+      {result && (
+        <div
+          className={`rounded-lg border p-3 text-sm ${
+            result.status === 'recorded'
+              ? 'border-green-500/30 bg-green-500/10 text-green-300'
+              : result.status === 'unrecognized'
+                ? 'border-red-500/30 bg-red-500/10 text-red-300'
+                : 'border-amber-500/30 bg-amber-500/10 text-amber-200'
+          }`}
+        >
+          <div className="flex items-start justify-between gap-2">
+            <p>{result.message}</p>
+            <Button
+              size="icon"
+              variant="ghost"
+              className="h-5 w-5 shrink-0"
+              onClick={handleDismiss}
+              aria-label="Chiudi"
+            >
+              <X className="h-3 w-3" />
+            </Button>
+          </div>
+
+          {result.requiresConfirmation && result.status === 'parsed' && result.playerId && (
+            <div className="mt-2 flex gap-2">
+              <Button
+                size="sm"
+                onClick={handleConfirm}
+                disabled={confirming}
+                aria-label="Conferma punteggio"
+              >
+                {confirming ? <Loader2 className="h-3 w-3 animate-spin mr-1" /> : <Check className="h-3 w-3 mr-1" />}
+                Conferma
+              </Button>
+              <Button size="sm" variant="ghost" onClick={handleDismiss}>
+                Annulla
+              </Button>
+            </div>
+          )}
+
+          {result.status === 'ambiguous' && result.ambiguousCandidates.length > 0 && (
+            <p className="mt-1 text-xs">
+              Possibili: {result.ambiguousCandidates.join(', ')}
+            </p>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 5: Integrate into session page**
+
+In `apps/web/src/app/(authenticated)/sessions/[id]/page.tsx`, add `<ScoreAssistant>` below the scoreboard:
+
+```tsx
+import { ScoreAssistant } from '@/components/session/ScoreAssistant';
+
+// Inside the component, after <Scoreboard />:
+<div className="mt-4">
+  <ScoreAssistant
+    sessionId={params.id}
+    onScoreRecorded={() => queryClient.invalidateQueries({ queryKey: ['session-scores', params.id] })}
+  />
+</div>
+```
+
+- [ ] **Step 6: Run tests — expect PASS**
+
+```bash
+cd apps/web && pnpm vitest run src/components/session/__tests__/ScoreAssistant.test.tsx --reporter=verbose
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git commit -m "feat(session): add ScoreAssistant panel with NLU score parsing and confirmation"
+```
+
+---
+
+## Phase 2: Enhanced Save/Resume
+
+### What exists (DO NOT rebuild)
+
+| Component | Path |
+|---|---|
+| `PauseSessionDialog` | `components/session/PauseSessionDialog.tsx` — has photo upload + "Skip & Pause" |
+| `ResumePhotoReview` | `components/session/ResumePhotoReview.tsx` — full-screen photo review |
+| `SessionSnapshot` | `GameManagement/Domain/Entities/SessionSnapshot/` — delta-based snapshots |
+| `PauseLiveSessionCommand` | `GameManagement/Application/Commands/LiveSessions/PauseLiveSessionCommand.cs` |
+| `SaveLiveSessionCommand` | `GameManagement/Application/Commands/LiveSessions/SaveLiveSessionCommand.cs` |
+| `CreateSnapshotCommand` | `GameManagement/Application/Commands/SessionSnapshot/SessionSnapshotCommands.cs` |
+| `UpdateAgentSessionStateCommand` | `KnowledgeBase/Application/Commands/UpdateAgentSessionStateCommand.cs` |
+
+### Task B1: SaveCompleteSessionStateCommand (Backend Saga)
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/LiveSessions/SaveCompleteSessionStateCommand.cs`
+- Create: `apps/api/src/Api/BoundedContexts/GameManagement/Application/Handlers/LiveSessions/SaveCompleteSessionStateCommandHandler.cs`
+- Create: `apps/api/src/Api/BoundedContexts/GameManagement/Application/DTOs/SessionSaveResultDto.cs`
+- Create: `apps/api/tests/Api.Tests/Unit/BoundedContexts/GameManagement/Application/Handlers/LiveSessions/SaveCompleteSessionStateCommandHandlerTests.cs`
+
+**Purpose:** One command that orchestrates: pause session + create snapshot + persist agent state + generate text recap.
+
+- [ ] **Step 1: Create DTOs**
+
+```csharp
+// apps/api/src/Api/BoundedContexts/GameManagement/Application/DTOs/SessionSaveResultDto.cs
+namespace Api.BoundedContexts.GameManagement.Application.DTOs;
+
+public sealed record SessionSaveResultDto
+{
+    public required Guid SessionId { get; init; }
+    public required int SnapshotIndex { get; init; }
+    public required string Recap { get; init; }  // Human-readable recap text
+    public required int PhotoCount { get; init; }
+    public required DateTime SavedAt { get; init; }
+}
+```
+
+- [ ] **Step 2: Write failing test**
+
+```csharp
+namespace Api.Tests.Unit.BoundedContexts.GameManagement.Application.Handlers.LiveSessions;
+
+public class SaveCompleteSessionStateCommandHandlerTests
+{
+    private readonly IMediator _mediator = Substitute.For<IMediator>();
+    private readonly ILiveSessionRepository _sessionRepo = Substitute.For<ILiveSessionRepository>();
+    private readonly ILogger<SaveCompleteSessionStateCommandHandler> _logger =
+        Substitute.For<ILogger<SaveCompleteSessionStateCommandHandler>>();
+
+    [Fact]
+    public async Task Handle_ActiveSession_PausesAndCreatesSnapshot()
+    {
+        var sessionId = Guid.NewGuid();
+        var session = CreateTestSession(sessionId, LiveSessionStatus.InProgress);
+
+        _sessionRepo.GetByIdAsync(sessionId, Arg.Any<CancellationToken>())
+            .Returns(session);
+
+        _mediator.Send(Arg.Any<CreateSnapshotCommand>(), Arg.Any<CancellationToken>())
+            .Returns(new SessionSnapshotDto { SnapshotIndex = 5 });
+
+        var handler = new SaveCompleteSessionStateCommandHandler(
+            _mediator, _sessionRepo, _logger);
+
+        var result = await handler.Handle(
+            new SaveCompleteSessionStateCommand(sessionId), CancellationToken.None);
+
+        Assert.Equal(sessionId, result.SessionId);
+        Assert.Equal(5, result.SnapshotIndex);
+        Assert.NotEmpty(result.Recap);
+
+        // Verify pause was called
+        await _mediator.Received(1).Send(
+            Arg.Is<PauseLiveSessionCommand>(c => c.SessionId == sessionId),
+            Arg.Any<CancellationToken>());
+
+        // Verify snapshot was created
+        await _mediator.Received(1).Send(
+            Arg.Is<CreateSnapshotCommand>(c => c.SessionId == sessionId),
+            Arg.Any<CancellationToken>());
+    }
+
+    [Fact]
+    public async Task Handle_AlreadyPausedSession_SkipsPauseCreatesSnapshot()
+    {
+        var sessionId = Guid.NewGuid();
+        var session = CreateTestSession(sessionId, LiveSessionStatus.Paused);
+
+        _sessionRepo.GetByIdAsync(sessionId, Arg.Any<CancellationToken>())
+            .Returns(session);
+
+        _mediator.Send(Arg.Any<CreateSnapshotCommand>(), Arg.Any<CancellationToken>())
+            .Returns(new SessionSnapshotDto { SnapshotIndex = 3 });
+
+        var handler = new SaveCompleteSessionStateCommandHandler(
+            _mediator, _sessionRepo, _logger);
+
+        var result = await handler.Handle(
+            new SaveCompleteSessionStateCommand(sessionId), CancellationToken.None);
+
+        // Should NOT call pause (already paused)
+        await _mediator.DidNotReceive().Send(
+            Arg.Any<PauseLiveSessionCommand>(), Arg.Any<CancellationToken>());
+
+        // Should still create snapshot
+        await _mediator.Received(1).Send(
+            Arg.Any<CreateSnapshotCommand>(), Arg.Any<CancellationToken>());
+    }
+}
+```
+
+- [ ] **Step 3: Implement command + handler**
+
+```csharp
+// apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/LiveSessions/SaveCompleteSessionStateCommand.cs
+namespace Api.BoundedContexts.GameManagement.Application.Commands.LiveSessions;
+
+public sealed record SaveCompleteSessionStateCommand(Guid SessionId) : IRequest<SessionSaveResultDto>;
+```
+
+```csharp
+// apps/api/src/Api/BoundedContexts/GameManagement/Application/Handlers/LiveSessions/SaveCompleteSessionStateCommandHandler.cs
+namespace Api.BoundedContexts.GameManagement.Application.Handlers.LiveSessions;
+
+internal sealed class SaveCompleteSessionStateCommandHandler
+    : IRequestHandler<SaveCompleteSessionStateCommand, SessionSaveResultDto>
+{
+    private readonly IMediator _mediator;
+    private readonly ILiveSessionRepository _sessionRepo;
+    private readonly ILogger<SaveCompleteSessionStateCommandHandler> _logger;
+
+    public SaveCompleteSessionStateCommandHandler(
+        IMediator mediator,
+        ILiveSessionRepository sessionRepo,
+        ILogger<SaveCompleteSessionStateCommandHandler> logger)
+    {
+        _mediator = mediator;
+        _sessionRepo = sessionRepo;
+        _logger = logger;
+    }
+
+    public async Task<SessionSaveResultDto> Handle(
+        SaveCompleteSessionStateCommand command, CancellationToken ct)
+    {
+        var session = await _sessionRepo.GetByIdAsync(command.SessionId, ct)
+            ?? throw new NotFoundException($"Session {command.SessionId} not found");
+
+        // 1. Pause if active
+        if (session.Status == LiveSessionStatus.InProgress)
+        {
+            await _mediator.Send(new PauseLiveSessionCommand(command.SessionId), ct);
+        }
+
+        // 2. Save session state
+        await _mediator.Send(new SaveLiveSessionCommand(command.SessionId), ct);
+
+        // 3. Create snapshot
+        var snapshot = await _mediator.Send(
+            new CreateSnapshotCommand(command.SessionId, SnapshotTrigger.ManualSave,
+                $"Salvataggio completo — turno {session.CurrentTurnIndex}"), ct);
+
+        // 4. Persist agent state (if agent session exists)
+        if (session.ChatSessionId.HasValue)
+        {
+            try
+            {
+                await _mediator.Send(
+                    new SaveAgentSessionStateCommand(session.ChatSessionId.Value), ct);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to persist agent state for session {SessionId}", command.SessionId);
+            }
+        }
+
+        // 5. Count photos for this snapshot
+        var photoCount = await _mediator.Send(
+            new GetSnapshotPhotoCountQuery(command.SessionId, snapshot.SnapshotIndex), ct);
+
+        // 6. Generate recap text
+        var recap = GenerateRecap(session, snapshot.SnapshotIndex, photoCount);
+
+        return new SessionSaveResultDto
+        {
+            SessionId = command.SessionId,
+            SnapshotIndex = snapshot.SnapshotIndex,
+            Recap = recap,
+            PhotoCount = photoCount,
+            SavedAt = DateTime.UtcNow,
+        };
+    }
+
+    private static string GenerateRecap(LiveGameSession session, int snapshotIndex, int photoCount)
+    {
+        var players = session.Players;
+        var scores = session.RoundScores;
+
+        var sb = new System.Text.StringBuilder();
+        sb.AppendLine($"Partita salvata al turno {session.CurrentTurnIndex}.");
+
+        if (players.Count > 0)
+        {
+            sb.AppendLine($"Giocatori: {string.Join(", ", players.Select(p => p.Name))}.");
+        }
+
+        // Top scores summary
+        var playerTotals = scores
+            .GroupBy(s => s.PlayerId)
+            .Select(g => new { PlayerId = g.Key, Total = g.Sum(s => s.Value) })
+            .OrderByDescending(x => x.Total)
+            .ToList();
+
+        if (playerTotals.Count > 0)
+        {
+            var topPlayer = players.FirstOrDefault(p => p.Id == playerTotals[0].PlayerId);
+            sb.AppendLine($"In testa: {topPlayer?.Name ?? "?"} con {playerTotals[0].Total} punti.");
+        }
+
+        if (photoCount > 0)
+            sb.AppendLine($"{photoCount} foto salvate.");
+
+        sb.AppendLine($"Snapshot #{snapshotIndex} creato.");
+
+        return sb.ToString();
+    }
+}
+```
+
+**Note:** `SaveAgentSessionStateCommand` and `GetSnapshotPhotoCountQuery` may need to be created as thin wrappers. Check existing commands first. If `SaveAgentSessionStateCommand` doesn't exist, create it as a command that calls `agentSession.UpdateGameState()` with the current session state.
+
+- [ ] **Step 4: Run tests — expect PASS**
+- [ ] **Step 5: Add HTTP endpoint**
+
+In `LiveSessionEndpoints.cs`:
+```csharp
+group.MapPost("/{sessionId:guid}/save-complete", HandleSaveComplete)
+    .RequireSession()
+    .RequireAuthorization()
+    .WithName("SaveCompleteSessionState");
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git commit -m "feat(game-mgmt): add SaveCompleteSessionStateCommand — orchestrates pause+snapshot+agent persist"
+```
+
+---
+
+### Task B2: GetSessionResumeContextQuery
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/LiveSessions/GetSessionResumeContextQuery.cs`
+- Create: `apps/api/src/Api/BoundedContexts/GameManagement/Application/DTOs/SessionResumeContextDto.cs`
+
+**Purpose:** Returns everything needed to resume: last snapshot, photos, scores, agent recap text.
+
+- [ ] **Step 1: Create DTOs and query**
+
+```csharp
+// apps/api/src/Api/BoundedContexts/GameManagement/Application/DTOs/SessionResumeContextDto.cs
+namespace Api.BoundedContexts.GameManagement.Application.DTOs;
+
+public sealed record SessionResumeContextDto
+{
+    public required Guid SessionId { get; init; }
+    public required string GameTitle { get; init; }
+    public required int LastSnapshotIndex { get; init; }
+    public required int CurrentTurn { get; init; }
+    public required string? CurrentPhase { get; init; }
+    public required DateTime PausedAt { get; init; }
+    public required string Recap { get; init; }
+    public required IReadOnlyList<PlayerScoreSummary> PlayerScores { get; init; }
+    public required IReadOnlyList<SessionPhotoSummary> Photos { get; init; }
+}
+
+public sealed record PlayerScoreSummary(Guid PlayerId, string Name, int TotalScore, int Rank);
+public sealed record SessionPhotoSummary(Guid AttachmentId, string? ThumbnailUrl, string? Caption, string AttachmentType);
+```
+
+```csharp
+// apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/LiveSessions/GetSessionResumeContextQuery.cs
+namespace Api.BoundedContexts.GameManagement.Application.Queries.LiveSessions;
+
+public sealed record GetSessionResumeContextQuery(Guid SessionId) : IRequest<SessionResumeContextDto>;
+```
+
+- [ ] **Step 2: Implement handler** (loads session, scores, last snapshot photos, builds recap)
+
+- [ ] **Step 3: Add endpoint**
+
+```csharp
+group.MapGet("/{sessionId:guid}/resume-context", HandleGetResumeContext)
+    .RequireSession()
+    .RequireAuthorization()
+    .WithName("GetSessionResumeContext");
+```
+
+- [ ] **Step 4: Test + Commit**
+
+```bash
+git commit -m "feat(game-mgmt): add GetSessionResumeContextQuery for enhanced resume experience"
+```
+
+---
+
+### Task B3: Frontend Enhanced Pause/Resume
+
+**Files:**
+- Modify: `apps/web/src/components/session/PauseSessionDialog.tsx`
+- Create: `apps/web/src/components/session/SaveCompleteDialog.tsx`
+- Modify: `apps/web/src/components/session/ResumePhotoReview.tsx`
+- Create: `apps/web/src/components/session/ResumeSessionPanel.tsx`
+- Create: `apps/web/src/components/session/__tests__/SaveCompleteDialog.test.tsx`
+- Create: `apps/web/src/components/session/__tests__/ResumeSessionPanel.test.tsx`
+
+**Purpose:** Replace basic pause dialog with "Salva Stato Completo" flow. Add resume panel with recap + photos.
+
+- [ ] **Step 1: Write failing test for SaveCompleteDialog**
+
+```typescript
+// apps/web/src/components/session/__tests__/SaveCompleteDialog.test.tsx
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi, describe, it, expect } from 'vitest';
+
+const mockSaveComplete = vi.fn();
+vi.mock('@/lib/api', () => ({
+  api: { liveSessions: { saveComplete: (...args: unknown[]) => mockSaveComplete(...args) } },
+}));
+
+import { SaveCompleteDialog } from '../SaveCompleteDialog';
+
+describe('SaveCompleteDialog', () => {
+  it('shows save steps and progress', async () => {
+    const user = userEvent.setup();
+    mockSaveComplete.mockResolvedValue({
+      sessionId: 'sess-1',
+      snapshotIndex: 5,
+      recap: 'Partita salvata al turno 5. In testa: Marco con 45 punti.',
+      photoCount: 2,
+      savedAt: new Date().toISOString(),
+    });
+
+    render(
+      <SaveCompleteDialog
+        open={true}
+        onOpenChange={vi.fn()}
+        sessionId="sess-1"
+        onSaveComplete={vi.fn()}
+      />
+    );
+
+    expect(screen.getByText(/salva stato completo/i)).toBeInTheDocument();
+
+    const saveBtn = screen.getByRole('button', { name: /salva tutto/i });
+    await user.click(saveBtn);
+
+    await waitFor(() => {
+      expect(screen.getByText(/partita salvata/i)).toBeInTheDocument();
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Implement SaveCompleteDialog**
+
+```tsx
+// apps/web/src/components/session/SaveCompleteDialog.tsx
+'use client';
+
+import { useCallback, useState } from 'react';
+import { Camera, Check, Loader2, Save } from 'lucide-react';
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/overlays/alert-dialog-primitives';
+import { Button } from '@/components/ui/button';
+import { api } from '@/lib/api';
+import { PhotoUploadModal } from './PhotoUploadModal';
+
+interface SaveCompleteDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  sessionId: string;
+  playerId?: string;
+  snapshotIndex?: number;
+  onSaveComplete: () => void;
+}
+
+type SavePhase = 'confirm' | 'photos' | 'saving' | 'done';
+
+export function SaveCompleteDialog({
+  open, onOpenChange, sessionId, playerId, snapshotIndex, onSaveComplete,
+}: SaveCompleteDialogProps) {
+  const [phase, setPhase] = useState<SavePhase>('confirm');
+  const [recap, setRecap] = useState('');
+  const [photoModalOpen, setPhotoModalOpen] = useState(false);
+
+  const handleSave = useCallback(async () => {
+    setPhase('saving');
+    try {
+      const result = await api.liveSessions.saveComplete(sessionId);
+      setRecap(result.recap);
+      setPhase('done');
+    } catch {
+      setPhase('confirm');
+    }
+  }, [sessionId]);
+
+  const handleClose = useCallback(() => {
+    onOpenChange(false);
+    if (phase === 'done') onSaveComplete();
+    setPhase('confirm');
+    setRecap('');
+  }, [onOpenChange, onSaveComplete, phase]);
+
+  return (
+    <>
+      <AlertDialog open={open} onOpenChange={onOpenChange}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle className="flex items-center gap-2">
+              <Save className="h-5 w-5" />
+              Salva Stato Completo
+            </AlertDialogTitle>
+            <AlertDialogDescription>
+              {phase === 'confirm' && 'Vuoi salvare lo stato della partita? Potrai riprendere in un secondo momento.'}
+              {phase === 'saving' && 'Salvataggio in corso...'}
+              {phase === 'done' && recap}
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+
+          {phase === 'confirm' && (
+            <div className="space-y-3 py-2">
+              <p className="text-sm text-muted-foreground">Il salvataggio include:</p>
+              <ul className="text-sm space-y-1 ml-4 list-disc text-muted-foreground">
+                <li>Punteggi e stato del turno</li>
+                <li>Memoria dell&apos;agente AI</li>
+                <li>Foto del tavolo (opzionale)</li>
+              </ul>
+            </div>
+          )}
+
+          {phase === 'saving' && (
+            <div className="flex items-center justify-center py-6">
+              <Loader2 className="h-8 w-8 animate-spin text-amber-500" />
+            </div>
+          )}
+
+          {phase === 'done' && (
+            <div className="rounded-lg border border-green-500/30 bg-green-500/10 p-3 text-sm text-green-300">
+              <Check className="inline h-4 w-4 mr-1" />
+              {recap}
+            </div>
+          )}
+
+          <AlertDialogFooter>
+            {phase === 'confirm' && (
+              <>
+                <Button variant="outline" onClick={() => setPhotoModalOpen(true)}>
+                  <Camera className="h-4 w-4 mr-2" /> Scatta Foto Prima
+                </Button>
+                <Button onClick={handleSave} aria-label="Salva tutto">
+                  <Save className="h-4 w-4 mr-2" /> Salva Tutto
+                </Button>
+              </>
+            )}
+            {phase === 'done' && (
+              <Button onClick={handleClose}>Chiudi</Button>
+            )}
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+
+      <PhotoUploadModal
+        open={photoModalOpen}
+        onOpenChange={setPhotoModalOpen}
+        sessionId={sessionId}
+        playerId={playerId}
+        snapshotIndex={snapshotIndex}
+        onUploadComplete={() => setPhotoModalOpen(false)}
+      />
+    </>
+  );
+}
+```
+
+- [ ] **Step 3: Replace PauseSessionDialog usage with SaveCompleteDialog**
+
+In `LiveSessionView.tsx` and `sessions/[id]/page.tsx`, replace `PauseSessionDialog` with `SaveCompleteDialog` when pausing.
+
+- [ ] **Step 4: Create ResumeSessionPanel**
+
+```tsx
+// apps/web/src/components/session/ResumeSessionPanel.tsx
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { Camera, Clock, Play, Trophy, Users } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { api } from '@/lib/api';
+import { formatDistanceToNow } from 'date-fns';
+import { it } from 'date-fns/locale';
+
+interface ResumeSessionPanelProps {
+  sessionId: string;
+  onResume: () => void;
+}
+
+export function ResumeSessionPanel({ sessionId, onResume }: ResumeSessionPanelProps) {
+  const { data: context, isLoading } = useQuery({
+    queryKey: ['session-resume-context', sessionId],
+    queryFn: () => api.liveSessions.getResumeContext(sessionId),
+  });
+
+  if (isLoading || !context) return null;
+
+  return (
+    <div className="rounded-xl border border-amber-500/30 bg-amber-500/5 p-6 space-y-4">
+      <div className="flex items-center justify-between">
+        <h3 className="font-quicksand font-bold text-lg">{context.gameTitle}</h3>
+        <span className="text-xs text-muted-foreground flex items-center gap-1">
+          <Clock className="h-3 w-3" />
+          {formatDistanceToNow(new Date(context.pausedAt), { addSuffix: true, locale: it })}
+        </span>
+      </div>
+
+      <p className="text-sm text-muted-foreground">{context.recap}</p>
+
+      {/* Score summary */}
+      {context.playerScores.length > 0 && (
+        <div className="flex items-center gap-2 flex-wrap">
+          <Users className="h-4 w-4 text-muted-foreground" />
+          {context.playerScores.map(p => (
+            <span
+              key={p.playerId}
+              className={`text-sm px-2 py-0.5 rounded-full ${
+                p.rank === 1
+                  ? 'bg-amber-500/20 text-amber-300 font-medium'
+                  : 'bg-slate-700/50 text-slate-300'
+              }`}
+            >
+              {p.rank === 1 && <Trophy className="inline h-3 w-3 mr-1" />}
+              {p.name}: {p.totalScore}
+            </span>
+          ))}
+        </div>
+      )}
+
+      {/* Photo thumbnails */}
+      {context.photos.length > 0 && (
+        <div className="flex items-center gap-2">
+          <Camera className="h-4 w-4 text-muted-foreground" />
+          <div className="flex gap-1">
+            {context.photos.slice(0, 4).map(photo => (
+              <div
+                key={photo.attachmentId}
+                className="h-10 w-10 rounded bg-slate-700 overflow-hidden"
+              >
+                {photo.thumbnailUrl && (
+                  <img
+                    src={photo.thumbnailUrl}
+                    alt={photo.caption ?? 'Foto sessione'}
+                    className="h-full w-full object-cover"
+                  />
+                )}
+              </div>
+            ))}
+            {context.photos.length > 4 && (
+              <span className="text-xs text-muted-foreground self-center">
+                +{context.photos.length - 4}
+              </span>
+            )}
+          </div>
+        </div>
+      )}
+
+      <Button onClick={onResume} className="w-full">
+        <Play className="h-4 w-4 mr-2" /> Riprendi Partita (turno {context.currentTurn})
+      </Button>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 5: Add ResumeSessionPanel to sessions list page**
+
+In `apps/web/src/app/(authenticated)/sessions/page.tsx`, show `ResumeSessionPanel` for paused sessions at the top of the page, above the active/history tabs.
+
+- [ ] **Step 6: Run tests — expect PASS**
+- [ ] **Step 7: Commit**
+
+```bash
+git commit -m "feat(session): enhanced save/resume — SaveCompleteDialog + ResumeSessionPanel with recap and photos"
+```
+
+---
+
+## Phase 3: Game Night Quick Start Wizard
+
+### Task C1: GameNightWizard Component
+
+**Files:**
+- Create: `apps/web/src/components/game-night/GameNightWizard.tsx`
+- Create: `apps/web/src/components/game-night/steps/SearchGameStep.tsx`
+- Create: `apps/web/src/components/game-night/steps/UploadRulesStep.tsx`
+- Create: `apps/web/src/components/game-night/steps/CreateSessionStep.tsx`
+- Create: `apps/web/src/components/game-night/__tests__/GameNightWizard.test.tsx`
+- Modify: `apps/web/src/app/(authenticated)/sessions/new/page.tsx` (add "Quick Start" option)
+
+**Purpose:** A streamlined 3-step wizard: (1) Find game (catalog → BGG fallback) → (2) Upload PDF + disclaimer → (3) Create session with players. All in one drawer.
+
+**Key principle:** Reuse existing components — `GameSourceStep` pattern for search, `CopyrightDisclaimerModal` for disclaimer, `PdfUploadStep` pattern for upload.
+
+- [ ] **Step 1: Write test**
+
+```typescript
+// apps/web/src/components/game-night/__tests__/GameNightWizard.test.tsx
+import { render, screen } from '@testing-library/react';
+import { vi, describe, it, expect } from 'vitest';
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    sharedGames: { search: vi.fn().mockResolvedValue({ items: [], totalCount: 0 }) },
+    bgg: { search: vi.fn(), getGameDetails: vi.fn() },
+    library: { addPrivateGame: vi.fn() },
+    liveSessions: { create: vi.fn() },
+  },
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+import { GameNightWizard } from '../GameNightWizard';
+
+describe('GameNightWizard', () => {
+  it('renders step 1: find game', () => {
+    render(<GameNightWizard onComplete={vi.fn()} />);
+    expect(screen.getByText(/trova il gioco/i)).toBeInTheDocument();
+    expect(screen.getByText(/1.*3/)).toBeInTheDocument(); // Step 1 of 3
+  });
+});
+```
+
+- [ ] **Step 2: Implement GameNightWizard**
+
+The wizard has 3 steps:
+1. **SearchGameStep**: Catalog search with auto BGG fallback (reuses `GameSourceStep` search logic). Returns `{ gameId, gameTitle, isFromBgg }`.
+2. **UploadRulesStep**: Shows `CopyrightDisclaimerModal` → then `PdfUploadStep` → then `PdfProcessingStatus`. Has "Salta" (skip) to proceed without PDF. Returns `{ pdfId? }`.
+3. **CreateSessionStep**: Player name inputs (2-8 players), scoring dimensions from game metadata. Returns `{ sessionId }`.
+
+On completion: redirects to `/sessions/{sessionId}` — the agent is ready (or shows degraded mode banner if PDF is still processing).
+
+```tsx
+// apps/web/src/components/game-night/GameNightWizard.tsx
+'use client';
+
+import { useCallback, useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { SearchGameStep } from './steps/SearchGameStep';
+import { UploadRulesStep } from './steps/UploadRulesStep';
+import { CreateSessionStep } from './steps/CreateSessionStep';
+
+type WizardStep = 'search' | 'upload' | 'session';
+
+interface GameNightWizardProps {
+  onComplete: (sessionId: string) => void;
+}
+
+interface WizardState {
+  gameId?: string;
+  gameTitle?: string;
+  privateGameId?: string;
+  pdfId?: string;
+}
+
+export function GameNightWizard({ onComplete }: GameNightWizardProps) {
+  const [step, setStep] = useState<WizardStep>('search');
+  const [state, setState] = useState<WizardState>({});
+  const router = useRouter();
+
+  const stepIndex = step === 'search' ? 1 : step === 'upload' ? 2 : 3;
+
+  const handleGameFound = useCallback((data: {
+    gameId?: string; privateGameId?: string; gameTitle: string;
+  }) => {
+    setState(prev => ({ ...prev, ...data }));
+    setStep('upload');
+  }, []);
+
+  const handleUploadComplete = useCallback((pdfId?: string) => {
+    setState(prev => ({ ...prev, pdfId }));
+    setStep('session');
+  }, []);
+
+  const handleSessionCreated = useCallback((sessionId: string) => {
+    onComplete(sessionId);
+    router.push(`/sessions/${sessionId}`);
+  }, [onComplete, router]);
+
+  return (
+    <div className="space-y-6">
+      {/* Progress indicator */}
+      <div className="flex items-center justify-center gap-2 text-sm text-muted-foreground">
+        <span className={stepIndex >= 1 ? 'text-amber-400 font-medium' : ''}>1. Trova il gioco</span>
+        <span className="text-slate-600">→</span>
+        <span className={stepIndex >= 2 ? 'text-amber-400 font-medium' : ''}>2. Regolamento</span>
+        <span className="text-slate-600">→</span>
+        <span className={stepIndex >= 3 ? 'text-amber-400 font-medium' : ''}>3. Giocatori</span>
+      </div>
+
+      {step === 'search' && (
+        <SearchGameStep onGameFound={handleGameFound} />
+      )}
+
+      {step === 'upload' && (
+        <UploadRulesStep
+          gameId={state.gameId}
+          privateGameId={state.privateGameId}
+          gameTitle={state.gameTitle ?? ''}
+          onComplete={handleUploadComplete}
+          onSkip={() => handleUploadComplete()}
+        />
+      )}
+
+      {step === 'session' && (
+        <CreateSessionStep
+          gameId={state.gameId ?? state.privateGameId ?? ''}
+          gameTitle={state.gameTitle ?? ''}
+          onSessionCreated={handleSessionCreated}
+        />
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Implement SearchGameStep** (reuses `GameSourceStep` search patterns — catalog search with BGG auto-fallback, existing `api.bgg.search` and `api.sharedGames.search`)
+
+- [ ] **Step 4: Implement UploadRulesStep** (wraps `CopyrightDisclaimerModal` + existing `PdfUploadStep` + "Salta" skip button)
+
+- [ ] **Step 5: Implement CreateSessionStep** (player name form + calls `api.liveSessions.create`)
+
+- [ ] **Step 6: Add "Serata di Gioco" button to sessions/new page**
+
+In `apps/web/src/app/(authenticated)/sessions/new/page.tsx`, add a prominent card at the top:
+
+```tsx
+<div className="rounded-xl border-2 border-amber-500/30 bg-amber-500/5 p-6 mb-6">
+  <h2 className="font-quicksand font-bold text-xl mb-2">Serata di Gioco</h2>
+  <p className="text-sm text-muted-foreground mb-4">
+    Trova un gioco, carica il regolamento e inizia subito — l&apos;agente AI ti assiste.
+  </p>
+  <Button onClick={() => setShowWizard(true)}>
+    Inizia Serata di Gioco
+  </Button>
+</div>
+```
+
+- [ ] **Step 7: Run tests — expect PASS**
+- [ ] **Step 8: Commit**
+
+```bash
+git commit -m "feat(game-night): add GameNightWizard — 3-step quick start for improvised game nights"
+```
+
+---
+
+### Task C2: Degraded Mode Banner
+
+**Files:**
+- Create: `apps/web/src/components/session/KbProcessingBanner.tsx`
+- Create: `apps/web/src/components/session/__tests__/KbProcessingBanner.test.tsx`
+- Modify: `apps/web/src/app/(authenticated)/sessions/[id]/layout.tsx`
+
+**Purpose:** When a session starts before KB processing completes, show a banner that auto-updates when ready.
+
+- [ ] **Step 1: Implement KbProcessingBanner**
+
+```tsx
+// apps/web/src/components/session/KbProcessingBanner.tsx
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Bot, Check, Loader2 } from 'lucide-react';
+
+interface KbProcessingBannerProps {
+  gameId: string;
+  onReady?: () => void;
+}
+
+export function KbProcessingBanner({ gameId, onReady }: KbProcessingBannerProps) {
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    // Poll KB status every 10 seconds
+    const interval = setInterval(async () => {
+      try {
+        const response = await fetch(`/api/v1/documents/game/${gameId}/status`);
+        const data = await response.json();
+        if (data.isReady) {
+          setReady(true);
+          onReady?.();
+          clearInterval(interval);
+        }
+      } catch { /* ignore polling errors */ }
+    }, 10_000);
+
+    return () => clearInterval(interval);
+  }, [gameId, onReady]);
+
+  if (ready) {
+    return (
+      <div className="rounded-lg border border-green-500/30 bg-green-500/10 px-4 py-2 text-sm text-green-300 flex items-center gap-2">
+        <Check className="h-4 w-4" />
+        Regolamento pronto! L&apos;agente AI conosce le regole.
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-lg border border-amber-500/30 bg-amber-500/10 px-4 py-2 text-sm text-amber-200 flex items-center gap-2">
+      <Loader2 className="h-4 w-4 animate-spin" />
+      Regolamento in elaborazione... L&apos;agente avrà accesso alle regole tra poco.
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Integrate into session layout** (show banner when session's game has no indexed KB)
+- [ ] **Step 3: Test + Commit**
+
+```bash
+git commit -m "feat(session): add KbProcessingBanner for degraded mode — auto-updates when KB ready"
+```
+
+---
+
+## API Client Additions Summary
+
+Add these methods to the frontend API client (`apps/web/src/lib/api/`):
+
+| Client | Method | Endpoint |
+|---|---|---|
+| `scoreTrackingClient` (NEW) | `parseScore(sessionId, message, autoRecord)` | `POST /live-sessions/{id}/scores/parse` |
+| `scoreTrackingClient` (NEW) | `confirmScore(sessionId, data)` | `POST /live-sessions/{id}/scores/confirm` |
+| `liveSessionsClient` (MODIFY) | `saveComplete(sessionId)` | `POST /live-sessions/{id}/save-complete` |
+| `liveSessionsClient` (MODIFY) | `getResumeContext(sessionId)` | `GET /live-sessions/{id}/resume-context` |
+
+---
+
+## DI Registrations Summary
+
+| Service | Registration File | Lifetime |
+|---|---|---|
+| `IPlayerNameResolutionService` → `PlayerNameResolutionService` | `GameManagementServiceExtensions.cs` | Scoped |
+| `ParseAndRecordScoreCommandHandler` | Auto-registered by MediatR assembly scan | — |
+| `ConfirmScoreCommandHandler` | Auto-registered by MediatR assembly scan | — |
+| `SaveCompleteSessionStateCommandHandler` | Auto-registered by MediatR assembly scan | — |
+
+---
+
+## Testing Strategy
+
+### Unit Tests (per phase)
+
+| Phase | Test Class | Count |
+|---|---|---|
+| A1 | `PlayerNameResolutionServiceTests` | 5 tests |
+| A2 | `ParseAndRecordScoreCommandHandlerTests` | 5 tests |
+| A3 | `ConfirmScoreCommandHandlerTests` | 2 tests |
+| A5 | `ScoreAssistant.test.tsx` | 4 tests |
+| B1 | `SaveCompleteSessionStateCommandHandlerTests` | 3 tests |
+| B3 | `SaveCompleteDialog.test.tsx` | 3 tests |
+| B3 | `ResumeSessionPanel.test.tsx` | 3 tests |
+| C1 | `GameNightWizard.test.tsx` | 3 tests |
+| C2 | `KbProcessingBanner.test.tsx` | 2 tests |
+
+### Integration Tests
+
+After all phases, create integration test verifying the full flow:
+- Parse score → record → verify in scoreboard
+- Save complete → verify snapshot + photos
+- Resume → verify context returned
+
+### E2E Test (Playwright)
+
+One E2E test covering the happy path: search game → add → upload PDF → create session → score via assistant → pause → resume.
+
+---
+
+## Commit History Target
+
+```
+feat(game-mgmt): add PlayerNameResolutionService for fuzzy player name matching
+feat(kb): add ParseAndRecordScoreCommand — NLU bridge to LiveGameSession scoring
+feat(kb): add ConfirmScoreCommand for user-confirmed score recording
+feat(routing): add /scores/parse and /scores/confirm endpoints for AI score tracking
+feat(session): add ScoreAssistant panel with NLU score parsing and confirmation
+feat(game-mgmt): add SaveCompleteSessionStateCommand — orchestrates pause+snapshot+agent persist
+feat(game-mgmt): add GetSessionResumeContextQuery for enhanced resume experience
+feat(session): enhanced save/resume — SaveCompleteDialog + ResumeSessionPanel with recap and photos
+feat(game-night): add GameNightWizard — 3-step quick start for improvised game nights
+feat(session): add KbProcessingBanner for degraded mode — auto-updates when KB ready
+test: add integration tests for AI score tracking and save/resume flows
+test(e2e): add game night journey happy path E2E test
+```


### PR DESCRIPTION
## Summary
- **PlayerNameResolutionService**: Fuzzy player name → GUID matching (exact, first-name, contains)
- **ParseAndRecordScoreCommand + Handler**: NLU parse via `IStateParser`, resolves player, auto-records at ≥80% confidence
- **ConfirmScoreCommand + Handler**: Manual confirmation flow for low-confidence parses
- **2 HTTP endpoints**: `POST /scores/parse` + `POST /scores/confirm` on LiveSession routes
- **ScoreAssistant** React component: NL score input with confirmation cards, integrated into `LiveSessionView`
- **12 backend + 8 frontend tests** all passing

## Architecture
```
User: "Marco 5 punti agricoltura"
  → IStateParser.ParseAsync() → StateExtractionResult
  → PlayerNameResolutionService.ResolvePlayer() → PlayerId
  → If confidence ≥ 0.8: auto RecordLiveSessionScoreCommand
  → If confidence < 0.8: return parsed result for UI confirmation
```

## DoD Checklist
- [x] `PlayerNameResolutionService` with 5 unit tests
- [x] `ParseAndRecordScoreCommand` with 5 unit tests
- [x] `ConfirmScoreCommand` with 2 unit tests
- [x] Two HTTP endpoints wired with FluentValidation
- [x] `ScoreAssistant` React component with 8 vitest tests
- [x] Score tracking methods in `liveSessionsClient`
- [x] DI registration for `IPlayerNameResolutionService`
- [x] All existing tests pass

## Test plan
- [ ] Backend: `dotnet test --filter "PlayerNameResolution|ParseAndRecordScore|ConfirmScore"` — 12 tests
- [ ] Frontend: `vitest run ScoreAssistant` — 8 tests
- [ ] Manual: Send NL score input, verify parsing, confirm, check scoreboard update

Closes #121

🤖 Generated with [Claude Code](https://claude.com/claude-code)