### PR TITLE
I5: Automated rollback script for failed deployments

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -496,25 +496,66 @@ jobs:
             echo "✅ All endpoints within threshold"
           fi
 
-  # Rollback capability
+  # Auto-rollback on deploy or validation failure
   rollback:
-    name: Rollback (Manual)
+    name: Auto-Rollback
     runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
-    needs: [deploy]
-    if: failure()
-    environment:
-      name: production-rollback
+    needs: [build, deploy, validate]
+    if: failure() && vars.DEPLOY_METHOD == 'ssh'
     steps:
-      - name: Trigger Rollback
+      - name: Rollback via SSH
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.PRODUCTION_HOST }}
+          username: ${{ secrets.PRODUCTION_USER }}
+          key: ${{ secrets.PRODUCTION_SSH_KEY }}
+          script: |
+            set -e
+            cd /opt/meepleai
+
+            echo "🔄 Auto-rollback triggered — restoring previous images..."
+
+            # Find the previous API image (second most recent, excluding current)
+            PREV_API=$(docker images --format '{{.Repository}}:{{.Tag}}' | grep 'api:v' | head -2 | tail -1)
+            PREV_WEB=$(docker images --format '{{.Repository}}:{{.Tag}}' | grep 'web:v' | head -2 | tail -1)
+
+            if [ -z "$PREV_API" ] || [ -z "$PREV_WEB" ]; then
+              # Fallback: use the "latest" tag from before this deploy
+              echo "⚠️ Could not find previous versioned images, using last known good"
+              PREV_API=$(docker images --format '{{.Repository}}:{{.Tag}}' | grep 'api:' | grep -v 'staging' | head -1)
+              PREV_WEB=$(docker images --format '{{.Repository}}:{{.Tag}}' | grep 'web:' | grep -v 'staging' | head -1)
+            fi
+
+            echo "Rolling back to: API=$PREV_API, WEB=$PREV_WEB"
+
+            export API_IMAGE="$PREV_API"
+            export WEB_IMAGE="$PREV_WEB"
+
+            # Rollback containers
+            docker compose -f compose.prod.yml up -d --no-deps api web
+
+            # Verify rollback
+            for i in {1..12}; do
+              if curl -sf http://localhost:8080/health > /dev/null 2>&1; then
+                echo "✅ Rollback successful — services healthy"
+                exit 0
+              fi
+              echo "⏳ Waiting for rollback health... ($i/12)"
+              sleep 5
+            done
+
+            echo "❌ CRITICAL: Rollback health check failed!"
+            exit 1
+
+      - name: Rollback Summary
+        if: always()
         run: |
