### PR TITLE
C5: Add staging Traefik config files (GitOps)

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -185,16 +185,22 @@ jobs:
             docker compose -f docker-compose.yml -f compose.staging.yml -f compose.staging-traefik.yml \
               --profile minimal up -d --no-deps api web
 
-            # Health check (internal - avoids SSL issues)
-            sleep 15
-            curl -sf http://localhost:8080/health | python3 -c "
+            # Health check (internal - avoids SSL issues, polls instead of sleep)
+            for i in $(seq 1 20); do
+              if curl -sf http://localhost:8080/health | python3 -c "
             import sys,json
             d=json.load(sys.stdin)
             healthy = [c['name'] for c in d['checks'] if c['status']=='Healthy']
             print(f'Healthy services: {len(healthy)}')
             assert any(c['name']=='postgres' and c['status']=='Healthy' for c in d['checks']), 'postgres unhealthy'
             assert any(c['name']=='redis' and c['status']=='Healthy' for c in d['checks']), 'redis unhealthy'
-            " || exit 1
+            "; then
+                echo "✅ Internal health check passed"
+                break
+              fi
+              echo "⏳ Waiting for API to be healthy... ($i/20)"
+              sleep 5
+            done
 
             # Cleanup old images
             docker image prune -f
@@ -209,19 +215,29 @@ jobs:
         run: |
           echo "🔍 Running health checks..."
 
-          # API Health
+          # API Health (routed via Traefik subdomain)
+          API_HEALTHY=false
           for i in {1..30}; do
-            if curl -sf https://meepleai.app/health; then
+            if curl -sf https://api.meepleai.app/health; then
               echo "✅ API healthy"
+              API_HEALTHY=true
               break
             fi
             echo "⏳ Waiting for API... ($i/30)"
             sleep 10
           done
+          if [ "$API_HEALTHY" != "true" ]; then
+            echo "❌ API health check failed after 30 attempts"
+            exit 1
+          fi
 
           # Web Health
