### PR TITLE
feat(infra): secrets sync tool with manifest-based policy

### DIFF
--- a/infra/scripts/sync-secrets.ps1
+++ b/infra/scripts/sync-secrets.ps1
@@ -1,0 +1,685 @@
+<#
+.SYNOPSIS
+    Sync secrets between local and staging server with service restart orchestration.
+
+.DESCRIPTION
+    Manages bidirectional secret sync between local dev/staging files and the
+    staging server at meepleai.app. Uses a YAML manifest (secrets-sync.yml)
+    to determine sync policy per secret and which services to restart.
+
+.PARAMETER Pull
+    Download server secrets to local staging/ mirror.
+
+.PARAMETER Push
+    Upload local secrets to server (default mode if no switch specified).
+
+.PARAMETER Status
+    Show diff between local and server secrets without taking action.
+
+.PARAMETER Only
+    Filter to a single secret name (without .secret extension).
+
+.PARAMETER DryRun
+    Show actions without executing them.
+
+.PARAMETER Force
+    Skip confirmation prompts.
+
+.PARAMETER SkipRestart
+    Upload secrets but don't restart services.
+
+.EXAMPLE
+    # Pull all secrets from server
+    pwsh infra/scripts/sync-secrets.ps1 -Pull
+
+    # Push changes (default mode)
+    pwsh infra/scripts/sync-secrets.ps1
+
+    # Check status only
+    pwsh infra/scripts/sync-secrets.ps1 -Status
+
+    # Push single secret with dry run
+    pwsh infra/scripts/sync-secrets.ps1 -Only openrouter -DryRun
+#>
+
+[CmdletBinding(DefaultParameterSetName = 'Push')]
+param(
+    [Parameter(ParameterSetName = 'Pull')]
+    [switch]$Pull,
+
+    [Parameter(ParameterSetName = 'Push')]
+    [switch]$Push,
+
+    [Parameter(ParameterSetName = 'Status')]
+    [switch]$Status,
+
+    [string]$Only,
+    [switch]$DryRun,
+    [switch]$Force,
+    [switch]$SkipRestart
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+# ── Paths ──────────────────────────────────────────────────────────────────────
+$ScriptRoot = $PSScriptRoot
+$InfraRoot = Split-Path $ScriptRoot -Parent
+$SecretsDir = Join-Path $InfraRoot 'secrets'
+$StagingDir = Join-Path $SecretsDir 'staging'
+$ManifestPath = Join-Path $SecretsDir 'secrets-sync.yml'
+$TempRoot = Join-Path $env:TEMP 'meepleai-secrets-sync'
+
+# ── Cleanup trap ───────────────────────────────────────────────────────────────
+function Cleanup-Temp {
+    if (Test-Path $TempRoot) {
+        Remove-Item $TempRoot -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+trap { Cleanup-Temp }
+
+# ── YAML Parser (regex-based, no external deps) ───────────────────────────────
+function Parse-Manifest {
+    param([string]$Path)
+
+    if (-not (Test-Path $Path)) {
+        Write-Host "ERROR: Manifest not found: $Path" -ForegroundColor Red
+        exit 1
+    }
+
+    $content = Get-Content $Path -Raw
+    $result = @{
+        secrets       = @{}
+        service_map   = @{}
+        stateful      = @()
+        server        = @{}
+    }
+
+    # Parse secrets section
+    $inSection = $null
+    foreach ($line in (Get-Content $Path)) {
+        $trimmed = $line.Trim()
+
+        # Skip comments and empty lines
+        if ($trimmed -eq '' -or $trimmed.StartsWith('#')) { continue }
+
+        # Detect top-level sections
+        if ($trimmed -eq 'secrets:') { $inSection = 'secrets'; continue }
+        if ($trimmed -eq 'service_map:') { $inSection = 'service_map'; continue }
+        if ($trimmed -match '^stateful_services:\s*\[(.+)\]$') {
+            $result.stateful = $Matches[1] -split ',\s*' | ForEach-Object { $_.Trim() }
+            $inSection = $null
+            continue
+        }
+        if ($trimmed -eq 'server:') { $inSection = 'server'; continue }
+
+        # Parse key-value pairs within sections
+        if ($inSection -eq 'secrets' -and $trimmed -match '^\s*(\S+\.secret):\s*(sync|staging-only|skip)\s*$') {
+            $result.secrets[$Matches[1]] = $Matches[2]
+        }
+        elseif ($inSection -eq 'service_map' -and $trimmed -match '^\s*(\S+\.secret):\s*\[(.+)\]\s*$') {
+            $result.service_map[$Matches[1]] = $Matches[2] -split ',\s*' | ForEach-Object { $_.Trim() }
+        }
+        elseif ($inSection -eq 'server') {
+            if ($trimmed -match '^\s*host:\s*(.+)$') { $result.server.host = $Matches[1].Trim() }
+            elseif ($trimmed -match '^\s*user:\s*(.+)$') { $result.server.user = $Matches[1].Trim() }
+            elseif ($trimmed -match '^\s*key_path:\s*"?([^"]+)"?\s*$') { $result.server.key_path = $Matches[1].Trim() }
+            elseif ($trimmed -match '^\s*remote_secrets_path:\s*(.+)$') { $result.server.remote_secrets_path = $Matches[1].Trim() }
+            elseif ($trimmed -match '^\s*compose_dir:\s*(.+)$') { $result.server.compose_dir = $Matches[1].Trim() }
+            elseif ($trimmed -match '^\s*compose_cmd:\s*>-?\s*$') { $inSection = 'server_compose_cmd' }
+        }
+        elseif ($inSection -eq 'server_compose_cmd') {
+            if ($trimmed -match '^\s+-f\s' -or $trimmed -match '^docker\s') {
+                if (-not $result.server.compose_cmd) {
+                    $result.server.compose_cmd = $trimmed
+                } else {
+                    $result.server.compose_cmd += ' ' + $trimmed
+                }
+            } else {
+                # End of multi-line compose_cmd, re-parse this line
+                $inSection = $null
+                if ($trimmed -eq 'secrets:') { $inSection = 'secrets' }
+                elseif ($trimmed -eq 'service_map:') { $inSection = 'service_map' }
+                elseif ($trimmed -eq 'server:') { $inSection = 'server' }
+            }
+        }
+    }
+
+    return $result
+}
+
+# ── SSH helpers ────────────────────────────────────────────────────────────────
+function Get-SshArgs {
+    param([hashtable]$Server)
+    $keyPath = $Server.key_path
+    return @(
+        '-o', 'ConnectTimeout=5',
+        '-o', 'BatchMode=yes',
+        '-o', 'StrictHostKeyChecking=accept-new',
+        '-i', $keyPath,
+        "$($Server.user)@$($Server.host)"
+    )
+}
+
+function Get-ScpArgs {
+    param([hashtable]$Server)
+    $keyPath = $Server.key_path
+    return @(
+        '-o', 'ConnectTimeout=5',
+        '-o', 'BatchMode=yes',
+        '-o', 'StrictHostKeyChecking=accept-new',
+        '-i', $keyPath
+    )
+}
+
+function Test-SshConnection {
+    param([hashtable]$Server)
+    Write-Host 'Checking SSH connectivity...' -ForegroundColor Cyan
+    $sshArgs = Get-SshArgs $Server
+    $proc = Start-Process -FilePath 'ssh' -ArgumentList ($sshArgs + @('echo', 'ok')) `
+        -NoNewWindow -Wait -PassThru -RedirectStandardOutput "$TempRoot\ssh-test.txt" -RedirectStandardError "$TempRoot\ssh-test-err.txt"
+    if ($proc.ExitCode -ne 0) {
+        $errMsg = if (Test-Path "$TempRoot\ssh-test-err.txt") { Get-Content "$TempRoot\ssh-test-err.txt" -Raw } else { 'Unknown error' }
+        Write-Host "ERROR: SSH connection failed to $($Server.user)@$($Server.host)" -ForegroundColor Red
+        Write-Host $errMsg -ForegroundColor Red
+        exit 1
+    }
+    Write-Host "  Connected to $($Server.user)@$($Server.host)" -ForegroundColor Green
+}
+
+function Invoke-Ssh {
+    param([hashtable]$Server, [string]$Command)
+    $sshArgs = Get-SshArgs $Server
+    $outFile = Join-Path $TempRoot "ssh-out-$([guid]::NewGuid().ToString('N')).txt"
+    $errFile = Join-Path $TempRoot "ssh-err-$([guid]::NewGuid().ToString('N')).txt"
+    $proc = Start-Process -FilePath 'ssh' -ArgumentList ($sshArgs + @($Command)) `
+        -NoNewWindow -Wait -PassThru -RedirectStandardOutput $outFile -RedirectStandardError $errFile
+    $output = if (Test-Path $outFile) { Get-Content $outFile -Raw } else { '' }
+    $errOutput = if (Test-Path $errFile) { Get-Content $errFile -Raw } else { '' }
+    if ($proc.ExitCode -ne 0) {
+        Write-Host "SSH command failed: $Command" -ForegroundColor Red
+        if ($errOutput) { Write-Host $errOutput -ForegroundColor Red }
+        return $null
+    }
+    return $output
+}
+
+function Invoke-ScpDownload {
+    param([hashtable]$Server, [string]$RemotePath, [string]$LocalPath)
+    $scpArgs = Get-ScpArgs $Server
+    $remote = "$($Server.user)@$($Server.host):$RemotePath"
+    $proc = Start-Process -FilePath 'scp' -ArgumentList ($scpArgs + @($remote, $LocalPath)) `
+        -NoNewWindow -Wait -PassThru -RedirectStandardError "$TempRoot\scp-err.txt"
+    return $proc.ExitCode -eq 0
+}
+
+function Invoke-ScpUpload {
+    param([hashtable]$Server, [string]$LocalPath, [string]$RemotePath)
+    $scpArgs = Get-ScpArgs $Server
+    $remote = "$($Server.user)@$($Server.host):$RemotePath"
+    $proc = Start-Process -FilePath 'scp' -ArgumentList ($scpArgs + @($LocalPath, $remote)) `
+        -NoNewWindow -Wait -PassThru -RedirectStandardError "$TempRoot\scp-err.txt"
+    return $proc.ExitCode -eq 0
+}
+
+# ── Hash helper ────────────────────────────────────────────────────────────────
+function Get-FileHashValue {
+    param([string]$Path)
+    if (-not (Test-Path $Path)) { return $null }
+    return (Get-FileHash -Path $Path -Algorithm SHA256).Hash
+}
+
+# ── Confirmation helper ───────────────────────────────────────────────────────
+function Confirm-Action {
+    param([string]$Message)
+    if ($Force) { return $true }
+    if ($DryRun) { return $false }
+    Write-Host ""
+    $response = Read-Host "$Message [y/N]"
+    return $response -eq 'y' -or $response -eq 'Y'
+}
+
+# ── Table display helpers ─────────────────────────────────────────────────────
+function Show-StatusTable {
+    param([array]$Rows, [bool]$ShowServices = $false)
+
+    # Calculate column widths
+    $nameWidth = ($Rows | ForEach-Object { $_.Name.Length } | Measure-Object -Maximum).Maximum
+    $nameWidth = [Math]::Max($nameWidth, 6)  # minimum "Secret" header
+    $statusWidth = 8
+
+    if ($ShowServices) {
+        $svcWidth = ($Rows | ForEach-Object { $_.Services.Length } | Measure-Object -Maximum).Maximum
+        $svcWidth = [Math]::Max($svcWidth, 8)  # minimum "Services" header
+
+        $headerFmt = "  {0,-$nameWidth}  {1,-$statusWidth}  {2,-$svcWidth}"
+        Write-Host ""
+        Write-Host ($headerFmt -f 'Secret', 'Status', 'Services') -ForegroundColor White
+        Write-Host ("  " + ('-' * $nameWidth) + "  " + ('-' * $statusWidth) + "  " + ('-' * $svcWidth)) -ForegroundColor DarkGray
+    } else {
+        $headerFmt = "  {0,-$nameWidth}  {1,-$statusWidth}"
+        Write-Host ""
+        Write-Host ($headerFmt -f 'Secret', 'Status') -ForegroundColor White
+        Write-Host ("  " + ('-' * $nameWidth) + "  " + ('-' * $statusWidth)) -ForegroundColor DarkGray
+    }
+
+    foreach ($row in $Rows) {
+        $color = switch ($row.Status) {
+            'NEW'     { 'Yellow' }
+            'UPDATED' { 'Yellow' }
+            'CHANGED' { 'Yellow' }
+            'OK'      { 'Green' }
+            'SKIP'    { 'DarkGray' }
+            'MISSING' { 'Red' }
+            default   { 'White' }
+        }
+
+        if ($ShowServices) {
+            $line = $headerFmt -f $row.Name, $row.Status, $row.Services
+        } else {
+            $line = ("  {0,-$nameWidth}  {1,-$statusWidth}" -f $row.Name, $row.Status)
+        }
+        Write-Host $line -ForegroundColor $color
+    }
+    Write-Host ""
+}
+
+# ── PULL MODE ──────────────────────────────────────────────────────────────────
+function Invoke-Pull {
+    $manifest = Parse-Manifest $ManifestPath
+    $server = $manifest.server
+
+    # Ensure temp dir
+    New-Item -ItemType Directory -Path $TempRoot -Force | Out-Null
+
+    # Test connectivity
+    Test-SshConnection $server
+
+    Write-Host "`nPulling secrets from server..." -ForegroundColor Cyan
+
+    # Download all *.secret files via tar
+    $tarRemote = "$($server.remote_secrets_path)"
+    $tarFile = Join-Path $TempRoot 'server-secrets.tar'
+    $extractDir = Join-Path $TempRoot 'server'
+    New-Item -ItemType Directory -Path $extractDir -Force | Out-Null
+
+    if ($Only) {
+        $secretName = if ($Only.EndsWith('.secret')) { $Only } else { "$Only.secret" }
+        $remoteFile = "$tarRemote/$secretName"
+        $localTemp = Join-Path $extractDir $secretName
+        Write-Host "  Downloading $secretName..." -ForegroundColor Gray
+        if (-not $DryRun) {
+            $ok = Invoke-ScpDownload $server $remoteFile $localTemp
+            if (-not $ok) {
+                Write-Host "ERROR: Failed to download $secretName" -ForegroundColor Red
+                Cleanup-Temp
+                exit 1
+            }
+        }
+    } else {
+        Write-Host "  Downloading all secrets via tar..." -ForegroundColor Gray
+        if (-not $DryRun) {
+            $tarCmd = "cd $tarRemote && tar cf - *.secret 2>/dev/null"
+            $sshArgs = Get-SshArgs $server
+            # Use ssh + tar to download all secrets at once
+            $errFile = Join-Path $TempRoot 'tar-err.txt'
+            $proc = Start-Process -FilePath 'ssh' -ArgumentList ($sshArgs + @($tarCmd)) `
+                -NoNewWindow -Wait -PassThru `
+                -RedirectStandardOutput $tarFile `
+                -RedirectStandardError $errFile
+
+            if ($proc.ExitCode -ne 0 -or -not (Test-Path $tarFile) -or (Get-Item $tarFile).Length -eq 0) {
+                Write-Host "ERROR: Failed to download secrets from server" -ForegroundColor Red
+                Cleanup-Temp
+                exit 1
+            }
+
+            # Extract tar
+            tar -xf $tarFile -C $extractDir 2>$null
+        }
+    }
+
+    # Compare with local staging/
+    $rows = @()
+    $serverFiles = if ($DryRun) {
+        # In dry-run, list from manifest
+        $manifest.secrets.Keys | Sort-Object
+    } else {
+        Get-ChildItem -Path $extractDir -Filter '*.secret' -ErrorAction SilentlyContinue | ForEach-Object { $_.Name } | Sort-Object
+    }
+
+    if ($Only) {
+        $filterName = if ($Only.EndsWith('.secret')) { $Only } else { "$Only.secret" }
+        $serverFiles = $serverFiles | Where-Object { $_ -eq $filterName }
+    }
+
+    foreach ($name in $serverFiles) {
+        $serverFile = Join-Path $extractDir $name
+        $localFile = Join-Path $StagingDir $name
+
+        if ($DryRun) {
+            $status = if (Test-Path $localFile) { 'UPDATED' } else { 'NEW' }
+        } else {
+            $serverHash = Get-FileHashValue $serverFile
+            $localHash = Get-FileHashValue $localFile
+
+            if (-not $localHash) {
+                $status = 'NEW'
+            } elseif ($serverHash -eq $localHash) {
+                $status = 'OK'
+            } else {
+                $status = 'UPDATED'
+            }
+        }
+
+        $rows += @{ Name = $name; Status = $status; Services = '' }
+    }
+
+    Show-StatusTable $rows
+
+    $changedCount = ($rows | Where-Object { $_.Status -ne 'OK' }).Count
+    if ($changedCount -eq 0) {
+        Write-Host "All secrets are up to date." -ForegroundColor Green
+        Cleanup-Temp
+        return
+    }
+
+    if ($DryRun) {
+        Write-Host "[DRY RUN] Would save $changedCount secret(s) to staging/" -ForegroundColor Yellow
+        Cleanup-Temp
+        return
+    }
+
+    if (-not (Confirm-Action "Save $changedCount secret(s) to staging/?")) {
+        Write-Host "Cancelled." -ForegroundColor Yellow
+        Cleanup-Temp
+        return
+    }
+
+    # Ensure staging dir exists
+    New-Item -ItemType Directory -Path $StagingDir -Force | Out-Null
+
+    # Copy changed/new files to staging
+    foreach ($row in $rows) {
+        if ($row.Status -eq 'OK') { continue }
+        $src = Join-Path $extractDir $row.Name
+        $dst = Join-Path $StagingDir $row.Name
+        Copy-Item $src $dst -Force
+        Write-Host "  Saved: $($row.Name)" -ForegroundColor Green
+    }
+
+    Write-Host "`nPull complete. $changedCount secret(s) updated in staging/." -ForegroundColor Green
+    Cleanup-Temp
+}
+
+# ── PUSH / STATUS MODE ────────────────────────────────────────────────────────
+function Invoke-PushOrStatus {
+    param([bool]$StatusOnly = $false)
+
+    $manifest = Parse-Manifest $ManifestPath
+    $server = $manifest.server
+
+    # Ensure temp dir
+    New-Item -ItemType Directory -Path $TempRoot -Force | Out-Null
+
+    # Test connectivity
+    Test-SshConnection $server
+
+    $modeName = if ($StatusOnly) { 'Status' } else { 'Push' }
+    Write-Host "`n$modeName — comparing local secrets with server..." -ForegroundColor Cyan
+
+    # Step 1: Resolve source for each secret per manifest policy
+    $secretSources = @{}
+    $errors = @()
+    foreach ($entry in $manifest.secrets.GetEnumerator()) {
+        $name = $entry.Key
+        $policy = $entry.Value
+
+        if ($Only) {
+            $filterName = if ($Only.EndsWith('.secret')) { $Only } else { "$Only.secret" }
+            if ($name -ne $filterName) { continue }
+        }
+
+        switch ($policy) {
+            'sync' {
+                $src = Join-Path $SecretsDir $name
+                if (-not (Test-Path $src)) {
+                    $errors += "Missing source for '$name' (policy=sync): $src"
+                } else {
+                    $secretSources[$name] = $src
+                }
+            }
+            'staging-only' {
+                $src = Join-Path $StagingDir $name
+                if (-not (Test-Path $src)) {
+                    $errors += "Missing source for '$name' (policy=staging-only): $src"
+                } else {
+                    $secretSources[$name] = $src
+                }
+            }
+            'skip' {
+                # Intentionally skipped
+            }
+        }
+    }
+
+    if ($errors.Count -gt 0) {
+        Write-Host "`nWARNING: Some secrets have missing source files:" -ForegroundColor Yellow
+        foreach ($err in $errors) {
+            Write-Host "  $err" -ForegroundColor Yellow
+        }
+        Write-Host ""
+    }
+
+    if ($secretSources.Count -eq 0) {
+        Write-Host "No secrets to process." -ForegroundColor Yellow
+        Cleanup-Temp
+        return
+    }
+
+    # Step 2: Download current server files for comparison
+    $serverDir = Join-Path $TempRoot 'server-current'
+    New-Item -ItemType Directory -Path $serverDir -Force | Out-Null
+
+    if (-not $DryRun) {
+        Write-Host "  Downloading current server secrets for comparison..." -ForegroundColor Gray
+        foreach ($name in $secretSources.Keys) {
+            $remoteFile = "$($server.remote_secrets_path)/$name"
+            $localTemp = Join-Path $serverDir $name
+            Invoke-ScpDownload $server $remoteFile $localTemp | Out-Null
+        }
+    }
+
+    # Step 3: Compare each secret
+    $rows = @()
+    $changedSecrets = @()
+
+    foreach ($entry in ($secretSources.GetEnumerator() | Sort-Object -Property Key)) {
+        $name = $entry.Key
+        $localPath = $entry.Value
+        $serverPath = Join-Path $serverDir $name
+
+        $services = if ($manifest.service_map.ContainsKey($name)) {
+            ($manifest.service_map[$name] -join ', ')
+        } else { '-' }
+
+        if ($DryRun) {
+            $status = 'CHANGED'
+            $changedSecrets += $name
+        } else {
+            $localHash = Get-FileHashValue $localPath
+            $serverHash = Get-FileHashValue $serverPath
+
+            if (-not $serverHash) {
+                $status = 'NEW'
+                $changedSecrets += $name
+            } elseif ($localHash -eq $serverHash) {
+                $status = 'OK'
+            } else {
+                $status = 'CHANGED'
+                $changedSecrets += $name
+            }
+        }
+
+        $rows += @{ Name = $name; Status = $status; Services = $services }
+    }
+
+    # Add skipped secrets to table
+    foreach ($entry in $manifest.secrets.GetEnumerator()) {
+        if ($entry.Value -eq 'skip') {
+            if ($Only) {
+                $filterName = if ($Only.EndsWith('.secret')) { $Only } else { "$Only.secret" }
+                if ($entry.Key -ne $filterName) { continue }
+            }
+            $rows += @{ Name = $entry.Key; Status = 'SKIP'; Services = '-' }
+        }
+    }
+
+    $rows = $rows | Sort-Object { $_.Name }
+    Show-StatusTable $rows -ShowServices $true
+
+    # Status mode: stop here
+    if ($StatusOnly) {
+        $changedCount = $changedSecrets.Count
+        if ($changedCount -eq 0) {
+            Write-Host "All secrets are in sync." -ForegroundColor Green
+        } else {
+            Write-Host "$changedCount secret(s) have changes." -ForegroundColor Yellow
+        }
+        Cleanup-Temp
+        return
+    }
+
+    # Push mode: continue with upload
+    if ($changedSecrets.Count -eq 0) {
+        Write-Host "All secrets are in sync. Nothing to push." -ForegroundColor Green
+        Cleanup-Temp
+        return
+    }
+
+    # Step 5: Stateful service warning
+    $impactedServices = @()
+    foreach ($name in $changedSecrets) {
+        if ($manifest.service_map.ContainsKey($name)) {
+            $impactedServices += $manifest.service_map[$name]
+        }
+    }
+    $impactedServices = $impactedServices | Select-Object -Unique | Sort-Object
+
+    $statefulImpacted = $impactedServices | Where-Object { $manifest.stateful -contains $_ }
+    if ($statefulImpacted) {
+        Write-Host "" -ForegroundColor Red
+        foreach ($svc in $statefulImpacted) {
+            $causingSecret = $changedSecrets | Where-Object {
+                $manifest.service_map.ContainsKey($_) -and $manifest.service_map[$_] -contains $svc
+            }
+            Write-Host "  WARNING: $($causingSecret -join ', ') changed -> $svc is stateful!" -ForegroundColor Red
+        }
+        Write-Host "  Changing passwords on running stateful services may cause data" -ForegroundColor Red
+        Write-Host "  inaccessibility. The volume retains the old password." -ForegroundColor Red
+        Write-Host "  Proceed only if you know what you're doing." -ForegroundColor Red
+        Write-Host ""
+    }
+
+    if ($DryRun) {
+        Write-Host "[DRY RUN] Would upload $($changedSecrets.Count) secret(s) and restart: $($impactedServices -join ', ')" -ForegroundColor Yellow
+        Cleanup-Temp
+        return
+    }
+
+    if (-not (Confirm-Action "Upload $($changedSecrets.Count) changed secret(s) to server?")) {
+        Write-Host "Cancelled." -ForegroundColor Yellow
+        Cleanup-Temp
+        return
+    }
+
+    # Step 6: Backup on server
+    Write-Host "`nBacking up changed secrets on server..." -ForegroundColor Cyan
+    $dateStamp = Get-Date -Format 'yyyyMMdd'
+    $backupDir = "$($server.remote_secrets_path)/backup"
+    Invoke-Ssh $server "mkdir -p $backupDir" | Out-Null
+
+    foreach ($name in $changedSecrets) {
+        $remoteSrc = "$($server.remote_secrets_path)/$name"
+        $backupDst = "$backupDir/$name.$dateStamp"
+        $result = Invoke-Ssh $server "[ -f '$remoteSrc' ] && cp '$remoteSrc' '$backupDst' && echo 'ok' || echo 'skip'"
+        if ($result -and $result.Trim() -eq 'ok') {
+            Write-Host "  Backed up: $name -> backup/$name.$dateStamp" -ForegroundColor Gray
+        }
+    }
+
+    # Step 7: Upload changed files
+    Write-Host "`nUploading secrets..." -ForegroundColor Cyan
+    foreach ($name in $changedSecrets) {
+        $localPath = $secretSources[$name]
+        $remotePath = "$($server.remote_secrets_path)/$name"
+        $ok = Invoke-ScpUpload $server $localPath $remotePath
+        if ($ok) {
+            Write-Host "  Uploaded: $name" -ForegroundColor Green
+        } else {
+            Write-Host "  FAILED: $name" -ForegroundColor Red
+        }
+    }
+
+    # Step 8-9: Restart services
+    if ($SkipRestart) {
+        Write-Host "`nSkipping service restart (-SkipRestart)." -ForegroundColor Yellow
+        Cleanup-Temp
+        return
+    }
+
+    if ($impactedServices.Count -eq 0) {
+        Write-Host "`nNo services to restart." -ForegroundColor Green
+        Cleanup-Temp
+        return
+    }
+
+    Write-Host "`nServices to restart: $($impactedServices -join ', ')" -ForegroundColor Cyan
+
+    if (-not (Confirm-Action "Restart these services?")) {
+        Write-Host "Skipping restart." -ForegroundColor Yellow
+        Cleanup-Temp
+        return
+    }
+
+    # Step 10: Re-source env and restart
+    Write-Host "`nRestarting services..." -ForegroundColor Cyan
+    $serviceList = $impactedServices -join ' '
+    $composeDir = $server.compose_dir
+    $composeCmd = $server.compose_cmd
+
+    $restartCmd = "cd $composeDir && set -a; for f in secrets/*.secret; do source `"`$f`" 2>/dev/null; done; set +a && $composeCmd up -d --force-recreate $serviceList"
+    $result = Invoke-Ssh $server $restartCmd
+    if ($result) {
+        Write-Host $result -ForegroundColor Gray
+    }
+
+    # Step 11: Verify health
+    Write-Host "`nVerifying service status..." -ForegroundColor Cyan
+    $psCmd = "cd $composeDir && $composeCmd ps $serviceList"
+    $result = Invoke-Ssh $server $psCmd
+    if ($result) {
+        Write-Host $result
+    }
+
+    Write-Host "`nPush complete." -ForegroundColor Green
+    Cleanup-Temp
+}
+
+# ── MAIN ───────────────────────────────────────────────────────────────────────
+Write-Host ""
+Write-Host "=== MeepleAI Secrets Sync ===" -ForegroundColor Cyan
+Write-Host ""
+
+# Ensure temp dir exists
+New-Item -ItemType Directory -Path $TempRoot -Force | Out-Null
+
+if ($Pull) {
+    Invoke-Pull
+} elseif ($Status) {
+    Invoke-PushOrStatus -StatusOnly $true
+} else {
+    # Default: Push mode
+    Invoke-PushOrStatus -StatusOnly $false
+}

--- a/infra/scripts/sync-secrets.ps1
+++ b/infra/scripts/sync-secrets.ps1
@@ -93,7 +93,10 @@ function Parse-Manifest {
         secrets       = @{}
         service_map   = @{}
         stateful      = @()
-        server        = @{}
+        server        = @{
+            host = ''; user = ''; key_path = ''
+            remote_secrets_path = ''; compose_dir = ''; compose_cmd = ''
+        }
     }
 
     # Parse secrets section
@@ -130,7 +133,7 @@ function Parse-Manifest {
             elseif ($trimmed -match '^\s*compose_cmd:\s*>-?\s*$') { $inSection = 'server_compose_cmd' }
         }
         elseif ($inSection -eq 'server_compose_cmd') {
-            if ($trimmed -match '^\s+-f\s' -or $trimmed -match '^docker\s') {
+            if ($trimmed -match '^-f\s' -or $trimmed -match '^docker\s') {
                 if (-not $result.server.compose_cmd) {
                     $result.server.compose_cmd = $trimmed
                 } else {
@@ -152,7 +155,7 @@ function Parse-Manifest {
 # ── SSH helpers ────────────────────────────────────────────────────────────────
 function Get-SshArgs {
     param([hashtable]$Server)
-    $keyPath = $Server.key_path
+    $keyPath = "`"$($Server.key_path)`""
     return @(
         '-o', 'ConnectTimeout=5',
         '-o', 'BatchMode=yes',
@@ -164,7 +167,7 @@ function Get-SshArgs {
 
 function Get-ScpArgs {
     param([hashtable]$Server)
-    $keyPath = $Server.key_path
+    $keyPath = "`"$($Server.key_path)`""
     return @(
         '-o', 'ConnectTimeout=5',
         '-o', 'BatchMode=yes',
@@ -298,64 +301,50 @@ function Invoke-Pull {
 
     Write-Host "`nPulling secrets from server..." -ForegroundColor Cyan
 
-    # Download all *.secret files via tar
-    $tarRemote = "$($server.remote_secrets_path)"
-    $tarFile = Join-Path $TempRoot 'server-secrets.tar'
-    $extractDir = Join-Path $TempRoot 'server'
-    New-Item -ItemType Directory -Path $extractDir -Force | Out-Null
+    $remotePath = $server.remote_secrets_path
+    $downloadDir = Join-Path $TempRoot 'server'
+    New-Item -ItemType Directory -Path $downloadDir -Force | Out-Null
+
+    # List secret files on server
+    $listOutput = Invoke-Ssh $server "ls -1 $remotePath/*.secret 2>/dev/null | xargs -n1 basename"
+    if (-not $listOutput) {
+        Write-Host "ERROR: No secret files found on server" -ForegroundColor Red
+        Cleanup-Temp
+        exit 1
+    }
+    $remoteFiles = @($listOutput.Trim() -split "`n" | ForEach-Object { $_.Trim() } | Where-Object { $_ -ne '' })
 
     if ($Only) {
-        $secretName = if ($Only.EndsWith('.secret')) { $Only } else { "$Only.secret" }
-        $remoteFile = "$tarRemote/$secretName"
-        $localTemp = Join-Path $extractDir $secretName
-        Write-Host "  Downloading $secretName..." -ForegroundColor Gray
-        if (-not $DryRun) {
-            $ok = Invoke-ScpDownload $server $remoteFile $localTemp
+        $filterName = if ($Only.EndsWith('.secret')) { $Only } else { "$Only.secret" }
+        $remoteFiles = @($remoteFiles | Where-Object { $_ -eq $filterName })
+    }
+
+    # Download each file via SCP
+    $failedDownloads = @()
+    if (-not $DryRun) {
+        foreach ($name in $remoteFiles) {
+            Write-Host "  Downloading $name..." -ForegroundColor Gray
+            $ok = Invoke-ScpDownload $server "$remotePath/$name" (Join-Path $downloadDir $name)
             if (-not $ok) {
-                Write-Host "ERROR: Failed to download $secretName" -ForegroundColor Red
-                Cleanup-Temp
-                exit 1
+                Write-Host "  WARNING: Failed to download $name, retrying..." -ForegroundColor Yellow
+                Start-Sleep -Milliseconds 500
+                $ok = Invoke-ScpDownload $server "$remotePath/$name" (Join-Path $downloadDir $name)
+                if (-not $ok) {
+                    Write-Host "  ERROR: Failed to download $name after retry" -ForegroundColor Red
+                    $failedDownloads += $name
+                }
             }
         }
-    } else {
-        Write-Host "  Downloading all secrets via tar..." -ForegroundColor Gray
-        if (-not $DryRun) {
-            $tarCmd = "cd $tarRemote && tar cf - *.secret 2>/dev/null"
-            $sshArgs = Get-SshArgs $server
-            # Use ssh + tar to download all secrets at once
-            $errFile = Join-Path $TempRoot 'tar-err.txt'
-            $proc = Start-Process -FilePath 'ssh' -ArgumentList ($sshArgs + @($tarCmd)) `
-                -NoNewWindow -Wait -PassThru `
-                -RedirectStandardOutput $tarFile `
-                -RedirectStandardError $errFile
-
-            if ($proc.ExitCode -ne 0 -or -not (Test-Path $tarFile) -or (Get-Item $tarFile).Length -eq 0) {
-                Write-Host "ERROR: Failed to download secrets from server" -ForegroundColor Red
-                Cleanup-Temp
-                exit 1
-            }
-
-            # Extract tar
-            tar -xf $tarFile -C $extractDir 2>$null
+        # Exclude failed downloads
+        if ($failedDownloads.Count -gt 0) {
+            $remoteFiles = @($remoteFiles | Where-Object { $_ -notin $failedDownloads })
         }
     }
 
     # Compare with local staging/
     $rows = @()
-    $serverFiles = if ($DryRun) {
-        # In dry-run, list from manifest
-        $manifest.secrets.Keys | Sort-Object
-    } else {
-        Get-ChildItem -Path $extractDir -Filter '*.secret' -ErrorAction SilentlyContinue | ForEach-Object { $_.Name } | Sort-Object
-    }
-
-    if ($Only) {
-        $filterName = if ($Only.EndsWith('.secret')) { $Only } else { "$Only.secret" }
-        $serverFiles = $serverFiles | Where-Object { $_ -eq $filterName }
-    }
-
-    foreach ($name in $serverFiles) {
-        $serverFile = Join-Path $extractDir $name
+    foreach ($name in ($remoteFiles | Sort-Object)) {
+        $serverFile = Join-Path $downloadDir $name
         $localFile = Join-Path $StagingDir $name
 
         if ($DryRun) {
@@ -378,7 +367,8 @@ function Invoke-Pull {
 
     Show-StatusTable $rows
 
-    $changedCount = ($rows | Where-Object { $_.Status -ne 'OK' }).Count
+    $changed = @($rows | Where-Object { $_.Status -ne 'OK' })
+    $changedCount = $changed.Count
     if ($changedCount -eq 0) {
         Write-Host "All secrets are up to date." -ForegroundColor Green
         Cleanup-Temp
@@ -401,9 +391,8 @@ function Invoke-Pull {
     New-Item -ItemType Directory -Path $StagingDir -Force | Out-Null
 
     # Copy changed/new files to staging
-    foreach ($row in $rows) {
-        if ($row.Status -eq 'OK') { continue }
-        $src = Join-Path $extractDir $row.Name
+    foreach ($row in $changed) {
+        $src = Join-Path $downloadDir $row.Name
         $dst = Join-Path $StagingDir $row.Name
         Copy-Item $src $dst -Force
         Write-Host "  Saved: $($row.Name)" -ForegroundColor Green
@@ -464,7 +453,7 @@ function Invoke-PushOrStatus {
         }
     }
 
-    if ($errors.Count -gt 0) {
+    if (@($errors).Count -gt 0) {
         Write-Host "`nWARNING: Some secrets have missing source files:" -ForegroundColor Yellow
         foreach ($err in $errors) {
             Write-Host "  $err" -ForegroundColor Yellow
@@ -472,7 +461,7 @@ function Invoke-PushOrStatus {
         Write-Host ""
     }
 
-    if ($secretSources.Count -eq 0) {
+    if (@($secretSources.Keys).Count -eq 0) {
         Write-Host "No secrets to process." -ForegroundColor Yellow
         Cleanup-Temp
         return
@@ -552,7 +541,7 @@ function Invoke-PushOrStatus {
     }
 
     # Push mode: continue with upload
-    if ($changedSecrets.Count -eq 0) {
+    if (@($changedSecrets).Count -eq 0) {
         Write-Host "All secrets are in sync. Nothing to push." -ForegroundColor Green
         Cleanup-Temp
         return
@@ -629,7 +618,7 @@ function Invoke-PushOrStatus {
         return
     }
 
-    if ($impactedServices.Count -eq 0) {
+    if (@($impactedServices).Count -eq 0) {
         Write-Host "`nNo services to restart." -ForegroundColor Green
         Cleanup-Temp
         return

--- a/infra/secrets/secrets-sync.yml
+++ b/infra/secrets/secrets-sync.yml
@@ -1,0 +1,67 @@
+# Secret sync policy for staging server
+# Policy types:
+#   sync            - Same value local and staging, source: infra/secrets/<name>
+#   staging-only    - Staging-specific value, source: infra/secrets/staging/<name>
+#   skip            - Not synced (manual management only)
+
+secrets:
+  # Common — same value everywhere
+  openrouter.secret: sync
+  bgg.secret: sync
+  embedding-service.secret: sync
+  reranker-service.secret: sync
+  smoldocling-service.secret: sync
+  unstructured-service.secret: sync
+
+  # Staging-specific — different values than local dev
+  database.secret: staging-only
+  redis.secret: staging-only
+  qdrant.secret: staging-only
+  jwt.secret: staging-only
+  admin.secret: staging-only
+  oauth.secret: staging-only
+  n8n.secret: staging-only
+  monitoring.secret: staging-only
+  email.secret: staging-only
+
+  # Not synced
+  storage.secret: skip
+  traefik.secret: skip
+  gmail-app-password.secret: skip
+
+# Secret-to-service dependency map
+# Used for selective restart after sync
+service_map:
+  database.secret: [postgres, api, n8n]
+  redis.secret: [redis, api]
+  qdrant.secret: [qdrant, api]
+  jwt.secret: [api]
+  admin.secret: [api]
+  openrouter.secret: [api]
+  oauth.secret: [api]
+  bgg.secret: [api]
+  email.secret: [api, alertmanager]
+  embedding-service.secret: [embedding-service]
+  reranker-service.secret: [reranker-service]
+  smoldocling-service.secret: [smoldocling-service]
+  unstructured-service.secret: [unstructured-service]
+  monitoring.secret: [grafana, alertmanager]
+  n8n.secret: [n8n]
+  storage.secret: [minio, minio-setup, api]
+  traefik.secret: [traefik]
+
+# Stateful services — password change warning
+stateful_services: [postgres, redis, qdrant]
+
+# Server connection
+server:
+  host: 204.168.135.69
+  user: deploy
+  key_path: "D:\\Repositories\\SSH Keys\\meepleai-staging"
+  remote_secrets_path: /opt/meepleai/repo/infra/secrets
+  compose_dir: /opt/meepleai/repo/infra
+  compose_cmd: >-
+    docker compose
+    -f docker-compose.yml
+    -f compose.staging.yml
+    -f compose.staging-traefik.yml


### PR DESCRIPTION
## Summary
- `sync-secrets.ps1`: Pull/Push/Status modes for syncing secrets between local and staging server
- `secrets-sync.yml`: manifest declaring sync policy (sync/staging-only/skip) per secret + service dependency map
- Supports selective restart of impacted Docker services with confirmation
- Stateful service warnings (postgres/redis/qdrant), server backup, dry-run, retry logic

## Test plan
- [x] `-Pull -DryRun` — SSH connection + file listing
- [x] `-Pull -Force` — Downloaded 17 secrets from server
- [x] `-Status` — Correct diff detection (OK/CHANGED)
- [x] `-Status -Only jwt` — Single secret filter
- [x] `-Push -DryRun -Only jwt` — Change detection + service mapping
- [ ] `-Push` real run (manual test on next secret update)

🤖 Generated with [Claude Code](https://claude.com/claude-code)