### PR TITLE
R4: Runner health alerting and fallback notification

### DIFF
--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -71,6 +71,7 @@ jobs:
   build:
     name: Build Production Images
     runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    timeout-minutes: 45
     needs: [staging-check, test]
     if: always() && needs.test.result == 'success' && (needs.staging-check.result == 'success' || needs.staging-check.result == 'skipped')
     outputs:
@@ -78,6 +79,12 @@ jobs:
       web_image: ${{ steps.meta-web.outputs.tags }}
       version: ${{ steps.version.outputs.version }}
     steps:
+      - name: Check Runner Fallback
+        if: vars.RUNNER != '' && !contains(runner.name, vars.RUNNER)
+        run: |
+          echo "::warning::Self-hosted runner '${{ vars.RUNNER }}' unavailable — fell back to GitHub-hosted runner"
+          echo "⚠️ This may produce x86 images incompatible with ARM64 production server"
+
       - name: Verify ARM64 runner
         if: vars.RUNNER != ''
         run: |
@@ -200,6 +207,7 @@ jobs:
   deploy:
     name: Deploy to Production
     runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    timeout-minutes: 20
     needs: [build, approve]
     environment:
       name: production

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -41,6 +41,7 @@ jobs:
   build:
     name: Build Images
     runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    timeout-minutes: 45
     needs: [test]
     if: always() && (needs.test.result == 'success' || (github.event_name == 'workflow_dispatch' && inputs.skip_tests == true))
     outputs:
@@ -48,6 +49,12 @@ jobs:
       web_image: ${{ steps.meta-web.outputs.tags }}
       version: ${{ steps.version.outputs.version }}
     steps:
+      - name: Check Runner Fallback
+        if: vars.RUNNER != '' && !contains(runner.name, vars.RUNNER)
+        run: |
+          echo "::warning::Self-hosted runner '${{ vars.RUNNER }}' unavailable — fell back to GitHub-hosted runner"
+          echo "⚠️ This may produce x86 images incompatible with ARM64 staging server"
+
       - name: Verify ARM64 runner
         if: vars.RUNNER != ''
         run: |
@@ -149,6 +156,7 @@ jobs:
   deploy:
     name: Deploy to Staging
     runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
+    timeout-minutes: 15
     needs: [build]
     environment:
       name: staging


### PR DESCRIPTION
## Summary
- Add `timeout-minutes` to build (45min) and deploy (15-20min) jobs
- Add runner fallback detection step that warns when self-hosted runner is unavailable
- Applied to both staging and production deploy workflows

## Test plan
- [ ] Verify YAML syntax valid
- [ ] Job times out if runner hangs (instead of waiting forever)
- [ ] Warning annotation appears when fallback runner used

Closes #186

🤖 Generated with [Claude Code](https://claude.com/claude-code)