### PR TITLE
R5: Structured changelog generation from PR titles

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,39 @@
+changelog:
+  exclude:
+    labels:
+      - skip-changelog
+    authors:
+      - dependabot
+      - github-actions
+  categories:
+    - title: "🚀 Features"
+      labels:
+        - enhancement
+        - feature
+    - title: "🐛 Bug Fixes"
+      labels:
+        - bug
+        - fix
+    - title: "🏗️ Infrastructure & CI/CD"
+      labels:
+        - area/infra
+        - area/cicd
+    - title: "📚 Documentation"
+      labels:
+        - documentation
+        - docs
+    - title: "🧪 Testing"
+      labels:
+        - test
+        - testing
+    - title: "🔒 Security"
+      labels:
+        - security
+    - title: "🧹 Maintenance"
+      labels:
+        - chore
+        - maintenance
+        - dependencies
+    - title: "Other Changes"
+      labels:
+        - "*"


### PR DESCRIPTION
## Summary
- Add `.github/release.yml` for GitHub's auto-generated release notes
- Categories: Features, Bug Fixes, Infrastructure, Documentation, Testing, Security, Maintenance
- Excludes dependabot and github-actions from changelogs
- Works with existing `softprops/action-gh-release` in deploy-production.yml

## Test plan
- [ ] Create a tag release and verify categories appear
- [ ] Verify dependabot PRs are excluded
- [ ] Verify label-based categorization works

Closes #187

🤖 Generated with [Claude Code](https://claude.com/claude-code)