### PR TITLE
feat(game-night): quick start wizard + KB banner (#123)

### DIFF
--- a/apps/web/src/app/(authenticated)/sessions/new/page.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/new/page.tsx
@@ -9,9 +9,10 @@
  * Shows "Serata di Gioco" quick start option + existing 4-step wizard.
  */
 
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
 
 import { PartyPopper } from 'lucide-react';
+import { useRouter } from 'next/navigation';
 
 import { GameNightWizard } from '@/components/game-night/GameNightWizard';
 import { SessionCreationWizard } from '@/components/session/SessionCreationWizard';
@@ -19,6 +20,14 @@ import { Button } from '@/components/ui/primitives/button';
 
 export default function NewSessionPage() {
   const [showWizard, setShowWizard] = useState(false);
+  const router = useRouter();
+
+  const handleWizardComplete = useCallback(
+    (sessionId: string) => {
+      router.push(`/sessions/${sessionId}/play`);
+    },
+    [router]
+  );
 
   return (
     <div className="container mx-auto px-4 py-6 space-y-6">
@@ -54,7 +63,7 @@ export default function NewSessionPage() {
               Chiudi
             </Button>
           </div>
-          <GameNightWizard onComplete={() => setShowWizard(false)} />
+          <GameNightWizard onComplete={handleWizardComplete} />
         </div>
       )}
 

--- a/apps/web/src/app/(authenticated)/sessions/new/page.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/new/page.tsx
@@ -1,17 +1,65 @@
+'use client';
+
 /**
  * New Session Page
  *
  * Issue #5041 — Sessions Redesign Phase 1
+ * Issue #123 — Game Night Quick Start Wizard entry point
  *
- * 4-step creation wizard for starting a new game session.
+ * Shows "Serata di Gioco" quick start option + existing 4-step wizard.
  */
 
+import { useState } from 'react';
+
+import { PartyPopper } from 'lucide-react';
+
+import { GameNightWizard } from '@/components/game-night/GameNightWizard';
 import { SessionCreationWizard } from '@/components/session/SessionCreationWizard';
+import { Button } from '@/components/ui/primitives/button';
 
 export default function NewSessionPage() {
+  const [showWizard, setShowWizard] = useState(false);
+
   return (
-    <div className="container mx-auto px-4 py-6">
-      <SessionCreationWizard />
+    <div className="container mx-auto px-4 py-6 space-y-6">
+      {/* Game Night Quick Start */}
+      {!showWizard ? (
+        <div
+          className="rounded-xl border-2 border-amber-500/30 bg-amber-500/5 p-6"
+          data-testid="game-night-entry"
+        >
+          <h2 className="font-quicksand font-bold text-xl mb-2">Serata di Gioco</h2>
+          <p className="text-sm text-muted-foreground mb-4">
+            Trova un gioco, carica il regolamento e inizia subito — l&apos;agente AI ti assiste.
+          </p>
+          <Button
+            onClick={() => setShowWizard(true)}
+            className="bg-amber-600 hover:bg-amber-700 text-white"
+            data-testid="start-game-night-button"
+          >
+            <PartyPopper className="h-4 w-4 mr-2" aria-hidden="true" />
+            Inizia Serata di Gioco
+          </Button>
+        </div>
+      ) : (
+        <div className="rounded-xl border border-slate-200 dark:border-slate-700 p-6">
+          <div className="flex items-center justify-between mb-4">
+            <h2 className="font-quicksand font-bold text-xl">Serata di Gioco</h2>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => setShowWizard(false)}
+              data-testid="close-wizard-button"
+            >
+              Chiudi
+            </Button>
+          </div>
+          <GameNightWizard onComplete={() => setShowWizard(false)} />
+        </div>
+      )}
+
+      {/* Existing Session Creation Wizard */}
+      {!showWizard && <SessionCreationWizard />}
     </div>
   );
 }

--- a/apps/web/src/components/game-night/GameNightWizard.tsx
+++ b/apps/web/src/components/game-night/GameNightWizard.tsx
@@ -13,8 +13,6 @@
 
 import { useCallback, useState } from 'react';
 
-import { useRouter } from 'next/navigation';
-
 import { WizardSteps } from '@/components/wizard/WizardSteps';
 
 import { CreateSessionStep } from './steps/CreateSessionStep';
@@ -36,6 +34,7 @@ interface WizardState {
   gameTitle?: string;
   privateGameId?: string;
   pdfId?: string;
+  bggId?: number;
 }
 
 const WIZARD_STEPS = [
@@ -51,10 +50,9 @@ const WIZARD_STEPS = [
 export function GameNightWizard({ onComplete }: GameNightWizardProps) {
   const [step, setStep] = useState<WizardStep>('search');
   const [state, setState] = useState<WizardState>({});
-  const router = useRouter();
 
   const handleGameFound = useCallback(
-    (data: { gameId?: string; privateGameId?: string; gameTitle: string }) => {
+    (data: { gameId?: string; privateGameId?: string; gameTitle: string; bggId?: number }) => {
       setState(prev => ({ ...prev, ...data }));
       setStep('upload');
     },
@@ -69,9 +67,8 @@ export function GameNightWizard({ onComplete }: GameNightWizardProps) {
   const handleSessionCreated = useCallback(
     (sessionId: string) => {
       onComplete(sessionId);
-      router.push(`/sessions/${sessionId}/play`);
     },
-    [onComplete, router]
+    [onComplete]
   );
 
   return (
@@ -92,7 +89,7 @@ export function GameNightWizard({ onComplete }: GameNightWizardProps) {
 
       {step === 'session' && (
         <CreateSessionStep
-          gameId={state.gameId ?? state.privateGameId ?? ''}
+          gameId={state.gameId}
           gameTitle={state.gameTitle ?? ''}
           onSessionCreated={handleSessionCreated}
         />

--- a/apps/web/src/components/game-night/GameNightWizard.tsx
+++ b/apps/web/src/components/game-night/GameNightWizard.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+/**
+ * GameNightWizard — 3-step quick start for improvised game nights.
+ *
+ * Steps:
+ *   1. Find game (catalog → BGG)
+ *   2. Upload rules PDF (optional, with copyright disclaimer)
+ *   3. Create session with players
+ *
+ * Issue #123 — Game Night Quick Start Wizard
+ */
+
+import { useCallback, useState } from 'react';
+
+import { useRouter } from 'next/navigation';
+
+import { WizardSteps } from '@/components/wizard/WizardSteps';
+
+import { CreateSessionStep } from './steps/CreateSessionStep';
+import { SearchGameStep } from './steps/SearchGameStep';
+import { UploadRulesStep } from './steps/UploadRulesStep';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+type WizardStep = 'search' | 'upload' | 'session';
+
+interface GameNightWizardProps {
+  onComplete: (sessionId: string) => void;
+}
+
+interface WizardState {
+  gameId?: string;
+  gameTitle?: string;
+  privateGameId?: string;
+  pdfId?: string;
+}
+
+const WIZARD_STEPS = [
+  { id: 'search', label: 'Trova il gioco' },
+  { id: 'upload', label: 'Regolamento' },
+  { id: 'session', label: 'Giocatori' },
+];
+
+// ============================================================================
+// Component
+// ============================================================================
+
+export function GameNightWizard({ onComplete }: GameNightWizardProps) {
+  const [step, setStep] = useState<WizardStep>('search');
+  const [state, setState] = useState<WizardState>({});
+  const router = useRouter();
+
+  const handleGameFound = useCallback(
+    (data: { gameId?: string; privateGameId?: string; gameTitle: string }) => {
+      setState(prev => ({ ...prev, ...data }));
+      setStep('upload');
+    },
+    []
+  );
+
+  const handleUploadComplete = useCallback((pdfId?: string) => {
+    setState(prev => ({ ...prev, pdfId }));
+    setStep('session');
+  }, []);
+
+  const handleSessionCreated = useCallback(
+    (sessionId: string) => {
+      onComplete(sessionId);
+      router.push(`/sessions/${sessionId}/play`);
+    },
+    [onComplete, router]
+  );
+
+  return (
+    <div className="space-y-6" data-testid="game-night-wizard">
+      <WizardSteps steps={WIZARD_STEPS} currentStep={step} />
+
+      {step === 'search' && <SearchGameStep onGameFound={handleGameFound} />}
+
+      {step === 'upload' && (
+        <UploadRulesStep
+          gameId={state.gameId}
+          privateGameId={state.privateGameId}
+          gameTitle={state.gameTitle ?? ''}
+          onComplete={handleUploadComplete}
+          onSkip={() => handleUploadComplete()}
+        />
+      )}
+
+      {step === 'session' && (
+        <CreateSessionStep
+          gameId={state.gameId ?? state.privateGameId ?? ''}
+          gameTitle={state.gameTitle ?? ''}
+          onSessionCreated={handleSessionCreated}
+        />
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/game-night/__tests__/GameNightWizard.test.tsx
+++ b/apps/web/src/components/game-night/__tests__/GameNightWizard.test.tsx
@@ -7,6 +7,7 @@ const mockBggSearch = vi.fn();
 const mockCreateSession = vi.fn();
 const mockAddPlayer = vi.fn();
 const mockStartSession = vi.fn();
+const mockPush = vi.fn();
 
 vi.mock('@/lib/api', () => ({
   api: {
@@ -25,7 +26,11 @@ vi.mock('@/lib/api', () => ({
 }));
 
 vi.mock('next/navigation', () => ({
-  useRouter: () => ({ push: vi.fn() }),
+  useRouter: () => ({ push: mockPush }),
+}));
+
+vi.mock('next/image', () => ({
+  default: (props: Record<string, unknown>) => <img {...props} />,
 }));
 
 vi.mock('@/components/library/PdfProcessingStatus', () => ({
@@ -60,7 +65,7 @@ describe('GameNightWizard', () => {
     expect(screen.getByTestId('game-search-input')).toBeInTheDocument();
   });
 
-  it('searches catalog and shows results', async () => {
+  it('searches catalog via Enter key and shows results', async () => {
     const user = userEvent.setup();
     mockSearch.mockResolvedValue({
       items: [{ id: 'g1', title: 'Agricola', thumbnailUrl: '/thumb.jpg', yearPublished: 2007 }],
@@ -69,15 +74,11 @@ describe('GameNightWizard', () => {
 
     render(<GameNightWizard onComplete={onComplete} />);
 
-    await user.type(screen.getByTestId('game-search-input'), 'Agri');
-    await user.click(screen.getByRole('button', { name: '' })); // Search button (icon-only)
-
-    // Use keyboard enter instead
-    await user.clear(screen.getByTestId('game-search-input'));
     await user.type(screen.getByTestId('game-search-input'), 'Agricola{Enter}');
 
     await waitFor(() => {
-      expect(mockSearch).toHaveBeenCalled();
+      expect(mockSearch).toHaveBeenCalledTimes(1);
+      expect(mockSearch).toHaveBeenCalledWith(expect.objectContaining({ searchTerm: 'Agricola' }));
     });
 
     const results = await screen.findByTestId('game-search-results');
@@ -137,7 +138,9 @@ describe('GameNightWizard', () => {
     await user.click(screen.getByTestId('create-session-button'));
 
     await waitFor(() => {
-      expect(mockCreateSession).toHaveBeenCalledWith(expect.objectContaining({ gameId: 'g1' }));
+      expect(mockCreateSession).toHaveBeenCalledWith(
+        expect.objectContaining({ gameId: 'g1', gameName: 'Ticket to Ride' })
+      );
     });
 
     expect(mockAddPlayer).toHaveBeenCalledTimes(2);
@@ -167,5 +170,43 @@ describe('GameNightWizard', () => {
     // Add a player
     await user.click(screen.getByTestId('add-player-button'));
     expect(screen.getByTestId('player-input-2')).toBeInTheDocument();
+  });
+
+  it('creates session without gameId for BGG-only games', async () => {
+    const user = userEvent.setup();
+    // No catalog results → triggers BGG fallback
+    mockSearch.mockResolvedValue({ items: [], totalCount: 0 });
+    mockBggSearch.mockResolvedValue({
+      results: [{ bggId: 42, name: 'Everdell', thumbnailUrl: null, yearPublished: 2018 }],
+    });
+    mockCreateSession.mockResolvedValue('sess-bgg');
+    mockAddPlayer.mockResolvedValue(undefined);
+    mockStartSession.mockResolvedValue(undefined);
+
+    render(<GameNightWizard onComplete={onComplete} />);
+
+    // Search triggers BGG fallback
+    await user.type(screen.getByTestId('game-search-input'), 'Everdell{Enter}');
+    await waitFor(() => expect(screen.getByText('Everdell')).toBeInTheDocument());
+    await user.click(screen.getByText('Everdell'));
+
+    // Skip PDF upload
+    await user.click(screen.getByTestId('skip-rules-button'));
+
+    // Add players and create session
+    await user.type(screen.getByTestId('player-input-0'), 'Anna');
+    await user.type(screen.getByTestId('player-input-1'), 'Paolo');
+    await user.click(screen.getByTestId('create-session-button'));
+
+    await waitFor(() => {
+      // Should create with gameName only, no gameId
+      expect(mockCreateSession).toHaveBeenCalledWith(
+        expect.objectContaining({ gameName: 'Everdell' })
+      );
+      const callArg = mockCreateSession.mock.calls[0][0];
+      expect(callArg).not.toHaveProperty('gameId');
+    });
+
+    expect(onComplete).toHaveBeenCalledWith('sess-bgg');
   });
 });

--- a/apps/web/src/components/game-night/__tests__/GameNightWizard.test.tsx
+++ b/apps/web/src/components/game-night/__tests__/GameNightWizard.test.tsx
@@ -1,0 +1,171 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+
+const mockSearch = vi.fn();
+const mockBggSearch = vi.fn();
+const mockCreateSession = vi.fn();
+const mockAddPlayer = vi.fn();
+const mockStartSession = vi.fn();
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    sharedGames: {
+      search: (...args: unknown[]) => mockSearch(...args),
+    },
+    bgg: {
+      search: (...args: unknown[]) => mockBggSearch(...args),
+    },
+    liveSessions: {
+      createSession: (...args: unknown[]) => mockCreateSession(...args),
+      addPlayer: (...args: unknown[]) => mockAddPlayer(...args),
+      startSession: (...args: unknown[]) => mockStartSession(...args),
+    },
+  },
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+vi.mock('@/components/library/PdfProcessingStatus', () => ({
+  PdfProcessingStatus: () => <div data-testid="pdf-processing-status">Processing...</div>,
+}));
+
+vi.mock('@/components/pdf/CopyrightDisclaimerModal', () => ({
+  CopyrightDisclaimerModal: ({ open, onAccept }: { open: boolean; onAccept: () => void }) =>
+    open ? (
+      <div data-testid="copyright-modal">
+        <button data-testid="accept-disclaimer" onClick={onAccept}>
+          Confermo
+        </button>
+      </div>
+    ) : null,
+}));
+
+import { GameNightWizard } from '../GameNightWizard';
+
+describe('GameNightWizard', () => {
+  const onComplete = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders step 1: find game', () => {
+    render(<GameNightWizard onComplete={onComplete} />);
+
+    expect(screen.getByTestId('game-night-wizard')).toBeInTheDocument();
+    expect(screen.getByTestId('search-game-step')).toBeInTheDocument();
+    expect(screen.getByTestId('game-search-input')).toBeInTheDocument();
+  });
+
+  it('searches catalog and shows results', async () => {
+    const user = userEvent.setup();
+    mockSearch.mockResolvedValue({
+      items: [{ id: 'g1', title: 'Agricola', thumbnailUrl: '/thumb.jpg', yearPublished: 2007 }],
+      totalCount: 1,
+    });
+
+    render(<GameNightWizard onComplete={onComplete} />);
+
+    await user.type(screen.getByTestId('game-search-input'), 'Agri');
+    await user.click(screen.getByRole('button', { name: '' })); // Search button (icon-only)
+
+    // Use keyboard enter instead
+    await user.clear(screen.getByTestId('game-search-input'));
+    await user.type(screen.getByTestId('game-search-input'), 'Agricola{Enter}');
+
+    await waitFor(() => {
+      expect(mockSearch).toHaveBeenCalled();
+    });
+
+    const results = await screen.findByTestId('game-search-results');
+    expect(results).toBeInTheDocument();
+    expect(screen.getByText('Agricola')).toBeInTheDocument();
+  });
+
+  it('advances to step 2 on game selection, then to step 3 on skip', async () => {
+    const user = userEvent.setup();
+    mockSearch.mockResolvedValue({
+      items: [{ id: 'g1', title: 'Catan', thumbnailUrl: null, yearPublished: 1995 }],
+      totalCount: 1,
+    });
+
+    render(<GameNightWizard onComplete={onComplete} />);
+
+    // Search and select
+    await user.type(screen.getByTestId('game-search-input'), 'Catan{Enter}');
+    await waitFor(() => expect(screen.getByText('Catan')).toBeInTheDocument());
+    await user.click(screen.getByText('Catan'));
+
+    // Should be on step 2
+    expect(screen.getByTestId('upload-rules-step')).toBeInTheDocument();
+
+    // Skip upload
+    await user.click(screen.getByTestId('skip-rules-button'));
+
+    // Should be on step 3
+    expect(screen.getByTestId('create-session-step')).toBeInTheDocument();
+  });
+
+  it('creates session with players on step 3', async () => {
+    const user = userEvent.setup();
+    mockSearch.mockResolvedValue({
+      items: [{ id: 'g1', title: 'Ticket to Ride', thumbnailUrl: null }],
+      totalCount: 1,
+    });
+    mockCreateSession.mockResolvedValue('sess-abc');
+    mockAddPlayer.mockResolvedValue(undefined);
+    mockStartSession.mockResolvedValue(undefined);
+
+    render(<GameNightWizard onComplete={onComplete} />);
+
+    // Step 1: search + select
+    await user.type(screen.getByTestId('game-search-input'), 'Ticket{Enter}');
+    await waitFor(() => expect(screen.getByText('Ticket to Ride')).toBeInTheDocument());
+    await user.click(screen.getByText('Ticket to Ride'));
+
+    // Step 2: skip
+    await user.click(screen.getByTestId('skip-rules-button'));
+
+    // Step 3: add players
+    await user.type(screen.getByTestId('player-input-0'), 'Marco');
+    await user.type(screen.getByTestId('player-input-1'), 'Luca');
+
+    // Create session
+    await user.click(screen.getByTestId('create-session-button'));
+
+    await waitFor(() => {
+      expect(mockCreateSession).toHaveBeenCalledWith(expect.objectContaining({ gameId: 'g1' }));
+    });
+
+    expect(mockAddPlayer).toHaveBeenCalledTimes(2);
+    expect(mockStartSession).toHaveBeenCalledWith('sess-abc');
+    expect(onComplete).toHaveBeenCalledWith('sess-abc');
+  });
+
+  it('allows adding and removing players', async () => {
+    const user = userEvent.setup();
+    mockSearch.mockResolvedValue({
+      items: [{ id: 'g1', title: 'Splendor' }],
+      totalCount: 1,
+    });
+
+    render(<GameNightWizard onComplete={onComplete} />);
+
+    // Navigate to step 3
+    await user.type(screen.getByTestId('game-search-input'), 'Splendor{Enter}');
+    await waitFor(() => expect(screen.getByText('Splendor')).toBeInTheDocument());
+    await user.click(screen.getByText('Splendor'));
+    await user.click(screen.getByTestId('skip-rules-button'));
+
+    // Should start with 2 player inputs
+    expect(screen.getByTestId('player-input-0')).toBeInTheDocument();
+    expect(screen.getByTestId('player-input-1')).toBeInTheDocument();
+
+    // Add a player
+    await user.click(screen.getByTestId('add-player-button'));
+    expect(screen.getByTestId('player-input-2')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/game-night/index.ts
+++ b/apps/web/src/components/game-night/index.ts
@@ -20,3 +20,4 @@ export type { LiveSessionViewProps } from './LiveSessionView';
 export { ScoreAssistant } from './ScoreAssistant';
 export { SaveCompleteDialog } from './SaveCompleteDialog';
 export { ResumeSessionPanel } from './ResumeSessionPanel';
+export { GameNightWizard } from './GameNightWizard';

--- a/apps/web/src/components/game-night/steps/CreateSessionStep.tsx
+++ b/apps/web/src/components/game-night/steps/CreateSessionStep.tsx
@@ -8,7 +8,7 @@
  * Issue #123 — Game Night Quick Start Wizard
  */
 
-import { useCallback, useState } from 'react';
+import { useCallback, useId, useState } from 'react';
 
 import { Loader2, Plus, Trash2, Users } from 'lucide-react';
 
@@ -22,9 +22,14 @@ import { cn } from '@/lib/utils';
 // ============================================================================
 
 interface CreateSessionStepProps {
-  gameId: string;
+  gameId?: string;
   gameTitle: string;
   onSessionCreated: (sessionId: string) => void;
+}
+
+interface PlayerSlot {
+  id: string;
+  name: string;
 }
 
 const PLAYER_COLORS = [
@@ -39,37 +44,43 @@ const PLAYER_COLORS = [
 ] as const;
 
 // ============================================================================
+// Helpers
+// ============================================================================
+
+let slotCounter = 0;
+function createSlot(name = ''): PlayerSlot {
+  return { id: `slot-${++slotCounter}`, name };
+}
+
+// ============================================================================
 // Component
 // ============================================================================
 
 export function CreateSessionStep({ gameId, gameTitle, onSessionCreated }: CreateSessionStepProps) {
-  const [players, setPlayers] = useState<string[]>(['', '']);
+  const formId = useId();
+  const [players, setPlayers] = useState<PlayerSlot[]>(() => [createSlot(), createSlot()]);
   const [isCreating, setIsCreating] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const canAddPlayer = players.length < 8;
   const canRemovePlayer = players.length > 2;
-  const validPlayers = players.filter(p => p.trim().length > 0);
+  const validPlayers = players.filter(p => p.name.trim().length > 0);
   const canCreate = validPlayers.length >= 2 && !isCreating;
 
-  const handlePlayerChange = useCallback((index: number, value: string) => {
-    setPlayers(prev => {
-      const next = [...prev];
-      next[index] = value;
-      return next;
-    });
+  const handlePlayerChange = useCallback((slotId: string, value: string) => {
+    setPlayers(prev => prev.map(p => (p.id === slotId ? { ...p, name: value } : p)));
   }, []);
 
   const handleAddPlayer = useCallback(() => {
     if (canAddPlayer) {
-      setPlayers(prev => [...prev, '']);
+      setPlayers(prev => [...prev, createSlot()]);
     }
   }, [canAddPlayer]);
 
   const handleRemovePlayer = useCallback(
-    (index: number) => {
+    (slotId: string) => {
       if (canRemovePlayer) {
-        setPlayers(prev => prev.filter((_, i) => i !== index));
+        setPlayers(prev => prev.filter(p => p.id !== slotId));
       }
     },
     [canRemovePlayer]
@@ -81,16 +92,16 @@ export function CreateSessionStep({ gameId, gameTitle, onSessionCreated }: Creat
     setError(null);
 
     try {
-      // Create session
+      // Create session — gameId is optional, gameName is always set
       const sessionId = await api.liveSessions.createSession({
-        gameId,
+        ...(gameId ? { gameId } : {}),
         gameName: gameTitle,
       });
 
       // Add players
       for (let i = 0; i < validPlayers.length; i++) {
         await api.liveSessions.addPlayer(sessionId, {
-          displayName: validPlayers[i],
+          displayName: validPlayers[i].name,
           color: PLAYER_COLORS[i % PLAYER_COLORS.length],
         });
       }
@@ -117,8 +128,8 @@ export function CreateSessionStep({ gameId, gameTitle, onSessionCreated }: Creat
       </div>
 
       <div className="space-y-2">
-        {players.map((name, index) => (
-          <div key={index} className="flex items-center gap-2">
+        {players.map((player, index) => (
+          <div key={player.id} className="flex items-center gap-2">
             <div
               className="h-8 w-8 rounded-full flex-shrink-0 flex items-center justify-center text-xs font-bold text-white"
               style={{
@@ -144,15 +155,16 @@ export function CreateSessionStep({ gameId, gameTitle, onSessionCreated }: Creat
             </div>
             <Input
               placeholder={`Giocatore ${index + 1}`}
-              value={name}
-              onChange={e => handlePlayerChange(index, e.target.value)}
+              value={player.name}
+              onChange={e => handlePlayerChange(player.id, e.target.value)}
               data-testid={`player-input-${index}`}
+              id={`${formId}-player-${index}`}
             />
             {canRemovePlayer && (
               <Button
                 variant="ghost"
                 size="icon"
-                onClick={() => handleRemovePlayer(index)}
+                onClick={() => handleRemovePlayer(player.id)}
                 className="flex-shrink-0 text-muted-foreground hover:text-destructive"
                 aria-label={`Rimuovi giocatore ${index + 1}`}
               >

--- a/apps/web/src/components/game-night/steps/CreateSessionStep.tsx
+++ b/apps/web/src/components/game-night/steps/CreateSessionStep.tsx
@@ -1,0 +1,204 @@
+'use client';
+
+/**
+ * CreateSessionStep — Step 3 of GameNightWizard.
+ *
+ * Player name inputs (2-8 players) + create session.
+ *
+ * Issue #123 — Game Night Quick Start Wizard
+ */
+
+import { useCallback, useState } from 'react';
+
+import { Loader2, Plus, Trash2, Users } from 'lucide-react';
+
+import { Button } from '@/components/ui/primitives/button';
+import { Input } from '@/components/ui/primitives/input';
+import { api } from '@/lib/api';
+import { cn } from '@/lib/utils';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface CreateSessionStepProps {
+  gameId: string;
+  gameTitle: string;
+  onSessionCreated: (sessionId: string) => void;
+}
+
+const PLAYER_COLORS = [
+  'Red',
+  'Blue',
+  'Green',
+  'Yellow',
+  'Purple',
+  'Orange',
+  'Pink',
+  'Teal',
+] as const;
+
+// ============================================================================
+// Component
+// ============================================================================
+
+export function CreateSessionStep({ gameId, gameTitle, onSessionCreated }: CreateSessionStepProps) {
+  const [players, setPlayers] = useState<string[]>(['', '']);
+  const [isCreating, setIsCreating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const canAddPlayer = players.length < 8;
+  const canRemovePlayer = players.length > 2;
+  const validPlayers = players.filter(p => p.trim().length > 0);
+  const canCreate = validPlayers.length >= 2 && !isCreating;
+
+  const handlePlayerChange = useCallback((index: number, value: string) => {
+    setPlayers(prev => {
+      const next = [...prev];
+      next[index] = value;
+      return next;
+    });
+  }, []);
+
+  const handleAddPlayer = useCallback(() => {
+    if (canAddPlayer) {
+      setPlayers(prev => [...prev, '']);
+    }
+  }, [canAddPlayer]);
+
+  const handleRemovePlayer = useCallback(
+    (index: number) => {
+      if (canRemovePlayer) {
+        setPlayers(prev => prev.filter((_, i) => i !== index));
+      }
+    },
+    [canRemovePlayer]
+  );
+
+  const handleCreate = useCallback(async () => {
+    if (!canCreate) return;
+    setIsCreating(true);
+    setError(null);
+
+    try {
+      // Create session
+      const sessionId = await api.liveSessions.createSession({
+        gameId,
+        gameName: gameTitle,
+      });
+
+      // Add players
+      for (let i = 0; i < validPlayers.length; i++) {
+        await api.liveSessions.addPlayer(sessionId, {
+          displayName: validPlayers[i],
+          color: PLAYER_COLORS[i % PLAYER_COLORS.length],
+        });
+      }
+
+      // Start the session
+      await api.liveSessions.startSession(sessionId);
+
+      onSessionCreated(sessionId);
+    } catch {
+      setError('Errore nella creazione della sessione. Riprova.');
+      setIsCreating(false);
+    }
+  }, [canCreate, gameId, gameTitle, validPlayers, onSessionCreated]);
+
+  return (
+    <div className="space-y-4" data-testid="create-session-step">
+      <div>
+        <h3 className="font-quicksand font-bold text-lg text-slate-900 dark:text-slate-100">
+          Giocatori
+        </h3>
+        <p className="text-sm text-muted-foreground mt-1">
+          Aggiungi i giocatori per <strong>{gameTitle}</strong> (min 2, max 8).
+        </p>
+      </div>
+
+      <div className="space-y-2">
+        {players.map((name, index) => (
+          <div key={index} className="flex items-center gap-2">
+            <div
+              className="h-8 w-8 rounded-full flex-shrink-0 flex items-center justify-center text-xs font-bold text-white"
+              style={{
+                backgroundColor:
+                  index === 0
+                    ? '#ef4444'
+                    : index === 1
+                      ? '#3b82f6'
+                      : index === 2
+                        ? '#22c55e'
+                        : index === 3
+                          ? '#eab308'
+                          : index === 4
+                            ? '#a855f7'
+                            : index === 5
+                              ? '#f97316'
+                              : index === 6
+                                ? '#ec4899'
+                                : '#14b8a6',
+              }}
+            >
+              {index + 1}
+            </div>
+            <Input
+              placeholder={`Giocatore ${index + 1}`}
+              value={name}
+              onChange={e => handlePlayerChange(index, e.target.value)}
+              data-testid={`player-input-${index}`}
+            />
+            {canRemovePlayer && (
+              <Button
+                variant="ghost"
+                size="icon"
+                onClick={() => handleRemovePlayer(index)}
+                className="flex-shrink-0 text-muted-foreground hover:text-destructive"
+                aria-label={`Rimuovi giocatore ${index + 1}`}
+              >
+                <Trash2 className="h-4 w-4" />
+              </Button>
+            )}
+          </div>
+        ))}
+      </div>
+
+      {canAddPlayer && (
+        <Button
+          variant="outline"
+          onClick={handleAddPlayer}
+          className="w-full"
+          data-testid="add-player-button"
+        >
+          <Plus className="h-4 w-4 mr-2" aria-hidden="true" />
+          Aggiungi giocatore
+        </Button>
+      )}
+
+      {error && (
+        <p className="text-sm text-destructive text-center" data-testid="create-session-error">
+          {error}
+        </p>
+      )}
+
+      <Button
+        onClick={handleCreate}
+        disabled={!canCreate}
+        className={cn('w-full bg-amber-600 hover:bg-amber-700 text-white')}
+        data-testid="create-session-button"
+      >
+        {isCreating ? (
+          <>
+            <Loader2 className="h-4 w-4 mr-2 animate-spin" aria-hidden="true" />
+            Creazione in corso...
+          </>
+        ) : (
+          <>
+            <Users className="h-4 w-4 mr-2" aria-hidden="true" />
+            Inizia Partita ({validPlayers.length} giocatori)
+          </>
+        )}
+      </Button>
+    </div>
+  );
+}

--- a/apps/web/src/components/game-night/steps/SearchGameStep.tsx
+++ b/apps/web/src/components/game-night/steps/SearchGameStep.tsx
@@ -12,6 +12,7 @@
 import { useCallback, useState } from 'react';
 
 import { Loader2, Search } from 'lucide-react';
+import Image from 'next/image';
 
 import { Button } from '@/components/ui/primitives/button';
 import { Input } from '@/components/ui/primitives/input';
@@ -23,7 +24,12 @@ import { cn } from '@/lib/utils';
 // ============================================================================
 
 interface SearchGameStepProps {
-  onGameFound: (data: { gameId?: string; privateGameId?: string; gameTitle: string }) => void;
+  onGameFound: (data: {
+    gameId?: string;
+    privateGameId?: string;
+    gameTitle: string;
+    bggId?: number;
+  }) => void;
 }
 
 interface GameResult {
@@ -96,8 +102,8 @@ export function SearchGameStep({ onGameFound }: SearchGameStepProps) {
       if (result.source === 'catalog') {
         onGameFound({ gameId: result.id, gameTitle: result.title });
       } else {
-        // BGG game — will need to be added as private game
-        onGameFound({ gameTitle: result.title });
+        // BGG game — session will use gameName only (no gameId)
+        onGameFound({ gameTitle: result.title, bggId: Number(result.id) });
       }
     },
     [onGameFound]
@@ -130,7 +136,11 @@ export function SearchGameStep({ onGameFound }: SearchGameStepProps) {
           onKeyDown={handleKeyDown}
           data-testid="game-search-input"
         />
-        <Button onClick={handleSearch} disabled={isSearching || !query.trim()}>
+        <Button
+          onClick={handleSearch}
+          disabled={isSearching || !query.trim()}
+          aria-label={isSearching ? 'Ricerca in corso' : 'Cerca'}
+        >
           {isSearching ? (
             <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
           ) : (
@@ -160,10 +170,12 @@ export function SearchGameStep({ onGameFound }: SearchGameStepProps) {
                 )}
               >
                 {result.thumbnailUrl ? (
-                  <img
+                  <Image
                     src={result.thumbnailUrl}
                     alt=""
-                    className="h-12 w-12 rounded object-cover flex-shrink-0"
+                    width={48}
+                    height={48}
+                    className="rounded object-cover flex-shrink-0"
                   />
                 ) : (
                   <div className="h-12 w-12 rounded bg-slate-200 dark:bg-slate-700 flex-shrink-0" />

--- a/apps/web/src/components/game-night/steps/SearchGameStep.tsx
+++ b/apps/web/src/components/game-night/steps/SearchGameStep.tsx
@@ -1,0 +1,191 @@
+'use client';
+
+/**
+ * SearchGameStep — Step 1 of GameNightWizard.
+ *
+ * Searches shared game catalog first, falls back to BGG.
+ * Returns game ID and title for subsequent steps.
+ *
+ * Issue #123 — Game Night Quick Start Wizard
+ */
+
+import { useCallback, useState } from 'react';
+
+import { Loader2, Search } from 'lucide-react';
+
+import { Button } from '@/components/ui/primitives/button';
+import { Input } from '@/components/ui/primitives/input';
+import { api } from '@/lib/api';
+import { cn } from '@/lib/utils';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface SearchGameStepProps {
+  onGameFound: (data: { gameId?: string; privateGameId?: string; gameTitle: string }) => void;
+}
+
+interface GameResult {
+  id: string;
+  title: string;
+  thumbnailUrl?: string;
+  source: 'catalog' | 'bgg';
+  yearPublished?: number;
+}
+
+// ============================================================================
+// Component
+// ============================================================================
+
+export function SearchGameStep({ onGameFound }: SearchGameStepProps) {
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<GameResult[]>([]);
+  const [isSearching, setIsSearching] = useState(false);
+  const [hasSearched, setHasSearched] = useState(false);
+
+  const handleSearch = useCallback(async () => {
+    if (!query.trim()) return;
+    setIsSearching(true);
+    setHasSearched(true);
+
+    try {
+      // Search catalog first
+      const catalogResponse = await api.sharedGames.search({
+        searchTerm: query.trim(),
+        page: 1,
+        pageSize: 5,
+        status: 1, // Published
+      });
+
+      const catalogResults: GameResult[] = (catalogResponse.items ?? []).map(g => ({
+        id: g.id,
+        title: g.title,
+        thumbnailUrl: g.thumbnailUrl ?? undefined,
+        source: 'catalog' as const,
+        yearPublished: g.yearPublished ?? undefined,
+      }));
+
+      // If no catalog results, try BGG
+      let bggResults: GameResult[] = [];
+      if (catalogResults.length === 0) {
+        try {
+          const bggResponse = await api.bgg.search(query.trim(), false, 1, 5);
+          bggResults = (bggResponse.results ?? []).map(g => ({
+            id: String(g.bggId),
+            title: g.name,
+            thumbnailUrl: g.thumbnailUrl ?? undefined,
+            source: 'bgg' as const,
+            yearPublished: g.yearPublished ?? undefined,
+          }));
+        } catch {
+          // BGG search is optional fallback
+        }
+      }
+
+      setResults([...catalogResults, ...bggResults]);
+    } catch {
+      setResults([]);
+    } finally {
+      setIsSearching(false);
+    }
+  }, [query]);
+
+  const handleSelect = useCallback(
+    (result: GameResult) => {
+      if (result.source === 'catalog') {
+        onGameFound({ gameId: result.id, gameTitle: result.title });
+      } else {
+        // BGG game — will need to be added as private game
+        onGameFound({ gameTitle: result.title });
+      }
+    },
+    [onGameFound]
+  );
+
+  const handleKeyDown = useCallback(
+    (e: React.KeyboardEvent) => {
+      if (e.key === 'Enter') {
+        e.preventDefault();
+        handleSearch();
+      }
+    },
+    [handleSearch]
+  );
+
+  return (
+    <div className="space-y-4" data-testid="search-game-step">
+      <div>
+        <h3 className="font-quicksand font-bold text-lg text-slate-900 dark:text-slate-100">
+          Trova il gioco
+        </h3>
+        <p className="text-sm text-muted-foreground mt-1">Cerca nel catalogo o su BoardGameGeek.</p>
+      </div>
+
+      <div className="flex gap-2">
+        <Input
+          placeholder="Nome del gioco..."
+          value={query}
+          onChange={e => setQuery(e.target.value)}
+          onKeyDown={handleKeyDown}
+          data-testid="game-search-input"
+        />
+        <Button onClick={handleSearch} disabled={isSearching || !query.trim()}>
+          {isSearching ? (
+            <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+          ) : (
+            <Search className="h-4 w-4" aria-hidden="true" />
+          )}
+        </Button>
+      </div>
+
+      {/* Results */}
+      {isSearching && (
+        <div className="flex items-center justify-center py-6">
+          <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+        </div>
+      )}
+
+      {!isSearching && results.length > 0 && (
+        <ul className="space-y-2" data-testid="game-search-results">
+          {results.map(result => (
+            <li key={`${result.source}-${result.id}`}>
+              <button
+                type="button"
+                onClick={() => handleSelect(result)}
+                className={cn(
+                  'w-full flex items-center gap-3 p-3 rounded-lg border',
+                  'hover:border-amber-500/50 hover:bg-amber-50/50 dark:hover:bg-amber-900/10',
+                  'transition-colors text-left'
+                )}
+              >
+                {result.thumbnailUrl ? (
+                  <img
+                    src={result.thumbnailUrl}
+                    alt=""
+                    className="h-12 w-12 rounded object-cover flex-shrink-0"
+                  />
+                ) : (
+                  <div className="h-12 w-12 rounded bg-slate-200 dark:bg-slate-700 flex-shrink-0" />
+                )}
+                <div className="min-w-0 flex-1">
+                  <p className="font-medium text-sm truncate">{result.title}</p>
+                  <p className="text-xs text-muted-foreground">
+                    {result.yearPublished && `${result.yearPublished} · `}
+                    {result.source === 'catalog' ? 'Catalogo MeepleAI' : 'BoardGameGeek'}
+                  </p>
+                </div>
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {!isSearching && hasSearched && results.length === 0 && (
+        <p className="text-sm text-muted-foreground text-center py-4">
+          Nessun risultato. Prova con un altro nome.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/game-night/steps/UploadRulesStep.tsx
+++ b/apps/web/src/components/game-night/steps/UploadRulesStep.tsx
@@ -1,0 +1,150 @@
+'use client';
+
+/**
+ * UploadRulesStep — Step 2 of GameNightWizard.
+ *
+ * Shows CopyrightDisclaimerModal → then file upload → processing status.
+ * Has "Salta" (skip) button to proceed without uploading a PDF.
+ *
+ * Issue #123 — Game Night Quick Start Wizard
+ */
+
+import { useCallback, useState } from 'react';
+
+import { FileText, SkipForward } from 'lucide-react';
+
+import { PdfProcessingStatus } from '@/components/library/PdfProcessingStatus';
+import { CopyrightDisclaimerModal } from '@/components/pdf/CopyrightDisclaimerModal';
+import { Button } from '@/components/ui/primitives/button';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface UploadRulesStepProps {
+  gameId?: string;
+  privateGameId?: string;
+  gameTitle: string;
+  onComplete: (pdfId?: string) => void;
+  onSkip: () => void;
+}
+
+type UploadPhase = 'prompt' | 'disclaimer' | 'upload' | 'processing';
+
+// ============================================================================
+// Component
+// ============================================================================
+
+export function UploadRulesStep({
+  gameId,
+  privateGameId,
+  gameTitle,
+  onComplete,
+  onSkip,
+}: UploadRulesStepProps) {
+  const [phase, setPhase] = useState<UploadPhase>('prompt');
+  const [uploadedFileName, setUploadedFileName] = useState<string | null>(null);
+
+  const effectiveGameId = gameId ?? privateGameId ?? null;
+
+  const handleDisclaimerAccept = useCallback(() => {
+    setPhase('upload');
+  }, []);
+
+  const handleDisclaimerCancel = useCallback(() => {
+    setPhase('prompt');
+  }, []);
+
+  const handleFileSelected = useCallback(async (e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    // Validate PDF
+    if (file.type !== 'application/pdf') return;
+    if (file.size > 50 * 1024 * 1024) return; // 50MB max
+
+    setUploadedFileName(file.name);
+    setPhase('processing');
+
+    // The actual upload is handled by the PdfProcessingStatus component's
+    // underlying infrastructure. For the wizard, we show the processing status
+    // and let the user continue when ready.
+  }, []);
+
+  return (
+    <div className="space-y-4" data-testid="upload-rules-step">
+      <div>
+        <h3 className="font-quicksand font-bold text-lg text-slate-900 dark:text-slate-100">
+          Regolamento (opzionale)
+        </h3>
+        <p className="text-sm text-muted-foreground mt-1">
+          Carica il PDF del regolamento di <strong>{gameTitle}</strong> per attivare
+          l&apos;assistente AI.
+        </p>
+      </div>
+
+      {phase === 'prompt' && (
+        <div className="space-y-3">
+          <Button
+            onClick={() => setPhase('disclaimer')}
+            className="w-full"
+            variant="outline"
+            data-testid="upload-rules-button"
+          >
+            <FileText className="h-4 w-4 mr-2" aria-hidden="true" />
+            Carica Regolamento PDF
+          </Button>
+          <Button
+            onClick={onSkip}
+            variant="ghost"
+            className="w-full text-muted-foreground"
+            data-testid="skip-rules-button"
+          >
+            <SkipForward className="h-4 w-4 mr-2" aria-hidden="true" />
+            Salta — gioca senza assistente AI
+          </Button>
+        </div>
+      )}
+
+      {phase === 'upload' && (
+        <div className="space-y-3">
+          <label
+            htmlFor="pdf-upload-input"
+            className="flex flex-col items-center justify-center rounded-lg border-2 border-dashed border-slate-300 dark:border-slate-600 p-8 cursor-pointer hover:border-amber-500/50 transition-colors"
+          >
+            <FileText className="h-8 w-8 text-muted-foreground mb-2" aria-hidden="true" />
+            <span className="text-sm font-medium">Seleziona il PDF del regolamento</span>
+            <span className="text-xs text-muted-foreground mt-1">Max 50MB</span>
+            <input
+              id="pdf-upload-input"
+              type="file"
+              accept=".pdf,application/pdf"
+              onChange={handleFileSelected}
+              className="hidden"
+              data-testid="pdf-file-input"
+            />
+          </label>
+          <Button onClick={() => setPhase('prompt')} variant="ghost" className="w-full">
+            Indietro
+          </Button>
+        </div>
+      )}
+
+      {phase === 'processing' && (
+        <div className="space-y-3">
+          <PdfProcessingStatus
+            gameId={effectiveGameId}
+            pdfFileName={uploadedFileName}
+            onContinue={() => onComplete(effectiveGameId ?? undefined)}
+          />
+        </div>
+      )}
+
+      <CopyrightDisclaimerModal
+        open={phase === 'disclaimer'}
+        onAccept={handleDisclaimerAccept}
+        onCancel={handleDisclaimerCancel}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/components/game-night/steps/UploadRulesStep.tsx
+++ b/apps/web/src/components/game-night/steps/UploadRulesStep.tsx
@@ -3,15 +3,15 @@
 /**
  * UploadRulesStep — Step 2 of GameNightWizard.
  *
- * Shows CopyrightDisclaimerModal → then file upload → processing status.
+ * Shows CopyrightDisclaimerModal → then file upload via XHR → processing status.
  * Has "Salta" (skip) button to proceed without uploading a PDF.
  *
  * Issue #123 — Game Night Quick Start Wizard
  */
 
-import { useCallback, useState } from 'react';
+import { useCallback, useRef, useState } from 'react';
 
-import { FileText, SkipForward } from 'lucide-react';
+import { FileText, Loader2, SkipForward } from 'lucide-react';
 
 import { PdfProcessingStatus } from '@/components/library/PdfProcessingStatus';
 import { CopyrightDisclaimerModal } from '@/components/pdf/CopyrightDisclaimerModal';
@@ -29,7 +29,9 @@ interface UploadRulesStepProps {
   onSkip: () => void;
 }
 
-type UploadPhase = 'prompt' | 'disclaimer' | 'upload' | 'processing';
+type UploadPhase = 'prompt' | 'disclaimer' | 'upload' | 'uploading' | 'processing';
+
+const MAX_FILE_SIZE = 50 * 1024 * 1024; // 50MB
 
 // ============================================================================
 // Component
@@ -43,7 +45,10 @@ export function UploadRulesStep({
   onSkip,
 }: UploadRulesStepProps) {
   const [phase, setPhase] = useState<UploadPhase>('prompt');
-  const [uploadedFileName, setUploadedFileName] = useState<string | null>(null);
+  const [uploadProgress, setUploadProgress] = useState(0);
+  const [pdfDocumentId, setPdfDocumentId] = useState<string | null>(null);
+  const [uploadError, setUploadError] = useState<string | null>(null);
+  const xhrRef = useRef<XMLHttpRequest | null>(null);
 
   const effectiveGameId = gameId ?? privateGameId ?? null;
 
@@ -55,21 +60,68 @@ export function UploadRulesStep({
     setPhase('prompt');
   }, []);
 
-  const handleFileSelected = useCallback(async (e: React.ChangeEvent<HTMLInputElement>) => {
-    const file = e.target.files?.[0];
-    if (!file) return;
+  const handleFileSelected = useCallback(
+    async (e: React.ChangeEvent<HTMLInputElement>) => {
+      const file = e.target.files?.[0];
+      if (!file) return;
 
-    // Validate PDF
-    if (file.type !== 'application/pdf') return;
-    if (file.size > 50 * 1024 * 1024) return; // 50MB max
+      // Validate PDF
+      if (file.type !== 'application/pdf') {
+        setUploadError('Solo file PDF sono supportati.');
+        return;
+      }
+      if (file.size > MAX_FILE_SIZE) {
+        setUploadError('Il file supera il limite di 50MB.');
+        return;
+      }
 
-    setUploadedFileName(file.name);
-    setPhase('processing');
+      setUploadError(null);
+      setPhase('uploading');
+      setUploadProgress(0);
 
-    // The actual upload is handled by the PdfProcessingStatus component's
-    // underlying infrastructure. For the wizard, we show the processing status
-    // and let the user continue when ready.
-  }, []);
+      const formData = new FormData();
+      formData.append('file', file);
+      if (effectiveGameId) {
+        formData.append('gameId', effectiveGameId);
+      }
+
+      const xhr = new XMLHttpRequest();
+      xhrRef.current = xhr;
+
+      xhr.upload.addEventListener('progress', ev => {
+        if (ev.lengthComputable) {
+          setUploadProgress(Math.round((ev.loaded / ev.total) * 100));
+        }
+      });
+
+      xhr.addEventListener('load', () => {
+        if (xhr.status >= 200 && xhr.status < 300) {
+          try {
+            const response = JSON.parse(xhr.responseText);
+            setPdfDocumentId(response.documentId ?? response.id ?? null);
+            setPhase('processing');
+          } catch {
+            setUploadError('Risposta server non valida.');
+            setPhase('upload');
+          }
+        } else {
+          setUploadError(`Upload fallito (${xhr.status}). Riprova.`);
+          setPhase('upload');
+        }
+      });
+
+      xhr.addEventListener('error', () => {
+        setUploadError("Errore di rete durante l'upload.");
+        setPhase('upload');
+      });
+
+      // Use relative URL to route through Next.js proxy (avoids CORS)
+      xhr.open('POST', '/api/v1/ingest/pdf');
+      xhr.withCredentials = true;
+      xhr.send(formData);
+    },
+    [effectiveGameId]
+  );
 
   return (
     <div className="space-y-4" data-testid="upload-rules-step">
@@ -82,6 +134,12 @@ export function UploadRulesStep({
           l&apos;assistente AI.
         </p>
       </div>
+
+      {uploadError && (
+        <p className="text-sm text-destructive" data-testid="upload-error">
+          {uploadError}
+        </p>
+      )}
 
       {phase === 'prompt' && (
         <div className="space-y-3">
@@ -130,12 +188,29 @@ export function UploadRulesStep({
         </div>
       )}
 
+      {phase === 'uploading' && (
+        <div className="space-y-3" data-testid="upload-progress">
+          <div className="flex items-center gap-3 p-4 rounded-lg border">
+            <Loader2 className="h-5 w-5 animate-spin text-amber-600" aria-hidden="true" />
+            <div className="flex-1">
+              <p className="text-sm font-medium">Upload in corso... {uploadProgress}%</p>
+              <div className="h-2 mt-2 rounded-full bg-slate-200 dark:bg-slate-700 overflow-hidden">
+                <div
+                  className="h-full bg-amber-500 transition-all duration-300"
+                  style={{ width: `${uploadProgress}%` }}
+                />
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
+
       {phase === 'processing' && (
         <div className="space-y-3">
           <PdfProcessingStatus
             gameId={effectiveGameId}
-            pdfFileName={uploadedFileName}
-            onContinue={() => onComplete(effectiveGameId ?? undefined)}
+            pdfFileName={null}
+            onContinue={() => onComplete(pdfDocumentId ?? undefined)}
           />
         </div>
       )}

--- a/apps/web/src/components/session/KbProcessingBanner.tsx
+++ b/apps/web/src/components/session/KbProcessingBanner.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+/**
+ * KbProcessingBanner — Degraded mode banner when KB is still processing.
+ *
+ * Polls document status every 10 seconds. Shows processing state,
+ * then transitions to "ready" when KB indexing completes.
+ *
+ * Issue #123 — Game Night Quick Start Wizard
+ */
+
+import { useEffect, useState } from 'react';
+
+import { Check, Loader2 } from 'lucide-react';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface KbProcessingBannerProps {
+  gameId: string;
+  onReady?: () => void;
+}
+
+// ============================================================================
+// Component
+// ============================================================================
+
+export function KbProcessingBanner({ gameId, onReady }: KbProcessingBannerProps) {
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    const interval = setInterval(async () => {
+      try {
+        const response = await fetch(`/api/v1/documents/game/${gameId}/status`);
+        const data = await response.json();
+        if (data.isReady) {
+          setReady(true);
+          onReady?.();
+          clearInterval(interval);
+        }
+      } catch {
+        // Ignore polling errors — will retry on next interval
+      }
+    }, 10_000);
+
+    return () => clearInterval(interval);
+  }, [gameId, onReady]);
+
+  if (ready) {
+    return (
+      <div
+        className="rounded-lg border border-green-500/30 bg-green-500/10 px-4 py-2 text-sm flex items-center gap-2 text-green-700 dark:text-green-300"
+        data-testid="kb-banner-ready"
+      >
+        <Check className="h-4 w-4" aria-hidden="true" />
+        Regolamento pronto! L&apos;agente AI conosce le regole.
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="rounded-lg border border-amber-500/30 bg-amber-500/10 px-4 py-2 text-sm flex items-center gap-2 text-amber-700 dark:text-amber-200"
+      data-testid="kb-banner-processing"
+    >
+      <Loader2 className="h-4 w-4 animate-spin" aria-hidden="true" />
+      Regolamento in elaborazione... L&apos;agente avrà accesso alle regole tra poco.
+    </div>
+  );
+}

--- a/apps/web/src/components/session/KbProcessingBanner.tsx
+++ b/apps/web/src/components/session/KbProcessingBanner.tsx
@@ -3,15 +3,15 @@
 /**
  * KbProcessingBanner — Degraded mode banner when KB is still processing.
  *
- * Polls document status every 10 seconds. Shows processing state,
- * then transitions to "ready" when KB indexing completes.
+ * Polls document status every 10 seconds, up to 30 attempts (5 min).
+ * Shows processing state, then transitions to "ready" when KB indexing completes.
  *
  * Issue #123 — Game Night Quick Start Wizard
  */
 
-import { useEffect, useState } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
-import { Check, Loader2 } from 'lucide-react';
+import { AlertTriangle, Check, Loader2 } from 'lucide-react';
 
 // ============================================================================
 // Types
@@ -22,32 +22,47 @@ interface KbProcessingBannerProps {
   onReady?: () => void;
 }
 
+type BannerState = 'processing' | 'ready' | 'timeout';
+
+const POLL_INTERVAL_MS = 10_000;
+const MAX_POLL_ATTEMPTS = 30; // 5 minutes
+
 // ============================================================================
 // Component
 // ============================================================================
 
 export function KbProcessingBanner({ gameId, onReady }: KbProcessingBannerProps) {
-  const [ready, setReady] = useState(false);
+  const [state, setState] = useState<BannerState>('processing');
+  const pollCount = useRef(0);
 
   useEffect(() => {
     const interval = setInterval(async () => {
+      pollCount.current++;
+
+      if (pollCount.current > MAX_POLL_ATTEMPTS) {
+        setState('timeout');
+        clearInterval(interval);
+        return;
+      }
+
       try {
         const response = await fetch(`/api/v1/documents/game/${gameId}/status`);
+        if (!response.ok) return; // Retry on next interval
         const data = await response.json();
         if (data.isReady) {
-          setReady(true);
+          setState('ready');
           onReady?.();
           clearInterval(interval);
         }
       } catch {
         // Ignore polling errors — will retry on next interval
       }
-    }, 10_000);
+    }, POLL_INTERVAL_MS);
 
     return () => clearInterval(interval);
   }, [gameId, onReady]);
 
-  if (ready) {
+  if (state === 'ready') {
     return (
       <div
         className="rounded-lg border border-green-500/30 bg-green-500/10 px-4 py-2 text-sm flex items-center gap-2 text-green-700 dark:text-green-300"
@@ -55,6 +70,18 @@ export function KbProcessingBanner({ gameId, onReady }: KbProcessingBannerProps)
       >
         <Check className="h-4 w-4" aria-hidden="true" />
         Regolamento pronto! L&apos;agente AI conosce le regole.
+      </div>
+    );
+  }
+
+  if (state === 'timeout') {
+    return (
+      <div
+        className="rounded-lg border border-slate-500/30 bg-slate-500/10 px-4 py-2 text-sm flex items-center gap-2 text-slate-700 dark:text-slate-300"
+        data-testid="kb-banner-timeout"
+      >
+        <AlertTriangle className="h-4 w-4" aria-hidden="true" />
+        L&apos;elaborazione sta richiedendo più tempo del previsto. Puoi continuare a giocare.
       </div>
     );
   }

--- a/apps/web/src/components/session/__tests__/KbProcessingBanner.test.tsx
+++ b/apps/web/src/components/session/__tests__/KbProcessingBanner.test.tsx
@@ -1,0 +1,69 @@
+import { render, screen, act } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+import { KbProcessingBanner } from '../KbProcessingBanner';
+
+describe('KbProcessingBanner', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+    vi.stubGlobal('fetch', vi.fn());
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.restoreAllMocks();
+  });
+
+  it('shows processing state initially', () => {
+    render(<KbProcessingBanner gameId="game-1" />);
+
+    expect(screen.getByTestId('kb-banner-processing')).toBeInTheDocument();
+    expect(screen.getByText(/regolamento in elaborazione/i)).toBeInTheDocument();
+  });
+
+  it('transitions to ready state when KB is indexed', async () => {
+    const onReady = vi.fn();
+    const mockFetch = vi.fn().mockResolvedValue({
+      json: () => Promise.resolve({ isReady: true }),
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    render(<KbProcessingBanner gameId="game-1" onReady={onReady} />);
+
+    // Initially processing
+    expect(screen.getByTestId('kb-banner-processing')).toBeInTheDocument();
+
+    // Advance timer to trigger poll
+    await act(async () => {
+      vi.advanceTimersByTime(10_000);
+    });
+
+    expect(screen.getByTestId('kb-banner-ready')).toBeInTheDocument();
+    expect(screen.getByText(/regolamento pronto/i)).toBeInTheDocument();
+    expect(onReady).toHaveBeenCalledTimes(1);
+  });
+
+  it('keeps polling when KB is not ready', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      json: () => Promise.resolve({ isReady: false }),
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    render(<KbProcessingBanner gameId="game-1" />);
+
+    // First poll
+    await act(async () => {
+      vi.advanceTimersByTime(10_000);
+    });
+
+    expect(screen.getByTestId('kb-banner-processing')).toBeInTheDocument();
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    // Second poll
+    await act(async () => {
+      vi.advanceTimersByTime(10_000);
+    });
+
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+});

--- a/apps/web/src/components/session/__tests__/KbProcessingBanner.test.tsx
+++ b/apps/web/src/components/session/__tests__/KbProcessingBanner.test.tsx
@@ -24,6 +24,7 @@ describe('KbProcessingBanner', () => {
   it('transitions to ready state when KB is indexed', async () => {
     const onReady = vi.fn();
     const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
       json: () => Promise.resolve({ isReady: true }),
     });
     vi.stubGlobal('fetch', mockFetch);
@@ -45,6 +46,7 @@ describe('KbProcessingBanner', () => {
 
   it('keeps polling when KB is not ready', async () => {
     const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
       json: () => Promise.resolve({ isReady: false }),
     });
     vi.stubGlobal('fetch', mockFetch);
@@ -65,5 +67,42 @@ describe('KbProcessingBanner', () => {
     });
 
     expect(mockFetch).toHaveBeenCalledTimes(2);
+  });
+
+  it('ignores non-ok responses and keeps polling', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    render(<KbProcessingBanner gameId="game-1" />);
+
+    await act(async () => {
+      vi.advanceTimersByTime(10_000);
+    });
+
+    // Still processing — did not crash
+    expect(screen.getByTestId('kb-banner-processing')).toBeInTheDocument();
+  });
+
+  it('shows timeout state after max poll attempts', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: () => Promise.resolve({ isReady: false }),
+    });
+    vi.stubGlobal('fetch', mockFetch);
+
+    render(<KbProcessingBanner gameId="game-1" />);
+
+    // Advance past max attempts (30 * 10s = 300s)
+    for (let i = 0; i < 31; i++) {
+      await act(async () => {
+        vi.advanceTimersByTime(10_000);
+      });
+    }
+
+    expect(screen.getByTestId('kb-banner-timeout')).toBeInTheDocument();
+    expect(screen.getByText(/più tempo del previsto/i)).toBeInTheDocument();
   });
 });


### PR DESCRIPTION
## Summary
- **GameNightWizard**: 3-step quick start (search game → upload PDF → create session with players)
- **KbProcessingBanner**: Auto-polling banner showing KB processing status with timeout
- **Entry point**: "Serata di Gioco" card on `/sessions/new` page

## Code Review Fixes (9 issues resolved)
### Critical
- PDF upload now actually uploads via XHR to `/api/v1/ingest/pdf` with progress bar (was no-op before)
- BGG games create session with `gameName` only — no invalid empty `gameId`
- Navigation race fixed: parent page owns `router.push`, wizard only calls `onComplete`

### Important
- `KbProcessingBanner`: validates `response.ok`, stops after 30 polls (5min timeout state)
- Search button has `aria-label` for screen readers
- `next/image` instead of raw `<img>` for thumbnails
- Stable player slot IDs instead of `key={index}` on removable list
- File validation errors shown to user (wrong type / oversized)
- Tests strengthened: 11 tests (was 8), BGG flow + timeout + error coverage

## Test plan
- [x] 11 unit tests pass (6 wizard + 5 banner)
- [x] 558 broader session/game-night tests pass (0 failures)
- [x] Frontend build passes (TypeScript + Next.js)
- [x] Backend build passes
- [ ] Manual: search catalog game → select → skip PDF → add 2 players → create session
- [ ] Manual: search BGG-only game → verify session creates with gameName
- [ ] Manual: upload PDF → verify XHR progress bar → processing status

Closes #123

🤖 Generated with [Claude Code](https://claude.com/claude-code)