### PR TITLE
R3: Deployment versioning file on server

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -269,6 +269,21 @@ jobs:
             sleep 10
             curl -sf https://meepleai.com/health || exit 1
 
+            # Record deployment version
+            cat > /opt/meepleai/DEPLOYMENT.json << VEREOF
+            {
+              "version": "${{ needs.build.outputs.version }}",
+              "api_image": "${{ needs.build.outputs.api_image }}",
+              "web_image": "${{ needs.build.outputs.web_image }}",
+              "environment": "production",
+              "deployed_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+              "deployed_by": "${{ github.actor }}",
+              "commit": "${{ github.sha }}",
+              "workflow_run": "${{ github.run_id }}"
+            }
+            VEREOF
+            echo "📋 Version recorded: ${{ needs.build.outputs.version }}"
+
             # Cleanup
             docker image prune -f
 

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -196,6 +196,21 @@ jobs:
             assert any(c['name']=='redis' and c['status']=='Healthy' for c in d['checks']), 'redis unhealthy'
             " || exit 1
 
+            # Record deployment version
+            cat > /opt/meepleai/repo/infra/DEPLOYMENT.json << VEREOF
+            {
+              "version": "${{ needs.build.outputs.version }}",
+              "api_image": "${{ needs.build.outputs.api_image }}",
+              "web_image": "${{ needs.build.outputs.web_image }}",
+              "environment": "staging",
+              "deployed_at": "$(date -u +%Y-%m-%dT%H:%M:%SZ)",
+              "deployed_by": "${{ github.actor }}",
+              "commit": "${{ github.sha }}",
+              "workflow_run": "${{ github.run_id }}"
+            }
+            VEREOF
+            echo "📋 Version recorded: ${{ needs.build.outputs.version }}"
+
             # Cleanup old images
             docker image prune -f
 


### PR DESCRIPTION
## Summary
- Write `DEPLOYMENT.json` on the server after each deploy (staging + production)
- Contains: version, images, timestamp, deployer, commit, workflow run ID
- Operators can `cat DEPLOYMENT.json` to see what's running

## Test plan
- [ ] Verify DEPLOYMENT.json written on staging deploy
- [ ] Verify DEPLOYMENT.json written on production deploy
- [ ] Verify JSON structure is valid

Closes #185

🤖 Generated with [Claude Code](https://claude.com/claude-code)