### PR TITLE
feat(admin): Operations Console + API client extensions (#125, #126)

### DIFF
--- a/apps/web/src/app/admin/(dashboard)/monitor/operations/AuditTab.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/operations/AuditTab.tsx
@@ -1,0 +1,276 @@
+'use client';
+
+/**
+ * AuditTab — Admin audit trail viewer
+ * Issue #130 — Audit Trail Viewer Tab (stub for #126 page setup)
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+
+import { ChevronDown, ChevronRight, Download, Loader2 } from 'lucide-react';
+
+import { Badge } from '@/components/ui/data-display/badge';
+import { Button } from '@/components/ui/primitives/button';
+import { Input } from '@/components/ui/primitives/input';
+import { api } from '@/lib/api';
+import type { AuditLogEntry, AuditLogListResult } from '@/lib/api/schemas';
+import { cn } from '@/lib/utils';
+
+export function AuditTab() {
+  const [data, setData] = useState<AuditLogListResult | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+  const [exporting, setExporting] = useState(false);
+
+  // Filters
+  const [actionFilter, setActionFilter] = useState('');
+  const [resourceFilter, setResourceFilter] = useState('');
+  const [resultFilter, setResultFilter] = useState('');
+  const [offset, setOffset] = useState(0);
+  const limit = 50;
+
+  const fetchData = useCallback(async () => {
+    try {
+      const result = await api.admin.getAuditLogs({
+        limit,
+        offset,
+        action: actionFilter || undefined,
+        resource: resourceFilter || undefined,
+        result: resultFilter || undefined,
+      });
+      setData(result);
+    } catch {
+      // silent
+    } finally {
+      setLoading(false);
+    }
+  }, [actionFilter, resourceFilter, resultFilter, offset]);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  const handleExport = async () => {
+    setExporting(true);
+    try {
+      const blob = await api.admin.exportAuditLogs({
+        action: actionFilter || undefined,
+        resource: resourceFilter || undefined,
+      });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `audit-log-${new Date().toISOString().slice(0, 10)}.csv`;
+      a.click();
+      URL.revokeObjectURL(url);
+    } finally {
+      setExporting(false);
+    }
+  };
+
+  const toggleExpand = (id: string) => {
+    setExpandedId(prev => (prev === id ? null : id));
+  };
+
+  return (
+    <div className="space-y-6" data-testid="audit-tab">
+      <div>
+        <h2 className="font-quicksand text-lg font-semibold">Audit Trail</h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Administrative action log with filtering and export.
+        </p>
+      </div>
+
+      {/* Filters */}
+      <div className="flex flex-wrap gap-3">
+        <Input
+          placeholder="Filter by action..."
+          value={actionFilter}
+          onChange={e => {
+            setActionFilter(e.target.value);
+            setOffset(0);
+          }}
+          className="w-48"
+          data-testid="audit-action-filter"
+        />
+        <Input
+          placeholder="Filter by resource..."
+          value={resourceFilter}
+          onChange={e => {
+            setResourceFilter(e.target.value);
+            setOffset(0);
+          }}
+          className="w-48"
+          data-testid="audit-resource-filter"
+        />
+        <select
+          value={resultFilter}
+          onChange={e => {
+            setResultFilter(e.target.value);
+            setOffset(0);
+          }}
+          className="rounded-md border bg-background px-3 py-2 text-sm"
+          data-testid="audit-result-filter"
+        >
+          <option value="">All Results</option>
+          <option value="Success">Success</option>
+          <option value="Failure">Failure</option>
+        </select>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={handleExport}
+          disabled={exporting}
+          data-testid="export-audit-button"
+        >
+          {exporting ? (
+            <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+          ) : (
+            <Download className="h-4 w-4 mr-2" />
+          )}
+          Export CSV
+        </Button>
+      </div>
+
+      {/* Table */}
+      {loading ? (
+        <div className="flex items-center justify-center py-10">
+          <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+        </div>
+      ) : (
+        <div className="rounded-xl border bg-white/70 dark:bg-zinc-900/70 backdrop-blur-md overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b text-xs text-muted-foreground">
+                <th className="w-8 py-3 px-2" />
+                <th className="text-left py-3 px-3">Timestamp</th>
+                <th className="text-left py-3 px-3">User</th>
+                <th className="text-left py-3 px-3">Action</th>
+                <th className="text-left py-3 px-3">Resource</th>
+                <th className="text-left py-3 px-3">Result</th>
+              </tr>
+            </thead>
+            <tbody>
+              {data?.entries.map(entry => (
+                <AuditRow
+                  key={entry.id}
+                  entry={entry}
+                  expanded={expandedId === entry.id}
+                  onToggle={() => toggleExpand(entry.id)}
+                />
+              ))}
+              {(!data || data.entries.length === 0) && (
+                <tr>
+                  <td colSpan={6} className="py-8 text-center text-sm text-muted-foreground">
+                    No audit log entries found.
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {/* Pagination */}
+      {data && data.totalCount > limit && (
+        <div className="flex items-center justify-between">
+          <p className="text-xs text-muted-foreground">
+            Showing {offset + 1}–{Math.min(offset + limit, data.totalCount)} of {data.totalCount}
+          </p>
+          <div className="flex gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={offset === 0}
+              onClick={() => setOffset(Math.max(0, offset - limit))}
+            >
+              Previous
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={offset + limit >= data.totalCount}
+              onClick={() => setOffset(offset + limit)}
+            >
+              Next
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function AuditRow({
+  entry,
+  expanded,
+  onToggle,
+}: {
+  entry: AuditLogEntry;
+  expanded: boolean;
+  onToggle: () => void;
+}) {
+  return (
+    <>
+      <tr
+        className={cn(
+          'border-b last:border-0 cursor-pointer hover:bg-slate-50/50 dark:hover:bg-zinc-800/30'
+        )}
+        onClick={onToggle}
+      >
+        <td className="py-3 px-2">
+          {expanded ? (
+            <ChevronDown className="h-4 w-4 text-muted-foreground" />
+          ) : (
+            <ChevronRight className="h-4 w-4 text-muted-foreground" />
+          )}
+        </td>
+        <td className="py-3 px-3 text-xs whitespace-nowrap">
+          {new Date(entry.createdAt).toLocaleString()}
+        </td>
+        <td className="py-3 px-3">
+          <div>
+            <p className="text-xs font-medium">{entry.userName ?? '—'}</p>
+            <p className="text-xs text-muted-foreground">{entry.userEmail ?? ''}</p>
+          </div>
+        </td>
+        <td className="py-3 px-3">
+          <Badge variant="outline" className="text-xs">
+            {entry.action}
+          </Badge>
+        </td>
+        <td className="py-3 px-3 text-xs">{entry.resource}</td>
+        <td className="py-3 px-3">
+          <Badge
+            variant={entry.result === 'Success' ? 'secondary' : 'destructive'}
+            className="text-xs"
+          >
+            {entry.result}
+          </Badge>
+        </td>
+      </tr>
+      {expanded && (
+        <tr className="bg-slate-50/30 dark:bg-zinc-800/20">
+          <td colSpan={6} className="px-6 py-3">
+            <div className="grid gap-2 text-xs sm:grid-cols-2">
+              <div>
+                <span className="text-muted-foreground">Resource ID: </span>
+                <span className="font-mono">{entry.resourceId ?? '—'}</span>
+              </div>
+              <div>
+                <span className="text-muted-foreground">IP Address: </span>
+                <span className="font-mono">{entry.ipAddress ?? '—'}</span>
+              </div>
+              {entry.details && (
+                <div className="sm:col-span-2">
+                  <span className="text-muted-foreground">Details: </span>
+                  <span>{entry.details}</span>
+                </div>
+              )}
+            </div>
+          </td>
+        </tr>
+      )}
+    </>
+  );
+}

--- a/apps/web/src/app/admin/(dashboard)/monitor/operations/EmergencyTab.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/operations/EmergencyTab.tsx
@@ -1,0 +1,264 @@
+'use client';
+
+/**
+ * EmergencyTab — LLM emergency override controls
+ * Issue #129 — Emergency Controls Tab (stub for #126 page setup)
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+
+import { AlertTriangle, CheckCircle2, Clock, Loader2, ShieldAlert, ShieldOff } from 'lucide-react';
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/overlays/alert-dialog-primitives';
+import { Button } from '@/components/ui/primitives/button';
+import { Input } from '@/components/ui/primitives/input';
+import { api } from '@/lib/api';
+import type { ActiveOverride } from '@/lib/api/schemas';
+import { cn } from '@/lib/utils';
+
+const OVERRIDE_ACTIONS = [
+  {
+    value: 'force-ollama-only',
+    label: 'Force Ollama Only',
+    description: 'Route all LLM requests through local Ollama',
+  },
+  {
+    value: 'reset-circuit-breaker',
+    label: 'Reset Circuit Breaker',
+    description: 'Reset the circuit breaker for a provider',
+  },
+  {
+    value: 'flush-quota-cache',
+    label: 'Flush Quota Cache',
+    description: 'Clear all cached free model quota data',
+  },
+] as const;
+
+export function EmergencyTab() {
+  const [overrides, setOverrides] = useState<ActiveOverride[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [activating, setActivating] = useState(false);
+
+  // Activation form state
+  const [action, setAction] = useState<string>(OVERRIDE_ACTIONS[0].value);
+  const [reason, setReason] = useState('');
+  const [duration, setDuration] = useState(30);
+  const [targetProvider, setTargetProvider] = useState('');
+
+  const fetchOverrides = useCallback(async () => {
+    try {
+      const result = await api.admin.getActiveEmergencyOverrides();
+      setOverrides(result);
+    } catch {
+      // silent
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchOverrides();
+    const interval = setInterval(fetchOverrides, 30_000);
+    return () => clearInterval(interval);
+  }, [fetchOverrides]);
+
+  const handleActivate = async () => {
+    if (!reason.trim()) return;
+    setActivating(true);
+    try {
+      await api.admin.activateEmergencyOverride({
+        action,
+        reason: reason.trim(),
+        durationMinutes: duration,
+        targetProvider: targetProvider.trim() || undefined,
+      });
+      setReason('');
+      setTargetProvider('');
+      fetchOverrides();
+    } finally {
+      setActivating(false);
+    }
+  };
+
+  const handleDeactivate = async (overrideAction: string) => {
+    await api.admin.deactivateEmergencyOverride(overrideAction);
+    fetchOverrides();
+  };
+
+  return (
+    <div className="space-y-6" data-testid="emergency-tab">
+      <div>
+        <h2 className="font-quicksand text-lg font-semibold">Emergency Controls</h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          LLM emergency overrides for production incidents.
+        </p>
+      </div>
+
+      {loading ? (
+        <div className="flex items-center justify-center py-10">
+          <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+        </div>
+      ) : (
+        <>
+          {/* Active Overrides */}
+          {overrides.length === 0 ? (
+            <div
+              className="flex flex-col items-center justify-center py-10 text-center"
+              data-testid="no-overrides"
+            >
+              <CheckCircle2 className="h-10 w-10 text-green-500 mb-3" />
+              <p className="text-sm font-medium">No active emergency overrides</p>
+              <p className="text-xs text-muted-foreground mt-1">
+                All LLM systems operating normally.
+              </p>
+            </div>
+          ) : (
+            <div className="space-y-3" data-testid="active-overrides">
+              {overrides.map(override => (
+                <div
+                  key={override.action}
+                  className={cn(
+                    'rounded-xl border-2 border-red-500/50 bg-red-50/50 dark:bg-red-950/20 p-4'
+                  )}
+                >
+                  <div className="flex items-start justify-between">
+                    <div className="flex items-center gap-2">
+                      <ShieldAlert className="h-5 w-5 text-red-600" />
+                      <div>
+                        <p className="font-medium text-sm">{override.action}</p>
+                        <p className="text-xs text-muted-foreground">{override.reason}</p>
+                      </div>
+                    </div>
+                    <AlertDialog>
+                      <AlertDialogTrigger asChild>
+                        <Button variant="outline" size="sm">
+                          <ShieldOff className="h-4 w-4 mr-1" />
+                          Deactivate
+                        </Button>
+                      </AlertDialogTrigger>
+                      <AlertDialogContent>
+                        <AlertDialogHeader>
+                          <AlertDialogTitle>Deactivate Override</AlertDialogTitle>
+                          <AlertDialogDescription>
+                            This will remove the &quot;{override.action}&quot; emergency override.
+                            LLM requests will resume normal routing.
+                          </AlertDialogDescription>
+                        </AlertDialogHeader>
+                        <AlertDialogFooter>
+                          <AlertDialogCancel>Cancel</AlertDialogCancel>
+                          <AlertDialogAction onClick={() => handleDeactivate(override.action)}>
+                            Deactivate
+                          </AlertDialogAction>
+                        </AlertDialogFooter>
+                      </AlertDialogContent>
+                    </AlertDialog>
+                  </div>
+                  <div className="flex items-center gap-4 mt-2 text-xs text-muted-foreground">
+                    <span className="flex items-center gap-1">
+                      <Clock className="h-3 w-3" />
+                      {override.remainingMinutes.toFixed(0)} min remaining
+                    </span>
+                    {override.targetProvider && <span>Provider: {override.targetProvider}</span>}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {/* Activate New Override */}
+          <div className="rounded-xl border bg-white/70 dark:bg-zinc-900/70 backdrop-blur-md p-4">
+            <div className="flex items-center gap-2 mb-4">
+              <AlertTriangle className="h-4 w-4 text-amber-600" />
+              <h3 className="font-quicksand font-semibold text-sm">Activate Emergency Override</h3>
+            </div>
+
+            <div className="grid gap-4 sm:grid-cols-2">
+              <div>
+                <label className="text-xs font-medium text-muted-foreground mb-1 block">
+                  Action
+                </label>
+                <select
+                  value={action}
+                  onChange={e => setAction(e.target.value)}
+                  className="w-full rounded-md border bg-background px-3 py-2 text-sm"
+                  data-testid="override-action-select"
+                >
+                  {OVERRIDE_ACTIONS.map(a => (
+                    <option key={a.value} value={a.value}>
+                      {a.label}
+                    </option>
+                  ))}
+                </select>
+                <p className="text-xs text-muted-foreground mt-1">
+                  {OVERRIDE_ACTIONS.find(a => a.value === action)?.description}
+                </p>
+              </div>
+
+              <div>
+                <label className="text-xs font-medium text-muted-foreground mb-1 block">
+                  Reason (required)
+                </label>
+                <Input
+                  value={reason}
+                  onChange={e => setReason(e.target.value)}
+                  placeholder="Production incident — high error rate..."
+                  data-testid="override-reason-input"
+                />
+              </div>
+
+              <div>
+                <label className="text-xs font-medium text-muted-foreground mb-1 block">
+                  Duration (minutes)
+                </label>
+                <Input
+                  type="number"
+                  min={5}
+                  max={1440}
+                  value={duration}
+                  onChange={e => setDuration(Number(e.target.value))}
+                  data-testid="override-duration-input"
+                />
+              </div>
+
+              {action === 'reset-circuit-breaker' && (
+                <div>
+                  <label className="text-xs font-medium text-muted-foreground mb-1 block">
+                    Target Provider (optional)
+                  </label>
+                  <Input
+                    value={targetProvider}
+                    onChange={e => setTargetProvider(e.target.value)}
+                    placeholder="openrouter"
+                    data-testid="override-provider-input"
+                  />
+                </div>
+              )}
+            </div>
+
+            <div className="mt-4">
+              <Button
+                onClick={handleActivate}
+                disabled={!reason.trim() || activating}
+                className="bg-red-600 hover:bg-red-700 text-white"
+                data-testid="activate-override-button"
+              >
+                {activating && <Loader2 className="h-4 w-4 mr-2 animate-spin" />}
+                Activate Override
+              </Button>
+            </div>
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/admin/(dashboard)/monitor/operations/NavConfig.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/operations/NavConfig.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+/**
+ * OperationsNavConfig — Registers ActionBar actions for /admin/monitor/operations
+ * Issue #126 — Operations Console page
+ */
+
+import { useEffect } from 'react';
+
+import { RefreshCw } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+
+import { useSetNavConfig } from '@/hooks/useSetNavConfig';
+
+export function OperationsNavConfig() {
+  const setNavConfig = useSetNavConfig();
+  const router = useRouter();
+
+  useEffect(() => {
+    setNavConfig({
+      miniNav: [],
+      actionBar: [
+        {
+          id: 'refresh',
+          label: 'Refresh',
+          icon: RefreshCw,
+          variant: 'primary',
+          onClick: () => router.refresh(),
+        },
+      ],
+    });
+  }, [setNavConfig, router]);
+
+  return null;
+}

--- a/apps/web/src/app/admin/(dashboard)/monitor/operations/QueueTab.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/operations/QueueTab.tsx
@@ -1,0 +1,291 @@
+'use client';
+
+/**
+ * QueueTab — PDF processing queue management
+ * Issue #128 — Queue Manager Tab (stub for #126 page setup)
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+
+import {
+  AlertCircle,
+  CheckCircle2,
+  Clock,
+  Loader2,
+  PauseCircle,
+  RotateCcw,
+  Trash2,
+  XCircle,
+} from 'lucide-react';
+
+import { Badge } from '@/components/ui/data-display/badge';
+import { Button } from '@/components/ui/primitives/button';
+import { Input } from '@/components/ui/primitives/input';
+import { api } from '@/lib/api';
+import type { PaginatedQueue, QueueStatus } from '@/lib/api/schemas';
+import { cn } from '@/lib/utils';
+
+const STATUS_CONFIG: Record<
+  string,
+  {
+    label: string;
+    variant: 'default' | 'secondary' | 'destructive' | 'outline';
+    icon: React.ReactNode;
+  }
+> = {
+  Pending: { label: 'Pending', variant: 'outline', icon: <Clock className="h-3 w-3" /> },
+  Processing: {
+    label: 'Processing',
+    variant: 'default',
+    icon: <Loader2 className="h-3 w-3 animate-spin" />,
+  },
+  Completed: {
+    label: 'Completed',
+    variant: 'secondary',
+    icon: <CheckCircle2 className="h-3 w-3" />,
+  },
+  Failed: { label: 'Failed', variant: 'destructive', icon: <XCircle className="h-3 w-3" /> },
+  Cancelled: { label: 'Cancelled', variant: 'outline', icon: <PauseCircle className="h-3 w-3" /> },
+};
+
+export function QueueTab() {
+  const [queue, setQueue] = useState<PaginatedQueue | null>(null);
+  const [status, setStatus] = useState<QueueStatus | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [statusFilter, setStatusFilter] = useState('');
+  const [search, setSearch] = useState('');
+  const [page, setPage] = useState(1);
+
+  const fetchData = useCallback(async () => {
+    try {
+      const [queueRes, statusRes] = await Promise.all([
+        api.admin.getProcessingQueue({
+          status: statusFilter || undefined,
+          search: search || undefined,
+          page,
+          pageSize: 20,
+        }),
+        api.admin.getQueueStatus(),
+      ]);
+      setQueue(queueRes);
+      setStatus(statusRes);
+    } catch {
+      // silent
+    } finally {
+      setLoading(false);
+    }
+  }, [statusFilter, search, page]);
+
+  useEffect(() => {
+    fetchData();
+    const interval = setInterval(fetchData, 15_000);
+    return () => clearInterval(interval);
+  }, [fetchData]);
+
+  const handleCancel = async (jobId: string) => {
+    await api.admin.cancelJob(jobId);
+    fetchData();
+  };
+
+  const handleRetry = async (jobId: string) => {
+    await api.admin.retryJob(jobId);
+    fetchData();
+  };
+
+  const handleRemove = async (jobId: string) => {
+    await api.admin.removeJob(jobId);
+    fetchData();
+  };
+
+  return (
+    <div className="space-y-6" data-testid="queue-tab">
+      <div>
+        <h2 className="font-quicksand text-lg font-semibold">Processing Queue</h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          PDF processing jobs, status, and queue health.
+        </p>
+      </div>
+
+      {/* Queue Status Banner */}
+      {status && (
+        <div
+          className={cn(
+            'rounded-lg border p-3 flex items-center gap-3',
+            status.isPaused
+              ? 'border-red-300 bg-red-50 dark:bg-red-950/20'
+              : status.isUnderPressure
+                ? 'border-amber-300 bg-amber-50 dark:bg-amber-950/20'
+                : 'border-green-300 bg-green-50 dark:bg-green-950/20'
+          )}
+          data-testid="queue-status-banner"
+        >
+          {status.isPaused ? (
+            <PauseCircle className="h-5 w-5 text-red-600" />
+          ) : status.isUnderPressure ? (
+            <AlertCircle className="h-5 w-5 text-amber-600" />
+          ) : (
+            <CheckCircle2 className="h-5 w-5 text-green-600" />
+          )}
+          <div className="flex-1">
+            <p className="text-sm font-medium">
+              {status.isPaused
+                ? 'Queue Paused'
+                : status.isUnderPressure
+                  ? 'Queue Under Pressure'
+                  : 'Queue Healthy'}
+            </p>
+            <p className="text-xs text-muted-foreground">
+              Depth: {status.queueDepth} · Workers: {status.maxConcurrentWorkers} · Est. wait:{' '}
+              {status.estimatedWaitMinutes.toFixed(0)}min
+            </p>
+          </div>
+        </div>
+      )}
+
+      {/* Filters */}
+      <div className="flex flex-wrap gap-3">
+        <Input
+          placeholder="Search by file name..."
+          value={search}
+          onChange={e => {
+            setSearch(e.target.value);
+            setPage(1);
+          }}
+          className="w-64"
+          data-testid="queue-search-input"
+        />
+        <select
+          value={statusFilter}
+          onChange={e => {
+            setStatusFilter(e.target.value);
+            setPage(1);
+          }}
+          className="rounded-md border bg-background px-3 py-2 text-sm"
+          data-testid="queue-status-filter"
+        >
+          <option value="">All Statuses</option>
+          <option value="Pending">Pending</option>
+          <option value="Processing">Processing</option>
+          <option value="Completed">Completed</option>
+          <option value="Failed">Failed</option>
+          <option value="Cancelled">Cancelled</option>
+        </select>
+      </div>
+
+      {/* Jobs Table */}
+      {loading ? (
+        <div className="flex items-center justify-center py-10">
+          <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+        </div>
+      ) : (
+        <div className="rounded-xl border bg-white/70 dark:bg-zinc-900/70 backdrop-blur-md overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b text-xs text-muted-foreground">
+                <th className="text-left py-3 px-4">File</th>
+                <th className="text-left py-3 px-3">Status</th>
+                <th className="text-right py-3 px-3">Priority</th>
+                <th className="text-left py-3 px-3">Created</th>
+                <th className="text-left py-3 px-3">Step</th>
+                <th className="text-right py-3 px-4">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {queue?.jobs.map(job => {
+                const cfg = STATUS_CONFIG[job.status] ?? STATUS_CONFIG.Pending;
+                return (
+                  <tr key={job.id} className="border-b last:border-0">
+                    <td className="py-3 px-4 font-mono text-xs max-w-[200px] truncate">
+                      {job.pdfFileName}
+                    </td>
+                    <td className="py-3 px-3">
+                      <Badge variant={cfg.variant} className="gap-1">
+                        {cfg.icon}
+                        {cfg.label}
+                      </Badge>
+                    </td>
+                    <td className="py-3 px-3 text-right">{job.priority}</td>
+                    <td className="py-3 px-3 text-xs">
+                      {new Date(job.createdAt).toLocaleString()}
+                    </td>
+                    <td className="py-3 px-3 text-xs text-muted-foreground">
+                      {job.currentStep ?? '—'}
+                    </td>
+                    <td className="py-3 px-4 text-right">
+                      <div className="flex items-center justify-end gap-1">
+                        {(job.status === 'Pending' || job.status === 'Processing') && (
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => handleCancel(job.id)}
+                            aria-label="Cancel job"
+                          >
+                            <XCircle className="h-4 w-4" />
+                          </Button>
+                        )}
+                        {job.status === 'Failed' && job.canRetry && (
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => handleRetry(job.id)}
+                            aria-label="Retry job"
+                          >
+                            <RotateCcw className="h-4 w-4" />
+                          </Button>
+                        )}
+                        {(job.status === 'Completed' || job.status === 'Cancelled') && (
+                          <Button
+                            variant="ghost"
+                            size="sm"
+                            onClick={() => handleRemove(job.id)}
+                            aria-label="Remove job"
+                          >
+                            <Trash2 className="h-4 w-4" />
+                          </Button>
+                        )}
+                      </div>
+                    </td>
+                  </tr>
+                );
+              })}
+              {(!queue || queue.jobs.length === 0) && (
+                <tr>
+                  <td colSpan={6} className="py-8 text-center text-sm text-muted-foreground">
+                    No jobs found.
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {/* Pagination */}
+      {queue && queue.totalPages > 1 && (
+        <div className="flex items-center justify-between">
+          <p className="text-xs text-muted-foreground">
+            Page {queue.page} of {queue.totalPages} ({queue.total} total)
+          </p>
+          <div className="flex gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={page <= 1}
+              onClick={() => setPage(p => p - 1)}
+            >
+              Previous
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={page >= queue.totalPages}
+              onClick={() => setPage(p => p + 1)}
+            >
+              Next
+            </Button>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/admin/(dashboard)/monitor/operations/ResourcesTab.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/operations/ResourcesTab.tsx
@@ -1,0 +1,264 @@
+'use client';
+
+/**
+ * ResourcesTab — Database, Cache, and Vector store metrics
+ * Issue #127 — Resources Dashboard Tab (stub for #126 page setup)
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+
+import { Database, HardDrive, Layers, Loader2, Trash2, Wrench } from 'lucide-react';
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogTrigger,
+} from '@/components/ui/overlays/alert-dialog-primitives';
+import { Button } from '@/components/ui/primitives/button';
+import { api } from '@/lib/api';
+import type {
+  CacheMetrics,
+  DatabaseMetrics,
+  TableSize,
+  VectorStoreMetrics,
+} from '@/lib/api/schemas';
+import { cn } from '@/lib/utils';
+
+interface MetricCardProps {
+  title: string;
+  icon: React.ReactNode;
+  children: React.ReactNode;
+  loading?: boolean;
+}
+
+function MetricCard({ title, icon, children, loading }: MetricCardProps) {
+  return (
+    <div
+      className={cn(
+        'rounded-xl border bg-white/70 dark:bg-zinc-900/70 backdrop-blur-md p-4',
+        'shadow-sm'
+      )}
+    >
+      <div className="flex items-center gap-2 mb-3">
+        {icon}
+        <h3 className="font-quicksand font-semibold text-sm">{title}</h3>
+      </div>
+      {loading ? (
+        <div className="flex items-center justify-center py-6">
+          <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+        </div>
+      ) : (
+        children
+      )}
+    </div>
+  );
+}
+
+function StatRow({ label, value }: { label: string; value: string | number }) {
+  return (
+    <div className="flex items-center justify-between py-1">
+      <span className="text-xs text-muted-foreground">{label}</span>
+      <span className="text-sm font-medium">{value}</span>
+    </div>
+  );
+}
+
+export function ResourcesTab() {
+  const [db, setDb] = useState<DatabaseMetrics | null>(null);
+  const [cache, setCache] = useState<CacheMetrics | null>(null);
+  const [vectors, setVectors] = useState<VectorStoreMetrics | null>(null);
+  const [tables, setTables] = useState<TableSize[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const fetchAll = useCallback(async () => {
+    try {
+      const [dbRes, cacheRes, vecRes, tablesRes] = await Promise.all([
+        api.admin.getResourceDatabaseMetrics(),
+        api.admin.getResourceCacheMetrics(),
+        api.admin.getResourceVectorMetrics(),
+        api.admin.getResourceDatabaseTopTables(10),
+      ]);
+      setDb(dbRes);
+      setCache(cacheRes);
+      setVectors(vecRes);
+      setTables(tablesRes);
+    } catch {
+      // silently fail — individual cards show empty state
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchAll();
+    const interval = setInterval(fetchAll, 60_000);
+    return () => clearInterval(interval);
+  }, [fetchAll]);
+
+  const handleClearCache = async () => {
+    await api.admin.clearCache();
+    fetchAll();
+  };
+
+  const handleVacuum = async (full: boolean) => {
+    await api.admin.vacuumDatabase(full);
+    fetchAll();
+  };
+
+  return (
+    <div className="space-y-6" data-testid="resources-tab">
+      <div>
+        <h2 className="font-quicksand text-lg font-semibold">Resources</h2>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Database, cache, and vector store health metrics.
+        </p>
+      </div>
+
+      {/* Metrics Cards */}
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+        <MetricCard
+          title="Database"
+          icon={<Database className="h-4 w-4 text-blue-600" />}
+          loading={loading}
+        >
+          {db && (
+            <div className="space-y-0.5">
+              <StatRow label="Size" value={db.sizeFormatted} />
+              <StatRow label="Connections" value={`${db.activeConnections}/${db.maxConnections}`} />
+              <StatRow label="Txn Committed" value={db.transactionsCommitted.toLocaleString()} />
+              <StatRow label="Txn Rolled Back" value={db.transactionsRolledBack.toLocaleString()} />
+              <StatRow
+                label="Growth (7d)"
+                value={`${db.growthLast7Days > 0 ? '+' : ''}${db.growthLast7Days}%`}
+              />
+            </div>
+          )}
+        </MetricCard>
+
+        <MetricCard
+          title="Cache (Redis)"
+          icon={<HardDrive className="h-4 w-4 text-red-600" />}
+          loading={loading}
+        >
+          {cache && (
+            <div className="space-y-0.5">
+              <StatRow
+                label="Memory"
+                value={`${cache.usedMemoryFormatted} / ${cache.maxMemoryFormatted}`}
+              />
+              <StatRow label="Usage" value={`${cache.memoryUsagePercent.toFixed(1)}%`} />
+              <StatRow label="Keys" value={cache.totalKeys.toLocaleString()} />
+              <StatRow label="Hit Rate" value={`${(cache.hitRate * 100).toFixed(1)}%`} />
+              <StatRow label="Evicted" value={cache.evictedKeys.toLocaleString()} />
+            </div>
+          )}
+        </MetricCard>
+
+        <MetricCard
+          title="Vector Store (Qdrant)"
+          icon={<Layers className="h-4 w-4 text-purple-600" />}
+          loading={loading}
+        >
+          {vectors && (
+            <div className="space-y-0.5">
+              <StatRow label="Collections" value={vectors.totalCollections} />
+              <StatRow label="Vectors" value={vectors.totalVectors.toLocaleString()} />
+              <StatRow label="Indexed" value={vectors.indexedVectors.toLocaleString()} />
+              <StatRow label="Memory" value={vectors.memoryFormatted} />
+            </div>
+          )}
+        </MetricCard>
+      </div>
+
+      {/* Top Tables */}
+      {tables.length > 0 && (
+        <div className="rounded-xl border bg-white/70 dark:bg-zinc-900/70 backdrop-blur-md p-4">
+          <h3 className="font-quicksand font-semibold text-sm mb-3">Top Tables by Size</h3>
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm">
+              <thead>
+                <tr className="border-b text-xs text-muted-foreground">
+                  <th className="text-left py-2 pr-4">Table</th>
+                  <th className="text-right py-2 px-4">Rows</th>
+                  <th className="text-right py-2 px-4">Size</th>
+                  <th className="text-right py-2 pl-4">Index</th>
+                </tr>
+              </thead>
+              <tbody>
+                {tables.map(t => (
+                  <tr key={t.tableName} className="border-b last:border-0">
+                    <td className="py-2 pr-4 font-mono text-xs">{t.tableName}</td>
+                    <td className="py-2 px-4 text-right">{t.rowCount.toLocaleString()}</td>
+                    <td className="py-2 px-4 text-right">{t.sizeFormatted}</td>
+                    <td className="py-2 pl-4 text-right">{t.indexSizeFormatted}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      )}
+
+      {/* Actions */}
+      <div className="flex flex-wrap gap-3">
+        <AlertDialog>
+          <AlertDialogTrigger asChild>
+            <Button variant="outline" size="sm" data-testid="clear-cache-button">
+              <Trash2 className="h-4 w-4 mr-2" />
+              Clear Cache
+            </Button>
+          </AlertDialogTrigger>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Clear Cache</AlertDialogTitle>
+              <AlertDialogDescription>
+                This will clear all cached data from Redis. Active sessions may experience slower
+                responses until the cache is rebuilt.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>Cancel</AlertDialogCancel>
+              <AlertDialogAction onClick={handleClearCache}>Clear Cache</AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+
+        <AlertDialog>
+          <AlertDialogTrigger asChild>
+            <Button variant="outline" size="sm" data-testid="vacuum-db-button">
+              <Wrench className="h-4 w-4 mr-2" />
+              Vacuum Database
+            </Button>
+          </AlertDialogTrigger>
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Vacuum Database</AlertDialogTitle>
+              <AlertDialogDescription>
+                VACUUM will reclaim storage and update statistics. A full vacuum locks the database
+                briefly but reclaims more space.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>Cancel</AlertDialogCancel>
+              <AlertDialogAction onClick={() => handleVacuum(false)}>
+                Standard Vacuum
+              </AlertDialogAction>
+              <AlertDialogAction
+                onClick={() => handleVacuum(true)}
+                className="bg-amber-600 hover:bg-amber-700"
+              >
+                Full Vacuum
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/admin/(dashboard)/monitor/operations/page.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/operations/page.tsx
@@ -1,0 +1,121 @@
+/**
+ * Admin Operations Console
+ * Issue #126 — Domain Operations Console page
+ *
+ * 4 tabs: Resources | Queue | Emergency | Audit
+ * Each tab lazy-loaded with Suspense + skeleton.
+ */
+
+import { Suspense } from 'react';
+
+import { Database, ListOrdered, ShieldAlert, ClipboardList } from 'lucide-react';
+
+import { AdminHubTabBar, type HubTab } from '@/components/admin/layout/AdminHubTabBar';
+import { AdminTabPersistence } from '@/components/admin/layout/AdminTabPersistence';
+
+import { AuditTab } from './AuditTab';
+import { EmergencyTab } from './EmergencyTab';
+import { OperationsNavConfig } from './NavConfig';
+import { QueueTab } from './QueueTab';
+import { ResourcesTab } from './ResourcesTab';
+
+interface OperationsPageProps {
+  searchParams: Promise<{ tab?: string }>;
+}
+
+const TABS: readonly HubTab[] = [
+  {
+    id: 'resources',
+    label: 'Resources',
+    href: '/admin/monitor/operations?tab=resources',
+    icon: <Database />,
+  },
+  {
+    id: 'queue',
+    label: 'Queue',
+    href: '/admin/monitor/operations?tab=queue',
+    icon: <ListOrdered />,
+  },
+  {
+    id: 'emergency',
+    label: 'Emergency',
+    href: '/admin/monitor/operations?tab=emergency',
+    icon: <ShieldAlert />,
+  },
+  {
+    id: 'audit',
+    label: 'Audit',
+    href: '/admin/monitor/operations?tab=audit',
+    icon: <ClipboardList />,
+  },
+] as const;
+
+type TabId = (typeof TABS)[number]['id'];
+
+function TabSkeleton() {
+  return (
+    <div className="space-y-3 pt-2">
+      <div className="h-10 w-48 rounded-lg bg-white/40 dark:bg-zinc-800/40 animate-pulse" />
+      <div className="grid gap-3 sm:grid-cols-2 lg:grid-cols-3">
+        {[1, 2, 3].map(i => (
+          <div key={i} className="h-24 rounded-xl bg-white/40 dark:bg-zinc-800/40 animate-pulse" />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function renderTabContent(tab: TabId) {
+  switch (tab) {
+    case 'resources':
+      return (
+        <Suspense fallback={<TabSkeleton />}>
+          <ResourcesTab />
+        </Suspense>
+      );
+    case 'queue':
+      return (
+        <Suspense fallback={<TabSkeleton />}>
+          <QueueTab />
+        </Suspense>
+      );
+    case 'emergency':
+      return (
+        <Suspense fallback={<TabSkeleton />}>
+          <EmergencyTab />
+        </Suspense>
+      );
+    case 'audit':
+      return (
+        <Suspense fallback={<TabSkeleton />}>
+          <AuditTab />
+        </Suspense>
+      );
+    default:
+      return null;
+  }
+}
+
+export default async function OperationsPage({ searchParams }: OperationsPageProps) {
+  const params = await searchParams;
+  const tab = (params.tab ?? 'resources') as TabId;
+
+  return (
+    <div className="space-y-5" data-testid="operations-page">
+      <OperationsNavConfig />
+      <div>
+        <h1 className="font-quicksand text-xl sm:text-2xl font-bold tracking-tight text-foreground">
+          Operations Console
+        </h1>
+        <p className="mt-0.5 text-sm text-muted-foreground">
+          Resources, processing queue, emergency controls, and audit trail.
+        </p>
+      </div>
+
+      <AdminHubTabBar tabs={TABS} activeTab={tab} />
+      <AdminTabPersistence hubName="operations" defaultTab="resources" />
+
+      <div className="pt-1">{renderTabContent(tab)}</div>
+    </div>
+  );
+}

--- a/apps/web/src/config/admin-dashboard-navigation.ts
+++ b/apps/web/src/config/admin-dashboard-navigation.ts
@@ -45,6 +45,7 @@ import {
   ClipboardListIcon,
   KeyIcon,
   MailIcon,
+  ScrollTextIcon,
 } from 'lucide-react';
 
 // ─── Types ───────────────────────────────────────────────────────────────────
@@ -334,6 +335,12 @@ export const DASHBOARD_SECTIONS: DashboardSection[] = [
         href: '/admin/monitor?tab=email',
         label: 'Email',
         icon: MailIcon,
+      },
+      // Operations Console (Issue #126)
+      {
+        href: '/admin/monitor/operations',
+        label: 'Operations',
+        icon: ScrollTextIcon,
       },
       // Config items
       {

--- a/apps/web/src/lib/api/clients/adminClient.ts
+++ b/apps/web/src/lib/api/clients/adminClient.ts
@@ -136,6 +136,20 @@ import {
   type EmailTemplateDto,
   type CreateEmailTemplateInput,
   type UpdateEmailTemplateInput,
+  DatabaseMetricsSchema,
+  type DatabaseMetrics,
+  CacheMetricsSchema,
+  type CacheMetrics,
+  TableSizeSchema,
+  type TableSize,
+  VectorStoreMetricsSchema,
+  type VectorStoreMetrics,
+  PaginatedQueueSchema,
+  type PaginatedQueue,
+  QueueStatusSchema,
+  type QueueStatus,
+  ActiveOverrideSchema,
+  type ActiveOverride,
 } from '../schemas';
 import {
   BulkDeleteResultSchema,
@@ -3007,6 +3021,161 @@ export function createAdminClient({ httpClient }: CreateAdminClientParams) {
         GetEmailTemplatesResponseSchema
       );
       return result ?? [];
+    },
+
+    // ========== Resources Monitoring (Issue #125) ==========
+
+    /**
+     * Get database metrics (size, connections, transactions)
+     * GET /api/v1/resources/database/metrics
+     */
+    async getResourceDatabaseMetrics(): Promise<DatabaseMetrics | null> {
+      return httpClient.get('/api/v1/resources/database/metrics', DatabaseMetricsSchema);
+    },
+
+    /**
+     * Get top database tables by size
+     * GET /api/v1/resources/database/tables/top
+     */
+    async getResourceDatabaseTopTables(limit = 10): Promise<TableSize[]> {
+      const result = await httpClient.get(
+        `/api/v1/resources/database/tables/top?limit=${limit}`,
+        z.array(TableSizeSchema)
+      );
+      return result ?? [];
+    },
+
+    /**
+     * Get cache (Redis) metrics
+     * GET /api/v1/resources/cache/metrics
+     */
+    async getResourceCacheMetrics(): Promise<CacheMetrics | null> {
+      return httpClient.get('/api/v1/resources/cache/metrics', CacheMetricsSchema);
+    },
+
+    /**
+     * Get vector store (Qdrant) metrics
+     * GET /api/v1/resources/vectors/metrics
+     */
+    async getResourceVectorMetrics(): Promise<VectorStoreMetrics | null> {
+      return httpClient.get('/api/v1/resources/vectors/metrics', VectorStoreMetricsSchema);
+    },
+
+    /**
+     * Clear all cache keys
+     * POST /api/v1/resources/cache/clear?confirmed=true
+     */
+    async clearCache(): Promise<void> {
+      await httpClient.post('/api/v1/resources/cache/clear?confirmed=true');
+    },
+
+    /**
+     * Run database VACUUM
+     * POST /api/v1/resources/database/vacuum?confirmed=true
+     */
+    async vacuumDatabase(fullVacuum = false): Promise<void> {
+      await httpClient.post(
+        `/api/v1/resources/database/vacuum?confirmed=true&fullVacuum=${fullVacuum}`
+      );
+    },
+
+    // ========== Processing Queue (Issue #125) ==========
+
+    /**
+     * Get paginated processing queue
+     * GET /api/v1/admin/queue/
+     */
+    async getProcessingQueue(params?: {
+      status?: string;
+      search?: string;
+      page?: number;
+      pageSize?: number;
+    }): Promise<PaginatedQueue | null> {
+      const qs = new URLSearchParams();
+      if (params?.status) qs.set('status', params.status);
+      if (params?.search) qs.set('search', params.search);
+      if (params?.page) qs.set('page', String(params.page));
+      if (params?.pageSize) qs.set('pageSize', String(params.pageSize));
+      const query = qs.toString();
+      return httpClient.get(
+        `/api/v1/admin/queue/${query ? `?${query}` : ''}`,
+        PaginatedQueueSchema
+      );
+    },
+
+    /**
+     * Get queue status (depth, pressure, workers)
+     * GET /api/v1/admin/queue/status
+     */
+    async getQueueStatus(): Promise<QueueStatus | null> {
+      return httpClient.get('/api/v1/admin/queue/status', QueueStatusSchema);
+    },
+
+    /**
+     * Cancel a processing job
+     * POST /api/v1/admin/queue/{jobId}/cancel
+     */
+    async cancelJob(jobId: string): Promise<void> {
+      await httpClient.post(`/api/v1/admin/queue/${jobId}/cancel`);
+    },
+
+    /**
+     * Retry a failed processing job
+     * POST /api/v1/admin/queue/{jobId}/retry
+     */
+    async retryJob(jobId: string): Promise<void> {
+      await httpClient.post(`/api/v1/admin/queue/${jobId}/retry`);
+    },
+
+    /**
+     * Remove a completed/cancelled job
+     * DELETE /api/v1/admin/queue/{jobId}
+     */
+    async removeJob(jobId: string): Promise<void> {
+      await httpClient.delete(`/api/v1/admin/queue/${jobId}`);
+    },
+
+    /**
+     * Reorder queue jobs
+     * PUT /api/v1/admin/queue/reorder
+     */
+    async reorderQueue(orderedJobIds: string[]): Promise<void> {
+      await httpClient.put('/api/v1/admin/queue/reorder', { orderedJobIds });
+    },
+
+    // ========== Emergency Controls (Issue #125) ==========
+
+    /**
+     * Get active LLM emergency overrides
+     * GET /api/v1/admin/llm/emergency/active
+     */
+    async getActiveEmergencyOverrides(): Promise<ActiveOverride[]> {
+      const result = await httpClient.get(
+        '/api/v1/admin/llm/emergency/active',
+        z.array(ActiveOverrideSchema)
+      );
+      return result ?? [];
+    },
+
+    /**
+     * Activate a new emergency override
+     * POST /api/v1/admin/llm/emergency/activate
+     */
+    async activateEmergencyOverride(params: {
+      action: string;
+      reason: string;
+      durationMinutes?: number;
+      targetProvider?: string;
+    }): Promise<void> {
+      await httpClient.post('/api/v1/admin/llm/emergency/activate', params);
+    },
+
+    /**
+     * Deactivate an emergency override
+     * POST /api/v1/admin/llm/emergency/deactivate
+     */
+    async deactivateEmergencyOverride(action: string): Promise<void> {
+      await httpClient.post('/api/v1/admin/llm/emergency/deactivate', { action });
     },
   };
 }

--- a/apps/web/src/lib/api/schemas/admin.schemas.ts
+++ b/apps/web/src/lib/api/schemas/admin.schemas.ts
@@ -624,6 +624,8 @@ export const AuditLogEntrySchema = z.object({
   details: z.string().nullable().optional(),
   ipAddress: z.string().nullable().optional(),
   createdAt: z.string().datetime(),
+  userName: z.string().nullable().optional(),
+  userEmail: z.string().nullable().optional(),
 });
 export type AuditLogEntry = z.infer<typeof AuditLogEntrySchema>;
 
@@ -853,5 +855,124 @@ export const BulkImportFromJsonResultSchema = z.object({
   errors: z.array(BulkImportErrorSchema),
 });
 export type BulkImportFromJsonResult = z.infer<typeof BulkImportFromJsonResultSchema>;
+
+// ========== Infrastructure Resources (Issue #125) ==========
+
+export const DatabaseMetricsSchema = z.object({
+  sizeBytes: z.number(),
+  sizeFormatted: z.string(),
+  growthLast7Days: z.number(),
+  growthLast30Days: z.number(),
+  growthLast90Days: z.number(),
+  activeConnections: z.number(),
+  maxConnections: z.number(),
+  transactionsCommitted: z.number(),
+  transactionsRolledBack: z.number(),
+  measuredAt: z.string().datetime(),
+});
+export type DatabaseMetrics = z.infer<typeof DatabaseMetricsSchema>;
+
+export const CacheMetricsSchema = z.object({
+  usedMemoryBytes: z.number(),
+  usedMemoryFormatted: z.string(),
+  maxMemoryBytes: z.number(),
+  maxMemoryFormatted: z.string(),
+  memoryUsagePercent: z.number(),
+  totalKeys: z.number(),
+  keyspaceHits: z.number(),
+  keyspaceMisses: z.number(),
+  hitRate: z.number(),
+  evictedKeys: z.number(),
+  expiredKeys: z.number(),
+  measuredAt: z.string().datetime(),
+});
+export type CacheMetrics = z.infer<typeof CacheMetricsSchema>;
+
+export const TableSizeSchema = z.object({
+  tableName: z.string(),
+  sizeBytes: z.number(),
+  sizeFormatted: z.string(),
+  rowCount: z.number(),
+  indexSizeBytes: z.number(),
+  indexSizeFormatted: z.string(),
+  totalSizeBytes: z.number(),
+  totalSizeFormatted: z.string(),
+});
+export type TableSize = z.infer<typeof TableSizeSchema>;
+
+export const VectorCollectionMetricsSchema = z.object({
+  collectionName: z.string(),
+  vectorCount: z.number(),
+  indexedCount: z.number(),
+  vectorDimensions: z.number(),
+  distanceMetric: z.string(),
+  memoryBytes: z.number(),
+  memoryFormatted: z.string(),
+});
+
+export const VectorStoreMetricsSchema = z.object({
+  totalCollections: z.number(),
+  totalVectors: z.number(),
+  indexedVectors: z.number(),
+  memoryBytes: z.number(),
+  memoryFormatted: z.string(),
+  collections: z.array(VectorCollectionMetricsSchema),
+  measuredAt: z.string().datetime(),
+});
+export type VectorStoreMetrics = z.infer<typeof VectorStoreMetricsSchema>;
+
+// ========== Processing Queue (Issue #125) ==========
+
+export const ProcessingJobSchema = z.object({
+  id: z.string().uuid(),
+  pdfDocumentId: z.string().uuid(),
+  pdfFileName: z.string(),
+  userId: z.string().uuid(),
+  status: z.string(),
+  priority: z.number(),
+  currentStep: z.string().nullable(),
+  createdAt: z.string().datetime(),
+  startedAt: z.string().datetime().nullable(),
+  completedAt: z.string().datetime().nullable(),
+  errorMessage: z.string().nullable(),
+  retryCount: z.number(),
+  maxRetries: z.number(),
+  canRetry: z.boolean(),
+});
+export type ProcessingJob = z.infer<typeof ProcessingJobSchema>;
+
+export const PaginatedQueueSchema = z.object({
+  jobs: z.array(ProcessingJobSchema),
+  total: z.number(),
+  page: z.number(),
+  pageSize: z.number(),
+  totalPages: z.number(),
+});
+export type PaginatedQueue = z.infer<typeof PaginatedQueueSchema>;
+
+export const QueueStatusSchema = z.object({
+  queueDepth: z.number(),
+  backpressureThreshold: z.number(),
+  isUnderPressure: z.boolean(),
+  isPaused: z.boolean(),
+  maxConcurrentWorkers: z.number(),
+  estimatedWaitMinutes: z.number(),
+});
+export type QueueStatus = z.infer<typeof QueueStatusSchema>;
+
+// ========== Emergency Controls (Issue #125) ==========
+
+export const ActiveOverrideSchema = z.object({
+  action: z.string(),
+  reason: z.string(),
+  adminUserId: z.string().uuid(),
+  targetProvider: z.string().nullable(),
+  activatedAt: z.string().datetime(),
+  expiresAt: z.string().datetime(),
+  remainingMinutes: z.number(),
+});
+export type ActiveOverride = z.infer<typeof ActiveOverrideSchema>;
+
+// Note: Audit Log schemas (AuditLogEntrySchema, AuditLogListResultSchema) defined above in Issue #3691 section
 
 // Note: PagedResult is defined in config.schemas.ts and re-exported via index.ts


### PR DESCRIPTION
## Summary
- **Issue #125**: Added 15 new admin API client methods covering Resources (6), Queue (6), and Emergency (3) endpoints with Zod schemas for DatabaseMetrics, CacheMetrics, VectorStoreMetrics, ProcessingJob, QueueStatus, and ActiveOverride DTOs
- **Issue #126**: Created Operations Console page at `/admin/monitor/operations` with 4 functional tabs (Resources, Queue, Emergency, Audit), NavConfig, sidebar navigation item, auto-refresh, action dialogs, pagination, and filtering

## Test plan
- [ ] Navigate to `/admin/monitor/operations` — page loads with 4 tabs
- [ ] Switch tabs via tab bar — URL updates, content changes
- [ ] Resources tab: shows DB/Cache/Vector metrics, Clear Cache and Vacuum dialogs work
- [ ] Queue tab: shows job list with status badges, filter/search/pagination work
- [ ] Emergency tab: shows active overrides or "all systems normal", activate form validates
- [ ] Audit tab: shows log entries with expandable rows, filters work, Export CSV downloads
- [ ] Sidebar: "Operations" item visible under System section

🤖 Generated with [Claude Code](https://claude.com/claude-code)