-          curl -sf https://meepleai.app || exit 1
-          echo "✅ Web healthy"
+          HTTP_STATUS=$(curl -s -o /dev/null -w "%{http_code}" https://meepleai.app)
+          if [ "$HTTP_STATUS" != "200" ]; then
+            echo "❌ Web returned status $HTTP_STATUS"
+            exit 1
+          fi
+          echo "✅ Web healthy (HTTP $HTTP_STATUS)"
 
       - name: Smoke Tests
         run: |

--- a/infra/compose.staging-traefik.yml
+++ b/infra/compose.staging-traefik.yml
@@ -1,0 +1,184 @@
+# Docker Compose - Staging Traefik Override for meepleai.app
+#
+# This file extends docker-compose.yml + compose.staging.yml with
+# Traefik reverse proxy and routing labels for the staging domain.
+#
+# Usage:
+#   docker compose -f docker-compose.yml -f compose.staging.yml -f compose.staging-traefik.yml \
+#     --profile minimal up -d
+#
+# Domain Configuration:
+#   - meepleai.app         → Web Frontend (Next.js)
+#   - api.meepleai.app     → Backend API (.NET)
+#   - grafana.meepleai.app → Monitoring Dashboard
+#   - traefik.meepleai.app → Traefik Dashboard (admin only)
+#
+# Prerequisites:
+#   - Cloudflare DNS configured for meepleai.app → server IP
+#   - Port 80 and 443 open on server firewall
+#   - secrets/traefik.secret configured (dashboard password)
+
+services:
+  # ============================================================================
+  # Security: Docker Socket Proxy (REQUIRED)
+  # Limits Traefik's Docker API access to read-only container info
+  # ============================================================================
+  docker-socket-proxy:
+    image: ghcr.io/tecnativa/docker-socket-proxy:0.3.0
+    container_name: meepleai-socket-proxy
+    restart: unless-stopped
+    environment:
+      CONTAINERS: 1
+      SERVICES: 0
+      TASKS: 0
+      NETWORKS: 0
+      NODES: 0
+      POST: 0
+      BUILD: 0
+      COMMIT: 0
+      CONFIGS: 0
+      DISTRIBUTION: 0
+      EXEC: 0
+      IMAGES: 0
+      INFO: 0
+      PLUGINS: 0
+      SECRETS: 0
+      SWARM: 0
+      SYSTEM: 0
+      VOLUMES: 0
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    networks:
+      - meepleai
+    security_opt:
+      - no-new-privileges=true
+    read_only: true
+    tmpfs:
+      - /run
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 128M
+
+  # ============================================================================
+  # Traefik Reverse Proxy - Staging Config
+  # ============================================================================
+  traefik:
+    image: traefik:v3.2
+    container_name: meepleai-traefik
+    restart: unless-stopped
+    depends_on:
+      - docker-socket-proxy
+    command:
+      - "--configFile=/etc/traefik/traefik.yml"
+    ports:
+      - "80:80"
+      - "443:443"
+    environment:
+      TZ: Europe/Rome
+    volumes:
+      - ./traefik/traefik.staging.yml:/etc/traefik/traefik.yml:ro
+      - ./traefik/dynamic:/etc/traefik/dynamic:ro
+      - ./traefik/letsencrypt:/letsencrypt
+      - ./traefik/logs:/var/log/traefik
+    labels:
+      - "traefik.enable=true"
+      # Dashboard - HTTPS with basic auth
+      - "traefik.http.routers.traefik-dashboard.rule=Host(`traefik.meepleai.app`)"
+      - "traefik.http.routers.traefik-dashboard.entrypoints=websecure"
+      - "traefik.http.routers.traefik-dashboard.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.traefik-dashboard.service=api@internal"
+      - "traefik.http.routers.traefik-dashboard.middlewares=dashboard-auth@file,ip-whitelist-admin@file"
+    healthcheck:
+      test: ["CMD", "traefik", "healthcheck"]
+      interval: 30s
+      timeout: 10s
+      retries: 3
+    networks:
+      - meepleai
+    security_opt:
+      - no-new-privileges=true
+    deploy:
+      resources:
+        limits:
+          cpus: '1.0'
+          memory: 512M
+        reservations:
+          cpus: '0.5'
+          memory: 256M
+
+  # ============================================================================
+  # API Backend - meepleai.app
+  # ============================================================================
+  api:
+    labels:
+      - "traefik.enable=true"
+      # Main API router
+      - "traefik.http.routers.api.rule=Host(`api.meepleai.app`)"
+      - "traefik.http.routers.api.entrypoints=websecure"
+      - "traefik.http.routers.api.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.api.middlewares=api-chain@file"
+      - "traefik.http.services.api.loadbalancer.server.port=8080"
+      - "traefik.http.services.api.loadbalancer.server.scheme=http"
+      # Health check endpoint
+      - "traefik.http.services.api.loadbalancer.healthcheck.path=/health"
+      - "traefik.http.services.api.loadbalancer.healthcheck.interval=30s"
+      # Auth endpoints with stricter rate limiting
+      - "traefik.http.routers.api-auth.rule=Host(`api.meepleai.app`) && PathPrefix(`/api/v1/auth`)"
+      - "traefik.http.routers.api-auth.entrypoints=websecure"
+      - "traefik.http.routers.api-auth.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.api-auth.middlewares=auth-chain@file"
+      - "traefik.http.routers.api-auth.service=api"
+      - "traefik.http.routers.api-auth.priority=100"
+    environment:
+      ASPNETCORE_ENVIRONMENT: Staging
+      ASPNETCORE_URLS: "http://+:8080"
+      CORS_ORIGINS: "https://meepleai.app,https://www.meepleai.app"
+
+  # ============================================================================
+  # Web Frontend - meepleai.app
+  # ============================================================================
+  web:
+    labels:
+      - "traefik.enable=true"
+      # Main website router
+      - "traefik.http.routers.web.rule=Host(`meepleai.app`) || Host(`www.meepleai.app`)"
+      - "traefik.http.routers.web.entrypoints=websecure"
+      - "traefik.http.routers.web.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.web.middlewares=web-chain@file"
+      - "traefik.http.services.web.loadbalancer.server.port=3000"
+    environment:
+      NODE_ENV: staging
+      NEXT_PUBLIC_API_BASE: "https://api.meepleai.app"
+      NEXT_PUBLIC_APP_URL: "https://meepleai.app"
+
+  # ============================================================================
+  # Grafana Monitoring - meepleai.app
+  # ============================================================================
+  grafana:
+    labels:
+      - "traefik.enable=true"
+      - "traefik.http.routers.grafana.rule=Host(`grafana.meepleai.app`)"
+      - "traefik.http.routers.grafana.entrypoints=websecure"
+      - "traefik.http.routers.grafana.tls.certresolver=letsencrypt"
+      - "traefik.http.routers.grafana.middlewares=security-headers@file"
+      - "traefik.http.services.grafana.loadbalancer.server.port=3000"
+    environment:
+      GF_SERVER_ROOT_URL: "https://grafana.meepleai.app"
+      GF_SERVER_DOMAIN: "grafana.meepleai.app"
+
+  # ============================================================================
+  # Prometheus (Internal Only - accessed via Grafana)
+  # ============================================================================
+  prometheus:
+    labels:
+      - "traefik.enable=false"
+
+# ============================================================================
+# Networks
+# ============================================================================
+networks:
+  meepleai:
+    name: meepleai
+    driver: bridge

--- a/infra/traefik/dynamic/middlewares.staging.yml
+++ b/infra/traefik/dynamic/middlewares.staging.yml
@@ -1,0 +1,139 @@
+# Traefik Dynamic Configuration - Staging Middlewares
+# Security headers and rate limiting for meepleai.app
+#
+# Environment-specific CORS:
+# - Development: localhost:3000, localhost:8080 (see middlewares.yml)
+# - Staging: meepleai.app (this file)
+# - Production: meepleai.io (see middlewares.prod.yml)
+
+http:
+  middlewares:
+    # CORS for API services - Staging
+    cors-api:
+      headers:
+        accessControlAllowOriginList:
+          - "https://meepleai.app"
+          - "https://www.meepleai.app"
+          - "https://api.meepleai.app"
+        accessControlAllowMethods:
+          - GET
+          - POST
+          - PUT
+          - DELETE
+          - PATCH
+          - OPTIONS
+        accessControlAllowHeaders:
+          - "Content-Type"
+          - "Authorization"
+          - "X-Requested-With"
+          - "Accept"
+          - "Origin"
+          - "X-CSRF-Token"
+        accessControlAllowCredentials: true
+        accessControlMaxAge: 7200
+        accessControlExposeHeaders:
+          - "X-Request-Id"
+          - "X-RateLimit-Limit"
+          - "X-RateLimit-Remaining"
+
+    # Security Headers (OWASP recommended)
+    security-headers:
+      headers:
+        browserXssFilter: true
+        contentTypeNosniff: true
+        frameDeny: true
+        stsIncludeSubdomains: true
+        stsPreload: true
+        stsSeconds: 31536000
+        customFrameOptionsValue: "SAMEORIGIN"
+        customResponseHeaders:
+          X-Robots-Tag: "noindex,nofollow,nosnippet,noarchive,notranslate,noimageindex"
+          X-Download-Options: "noopen"
+          X-Permitted-Cross-Domain-Policies: "none"
+          Referrer-Policy: "strict-origin-when-cross-origin"
+          Permissions-Policy: "camera=(), microphone=(), geolocation=(), payment=()"
+
+    # Rate Limiting - API (staging: same as production for realistic testing)
+    rate-limit-api:
+      rateLimit:
+        average: 100
+        burst: 200
+        period: 1m
+        sourceCriterion:
+          ipStrategy:
+            depth: 1
+
+    # Rate Limiting - Web
+    rate-limit-web:
+      rateLimit:
+        average: 200
+        burst: 400
+        period: 1m
+
+    # Rate Limiting - Auth endpoints (strict)
+    rate-limit-auth:
+      rateLimit:
+        average: 10
+        burst: 20
+        period: 1m
+
+    # Basic Auth for Dashboard
+    dashboard-auth:
+      basicAuth:
+        users:
+          # Generate with: htpasswd -nbB admin "your-password" | sed -e s/\\$/\\$\\$/g
+          - "admin:$$2y$$05$$REPLACE_WITH_BCRYPT_HASH"
+
+    # Compress responses
+    compress:
+      compress:
+        excludedContentTypes:
+          - text/event-stream
+
+    # Retry middleware
+    retry:
+      retry:
+        attempts: 3
+        initialInterval: 100ms
+
+    # Circuit breaker
+    circuit-breaker:
+      circuitBreaker:
+        expression: "NetworkErrorRatio() > 0.30 || ResponseCodeRatio(500, 600, 0, 600) > 0.25"
+        checkPeriod: 10s
+        fallbackDuration: 30s
+        recoveryDuration: 15s
+
+    # IP Whitelist (for admin endpoints)
+    ip-whitelist-admin:
+      ipAllowList:
+        sourceRange:
+          - "127.0.0.1/32"
+          - "10.0.0.0/8"
+          - "172.16.0.0/12"
+          - "192.168.0.0/16"
+
+    # Chain for API
+    api-chain:
+      chain:
+        middlewares:
+          - security-headers
+          - rate-limit-api
+          - circuit-breaker
+          - retry
+          - compress
+
+    # Chain for Web
+    web-chain:
+      chain:
+        middlewares:
+          - security-headers
+          - rate-limit-web
+          - compress
+
+    # Chain for Auth
+    auth-chain:
+      chain:
+        middlewares:
+          - security-headers
+          - rate-limit-auth

--- a/infra/traefik/traefik.staging.yml
+++ b/infra/traefik/traefik.staging.yml
@@ -1,0 +1,105 @@
+# Traefik v3.2 Staging Configuration for meepleai.app
+#
+# This file replaces traefik.yml for staging deployment
+# Features:
+# - HTTPS with Let's Encrypt automatic certificates
+# - HTTP to HTTPS redirect
+# - Security headers
+# - Rate limiting
+# - Docker socket proxy for security
+#
+# Usage:
+#   Mount as volume override in compose.staging-traefik.yml
+
+# API & Dashboard - SECURED
+api:
+  dashboard: true
+  # Dashboard requires authentication via middleware (see compose labels)
+
+# Entry Points
+entryPoints:
+  # HTTP - redirects to HTTPS
+  web:
+    address: ":80"
+    http:
+      redirections:
+        entryPoint:
+          to: websecure
+          scheme: https
+          permanent: true
+
+  # HTTPS - main entry point
+  websecure:
+    address: ":443"
+    http:
+      tls:
+        certResolver: letsencrypt
+        domains:
+          - main: "meepleai.app"
+            sans:
+              - "*.meepleai.app"
+      middlewares:
+        - security-headers@file
+
+# Logging - Staging settings (more verbose than production)
+log:
+  level: INFO
+  filePath: "/var/log/traefik/traefik.log"
+  format: json
+  maxSize: 50
+  maxBackups: 3
+  maxAge: 14
+  compress: true
+
+# Access Logs - with sensitive header filtering
+accessLog:
+  filePath: "/var/log/traefik/access.log"
+  format: json
+  bufferingSize: 100
+  fields:
+    headers:
+      defaultMode: keep
+      names:
+        Authorization: drop
+        Cookie: drop
+        Set-Cookie: drop
+
+# Providers
+providers:
+  # Docker Provider via Socket Proxy (SECURE)
+  docker:
+    endpoint: "tcp://docker-socket-proxy:2375"
+    exposedByDefault: false
+    network: "meepleai"
+    watch: true
+
+  # File Provider (dynamic configuration)
+  file:
+    directory: "/etc/traefik/dynamic"
+    watch: true
+
+# Let's Encrypt Certificate Resolver
+certificatesResolvers:
+  letsencrypt:
+    acme:
+      email: "admin@meepleai.app"
+      storage: "/letsencrypt/acme.json"
+      httpChallenge:
+        entryPoint: web
+
+# Metrics for Prometheus
+metrics:
+  prometheus:
+    addEntryPointsLabels: true
+    addRoutersLabels: true
+    addServicesLabels: true
+    buckets:
+      - 0.1
+      - 0.3
+      - 1.2
+      - 5.0
+
+# Global settings
+global:
+  checkNewVersion: false
+  sendAnonymousUsage: false


### PR DESCRIPTION
## Summary

- Create `compose.staging-traefik.yml` referenced by `deploy-staging.yml` but missing from repo (deploy blocker)
- Add `traefik.staging.yml` static config for Let's Encrypt HTTPS on `meepleai.app`
- Add `middlewares.staging.yml` for staging-specific CORS, rate limiting, security headers
- Fix health check URLs in deploy workflow to use `api.meepleai.app` subdomain routing
- Replace sleep-based health wait with polling loop

## Changes

### New Files
| File | Purpose |
|------|---------|
| `infra/compose.staging-traefik.yml` | Traefik + Docker labels routing for `meepleai.app` |
| `infra/traefik/traefik.staging.yml` | Static Traefik config: Let's Encrypt, socket proxy, logging |
| `infra/traefik/dynamic/middlewares.staging.yml` | CORS for `meepleai.app`, rate limiting, security headers |

### Modified Files
| File | Change |
|------|--------|
| `.github/workflows/deploy-staging.yml` | Health check URLs → `api.meepleai.app`, polling instead of `sleep 15` |

### Domain Routing
```
meepleai.app         → Web Frontend (Next.js :3000)
api.meepleai.app     → Backend API (.NET :8080)
grafana.meepleai.app → Monitoring (Grafana :3000)
traefik.meepleai.app → Traefik Dashboard (admin only)
```

### Pattern Consistency
Follows exact same pattern as production:
- `compose.meepleai.yml` → `compose.staging-traefik.yml`
- `traefik.prod.yml` → `traefik.staging.yml`
- `middlewares.prod.yml` → `middlewares.staging.yml`

## Test plan
- [ ] YAML syntax validates (no tabs, proper indentation)
- [ ] Pattern matches production compose.meepleai.yml structure (4 services with traefik.enable)
- [ ] Let's Encrypt config uses correct domain (meepleai.app)
- [ ] CORS origins match staging domain
- [ ] Health check URLs use api.meepleai.app subdomain
- [ ] Deploy workflow references correct compose file path

Closes #176

🤖 Generated with [Claude Code](https://claude.com/claude-code)