### PR TITLE
I3: Build-once-promote pattern (staging→production)

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -67,45 +67,21 @@ jobs:
     uses: ./.github/workflows/ci.yml
     secrets: inherit
 
-  # Build production images
+  # Promote staging images to production (build-once-promote pattern)
+  # Issue #179: Instead of rebuilding, retag the staging-tested images
+  # as production. This guarantees the exact artifact tested in staging
+  # is what gets deployed to production.
   build:
-    name: Build Production Images
+    name: Promote Staging Images
     runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
     timeout-minutes: 45
     needs: [staging-check, test]
     if: always() && needs.test.result == 'success' && (needs.staging-check.result == 'success' || needs.staging-check.result == 'skipped')
     outputs:
-      api_image: ${{ steps.meta-api.outputs.tags }}
-      web_image: ${{ steps.meta-web.outputs.tags }}
+      api_image: ${{ env.API_IMAGE }}:${{ steps.version.outputs.version }}
+      web_image: ${{ env.WEB_IMAGE }}:${{ steps.version.outputs.version }}
       version: ${{ steps.version.outputs.version }}
     steps:
-      - name: Check Runner Fallback
-        if: vars.RUNNER != '' && !contains(runner.name, vars.RUNNER)
-        run: |
-          echo "::warning::Self-hosted runner '${{ vars.RUNNER }}' unavailable — fell back to GitHub-hosted runner"
-          echo "⚠️ This may produce x86 images incompatible with ARM64 production server"
-
-      - name: Verify ARM64 runner
-        if: vars.RUNNER != ''
-        run: |
-          ARCH=$(uname -m)
-          echo "Runner architecture: $ARCH"
-          if [ "$ARCH" != "aarch64" ]; then
-            echo "::error::Expected aarch64 but got $ARCH — runner may have silently fallen back"
-            exit 1
-          fi
-
-      - name: Pre-build disk check (self-hosted)
-        if: vars.RUNNER != ''
-        run: |
-          # Requires GNU df (--output flag)
-          USAGE=$(df / --output=pcent | tail -1 | tr -d ' %')
-          echo "Disk usage: ${USAGE}%"
-          if [ "$USAGE" -gt 90 ]; then
-            echo "::error::Disk usage critical (${USAGE}%) — triggering emergency cleanup"
-            docker system prune -af --filter "until=24h" 2>/dev/null || true
-          fi
-
       - name: Checkout
         uses: actions/checkout@v4
         with:
@@ -124,9 +100,6 @@ jobs:
           echo "version=$VERSION" >> $GITHUB_OUTPUT
           echo "📦 Production Version: $VERSION"
 
-      - name: Setup Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
       - name: Login to GitHub Container Registry
         uses: docker/login-action@v3
         with:
