### PR TITLE
R1: Post-deploy E2E smoke tests on staging (#183)

### DIFF
--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -497,11 +497,47 @@ jobs:
             echo "| \`$ENDPOINT\` | $AVG | $P95 | $STATUS |" >> $GITHUB_STEP_SUMMARY
           done
 
+  # Post-deploy E2E smoke tests against live staging
+  e2e-staging:
+    name: Staging E2E Smoke Tests
+    runs-on: ubuntu-latest  # Needs browser support (not self-hosted ARM64)
+    needs: [validate]
+    if: needs.validate.result == 'success'
+    timeout-minutes: 10
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Frontend
+        uses: ./.github/actions/setup-frontend
+
+      - name: Setup Playwright
+        uses: ./.github/actions/setup-playwright
+
+      - name: Run Smoke Tests against Staging
+        working-directory: apps/web
+        env:
+          STAGING_URL: https://meepleai.app
+          CI: 'true'
+        run: |
+          echo "🧪 Running E2E smoke tests against staging..."
+          pnpm exec playwright test e2e/smoke.spec.ts \
+            --config=playwright.staging.config.ts \
+            --reporter=list
+
+      - name: Upload Test Report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: staging-e2e-report
+          path: apps/web/playwright-report/
+          retention-days: 7
+
   # Notify on completion
   notify:
     name: Notify
     runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
-    needs: [build, deploy, validate]
+    needs: [build, deploy, validate, e2e-staging]
     if: always()
     steps:
       - name: Slack Notification

--- a/apps/web/playwright.staging.config.ts
+++ b/apps/web/playwright.staging.config.ts
@@ -1,0 +1,42 @@
+/**
+ * Playwright config for post-deploy staging smoke tests.
+ * Runs smoke.spec.ts against the live staging environment (no local server).
+ *
+ * Usage (CI):
+ *   pnpm exec playwright test e2e/smoke.spec.ts --config=playwright.staging.config.ts
+ */
+
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  timeout: 60_000,
+  retries: 2,
+  workers: 1,
+  forbidOnly: true,
+  reporter: [['list'], ['html', { open: 'never' }]],
+
+  use: {
+    baseURL: process.env.STAGING_URL || 'https://meepleai.app',
+    trace: 'on-first-retry',
+    actionTimeout: 10_000,
+    navigationTimeout: 30_000,
+    launchOptions: {
+      args: [
+        '--no-sandbox',
+        '--disable-setuid-sandbox',
+        '--disable-dev-shm-usage',
+        '--disable-gpu',
+      ],
+    },
+  },
+
+  projects: [
+    {
+      name: 'staging-smoke',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+
+  // No webServer — tests run against the live staging deployment
+});


### PR DESCRIPTION
## Summary
- Add `e2e-staging` job to `deploy-staging.yml` that runs Playwright smoke tests against live staging after deploy validation
- Create `playwright.staging.config.ts` — dedicated config for staging (no webServer, baseURL = `https://meepleai.app`, Chromium only)
- Runs only `smoke.spec.ts` (~2-3 min, 8 tests) with retries and artifact upload
- Non-blocking: `notify` job updated to include `e2e-staging` in dependency chain

## Changes
- `.github/workflows/deploy-staging.yml`: New `e2e-staging` job after `validate`, uses setup-frontend + setup-playwright composite actions
- `apps/web/playwright.staging.config.ts`: Minimal staging config (no local server, live URL, single browser project)

## Test plan
- [ ] Verify workflow YAML is valid
- [ ] Trigger staging deploy and confirm e2e-staging job runs after validate
- [ ] Confirm smoke tests execute against live staging URL
- [ ] Verify test report artifact is uploaded

Closes #183

🤖 Generated with [Claude Code](https://claude.com/claude-code)