-          echo "🔄 Deployment failed, rollback may be needed"
-          echo "To rollback manually:"
-          echo "  1. Go to GitHub Actions"
-          echo "  2. Find previous successful deployment"
-          echo "  3. Re-run that workflow"
-          echo ""
-          echo "Or SSH to server and run:"
-          echo "  docker compose -f compose.prod.yml rollback"
+          echo "## 🔄 Auto-Rollback Executed" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Deploy or validation failed — previous version restored." >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "**Failed version:** \`${{ needs.build.outputs.version }}\`" >> $GITHUB_STEP_SUMMARY
+          echo "**Trigger:** Deploy/validation failure" >> $GITHUB_STEP_SUMMARY
 
   # Notifications
   notify:

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -513,17 +513,38 @@ jobs:
             set -e
             cd /opt/meepleai
 
-            echo "🔄 Auto-rollback triggered — restoring previous images..."
+            echo "🔄 Auto-rollback triggered — finding previous working version..."
 
-            # Find the previous API image (second most recent, excluding current)
-            PREV_API=$(docker images --format '{{.Repository}}:{{.Tag}}' | grep 'api:v' | head -2 | tail -1)
-            PREV_WEB=$(docker images --format '{{.Repository}}:{{.Tag}}' | grep 'web:v' | head -2 | tail -1)
+            PREV_API=""
+            PREV_WEB=""
 
+            # Strategy 1: Read from DEPLOYMENT.json (written by successful deploys)
+            if [ -f /opt/meepleai/DEPLOYMENT.json ]; then
+              PREV_API=$(jq -r '.api_image // empty' /opt/meepleai/DEPLOYMENT.json 2>/dev/null || true)
+              PREV_WEB=$(jq -r '.web_image // empty' /opt/meepleai/DEPLOYMENT.json 2>/dev/null || true)
+              if [ -n "$PREV_API" ] && [ -n "$PREV_WEB" ]; then
+                echo "📋 Found previous version from DEPLOYMENT.json"
+              fi
+            fi
+
+            # Strategy 2: Fallback to GHCR image history
             if [ -z "$PREV_API" ] || [ -z "$PREV_WEB" ]; then
-              # Fallback: use the "latest" tag from before this deploy
-              echo "⚠️ Could not find previous versioned images, using last known good"
+              echo "⚠️ DEPLOYMENT.json not available, searching local images..."
+              PREV_API=$(docker images --format '{{.Repository}}:{{.Tag}}' | grep -E 'api:(v|prod)' | head -2 | tail -1)
+              PREV_WEB=$(docker images --format '{{.Repository}}:{{.Tag}}' | grep -E 'web:(v|prod)' | head -2 | tail -1)
+            fi
+
+            # Strategy 3: Last resort — use the *-latest tags
+            if [ -z "$PREV_API" ] || [ -z "$PREV_WEB" ]; then
+              echo "⚠️ No versioned images found, trying latest tags..."
               PREV_API=$(docker images --format '{{.Repository}}:{{.Tag}}' | grep 'api:' | grep -v 'staging' | head -1)
               PREV_WEB=$(docker images --format '{{.Repository}}:{{.Tag}}' | grep 'web:' | grep -v 'staging' | head -1)
+            fi
+
+            if [ -z "$PREV_API" ] || [ -z "$PREV_WEB" ]; then
+              echo "❌ CRITICAL: Cannot find ANY previous images for rollback!"
+              echo "Manual intervention required."
+              exit 1
             fi
 
             echo "Rolling back to: API=$PREV_API, WEB=$PREV_WEB"

--- a/.github/workflows/rollback.yml
+++ b/.github/workflows/rollback.yml
@@ -1,0 +1,176 @@
+name: Manual Rollback
+
+on:
+  workflow_dispatch:
+    inputs:
+      environment:
+        description: 'Target environment'
+        required: true
+        type: choice
+        options:
+          - staging
+          - production
+      image_tag:
+        description: 'API/Web image tag to rollback to (e.g., staging-20260311-abc1234 or v2026.03.10-abc1234)'
+        required: true
+        type: string
+      restore_db:
+        description: 'Restore database from pre-migration backup (dangerous!)'
+        required: false
+        default: 'false'
+        type: boolean
+
+concurrency:
+  group: rollback-${{ inputs.environment }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  packages: read
+
+env:
+  REGISTRY: ghcr.io
+  API_IMAGE: ghcr.io/${{ github.repository }}/api
+  WEB_IMAGE: ghcr.io/${{ github.repository }}/web
+
+jobs:
+  rollback-staging:
+    name: Rollback Staging
+    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    if: inputs.environment == 'staging' && vars.DEPLOY_METHOD == 'ssh'
+    environment:
+      name: staging
+      url: https://meepleai.app
+    steps:
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Rollback Staging via SSH
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.STAGING_HOST }}
+          username: ${{ secrets.STAGING_USER }}
+          key: ${{ secrets.STAGING_SSH_KEY }}
+          script: |
+            set -e
+            cd /opt/meepleai/repo/infra
+
+            # Load secrets
+            set -a
+            for f in secrets/*.secret; do source "$f" 2>/dev/null; done
+            set +a
+
+            echo "🔄 Rolling back staging to tag: ${{ inputs.image_tag }}"
+
+            # Pull rollback images
+            docker pull ${{ env.API_IMAGE }}:${{ inputs.image_tag }}
+            docker pull ${{ env.WEB_IMAGE }}:${{ inputs.image_tag }}
+
+            export API_IMAGE="${{ env.API_IMAGE }}:${{ inputs.image_tag }}"
+            export WEB_IMAGE="${{ env.WEB_IMAGE }}:${{ inputs.image_tag }}"
+
+            # Rollback containers
+            docker compose -f docker-compose.yml -f compose.staging.yml -f compose.staging-traefik.yml \
+              --profile minimal up -d --no-deps api web
+
+            # Health check
+            for i in {1..12}; do
+              if curl -sf http://localhost:8080/health > /dev/null 2>&1; then
+                echo "✅ Staging rollback successful"
+                exit 0
+              fi
+              echo "⏳ Waiting... ($i/12)"
+              sleep 5
+            done
+
+            echo "❌ Rollback health check failed"
+            exit 1
+
+      - name: Summary
+        run: |
+          echo "## 🔄 Staging Rollback" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Item | Value |" >> $GITHUB_STEP_SUMMARY
+          echo "|------|-------|" >> $GITHUB_STEP_SUMMARY
+          echo "| Environment | staging |" >> $GITHUB_STEP_SUMMARY
+          echo "| Rolled back to | \`${{ inputs.image_tag }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| Triggered by | ${{ github.actor }} |" >> $GITHUB_STEP_SUMMARY
+
+  rollback-production:
+    name: Rollback Production
+    runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    if: inputs.environment == 'production' && vars.DEPLOY_METHOD == 'ssh'
+    environment:
+      name: production-rollback
+    steps:
+      - name: Login to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Rollback Production via SSH
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.PRODUCTION_HOST }}
+          username: ${{ secrets.PRODUCTION_USER }}
+          key: ${{ secrets.PRODUCTION_SSH_KEY }}
+          script: |
+            set -e
+            cd /opt/meepleai
+
+            echo "🔄 Rolling back production to tag: ${{ inputs.image_tag }}"
+
+            # Pull rollback images
+            docker pull ${{ env.API_IMAGE }}:${{ inputs.image_tag }}
+            docker pull ${{ env.WEB_IMAGE }}:${{ inputs.image_tag }}
+
+            export API_IMAGE="${{ env.API_IMAGE }}:${{ inputs.image_tag }}"
+            export WEB_IMAGE="${{ env.WEB_IMAGE }}:${{ inputs.image_tag }}"
+
+            # Optional: restore database from backup
+            if [ "${{ inputs.restore_db }}" = "true" ]; then
+              echo "⚠️ Restoring database from latest pre-migration backup..."
+              LATEST_BACKUP=$(ls -t /backups/pre-migration-prod-*.sql 2>/dev/null | head -1)
+              if [ -n "$LATEST_BACKUP" ]; then
+                echo "Restoring from: $LATEST_BACKUP"
+                docker compose -f compose.prod.yml exec -T postgres \
+                  psql -U postgres -d meepleai < "$LATEST_BACKUP"
+                echo "✅ Database restored"
+              else
+                echo "❌ No pre-migration backup found!"
+                exit 1
+              fi
+            fi
+
+            # Rollback containers
+            docker compose -f compose.prod.yml up -d --no-deps api web
+
+            # Health check
+            for i in {1..12}; do
+              if curl -sf http://localhost:8080/health > /dev/null 2>&1; then
+                echo "✅ Production rollback successful"
+                exit 0
+              fi
+              echo "⏳ Waiting... ($i/12)"
+              sleep 5
+            done
+
+            echo "❌ Rollback health check failed"
+            exit 1
+
+      - name: Summary
+        run: |
+          echo "## 🔄 Production Rollback" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "| Item | Value |" >> $GITHUB_STEP_SUMMARY
+          echo "|------|-------|" >> $GITHUB_STEP_SUMMARY
+          echo "| Environment | production |" >> $GITHUB_STEP_SUMMARY
+          echo "| Rolled back to | \`${{ inputs.image_tag }}\` |" >> $GITHUB_STEP_SUMMARY
+          echo "| DB Restored | ${{ inputs.restore_db }} |" >> $GITHUB_STEP_SUMMARY
+          echo "| Triggered by | ${{ github.actor }} |" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary
- Replace placeholder rollback job with real auto-rollback in production deploy
- Create standalone `rollback.yml` workflow for manual rollback of both environments
- Auto-rollback triggers on deploy/validate failure, restores previous images
- Manual rollback supports environment selection, image tag input, and optional DB restore

## Changes
- **deploy-production.yml**: Rollback job now SSHs to production, finds previous images, restores, and verifies health
- **rollback.yml** (new): Manual `workflow_dispatch` rollback for staging and production with GHCR auth and health verification

## Auto-Rollback Flow
```
deploy fails OR validate fails
  → rollback job triggers
  → SSH to production
  → find previous versioned images
  → docker compose up with previous images
  → poll health for 60s
  → report success/failure
```

## Manual Rollback
```
workflow_dispatch:
  environment: staging | production
  image_tag: "v2026.03.10-abc1234"
  restore_db: false (optional, dangerous)
```

## Test plan
- [ ] Verify YAML syntax is valid
- [ ] Auto-rollback triggers on deploy failure
- [ ] Manual rollback workflow appears in Actions tab
- [ ] Production rollback requires environment approval
- [ ] Health check polling works within 60s timeout

Closes #181

🤖 Generated with [Claude Code](https://claude.com/claude-code)