@@ -134,61 +107,55 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Extract API Metadata
-        id: meta-api
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.API_IMAGE }}
-          tags: |
-            type=raw,value=${{ steps.version.outputs.version }}
-            type=raw,value=latest
-
-      - name: Extract Web Metadata
-        id: meta-web
-        uses: docker/metadata-action@v5
-        with:
-          images: ${{ env.WEB_IMAGE }}
-          tags: |
-            type=raw,value=${{ steps.version.outputs.version }}
-            type=raw,value=latest
-
-      - name: Build and Push API Image
-        uses: docker/build-push-action@v5
-        with:
-          context: ./apps/api
-          file: ./apps/api/src/Api/Dockerfile
-          push: true
-          tags: ${{ steps.meta-api.outputs.tags }}
-          labels: ${{ steps.meta-api.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          build-args: |
-            ASPNETCORE_ENVIRONMENT=Production
-            VERSION=${{ steps.version.outputs.version }}
-
-      - name: Build and Push Web Image
-        uses: docker/build-push-action@v5
-        with:
-          context: ./apps/web
-          file: ./apps/web/Dockerfile
-          push: true
-          tags: ${{ steps.meta-web.outputs.tags }}
-          labels: ${{ steps.meta-web.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          build-args: |
-            NODE_ENV=production
-            NEXT_PUBLIC_ENV=production
-            VERSION=${{ steps.version.outputs.version }}
-
-      - name: Post-build cleanup (self-hosted)
-        if: always() && !contains(runner.name, 'GitHub Actions')
+      - name: Promote API Image (staging-latest → production tag)
         run: |
-          echo "🧹 Cleaning up Docker build artifacts on self-hosted runner..."
-          docker container prune -f 2>/dev/null || true
-          docker image prune -f 2>/dev/null || true
-          echo "✅ Cleanup complete"
-          df -h / | tail -1
+          echo "🔄 Promoting staging API image to production..."
+          # Pull the staging-tested image
+          docker pull ${{ env.API_IMAGE }}:staging-latest
+
+          # Retag as production version + latest
+          docker tag ${{ env.API_IMAGE }}:staging-latest ${{ env.API_IMAGE }}:${{ steps.version.outputs.version }}
+          docker tag ${{ env.API_IMAGE }}:staging-latest ${{ env.API_IMAGE }}:latest
+
+          # Push production tags
+          docker push ${{ env.API_IMAGE }}:${{ steps.version.outputs.version }}
+          docker push ${{ env.API_IMAGE }}:latest
+          echo "✅ API image promoted"
+
+      - name: Promote Web Image (staging-latest → production tag)
+        run: |
+          echo "🔄 Promoting staging Web image to production..."
+          # Pull the staging-tested image
+          docker pull ${{ env.WEB_IMAGE }}:staging-latest
+
+          # Retag as production version + latest
+          docker tag ${{ env.WEB_IMAGE }}:staging-latest ${{ env.WEB_IMAGE }}:${{ steps.version.outputs.version }}
+          docker tag ${{ env.WEB_IMAGE }}:staging-latest ${{ env.WEB_IMAGE }}:latest
+
+          # Push production tags
+          docker push ${{ env.WEB_IMAGE }}:${{ steps.version.outputs.version }}
+          docker push ${{ env.WEB_IMAGE }}:latest
+          echo "✅ Web image promoted"
+
+      - name: Verify Image Digests Match
+        run: |
+          echo "🔍 Verifying image integrity..."
+          # Confirm staging and production images have the same digest
+          STAGING_API=$(docker inspect --format='{{.Id}}' ${{ env.API_IMAGE }}:staging-latest)
+          PROD_API=$(docker inspect --format='{{.Id}}' ${{ env.API_IMAGE }}:${{ steps.version.outputs.version }})
+          if [ "$STAGING_API" != "$PROD_API" ]; then
+            echo "::error::API image digest mismatch!"
+            exit 1
+          fi
+
+          STAGING_WEB=$(docker inspect --format='{{.Id}}' ${{ env.WEB_IMAGE }}:staging-latest)
+          PROD_WEB=$(docker inspect --format='{{.Id}}' ${{ env.WEB_IMAGE }}:${{ steps.version.outputs.version }})
+          if [ "$STAGING_WEB" != "$PROD_WEB" ]; then
+            echo "::error::Web image digest mismatch!"
+            exit 1
+          fi
+
+          echo "✅ Image digests verified - same artifact as staging"
 
   # Manual approval gate before production deploy
   approve:

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -180,9 +180,9 @@ jobs:
           labels: ${{ steps.meta-api.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          build-args: |
-            ASPNETCORE_ENVIRONMENT=Staging
-            VERSION=${{ steps.version.outputs.version }}
+          # Note: No environment build-args. ASPNETCORE_ENVIRONMENT is injected
+          # at runtime via compose.staging.yml. Images are environment-agnostic
+          # to support build-once-promote pattern (Issue #179).
 
       - name: Build and Push Web Image
         if: needs.detect-changes.outputs.deploy_web == 'true'
@@ -195,10 +195,9 @@ jobs:
           labels: ${{ steps.meta-web.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          build-args: |
-            NODE_ENV=production
-            NEXT_PUBLIC_ENV=staging
-            VERSION=${{ steps.version.outputs.version }}
+          # Note: No environment build-args. NODE_ENV is set in Dockerfile,
+          # NEXT_PUBLIC_ENV has no ARG in Dockerfile (was silently ignored).
+          # Environment config is injected at runtime via compose files.
 
       - name: Build Summary
         run: |


### PR DESCRIPTION
## Summary

- Production now **promotes staging images** instead of rebuilding from source
- Remove misleading Docker build-args that were silently ignored
- Add image digest verification to confirm artifact integrity

## Problem

```
BEFORE: Staging builds Image A → Production builds Image B
        (Testing A, deploying B = defeats purpose of staging)

AFTER:  Staging builds Image A → Production retags Image A
        (Same artifact tested = same artifact deployed)
```

## Key Finding

The Dockerfiles have **no ARG instructions**. Build-args like `ASPNETCORE_ENVIRONMENT=Staging` were silently ignored by Docker. The images were already identical, but production wastefully rebuilt them. Environment config was always injected at runtime via compose files.

## Changes

| File | Change |
|------|--------|
| `deploy-staging.yml` | Remove misleading build-args (no effect on image) |
| `deploy-production.yml` | Replace full Docker build with `docker pull → docker tag → docker push` promotion |

## Promotion Flow

```
1. Pull staging-latest from GHCR
2. Tag as v2026.03.11-abc1234 + latest
3. Push production tags
4. Verify digests match (staging == production)
```

## Test plan
- [ ] Staging workflow still builds and pushes images correctly
- [ ] Production workflow pulls staging-latest and retags
- [ ] Image digest verification confirms same artifact
- [ ] Reduced production deploy time (no build step)
- [ ] Environment config still injected via compose files at runtime

Closes #179

🤖 Generated with [Claude Code](https://claude.com/claude-code)