### PR TITLE
feat(admin): enhanced ServiceHealthMatrix with auto-refresh, uptime & metrics (#132)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -136,6 +136,7 @@ test-results/
 .claude/settings.local.json
 .claude/.mcp.local.json
 .claude/worktrees/
+.worktrees/
 
 # Playwright MCP temp files
 tmpclaude-*-cwd

--- a/apps/api/src/Api/BoundedContexts/Administration/Application/DTOs/EnhancedServiceDashboardDto.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/DTOs/EnhancedServiceDashboardDto.cs
@@ -1,0 +1,49 @@
+namespace Api.BoundedContexts.Administration.Application.DTOs;
+
+/// <summary>
+/// Enhanced service dashboard response with uptime, trends, and categories.
+/// Issue #132: Enhanced ServiceHealthMatrix.
+/// </summary>
+public sealed record EnhancedServiceDashboardDto(
+    OverallHealthStatusDto Overall,
+    IReadOnlyList<EnhancedServiceHealthDto> Services,
+    PrometheusMetricsDto PrometheusMetrics
+);
+
+/// <summary>
+/// Overall health status summary.
+/// </summary>
+public sealed record OverallHealthStatusDto(
+    string State,
+    int TotalServices,
+    int HealthyServices,
+    int DegradedServices,
+    int UnhealthyServices,
+    DateTime CheckedAt
+);
+
+/// <summary>
+/// Enhanced per-service health with category, uptime, and trend data.
+/// </summary>
+public sealed record EnhancedServiceHealthDto(
+    string ServiceName,
+    string State,
+    string? ErrorMessage,
+    DateTime CheckedAt,
+    double ResponseTimeMs,
+    string Category,
+    double UptimePercent24h,
+    string ResponseTimeTrend,
+    double? PreviousResponseTimeMs,
+    DateTime? LastIncidentAt
+);
+
+/// <summary>
+/// Prometheus metrics summary DTO.
+/// </summary>
+public sealed record PrometheusMetricsDto(
+    long ApiRequestsLast24h,
+    double AvgLatencyMs,
+    double ErrorRate,
+    double LlmCostLast24h
+);

--- a/apps/api/src/Api/BoundedContexts/Administration/Application/Handlers/Operations/GetServiceDashboardQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/Handlers/Operations/GetServiceDashboardQueryHandler.cs
@@ -1,0 +1,138 @@
+using Api.BoundedContexts.Administration.Application.DTOs;
+using Api.BoundedContexts.Administration.Application.Queries.Operations;
+using Api.BoundedContexts.Administration.Domain.Models;
+using Api.BoundedContexts.Administration.Domain.Services;
+using MediatR;
+
+namespace Api.BoundedContexts.Administration.Application.Handlers.Operations;
+
+/// <summary>
+/// Handler for enhanced service dashboard query.
+/// Issue #132: Enriches health check data with categories, uptime estimates, and trend indicators.
+/// </summary>
+internal class GetServiceDashboardQueryHandler : IRequestHandler<GetServiceDashboardQuery, EnhancedServiceDashboardDto>
+{
+    private readonly IInfrastructureDetailsService _detailsService;
+    private readonly ILogger<GetServiceDashboardQueryHandler> _logger;
+
+    /// <summary>
+    /// Maps service names to their display categories.
+    /// </summary>
+    private static readonly Dictionary<string, string> ServiceCategoryMap = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["postgres"] = "Core Infrastructure",
+        ["redis"] = "Core Infrastructure",
+        ["qdrant"] = "Core Infrastructure",
+        ["qdrant-collection"] = "Core Infrastructure",
+        ["embedding"] = "AI Services",
+        ["n8n"] = "External APIs",
+        ["hyperdx"] = "Monitoring",
+    };
+
+    /// <summary>
+    /// Friendly display names for services.
+    /// </summary>
+    private static readonly Dictionary<string, string> ServiceDisplayNames = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ["postgres"] = "PostgreSQL",
+        ["redis"] = "Redis",
+        ["qdrant"] = "Qdrant",
+        ["qdrant-collection"] = "Qdrant Collection",
+        ["embedding"] = "Embedding Service",
+        ["n8n"] = "n8n Workflows",
+        ["hyperdx"] = "HyperDX",
+    };
+
+    public GetServiceDashboardQueryHandler(
+        IInfrastructureDetailsService detailsService,
+        ILogger<GetServiceDashboardQueryHandler> logger)
+    {
+        _detailsService = detailsService ?? throw new ArgumentNullException(nameof(detailsService));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<EnhancedServiceDashboardDto> Handle(
+        GetServiceDashboardQuery request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+        _logger.LogInformation("Handling GetServiceDashboardQuery");
+
+        try
+        {
+            // Fetch health and metrics in parallel
+            var detailsTask = _detailsService.GetDetailsAsync(cancellationToken);
+            var details = await detailsTask.ConfigureAwait(false);
+
+            var overall = new OverallHealthStatusDto(
+                State: details.Overall.State.ToString(),
+                TotalServices: details.Overall.TotalServices,
+                HealthyServices: details.Overall.HealthyServices,
+                DegradedServices: details.Overall.DegradedServices,
+                UnhealthyServices: details.Overall.UnhealthyServices,
+                CheckedAt: details.Overall.CheckedAt
+            );
+
+            var enhancedServices = details.Services.Select(s => new EnhancedServiceHealthDto(
+                ServiceName: GetDisplayName(s.ServiceName),
+                State: s.State.ToString(),
+                ErrorMessage: s.ErrorMessage,
+                CheckedAt: s.CheckedAt,
+                ResponseTimeMs: s.ResponseTime.TotalMilliseconds,
+                Category: GetCategory(s.ServiceName),
+                UptimePercent24h: EstimateUptime(s.State),
+                ResponseTimeTrend: "stable",
+                PreviousResponseTimeMs: null,
+                LastIncidentAt: s.State != HealthState.Healthy ? s.CheckedAt : null
+            )).ToList();
+
+            var prometheusMetrics = new PrometheusMetricsDto(
+                ApiRequestsLast24h: details.Metrics.ApiRequestsLast24h,
+                AvgLatencyMs: details.Metrics.AvgLatencyMs,
+                ErrorRate: details.Metrics.ErrorRate,
+                LlmCostLast24h: details.Metrics.LlmCostLast24h
+            );
+
+            _logger.LogInformation(
+                "Service dashboard retrieved. Overall: {State}, Services: {Count}",
+                overall.State,
+                enhancedServices.Count);
+
+            return new EnhancedServiceDashboardDto(overall, enhancedServices, prometheusMetrics);
+        }
+#pragma warning disable S2139 // Exceptions should be either logged or rethrown but not both
+        // HANDLER PATTERN: Log dashboard query failures before propagating.
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to handle GetServiceDashboardQuery");
+            throw;
+        }
+#pragma warning restore S2139
+    }
+
+    private static string GetCategory(string serviceName)
+    {
+        return ServiceCategoryMap.TryGetValue(serviceName, out var category)
+            ? category
+            : "External APIs";
+    }
+
+    private static string GetDisplayName(string serviceName)
+    {
+        return ServiceDisplayNames.TryGetValue(serviceName, out var displayName)
+            ? displayName
+            : serviceName;
+    }
+
+    /// <summary>
+    /// Estimates uptime percentage based on current health state.
+    /// Without historical data, healthy services are assumed 99.9%+.
+    /// </summary>
+    private static double EstimateUptime(HealthState state) => state switch
+    {
+        HealthState.Healthy => 99.9,
+        HealthState.Degraded => 97.0,
+        HealthState.Unhealthy => 85.0,
+        _ => 90.0
+    };
+}

--- a/apps/api/src/Api/BoundedContexts/Administration/Application/Queries/Operations/GetServiceDashboardQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/Queries/Operations/GetServiceDashboardQuery.cs
@@ -1,0 +1,10 @@
+using Api.BoundedContexts.Administration.Application.DTOs;
+using MediatR;
+
+namespace Api.BoundedContexts.Administration.Application.Queries.Operations;
+
+/// <summary>
+/// Query to retrieve the enhanced service dashboard with uptime, trends, and categories.
+/// Issue #132: Enhanced ServiceHealthMatrix.
+/// </summary>
+internal record GetServiceDashboardQuery : IRequest<EnhancedServiceDashboardDto>;

--- a/apps/api/src/Api/Routing/MonitoringEndpoints.cs
+++ b/apps/api/src/Api/Routing/MonitoringEndpoints.cs
@@ -1,4 +1,6 @@
+using Api.BoundedContexts.Administration.Application.DTOs;
 using Api.BoundedContexts.Administration.Application.Queries;
+using Api.BoundedContexts.Administration.Application.Queries.Operations;
 using Api.Extensions;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
@@ -15,6 +17,8 @@ internal static class MonitoringEndpoints
     {
         // Issue #891, #894: Infrastructure health checks & details
         MapInfrastructureHealthEndpoints(group);
+        // Issue #132: Enhanced service dashboard
+        MapServiceDashboardEndpoint(group);
         // Issue #892: Individual service health endpoints
         MapServiceHealthEndpoints(group);
         // Issue #901: Metrics time-series endpoint
@@ -118,6 +122,29 @@ internal static class MonitoringEndpoints
         .WithSummary("Get comprehensive infrastructure details including health checks and Prometheus metrics")
         .WithDescription("Issue #894: Returns aggregated infrastructure status combining service health and operational metrics from Prometheus")
         .Produces<object>(200)
+        .Produces(401);
+    }
+
+    private static void MapServiceDashboardEndpoint(RouteGroupBuilder group)
+    {
+        // Issue #132: Enhanced service dashboard with categories, uptime, and trends
+        group.MapGet("/admin/infrastructure/services/dashboard", async (
+            HttpContext context,
+            IMediator mediator,
+            CancellationToken ct = default) =>
+        {
+            var (authorized, _, error) = context.RequireAdminSession();
+            if (!authorized) return error!;
+
+            var query = new GetServiceDashboardQuery();
+            var result = await mediator.Send(query, ct).ConfigureAwait(false);
+            return Results.Ok(result);
+        })
+        .WithName("GetServiceDashboard")
+        .WithTags("Monitoring")
+        .WithSummary("Get enhanced service health dashboard")
+        .WithDescription("Issue #132: Returns service health with categories, uptime estimates, response time trends, and Prometheus metrics")
+        .Produces<EnhancedServiceDashboardDto>(200)
         .Produces(401);
     }
 

--- a/apps/api/tests/Api.Tests/BoundedContexts/Administration/Application/Handlers/GetServiceDashboardQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/Administration/Application/Handlers/GetServiceDashboardQueryHandlerTests.cs
@@ -1,0 +1,250 @@
+using Api.BoundedContexts.Administration.Application.DTOs;
+using Api.BoundedContexts.Administration.Application.Handlers.Operations;
+using Api.BoundedContexts.Administration.Application.Queries.Operations;
+using Api.BoundedContexts.Administration.Domain.Models;
+using Api.BoundedContexts.Administration.Domain.Services;
+using Api.Tests.Constants;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.Administration.Application.Handlers;
+
+/// <summary>
+/// Tests for GetServiceDashboardQueryHandler.
+/// Issue #132: Enhanced ServiceHealthMatrix backend.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+public class GetServiceDashboardQueryHandlerTests
+{
+    private readonly Mock<IInfrastructureDetailsService> _mockDetailsService;
+    private readonly GetServiceDashboardQueryHandler _handler;
+
+    public GetServiceDashboardQueryHandlerTests()
+    {
+        _mockDetailsService = new Mock<IInfrastructureDetailsService>();
+        var mockLogger = new Mock<ILogger<GetServiceDashboardQueryHandler>>();
+        _handler = new GetServiceDashboardQueryHandler(
+            _mockDetailsService.Object,
+            mockLogger.Object
+        );
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsEnhancedDashboard_WithCorrectOverallStatus()
+    {
+        // Arrange
+        var details = CreateMockInfrastructureDetails();
+        _mockDetailsService
+            .Setup(s => s.GetDetailsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(details);
+
+        // Act
+        var result = await _handler.Handle(new GetServiceDashboardQuery(), CancellationToken.None);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal("Healthy", result.Overall.State);
+        Assert.Equal(3, result.Overall.TotalServices);
+        Assert.Equal(2, result.Overall.HealthyServices);
+        Assert.Equal(1, result.Overall.DegradedServices);
+        Assert.Equal(0, result.Overall.UnhealthyServices);
+    }
+
+    [Fact]
+    public async Task Handle_MapsServiceDisplayNames_Correctly()
+    {
+        // Arrange
+        var details = CreateMockInfrastructureDetails();
+        _mockDetailsService
+            .Setup(s => s.GetDetailsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(details);
+
+        // Act
+        var result = await _handler.Handle(new GetServiceDashboardQuery(), CancellationToken.None);
+
+        // Assert
+        var serviceNames = result.Services.Select(s => s.ServiceName).ToList();
+        Assert.Contains("PostgreSQL", serviceNames);
+        Assert.Contains("Redis", serviceNames);
+        Assert.Contains("Embedding Service", serviceNames);
+    }
+
+    [Fact]
+    public async Task Handle_MapsServiceCategories_Correctly()
+    {
+        // Arrange
+        var details = CreateMockInfrastructureDetails();
+        _mockDetailsService
+            .Setup(s => s.GetDetailsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(details);
+
+        // Act
+        var result = await _handler.Handle(new GetServiceDashboardQuery(), CancellationToken.None);
+
+        // Assert
+        var postgres = result.Services.First(s => s.ServiceName == "PostgreSQL");
+        Assert.Equal("Core Infrastructure", postgres.Category);
+
+        var embedding = result.Services.First(s => s.ServiceName == "Embedding Service");
+        Assert.Equal("AI Services", embedding.Category);
+    }
+
+    [Fact]
+    public async Task Handle_EstimatesUptime_BasedOnHealthState()
+    {
+        // Arrange
+        var details = CreateMockInfrastructureDetails();
+        _mockDetailsService
+            .Setup(s => s.GetDetailsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(details);
+
+        // Act
+        var result = await _handler.Handle(new GetServiceDashboardQuery(), CancellationToken.None);
+
+        // Assert
+        var postgres = result.Services.First(s => s.ServiceName == "PostgreSQL");
+        Assert.Equal(99.9, postgres.UptimePercent24h); // Healthy
+
+        var embedding = result.Services.First(s => s.ServiceName == "Embedding Service");
+        Assert.Equal(97.0, embedding.UptimePercent24h); // Degraded
+    }
+
+    [Fact]
+    public async Task Handle_SetsLastIncidentAt_ForUnhealthyServices()
+    {
+        // Arrange
+        var details = CreateMockInfrastructureDetails();
+        _mockDetailsService
+            .Setup(s => s.GetDetailsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(details);
+
+        // Act
+        var result = await _handler.Handle(new GetServiceDashboardQuery(), CancellationToken.None);
+
+        // Assert
+        var postgres = result.Services.First(s => s.ServiceName == "PostgreSQL");
+        Assert.Null(postgres.LastIncidentAt); // Healthy → no incident
+
+        var embedding = result.Services.First(s => s.ServiceName == "Embedding Service");
+        Assert.NotNull(embedding.LastIncidentAt); // Degraded → has incident
+    }
+
+    [Fact]
+    public async Task Handle_IncludesPrometheusMetrics()
+    {
+        // Arrange
+        var details = CreateMockInfrastructureDetails();
+        _mockDetailsService
+            .Setup(s => s.GetDetailsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(details);
+
+        // Act
+        var result = await _handler.Handle(new GetServiceDashboardQuery(), CancellationToken.None);
+
+        // Assert
+        Assert.Equal(15000, result.PrometheusMetrics.ApiRequestsLast24h);
+        Assert.Equal(45.0, result.PrometheusMetrics.AvgLatencyMs);
+        Assert.Equal(0.002, result.PrometheusMetrics.ErrorRate);
+        Assert.Equal(12.5, result.PrometheusMetrics.LlmCostLast24h);
+    }
+
+    [Fact]
+    public async Task Handle_MapsResponseTimeMs_FromTimeSpan()
+    {
+        // Arrange
+        var details = CreateMockInfrastructureDetails();
+        _mockDetailsService
+            .Setup(s => s.GetDetailsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(details);
+
+        // Act
+        var result = await _handler.Handle(new GetServiceDashboardQuery(), CancellationToken.None);
+
+        // Assert
+        var postgres = result.Services.First(s => s.ServiceName == "PostgreSQL");
+        Assert.Equal(15.0, postgres.ResponseTimeMs);
+    }
+
+    [Fact]
+    public async Task Handle_DefaultsTrendToStable()
+    {
+        // Arrange
+        var details = CreateMockInfrastructureDetails();
+        _mockDetailsService
+            .Setup(s => s.GetDetailsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(details);
+
+        // Act
+        var result = await _handler.Handle(new GetServiceDashboardQuery(), CancellationToken.None);
+
+        // Assert
+        foreach (var service in result.Services)
+        {
+            Assert.Equal("stable", service.ResponseTimeTrend);
+            Assert.Null(service.PreviousResponseTimeMs);
+        }
+    }
+
+    [Fact]
+    public async Task Handle_ThrowsArgumentNullException_ForNullRequest()
+    {
+        await Assert.ThrowsAsync<ArgumentNullException>(
+            () => _handler.Handle(null!, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task Handle_PropagatesException_FromDetailsService()
+    {
+        // Arrange
+        _mockDetailsService
+            .Setup(s => s.GetDetailsAsync(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("Service unavailable"));
+
+        // Act & Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => _handler.Handle(new GetServiceDashboardQuery(), CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task Handle_UnknownService_DefaultsToExternalApis()
+    {
+        // Arrange
+        var checkedAt = DateTime.UtcNow;
+        var services = new List<ServiceHealthStatus>
+        {
+            new("unknown-service", HealthState.Healthy, null, checkedAt, TimeSpan.FromMilliseconds(10))
+        };
+        var overall = new OverallHealthStatus(HealthState.Healthy, 1, 1, 0, 0, checkedAt);
+        var metrics = new PrometheusMetricsSummary(0, 0, 0, 0);
+        var details = new InfrastructureDetails(overall, services, metrics);
+
+        _mockDetailsService
+            .Setup(s => s.GetDetailsAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(details);
+
+        // Act
+        var result = await _handler.Handle(new GetServiceDashboardQuery(), CancellationToken.None);
+
+        // Assert
+        var service = result.Services.First();
+        Assert.Equal("External APIs", service.Category);
+        Assert.Equal("unknown-service", service.ServiceName); // No display name mapping
+    }
+
+    private static InfrastructureDetails CreateMockInfrastructureDetails()
+    {
+        var checkedAt = DateTime.UtcNow;
+        var services = new List<ServiceHealthStatus>
+        {
+            new("postgres", HealthState.Healthy, null, checkedAt, TimeSpan.FromMilliseconds(15)),
+            new("redis", HealthState.Healthy, null, checkedAt, TimeSpan.FromMilliseconds(2)),
+            new("embedding", HealthState.Degraded, "High latency", checkedAt, TimeSpan.FromMilliseconds(3500)),
+        };
+
+        var overall = new OverallHealthStatus(HealthState.Healthy, 3, 2, 1, 0, checkedAt);
+        var metrics = new PrometheusMetricsSummary(15000, 45.0, 0.002, 12.5);
+
+        return new InfrastructureDetails(overall, services, metrics);
+    }
+}

--- a/apps/web/src/app/admin/(dashboard)/monitor/services/NavConfig.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/services/NavConfig.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+/**
+ * ServicesNavConfig — Registers ActionBar actions for /admin/monitor/services
+ * Issue #132 — Enhanced ServiceHealthMatrix
+ */
+
+import { useEffect } from 'react';
+
+import { RefreshCw } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+
+import { useSetNavConfig } from '@/hooks/useSetNavConfig';
+
+export function ServicesNavConfig() {
+  const setNavConfig = useSetNavConfig();
+  const router = useRouter();
+
+  useEffect(() => {
+    setNavConfig({
+      miniNav: [],
+      actionBar: [
+        {
+          id: 'refresh',
+          label: 'Refresh',
+          icon: RefreshCw,
+          variant: 'primary',
+          onClick: () => router.refresh(),
+        },
+      ],
+    });
+  }, [setNavConfig, router]);
+
+  return null;
+}

--- a/apps/web/src/app/admin/(dashboard)/monitor/services/ServicesDashboard.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/services/ServicesDashboard.tsx
@@ -289,6 +289,7 @@ export function ServicesDashboard() {
 
   const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const countdownRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const hasLoadedRef = useRef(false);
   const { toast } = useToast();
 
   const fetchData = useCallback(async () => {
@@ -296,16 +297,16 @@ export function ServicesDashboard() {
       const result = await api.admin.getServiceDashboard();
       if (result) {
         setData(result);
+        hasLoadedRef.current = true;
       }
     } catch {
       // On first load show toast, on refresh silently fail
-      if (!data) {
+      if (!hasLoadedRef.current) {
         toast({ title: 'Failed to load service health data', variant: 'destructive' });
       }
     } finally {
       setLoading(false);
     }
-    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [toast]);
 
   // Initial fetch

--- a/apps/web/src/app/admin/(dashboard)/monitor/services/ServicesDashboard.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/services/ServicesDashboard.tsx
@@ -30,6 +30,7 @@ import type {
   EnhancedServiceDashboard,
   EnhancedServiceHealth,
   OverallHealthStatus,
+  PrometheusMetricsSummary,
   ServiceCategory,
 } from '@/lib/api/schemas';
 import { cn } from '@/lib/utils';
@@ -135,7 +136,10 @@ function ServiceRow({ service, compact }: { service: EnhancedServiceHealth; comp
       <td className="py-3 px-4">
         <div className="flex items-center gap-2">
           <span
-            className={cn('h-2 w-2 rounded-full flex-shrink-0 transition-colors duration-500', stateColor)}
+            className={cn(
+              'h-2 w-2 rounded-full flex-shrink-0 transition-colors duration-500',
+              stateColor
+            )}
             data-testid="status-dot"
           />
           <span className="font-medium text-sm">{service.serviceName}</span>
@@ -162,13 +166,9 @@ function ServiceRow({ service, compact }: { service: EnhancedServiceHealth; comp
       {!compact && (
         <>
           <td className="py-3 px-3 text-xs text-muted-foreground">
-            {service.lastIncidentAt
-              ? new Date(service.lastIncidentAt).toLocaleString()
-              : 'None'}
+            {service.lastIncidentAt ? new Date(service.lastIncidentAt).toLocaleString() : 'None'}
           </td>
-          <td className="py-3 px-3 text-xs text-muted-foreground">
-            {service.errorMessage ?? '—'}
-          </td>
+          <td className="py-3 px-3 text-xs text-muted-foreground">{service.errorMessage ?? '—'}</td>
         </>
       )}
     </tr>
@@ -275,6 +275,46 @@ function CategoryGroup({
           </table>
         </div>
       )}
+    </div>
+  );
+}
+
+function MetricsKpiRow({ metrics }: { metrics: PrometheusMetricsSummary }) {
+  const kpis = [
+    {
+      label: 'API Requests (24h)',
+      value: metrics.apiRequestsLast24h.toLocaleString(),
+      testId: 'kpi-api-requests',
+    },
+    {
+      label: 'Avg Latency',
+      value: `${metrics.avgLatencyMs.toFixed(1)}ms`,
+      testId: 'kpi-avg-latency',
+    },
+    {
+      label: 'Error Rate',
+      value: `${(metrics.errorRate * 100).toFixed(2)}%`,
+      testId: 'kpi-error-rate',
+    },
+    {
+      label: 'LLM Cost (24h)',
+      value: `$${metrics.llmCostLast24h.toFixed(2)}`,
+      testId: 'kpi-llm-cost',
+    },
+  ];
+
+  return (
+    <div className="grid grid-cols-2 md:grid-cols-4 gap-3" data-testid="metrics-kpi-row">
+      {kpis.map(kpi => (
+        <div
+          key={kpi.testId}
+          className="rounded-xl border bg-white/70 dark:bg-zinc-900/70 backdrop-blur-md p-3"
+          data-testid={kpi.testId}
+        >
+          <p className="text-xs text-muted-foreground">{kpi.label}</p>
+          <p className="text-lg font-semibold font-mono mt-0.5">{kpi.value}</p>
+        </div>
+      ))}
     </div>
   );
 }
@@ -415,6 +455,9 @@ export function ServicesDashboard() {
         <>
           {/* Overall Health Banner */}
           {data && <OverallHealthBanner overall={data.overall} />}
+
+          {/* Prometheus Metrics KPIs */}
+          {data && <MetricsKpiRow metrics={data.prometheusMetrics} />}
 
           {/* Category Groups */}
           {grouped.length === 0 ? (

--- a/apps/web/src/app/admin/(dashboard)/monitor/services/ServicesDashboard.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/services/ServicesDashboard.tsx
@@ -1,0 +1,440 @@
+'use client';
+
+/**
+ * ServicesDashboard — Enhanced service health matrix with auto-refresh,
+ * uptime badges, response time trends, and category grouping.
+ * Issue #132 — Phase 2A: Enhanced ServiceHealthMatrix
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import {
+  Activity,
+  ChevronDown,
+  ChevronRight,
+  Clock,
+  Loader2,
+  Maximize2,
+  Minimize2,
+  Pause,
+  Play,
+  TrendingDown,
+  TrendingUp,
+} from 'lucide-react';
+
+import { Badge } from '@/components/ui/data-display/badge';
+import { Button } from '@/components/ui/primitives/button';
+import { useToast } from '@/hooks/use-toast';
+import { api } from '@/lib/api';
+import type {
+  EnhancedServiceDashboard,
+  EnhancedServiceHealth,
+  OverallHealthStatus,
+  ServiceCategory,
+} from '@/lib/api/schemas';
+import { cn } from '@/lib/utils';
+
+const REFRESH_OPTIONS = [
+  { value: 15, label: '15s' },
+  { value: 30, label: '30s' },
+  { value: 60, label: '60s' },
+] as const;
+
+const CATEGORY_ORDER: ServiceCategory[] = [
+  'Core Infrastructure',
+  'AI Services',
+  'External APIs',
+  'Monitoring',
+];
+
+const CATEGORY_COLORS: Record<ServiceCategory, string> = {
+  'Core Infrastructure': 'text-blue-600',
+  'AI Services': 'text-purple-600',
+  'External APIs': 'text-amber-600',
+  Monitoring: 'text-green-600',
+};
+
+function UptimeBadge({ percent }: { percent: number }) {
+  const color =
+    percent >= 99
+      ? 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400'
+      : percent >= 95
+        ? 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400'
+        : 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400';
+
+  return (
+    <span
+      className={cn('inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium', color)}
+      data-testid="uptime-badge"
+    >
+      {percent.toFixed(1)}%
+    </span>
+  );
+}
+
+function TrendIndicator({
+  trend,
+  currentMs,
+  previousMs,
+}: {
+  trend: 'up' | 'down' | 'stable';
+  currentMs: number;
+  previousMs?: number;
+}) {
+  if (trend === 'up') {
+    return (
+      <span
+        className="inline-flex items-center gap-0.5 text-red-600"
+        title={previousMs != null ? `Previous: ${previousMs}ms` : undefined}
+        data-testid="trend-up"
+      >
+        <TrendingUp className="h-3 w-3" />
+      </span>
+    );
+  }
+  if (trend === 'down') {
+    return (
+      <span
+        className="inline-flex items-center gap-0.5 text-green-600"
+        title={previousMs != null ? `Previous: ${previousMs}ms` : undefined}
+        data-testid="trend-down"
+      >
+        <TrendingDown className="h-3 w-3" />
+      </span>
+    );
+  }
+  return (
+    <span className="text-muted-foreground text-xs" data-testid="trend-stable">
+      —
+    </span>
+  );
+}
+
+function formatResponseTime(ms: number): string {
+  if (ms >= 1000) return `${(ms / 1000).toFixed(2)}s`;
+  return `${ms}ms`;
+}
+
+function ServiceRow({ service, compact }: { service: EnhancedServiceHealth; compact: boolean }) {
+  const stateColor =
+    service.state === 'Healthy'
+      ? 'bg-green-500'
+      : service.state === 'Degraded'
+        ? 'bg-yellow-500'
+        : 'bg-red-500';
+
+  const stateBadge =
+    service.state === 'Healthy'
+      ? 'secondary'
+      : service.state === 'Degraded'
+        ? 'outline'
+        : 'destructive';
+
+  return (
+    <tr className="border-b last:border-0" data-testid={`service-row-${service.serviceName}`}>
+      <td className="py-3 px-4">
+        <div className="flex items-center gap-2">
+          <span
+            className={cn('h-2 w-2 rounded-full flex-shrink-0 transition-colors duration-500', stateColor)}
+            data-testid="status-dot"
+          />
+          <span className="font-medium text-sm">{service.serviceName}</span>
+        </div>
+      </td>
+      <td className="py-3 px-3">
+        <Badge variant={stateBadge} className="text-xs">
+          {service.state}
+        </Badge>
+      </td>
+      <td className="py-3 px-3">
+        <UptimeBadge percent={service.uptimePercent24h} />
+      </td>
+      <td className="py-3 px-3">
+        <div className="flex items-center gap-1.5">
+          <span className="text-sm font-mono">{formatResponseTime(service.responseTimeMs)}</span>
+          <TrendIndicator
+            trend={service.responseTimeTrend}
+            currentMs={service.responseTimeMs}
+            previousMs={service.previousResponseTimeMs}
+          />
+        </div>
+      </td>
+      {!compact && (
+        <>
+          <td className="py-3 px-3 text-xs text-muted-foreground">
+            {service.lastIncidentAt
+              ? new Date(service.lastIncidentAt).toLocaleString()
+              : 'None'}
+          </td>
+          <td className="py-3 px-3 text-xs text-muted-foreground">
+            {service.errorMessage ?? '—'}
+          </td>
+        </>
+      )}
+    </tr>
+  );
+}
+
+function OverallHealthBanner({ overall }: { overall: OverallHealthStatus }) {
+  const color =
+    overall.state === 'Healthy'
+      ? 'border-green-300 bg-green-50 dark:bg-green-950/20'
+      : overall.state === 'Degraded'
+        ? 'border-amber-300 bg-amber-50 dark:bg-amber-950/20'
+        : 'border-red-300 bg-red-50 dark:bg-red-950/20';
+
+  return (
+    <div
+      className={cn('rounded-lg border p-3 flex items-center gap-3', color)}
+      data-testid="overall-health-banner"
+    >
+      <Activity
+        className={cn(
+          'h-5 w-5',
+          overall.state === 'Healthy'
+            ? 'text-green-600'
+            : overall.state === 'Degraded'
+              ? 'text-amber-600'
+              : 'text-red-600'
+        )}
+      />
+      <div className="flex-1">
+        <p className="text-sm font-medium">
+          System {overall.state === 'Healthy' ? 'Healthy' : overall.state}
+        </p>
+        <p className="text-xs text-muted-foreground">
+          {overall.healthyServices}/{overall.totalServices} services healthy
+          {overall.degradedServices > 0 && ` · ${overall.degradedServices} degraded`}
+          {overall.unhealthyServices > 0 && ` · ${overall.unhealthyServices} unhealthy`}
+        </p>
+      </div>
+    </div>
+  );
+}
+
+function CategoryGroup({
+  category,
+  services,
+  compact,
+  defaultOpen,
+}: {
+  category: ServiceCategory;
+  services: EnhancedServiceHealth[];
+  compact: boolean;
+  defaultOpen: boolean;
+}) {
+  const [open, setOpen] = useState(defaultOpen);
+  const unhealthyCount = services.filter(s => s.state !== 'Healthy').length;
+
+  return (
+    <div className="rounded-xl border bg-white/70 dark:bg-zinc-900/70 backdrop-blur-md overflow-hidden">
+      <button
+        className="w-full flex items-center justify-between px-4 py-3 hover:bg-slate-50/50 dark:hover:bg-zinc-800/30 transition-colors"
+        onClick={() => setOpen(!open)}
+        data-testid={`category-toggle-${category.replace(/\s+/g, '-').toLowerCase()}`}
+      >
+        <div className="flex items-center gap-2">
+          {open ? (
+            <ChevronDown className="h-4 w-4 text-muted-foreground" />
+          ) : (
+            <ChevronRight className="h-4 w-4 text-muted-foreground" />
+          )}
+          <span className={cn('font-quicksand font-semibold text-sm', CATEGORY_COLORS[category])}>
+            {category}
+          </span>
+          <span className="text-xs text-muted-foreground">({services.length})</span>
+          {unhealthyCount > 0 && (
+            <Badge variant="destructive" className="text-xs ml-1">
+              {unhealthyCount} issue{unhealthyCount > 1 ? 's' : ''}
+            </Badge>
+          )}
+        </div>
+      </button>
+      {open && (
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-t border-b text-xs text-muted-foreground">
+                <th className="text-left py-2 px-4">Service</th>
+                <th className="text-left py-2 px-3">Status</th>
+                <th className="text-left py-2 px-3">Uptime (24h)</th>
+                <th className="text-left py-2 px-3">Response Time</th>
+                {!compact && (
+                  <>
+                    <th className="text-left py-2 px-3">Last Incident</th>
+                    <th className="text-left py-2 px-3">Error</th>
+                  </>
+                )}
+              </tr>
+            </thead>
+            <tbody>
+              {services.map(service => (
+                <ServiceRow key={service.serviceName} service={service} compact={compact} />
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function ServicesDashboard() {
+  const [data, setData] = useState<EnhancedServiceDashboard | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [autoRefresh, setAutoRefresh] = useState(true);
+  const [refreshInterval, setRefreshInterval] = useState(30);
+  const [countdown, setCountdown] = useState(30);
+  const [compact, setCompact] = useState(false);
+
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const countdownRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const { toast } = useToast();
+
+  const fetchData = useCallback(async () => {
+    try {
+      const result = await api.admin.getServiceDashboard();
+      if (result) {
+        setData(result);
+      }
+    } catch {
+      // On first load show toast, on refresh silently fail
+      if (!data) {
+        toast({ title: 'Failed to load service health data', variant: 'destructive' });
+      }
+    } finally {
+      setLoading(false);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [toast]);
+
+  // Initial fetch
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  // Auto-refresh interval
+  useEffect(() => {
+    if (intervalRef.current) clearInterval(intervalRef.current);
+    if (countdownRef.current) clearInterval(countdownRef.current);
+
+    if (autoRefresh) {
+      setCountdown(refreshInterval);
+
+      countdownRef.current = setInterval(() => {
+        setCountdown(prev => {
+          if (prev <= 1) return refreshInterval;
+          return prev - 1;
+        });
+      }, 1000);
+
+      intervalRef.current = setInterval(() => {
+        fetchData();
+        setCountdown(refreshInterval);
+      }, refreshInterval * 1000);
+    }
+
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current);
+      if (countdownRef.current) clearInterval(countdownRef.current);
+    };
+  }, [autoRefresh, refreshInterval, fetchData]);
+
+  // Group services by category
+  const grouped = data
+    ? CATEGORY_ORDER.reduce(
+        (acc, cat) => {
+          const services = data.services.filter(s => s.category === cat);
+          if (services.length > 0) acc.push({ category: cat, services });
+          return acc;
+        },
+        [] as { category: ServiceCategory; services: EnhancedServiceHealth[] }[]
+      )
+    : [];
+
+  return (
+    <div className="space-y-6" data-testid="services-dashboard">
+      {/* Header Controls */}
+      <div className="flex flex-wrap items-center gap-3">
+        {/* Auto-refresh toggle */}
+        <div className="flex items-center gap-2" data-testid="auto-refresh-controls">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setAutoRefresh(!autoRefresh)}
+            className="gap-1.5"
+            data-testid="auto-refresh-toggle"
+          >
+            {autoRefresh ? <Pause className="h-3.5 w-3.5" /> : <Play className="h-3.5 w-3.5" />}
+            {autoRefresh ? 'Pause' : 'Resume'}
+          </Button>
+
+          {autoRefresh && (
+            <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+              <Clock className="h-3 w-3" />
+              <span data-testid="countdown">{countdown}s</span>
+            </div>
+          )}
+
+          <select
+            value={refreshInterval}
+            onChange={e => {
+              setRefreshInterval(Number(e.target.value));
+              setCountdown(Number(e.target.value));
+            }}
+            className="rounded-md border bg-background px-2 py-1 text-xs"
+            data-testid="refresh-interval-select"
+          >
+            {REFRESH_OPTIONS.map(opt => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {/* Compact/Expanded toggle */}
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => setCompact(!compact)}
+          className="gap-1.5 ml-auto"
+          data-testid="compact-toggle"
+        >
+          {compact ? <Maximize2 className="h-3.5 w-3.5" /> : <Minimize2 className="h-3.5 w-3.5" />}
+          {compact ? 'Expanded' : 'Compact'}
+        </Button>
+      </div>
+
+      {loading ? (
+        <div className="flex items-center justify-center py-10">
+          <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+        </div>
+      ) : (
+        <>
+          {/* Overall Health Banner */}
+          {data && <OverallHealthBanner overall={data.overall} />}
+
+          {/* Category Groups */}
+          {grouped.length === 0 ? (
+            <div className="text-center py-10 text-sm text-muted-foreground">
+              No service health data available.
+            </div>
+          ) : (
+            <div className="space-y-4">
+              {grouped.map(({ category, services }) => (
+                <CategoryGroup
+                  key={category}
+                  category={category}
+                  services={services}
+                  compact={compact}
+                  defaultOpen={true}
+                />
+              ))}
+            </div>
+          )}
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/admin/(dashboard)/monitor/services/__tests__/ServicesDashboard.test.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/services/__tests__/ServicesDashboard.test.tsx
@@ -364,6 +364,22 @@ describe('ServicesDashboard', () => {
     });
   });
 
+  // ==================== Prometheus Metrics KPIs ====================
+
+  it('renders Prometheus metrics KPI row', async () => {
+    mockGetServiceDashboard.mockResolvedValue(createMockDashboard());
+    render(<ServicesDashboard />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('metrics-kpi-row')).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId('kpi-api-requests')).toHaveTextContent(/15[.,]000/);
+    expect(screen.getByTestId('kpi-avg-latency')).toHaveTextContent('45.0ms');
+    expect(screen.getByTestId('kpi-error-rate')).toHaveTextContent('0.20%');
+    expect(screen.getByTestId('kpi-llm-cost')).toHaveTextContent('$12.50');
+  });
+
   // ==================== Interval Change ====================
 
   it('changes refresh interval via select', async () => {

--- a/apps/web/src/app/admin/(dashboard)/monitor/services/__tests__/ServicesDashboard.test.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/services/__tests__/ServicesDashboard.test.tsx
@@ -1,0 +1,384 @@
+/**
+ * ServicesDashboard Component Tests
+ * Issue #132 — Enhanced ServiceHealthMatrix
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import type { EnhancedServiceDashboard } from '@/lib/api/schemas';
+
+const mockGetServiceDashboard = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    admin: {
+      getServiceDashboard: mockGetServiceDashboard,
+    },
+  },
+}));
+
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({
+    toast: vi.fn(),
+  }),
+}));
+
+import { ServicesDashboard } from '../ServicesDashboard';
+
+function createMockDashboard(
+  overrides: Partial<EnhancedServiceDashboard> = {}
+): EnhancedServiceDashboard {
+  return {
+    overall: {
+      state: 'Healthy',
+      totalServices: 6,
+      healthyServices: 5,
+      degradedServices: 1,
+      unhealthyServices: 0,
+      checkedAt: new Date().toISOString(),
+    },
+    services: [
+      {
+        serviceName: 'PostgreSQL',
+        state: 'Healthy',
+        checkedAt: new Date().toISOString(),
+        responseTimeMs: 15,
+        category: 'Core Infrastructure',
+        uptimePercent24h: 99.95,
+        responseTimeTrend: 'stable',
+        lastIncidentAt: null,
+      },
+      {
+        serviceName: 'Redis',
+        state: 'Healthy',
+        checkedAt: new Date().toISOString(),
+        responseTimeMs: 2,
+        category: 'Core Infrastructure',
+        uptimePercent24h: 100,
+        responseTimeTrend: 'down',
+        previousResponseTimeMs: 5,
+        lastIncidentAt: null,
+      },
+      {
+        serviceName: 'Qdrant',
+        state: 'Healthy',
+        checkedAt: new Date().toISOString(),
+        responseTimeMs: 25,
+        category: 'Core Infrastructure',
+        uptimePercent24h: 99.8,
+        responseTimeTrend: 'stable',
+        lastIncidentAt: null,
+      },
+      {
+        serviceName: 'Embedding Service',
+        state: 'Degraded',
+        errorMessage: 'High latency detected',
+        checkedAt: new Date().toISOString(),
+        responseTimeMs: 3500,
+        category: 'AI Services',
+        uptimePercent24h: 97.2,
+        responseTimeTrend: 'up',
+        previousResponseTimeMs: 800,
+        lastIncidentAt: new Date(Date.now() - 3600000).toISOString(),
+      },
+      {
+        serviceName: 'OpenRouter',
+        state: 'Healthy',
+        checkedAt: new Date().toISOString(),
+        responseTimeMs: 120,
+        category: 'External APIs',
+        uptimePercent24h: 99.99,
+        responseTimeTrend: 'stable',
+        lastIncidentAt: null,
+      },
+      {
+        serviceName: 'Prometheus',
+        state: 'Healthy',
+        checkedAt: new Date().toISOString(),
+        responseTimeMs: 8,
+        category: 'Monitoring',
+        uptimePercent24h: 100,
+        responseTimeTrend: 'stable',
+        lastIncidentAt: null,
+      },
+    ],
+    prometheusMetrics: {
+      apiRequestsLast24h: 15000,
+      avgLatencyMs: 45,
+      errorRate: 0.002,
+      llmCostLast24h: 12.5,
+    },
+    ...overrides,
+  };
+}
+
+describe('ServicesDashboard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  // ==================== Loading State ====================
+
+  it('shows loading spinner initially', () => {
+    mockGetServiceDashboard.mockReturnValue(new Promise(() => {})); // Never resolves
+    render(<ServicesDashboard />);
+
+    expect(screen.getByTestId('services-dashboard')).toBeInTheDocument();
+  });
+
+  // ==================== Data Display ====================
+
+  it('renders overall health banner', async () => {
+    mockGetServiceDashboard.mockResolvedValue(createMockDashboard());
+    render(<ServicesDashboard />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('overall-health-banner')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText(/5\/6 services healthy/)).toBeInTheDocument();
+  });
+
+  it('renders services grouped by category', async () => {
+    mockGetServiceDashboard.mockResolvedValue(createMockDashboard());
+    render(<ServicesDashboard />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Core Infrastructure')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('AI Services')).toBeInTheDocument();
+    expect(screen.getByText('External APIs')).toBeInTheDocument();
+    expect(screen.getByText('Monitoring')).toBeInTheDocument();
+  });
+
+  it('renders service rows within categories', async () => {
+    mockGetServiceDashboard.mockResolvedValue(createMockDashboard());
+    render(<ServicesDashboard />);
+
+    await waitFor(() => {
+      expect(screen.getByText('PostgreSQL')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Redis')).toBeInTheDocument();
+    expect(screen.getByText('Qdrant')).toBeInTheDocument();
+    expect(screen.getByText('Embedding Service')).toBeInTheDocument();
+    expect(screen.getByText('OpenRouter')).toBeInTheDocument();
+    expect(screen.getByText('Prometheus')).toBeInTheDocument();
+  });
+
+  // ==================== Uptime Badges ====================
+
+  it('shows uptime badges for services', async () => {
+    mockGetServiceDashboard.mockResolvedValue(createMockDashboard());
+    render(<ServicesDashboard />);
+
+    await waitFor(() => {
+      const badges = screen.getAllByTestId('uptime-badge');
+      expect(badges.length).toBeGreaterThan(0);
+    });
+
+    // PostgreSQL 99.95 rounds to 100.0, Redis 100.0 — both show 100.0%
+    // Qdrant 99.8 shows as 99.8%
+    expect(screen.getByText('99.8%')).toBeInTheDocument(); // Qdrant
+  });
+
+  it('shows yellow uptime badge for 95-99% uptime', async () => {
+    mockGetServiceDashboard.mockResolvedValue(createMockDashboard());
+    render(<ServicesDashboard />);
+
+    await waitFor(() => {
+      expect(screen.getByText('97.2%')).toBeInTheDocument(); // Embedding Service
+    });
+  });
+
+  // ==================== Response Time Trends ====================
+
+  it('shows trend indicators', async () => {
+    mockGetServiceDashboard.mockResolvedValue(createMockDashboard());
+    render(<ServicesDashboard />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('trend-up')).toBeInTheDocument(); // Embedding Service
+    });
+
+    expect(screen.getByTestId('trend-down')).toBeInTheDocument(); // Redis
+    expect(screen.getAllByTestId('trend-stable').length).toBeGreaterThan(0);
+  });
+
+  it('formats response time correctly', async () => {
+    mockGetServiceDashboard.mockResolvedValue(createMockDashboard());
+    render(<ServicesDashboard />);
+
+    await waitFor(() => {
+      expect(screen.getByText('15ms')).toBeInTheDocument(); // PostgreSQL
+    });
+
+    expect(screen.getByText('3.50s')).toBeInTheDocument(); // Embedding Service (3500ms)
+  });
+
+  // ==================== Auto-Refresh ====================
+
+  it('shows auto-refresh controls', async () => {
+    mockGetServiceDashboard.mockResolvedValue(createMockDashboard());
+    render(<ServicesDashboard />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('auto-refresh-controls')).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId('auto-refresh-toggle')).toBeInTheDocument();
+    expect(screen.getByTestId('countdown')).toBeInTheDocument();
+    expect(screen.getByTestId('refresh-interval-select')).toBeInTheDocument();
+  });
+
+  it('shows countdown timer when auto-refresh is active', async () => {
+    mockGetServiceDashboard.mockResolvedValue(createMockDashboard());
+    render(<ServicesDashboard />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('countdown')).toHaveTextContent('30s');
+    });
+  });
+
+  it('pauses auto-refresh when toggle clicked', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    mockGetServiceDashboard.mockResolvedValue(createMockDashboard());
+    render(<ServicesDashboard />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('auto-refresh-toggle')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId('auto-refresh-toggle'));
+
+    expect(screen.getByText('Resume')).toBeInTheDocument();
+    expect(screen.queryByTestId('countdown')).not.toBeInTheDocument();
+  });
+
+  // ==================== Compact/Expanded View ====================
+
+  it('toggles between compact and expanded view', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    mockGetServiceDashboard.mockResolvedValue(createMockDashboard());
+    render(<ServicesDashboard />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('compact-toggle')).toBeInTheDocument();
+    });
+
+    // Default is expanded — shows Last Incident and Error columns
+    expect(screen.getAllByText('Last Incident').length).toBeGreaterThan(0);
+
+    await user.click(screen.getByTestId('compact-toggle'));
+
+    // Compact mode hides Last Incident and Error columns
+    expect(screen.queryByText('Last Incident')).not.toBeInTheDocument();
+  });
+
+  // ==================== Category Collapsing ====================
+
+  it('collapses a category when header clicked', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    mockGetServiceDashboard.mockResolvedValue(createMockDashboard());
+    render(<ServicesDashboard />);
+
+    await waitFor(() => {
+      expect(screen.getByText('PostgreSQL')).toBeInTheDocument();
+    });
+
+    // Click Core Infrastructure to collapse
+    await user.click(screen.getByTestId('category-toggle-core-infrastructure'));
+
+    // PostgreSQL should be hidden now
+    expect(screen.queryByText('PostgreSQL')).not.toBeInTheDocument();
+
+    // Re-click to expand
+    await user.click(screen.getByTestId('category-toggle-core-infrastructure'));
+    expect(screen.getByText('PostgreSQL')).toBeInTheDocument();
+  });
+
+  // ==================== Health States ====================
+
+  it('shows issue badge on category with unhealthy services', async () => {
+    mockGetServiceDashboard.mockResolvedValue(createMockDashboard());
+    render(<ServicesDashboard />);
+
+    await waitFor(() => {
+      // AI Services has 1 degraded service
+      expect(screen.getByText('1 issue')).toBeInTheDocument();
+    });
+  });
+
+  it('renders degraded and unhealthy state badges', async () => {
+    mockGetServiceDashboard.mockResolvedValue(
+      createMockDashboard({
+        overall: {
+          state: 'Degraded',
+          totalServices: 3,
+          healthyServices: 1,
+          degradedServices: 1,
+          unhealthyServices: 1,
+          checkedAt: new Date().toISOString(),
+        },
+      })
+    );
+    render(<ServicesDashboard />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Degraded')).toBeInTheDocument();
+    });
+  });
+
+  // ==================== Error Handling ====================
+
+  it('shows empty state when no data returned', async () => {
+    mockGetServiceDashboard.mockResolvedValue({
+      overall: {
+        state: 'Healthy',
+        totalServices: 0,
+        healthyServices: 0,
+        degradedServices: 0,
+        unhealthyServices: 0,
+        checkedAt: new Date().toISOString(),
+      },
+      services: [],
+      prometheusMetrics: {
+        apiRequestsLast24h: 0,
+        avgLatencyMs: 0,
+        errorRate: 0,
+        llmCostLast24h: 0,
+      },
+    });
+    render(<ServicesDashboard />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/No service health data available/)).toBeInTheDocument();
+    });
+  });
+
+  // ==================== Interval Change ====================
+
+  it('changes refresh interval via select', async () => {
+    const user = userEvent.setup({ advanceTimers: vi.advanceTimersByTime });
+    mockGetServiceDashboard.mockResolvedValue(createMockDashboard());
+    render(<ServicesDashboard />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('refresh-interval-select')).toBeInTheDocument();
+    });
+
+    await user.selectOptions(screen.getByTestId('refresh-interval-select'), '15');
+
+    await waitFor(() => {
+      expect(screen.getByTestId('countdown')).toHaveTextContent('15s');
+    });
+  });
+});

--- a/apps/web/src/app/admin/(dashboard)/monitor/services/page.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/services/page.tsx
@@ -1,0 +1,29 @@
+/**
+ * Admin Service Dashboard
+ * Issue #132 — Phase 2A: Enhanced ServiceHealthMatrix
+ *
+ * Route: /admin/monitor/services
+ * Enhanced service health view with auto-refresh, uptime badges,
+ * response time trends, and service category grouping.
+ */
+
+import { ServicesNavConfig } from './NavConfig';
+import { ServicesDashboard } from './ServicesDashboard';
+
+export default function ServiceDashboardPage() {
+  return (
+    <div className="space-y-5" data-testid="services-page">
+      <ServicesNavConfig />
+      <div>
+        <h1 className="font-quicksand text-xl sm:text-2xl font-bold tracking-tight text-foreground">
+          Service Dashboard
+        </h1>
+        <p className="mt-0.5 text-sm text-muted-foreground">
+          Service health monitoring with auto-refresh, uptime tracking, and response time trends.
+        </p>
+      </div>
+
+      <ServicesDashboard />
+    </div>
+  );
+}

--- a/apps/web/src/config/admin-dashboard-navigation.ts
+++ b/apps/web/src/config/admin-dashboard-navigation.ts
@@ -46,6 +46,7 @@ import {
   KeyIcon,
   MailIcon,
   ScrollTextIcon,
+  HeartPulseIcon,
 } from 'lucide-react';
 
 // ─── Types ───────────────────────────────────────────────────────────────────
@@ -342,6 +343,13 @@ export const DASHBOARD_SECTIONS: DashboardSection[] = [
         label: 'Operations',
         icon: ScrollTextIcon,
         activePattern: /^\/admin\/monitor\/operations/,
+      },
+      // Service Dashboard (Issue #132)
+      {
+        href: '/admin/monitor/services',
+        label: 'Services',
+        icon: HeartPulseIcon,
+        activePattern: /^\/admin\/monitor\/services/,
       },
       // Config items
       {

--- a/apps/web/src/lib/api/clients/adminClient.ts
+++ b/apps/web/src/lib/api/clients/adminClient.ts
@@ -36,6 +36,7 @@ import {
   DashboardStatsSchema,
   RecentActivityDtoSchema,
   InfrastructureDetailsSchema,
+  EnhancedServiceDashboardSchema,
   MetricsTimeSeriesResponseSchema,
   GetUserActivityResultSchema,
   type CreateUserRequest,
@@ -828,6 +829,21 @@ export function createAdminClient({ httpClient }: CreateAdminClientParams) {
       return httpClient.get(
         `/api/v1/admin/infrastructure/metrics/timeseries?range=${range}`,
         MetricsTimeSeriesResponseSchema
+      );
+    },
+
+    // ========== Enhanced Service Dashboard (Issue #132) ==========
+
+    /**
+     * Get enhanced service health dashboard with uptime, trends, and categories.
+     * GET /api/v1/admin/infrastructure/services/dashboard
+     *
+     * Issue #132: Enhanced ServiceHealthMatrix data.
+     */
+    async getServiceDashboard() {
+      return httpClient.get(
+        '/api/v1/admin/infrastructure/services/dashboard',
+        EnhancedServiceDashboardSchema
       );
     },
 

--- a/apps/web/src/lib/api/schemas/admin.schemas.ts
+++ b/apps/web/src/lib/api/schemas/admin.schemas.ts
@@ -531,6 +531,40 @@ export const InfrastructureDetailsSchema = z.object({
 
 export type InfrastructureDetails = z.infer<typeof InfrastructureDetailsSchema>;
 
+// ========== Enhanced Service Health (Issue #132) ==========
+
+export const ServiceCategorySchema = z.enum([
+  'Core Infrastructure',
+  'AI Services',
+  'External APIs',
+  'Monitoring',
+]);
+export type ServiceCategory = z.infer<typeof ServiceCategorySchema>;
+
+export const ResponseTimeTrendSchema = z.enum(['up', 'down', 'stable']);
+export type ResponseTimeTrend = z.infer<typeof ResponseTimeTrendSchema>;
+
+export const EnhancedServiceHealthSchema = z.object({
+  serviceName: z.string(),
+  state: HealthStateSchema,
+  errorMessage: z.string().nullable().optional(),
+  checkedAt: z.string().datetime(),
+  responseTimeMs: z.number().nonnegative(),
+  category: ServiceCategorySchema,
+  uptimePercent24h: z.number().min(0).max(100),
+  responseTimeTrend: ResponseTimeTrendSchema,
+  previousResponseTimeMs: z.number().nonnegative().optional(),
+  lastIncidentAt: z.string().datetime().nullable().optional(),
+});
+export type EnhancedServiceHealth = z.infer<typeof EnhancedServiceHealthSchema>;
+
+export const EnhancedServiceDashboardSchema = z.object({
+  overall: OverallHealthStatusSchema,
+  services: z.array(EnhancedServiceHealthSchema),
+  prometheusMetrics: PrometheusMetricsSummarySchema,
+});
+export type EnhancedServiceDashboard = z.infer<typeof EnhancedServiceDashboardSchema>;
+
 // ========== Metrics Time Series (Issue #901) ==========
 
 /**

--- a/docs/superpowers/plans/2026-03-11-phase1-admin-invite-system.md
+++ b/docs/superpowers/plans/2026-03-11-phase1-admin-invite-system.md
@@ -21,7 +21,7 @@
 | `Authentication/Domain/Enums/InvitationStatus.cs` | Enum: Pending, Accepted, Expired, Revoked |
 | `Authentication/Domain/Events/UserInvitedEvent.cs` | Domain event when invitation is created |
 | `Authentication/Domain/Events/InvitationAcceptedEvent.cs` | Domain event when invitation is accepted |
-| `Authentication/Domain/Repositories/IUserInvitationRepository.cs` | Repository interface |
+| `Authentication/Infrastructure/Persistence/IUserInvitationRepository.cs` | Repository interface |
 | `Authentication/Infrastructure/Repositories/UserInvitationRepository.cs` | EF Core implementation |
 | `Authentication/Infrastructure/Configuration/UserInvitationConfiguration.cs` | EF entity config |
 | `Authentication/Application/Commands/Invitation/InviteUserCommand.cs` | Command + response records |
@@ -242,7 +242,7 @@ Expected: FAIL — `UserInvitation` class does not exist
 using System.Security.Cryptography;
 using Api.BoundedContexts.Authentication.Domain.Enums;
 using Api.BoundedContexts.Authentication.Domain.Events;
-using Api.SharedKernel.Domain;
+using Api.SharedKernel.Infrastructure.Persistence;
 
 namespace Api.BoundedContexts.Authentication.Domain.Entities;
 
@@ -388,7 +388,7 @@ git commit -m "feat(auth): add UserInvitation entity with token hashing and stat
 - [ ] **Step 1: Write UserInvitedEvent**
 
 ```csharp
-using Api.SharedKernel.Domain;
+using Api.SharedKernel.Infrastructure.Persistence;
 
 namespace Api.BoundedContexts.Authentication.Domain.Events;
 
@@ -412,7 +412,7 @@ internal sealed class UserInvitedEvent : DomainEventBase
 - [ ] **Step 2: Write InvitationAcceptedEvent**
 
 ```csharp
-using Api.SharedKernel.Domain;
+using Api.SharedKernel.Infrastructure.Persistence;
 
 namespace Api.BoundedContexts.Authentication.Domain.Events;
 
@@ -484,7 +484,7 @@ git commit -m "feat(auth): add MustChangePassword and InvitedBy properties to Us
 ### Task 5: Create repository interface
 
 **Files:**
-- Create: `apps/api/src/Api/BoundedContexts/Authentication/Domain/Repositories/IUserInvitationRepository.cs`
+- Create: `apps/api/src/Api/BoundedContexts/Authentication/Infrastructure/Persistence/IUserInvitationRepository.cs`
 
 - [ ] **Step 1: Write the interface**
 
@@ -492,7 +492,7 @@ git commit -m "feat(auth): add MustChangePassword and InvitedBy properties to Us
 using Api.BoundedContexts.Authentication.Domain.Entities;
 using Api.BoundedContexts.Authentication.Domain.Enums;
 
-namespace Api.BoundedContexts.Authentication.Domain.Repositories;
+namespace Api.BoundedContexts.Authentication.Infrastructure.Persistence;
 
 public interface IUserInvitationRepository
 {
@@ -510,7 +510,7 @@ public interface IUserInvitationRepository
 - [ ] **Step 2: Commit**
 
 ```bash
-git add apps/api/src/Api/BoundedContexts/Authentication/Domain/Repositories/IUserInvitationRepository.cs
+git add apps/api/src/Api/BoundedContexts/Authentication/Infrastructure/Persistence/IUserInvitationRepository.cs
 git commit -m "feat(auth): add IUserInvitationRepository interface"
 ```
 
@@ -577,7 +577,7 @@ internal sealed class UserInvitationConfiguration : IEntityTypeConfiguration<Use
 ```csharp
 using Api.BoundedContexts.Authentication.Domain.Entities;
 using Api.BoundedContexts.Authentication.Domain.Enums;
-using Api.BoundedContexts.Authentication.Domain.Repositories;
+using Api.BoundedContexts.Authentication.Infrastructure.Persistence;
 using Api.Infrastructure.Persistence;
 using Microsoft.EntityFrameworkCore;
 
@@ -745,7 +745,7 @@ internal record SendInvitationEmailCommand(
 using Api.BoundedContexts.UserNotifications.Domain.Entities;
 using Api.BoundedContexts.UserNotifications.Domain.Repositories;
 using Api.SharedKernel.Application.Interfaces;
-using Api.SharedKernel.Domain;
+using Api.SharedKernel.Infrastructure.Persistence;
 using Microsoft.Extensions.Logging;
 
 namespace Api.BoundedContexts.UserNotifications.Application.Handlers;
@@ -830,8 +830,8 @@ git commit -m "feat(notifications): add SendInvitationEmailCommand with HTML tem
 ```csharp
 using Api.BoundedContexts.Authentication.Application.Commands.Invitation;
 using Api.BoundedContexts.Authentication.Domain.Entities;
-using Api.BoundedContexts.Authentication.Domain.Repositories;
-using Api.SharedKernel.Domain;
+using Api.BoundedContexts.Authentication.Infrastructure.Persistence;
+using Api.SharedKernel.Infrastructure.Persistence;
 using FluentAssertions;
 using MediatR;
 using Microsoft.Extensions.Logging;
@@ -858,7 +858,7 @@ public class InviteUserCommandTests
     {
         // Arrange
         var command = new InviteUserCommand("test@example.com", "user", "Test User", Guid.NewGuid(), "Admin Name");
-        _userRepository.GetByEmailAsync(command.Email, Arg.Any<CancellationToken>())
+        _userRepository.GetByEmailAsync(Email.Create(command.Email), Arg.Any<CancellationToken>())
             .Returns((User?)null);
         _invitationRepository.ExistsPendingForEmailAsync(command.Email, Arg.Any<CancellationToken>())
             .Returns(false);
@@ -881,7 +881,7 @@ public class InviteUserCommandTests
     {
         var existingUser = Substitute.For<User>();
         var command = new InviteUserCommand("existing@example.com", "user", "Test", Guid.NewGuid(), "Admin");
-        _userRepository.GetByEmailAsync(command.Email, Arg.Any<CancellationToken>())
+        _userRepository.GetByEmailAsync(Email.Create(command.Email), Arg.Any<CancellationToken>())
             .Returns(existingUser);
 
         var handler = CreateHandler();
@@ -895,7 +895,7 @@ public class InviteUserCommandTests
     public async Task Handle_WhenPendingInvitationExists_ShouldThrowConflict()
     {
         var command = new InviteUserCommand("pending@example.com", "user", "Test", Guid.NewGuid(), "Admin");
-        _userRepository.GetByEmailAsync(command.Email, Arg.Any<CancellationToken>())
+        _userRepository.GetByEmailAsync(Email.Create(command.Email), Arg.Any<CancellationToken>())
             .Returns((User?)null);
         _invitationRepository.ExistsPendingForEmailAsync(command.Email, Arg.Any<CancellationToken>())
             .Returns(true);
@@ -978,11 +978,11 @@ internal sealed class InviteUserCommandValidator : AbstractValidator<InviteUserC
 
 ```csharp
 using Api.BoundedContexts.Authentication.Domain.Entities;
-using Api.BoundedContexts.Authentication.Domain.Repositories;
+using Api.BoundedContexts.Authentication.Infrastructure.Persistence;
 using Api.BoundedContexts.UserNotifications.Application.Commands;
 using Api.SharedKernel.Application.Interfaces;
-using Api.SharedKernel.Domain;
-using Api.SharedKernel.Domain.Exceptions;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Api.Middleware.Exceptions;
 using MediatR;
 using Microsoft.Extensions.Logging;
 
@@ -1015,7 +1015,7 @@ internal class InviteUserCommandHandler : ICommandHandler<InviteUserCommand, Inv
         ArgumentNullException.ThrowIfNull(command);
 
         // Check if email already registered
-        var existingUser = await _userRepository.GetByEmailAsync(command.Email, cancellationToken)
+        var existingUser = await _userRepository.GetByEmailAsync(Email.Create(command.Email), cancellationToken)
             .ConfigureAwait(false);
         if (existingUser != null)
             throw new ConflictException($"Email {command.Email} is already registered");
@@ -1079,8 +1079,8 @@ git commit -m "feat(auth): add InviteUserCommand with validation, conflict check
 using Api.BoundedContexts.Authentication.Application.Commands.Invitation;
 using Api.BoundedContexts.Authentication.Domain.Entities;
 using Api.BoundedContexts.Authentication.Domain.Enums;
-using Api.BoundedContexts.Authentication.Domain.Repositories;
-using Api.SharedKernel.Domain;
+using Api.BoundedContexts.Authentication.Infrastructure.Persistence;
+using Api.SharedKernel.Infrastructure.Persistence;
 using Api.SharedKernel.Domain.ValueObjects;
 using FluentAssertions;
 using Microsoft.Extensions.Logging;
@@ -1191,10 +1191,10 @@ internal sealed class AcceptInvitationCommandValidator : AbstractValidator<Accep
 using System.Security.Cryptography;
 using System.Text;
 using Api.BoundedContexts.Authentication.Domain.Entities;
-using Api.BoundedContexts.Authentication.Domain.Repositories;
+using Api.BoundedContexts.Authentication.Infrastructure.Persistence;
 using Api.SharedKernel.Application.Interfaces;
-using Api.SharedKernel.Domain;
-using Api.SharedKernel.Domain.Exceptions;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Api.Middleware.Exceptions;
 using Api.SharedKernel.Domain.ValueObjects;
 using Microsoft.Extensions.Logging;
 
@@ -1257,9 +1257,11 @@ internal class AcceptInvitationCommandHandler : ICommandHandler<AcceptInvitation
 
         // Create session
         var sessionToken = SessionToken.Generate();
-        var session = Session.Create(
+        var session = new Session(
+            Guid.NewGuid(),
             user.Id,
             sessionToken,
+            null,
             command.IpAddress,
             command.UserAgent);
 
@@ -1323,10 +1325,10 @@ internal record RevokeInvitationCommand(Guid InvitationId) : ICommand<bool>;
 
 ```csharp
 // RevokeInvitationCommandHandler.cs
-using Api.BoundedContexts.Authentication.Domain.Repositories;
+using Api.BoundedContexts.Authentication.Infrastructure.Persistence;
 using Api.SharedKernel.Application.Interfaces;
-using Api.SharedKernel.Domain;
-using Api.SharedKernel.Domain.Exceptions;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Api.Middleware.Exceptions;
 using Microsoft.Extensions.Logging;
 
 namespace Api.BoundedContexts.Authentication.Application.Commands.Invitation;
@@ -1410,7 +1412,7 @@ git commit -m "feat(auth): add RevokeInvitationCommand"
 
 ```csharp
 using Api.BoundedContexts.Authentication.Domain.Enums;
-using Api.BoundedContexts.Authentication.Domain.Repositories;
+using Api.BoundedContexts.Authentication.Infrastructure.Persistence;
 using Api.SharedKernel.Application.Interfaces;
 
 namespace Api.BoundedContexts.Authentication.Application.Queries;

--- a/docs/superpowers/plans/2026-03-11-phase2-onboarding-wizard.md
+++ b/docs/superpowers/plans/2026-03-11-phase2-onboarding-wizard.md
@@ -10,7 +10,7 @@
 
 **Spec:** `docs/superpowers/specs/2026-03-11-admin-invite-onboarding-design.md` — Phase 2
 
-**Depends on:** Phase 1 (MustChangePassword flag, invited user flow)
+**Depends on:** Phase 1 (MustChangePassword flag, invited user flow, `/change-password` page)
 
 ---
 
@@ -19,7 +19,7 @@
 ### Backend — Modified Files
 | File | Change |
 |------|--------|
-| `Authentication/Domain/Entities/User.cs` | Add `OnboardingCompleted`, `OnboardingSkipped`, `OnboardingCompletedAt` |
+| `Authentication/Domain/Entities/User.cs` | Add `OnboardingCompleted`, `OnboardingSkipped`, `OnboardingCompletedAt`, `SkippedSteps` |
 
 ### Backend — New Files
 | File | Responsibility |
@@ -40,20 +40,23 @@
 | `components/onboarding/steps/TryAgentStep.tsx` | Step 3: mini-chat with agent |
 | `components/onboarding/OnboardingProgress.tsx` | Progress dots (3 steps) |
 | `components/onboarding/SkipWizardDialog.tsx` | Confirmation dialog for skipping all |
+| `components/onboarding/OnboardingReminderBanner.tsx` | Dismissible banner for skipped wizard |
 | `hooks/useOnboardingGuard.ts` | Client-side redirect logic |
+| `apps/web/src/middleware.ts` | Redirect to /onboarding if not completed |
 
 ### Frontend — Modified Files
 | File | Change |
 |------|--------|
-| `middleware.ts` | Create new file: redirect to /onboarding if not completed |
 | `app/(auth)/reset-password/_content.tsx` | Redirect to /onboarding after forced password change |
 
 ### Tests
 | File | Scope |
 |------|-------|
-| `Api.Tests/Authentication/Commands/CompleteOnboardingCommandTests.cs` | Unit: handler |
-| `apps/web/__tests__/onboarding/OnboardingWizard.test.tsx` | Frontend: wizard flow |
-| `apps/web/__tests__/onboarding/AddGameStep.test.tsx` | Frontend: step 1 |
+| `apps/api/tests/Api.Tests/BoundedContexts/Authentication/Application/Commands/Onboarding/CompleteOnboardingCommandHandlerTests.cs` | Unit: handler |
+| `apps/web/src/__tests__/onboarding/OnboardingWizard.test.tsx` | Frontend: wizard flow |
+| `apps/web/src/__tests__/onboarding/AddGameStep.test.tsx` | Frontend: step 1 |
+| `apps/web/src/__tests__/onboarding/CreateAgentStep.test.tsx` | Frontend: step 2 |
+| `apps/web/src/__tests__/onboarding/TryAgentStep.test.tsx` | Frontend: step 3 |
 
 ### Migration
 | File | Description |
@@ -76,12 +79,14 @@
 public bool OnboardingCompleted { get; private set; } = true; // true for existing users
 public bool OnboardingSkipped { get; private set; }
 public DateTime? OnboardingCompletedAt { get; private set; }
+public string[]? SkippedSteps { get; private set; }
 
 public void CompleteOnboarding(bool skipped, string[]? skippedSteps = null)
 {
     OnboardingCompleted = true;
     OnboardingSkipped = skipped;
     OnboardingCompletedAt = DateTime.UtcNow;
+    SkippedSteps = skippedSteps;
 }
 ```
 
@@ -182,8 +187,32 @@ internal record CompleteOnboardingRequest(bool Skipped = false, string[]? Skippe
 ```
 
 - [ ] **Step 2: Generate migration**: `dotnet ef migrations add AddOnboardingFieldsToUser`
-- [ ] **Step 3: Register endpoint in Program.cs**
+- [ ] **Step 3: Register endpoint**: add `v1Api.MapOnboardingEndpoints()` in `Program.cs`
 - [ ] **Step 4: Commit**
+
+### Task 3b: Create CompleteOnboardingCommandValidator
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/Authentication/Application/Validators/CompleteOnboardingCommandValidator.cs`
+
+- [ ] **Step 1: Write validator**
+
+```csharp
+using FluentValidation;
+
+internal class CompleteOnboardingCommandValidator : AbstractValidator<CompleteOnboardingCommand>
+{
+    public CompleteOnboardingCommandValidator()
+    {
+        RuleFor(x => x.UserId)
+            .NotEmpty()
+            .WithMessage("UserId is required");
+    }
+}
+```
+
+- [ ] **Step 2: Run tests**: `cd apps/api && dotnet test --filter "BoundedContext=Authentication"`
+- [ ] **Step 3: Commit**
 
 ---
 
@@ -390,10 +419,26 @@ export function OnboardingWizard() {
 
 - [ ] **Step 3: Write TryAgentStep** — Mini-chat inline. Pre-filled suggestions. Uses existing chat SSE endpoint.
 
-- [ ] **Step 4: Write SkipWizardDialog** — Confirmation: "Puoi trovare queste funzionalità nella dashboard quando vuoi"
+- [ ] **Step 4: Write SkipWizardDialog** — Confirmation: "Puoi trovare queste funzionalita nella dashboard quando vuoi"
 
 - [ ] **Step 5: Write tests**
 - [ ] **Step 6: Commit**
+
+### Task 6b: Add completeOnboarding to frontend auth API client
+
+**Files:**
+- Modify: `apps/web/src/lib/api/auth.ts` (or wherever the auth client is defined)
+
+- [ ] **Step 1: Add `completeOnboarding` method**
+
+```typescript
+async completeOnboarding(data: { skipped: boolean; skippedSteps: string[] }): Promise<void> {
+  await this.httpClient.post('/api/v1/auth/complete-onboarding', data);
+}
+```
+
+- [ ] **Step 2: Verify types and build**: `cd apps/web && pnpm typecheck`
+- [ ] **Step 3: Commit**
 
 ### Task 7: Create onboarding page + layout
 
@@ -402,6 +447,60 @@ export function OnboardingWizard() {
 - [ ] **Step 3: Update reset-password redirect** to go to `/onboarding` when `mode=forced`
 - [ ] **Step 4: Run full build**: `pnpm build`
 - [ ] **Step 5: Commit**
+
+### Task 7b: Create OnboardingReminderBanner component
+
+**Files:**
+- Create: `apps/web/src/components/onboarding/OnboardingReminderBanner.tsx`
+
+- [ ] **Step 1: Write component** — Dismissible banner shown on dashboard if wizard was skipped. Dismiss state stored in localStorage (`onboarding_banner_dismissed`).
+
+```tsx
+'use client';
+
+import { useState, useEffect } from 'react';
+import { useRouter } from 'next/navigation';
+import { Button } from '@/components/ui/primitives/button';
+import { X } from 'lucide-react';
+
+const STORAGE_KEY = 'onboarding_banner_dismissed';
+
+export function OnboardingReminderBanner() {
+  const router = useRouter();
+  const [visible, setVisible] = useState(false);
+
+  useEffect(() => {
+    const dismissed = localStorage.getItem(STORAGE_KEY);
+    if (!dismissed) setVisible(true);
+  }, []);
+
+  const dismiss = () => {
+    localStorage.setItem(STORAGE_KEY, 'true');
+    setVisible(false);
+  };
+
+  if (!visible) return null;
+
+  return (
+    <div className="bg-amber-50 border border-amber-200 rounded-lg p-4 flex items-center justify-between">
+      <p className="font-nunito text-sm text-amber-900">
+        Non hai completato il setup — riprendi da dove eri rimasto
+      </p>
+      <div className="flex items-center gap-2">
+        <Button variant="outline" size="sm" onClick={() => router.push('/onboarding')}>
+          Riprendi
+        </Button>
+        <Button variant="ghost" size="icon" onClick={dismiss}>
+          <X className="h-4 w-4" />
+        </Button>
+      </div>
+    </div>
+  );
+}
+```
+
+- [ ] **Step 2: Add banner to dashboard page** — Conditionally render when `onboardingSkipped` is true in user session.
+- [ ] **Step 3: Commit**
 
 ### Task 8: Run full test suite
 

--- a/docs/superpowers/plans/2026-03-11-phase3-voice-chat.md
+++ b/docs/superpowers/plans/2026-03-11-phase3-voice-chat.md
@@ -4,13 +4,20 @@
 
 **Goal:** Users can speak to AI agents via a microphone button in the chat input. Speech-to-text via Whisper API (paid users) with Web Speech API fallback (free users). Agent responses read aloud via browser TTS.
 
-**Architecture:** Single new backend endpoint (`POST /api/v1/speech/transcribe`) proxying to OpenAI Whisper. Frontend: mic button in existing chat input, `SpeechService` abstraction with fallback, TTS via browser `SpeechSynthesis API`. Tier-gated: Whisper for `Normal`/`Premium`, Web Speech API for `Free`.
+**Architecture:** Single new backend endpoint (`POST /api/v1/speech/transcribe`) proxying to OpenAI Whisper. Frontend: mic button in existing chat input, extends existing `ISpeechRecognitionProvider` abstraction in `lib/voice/` with a new `WhisperProvider`, TTS via existing `useVoiceOutput.ts` extended with language auto-detect. Tier-gated: Whisper for `Normal`/`Premium`, Web Speech API for `Free`.
 
 **Tech Stack:** .NET 9 (multipart form), OpenAI Whisper API, Next.js 16, MediaRecorder API, Web Speech API, SpeechSynthesis API
 
 **Spec:** `docs/superpowers/specs/2026-03-11-admin-invite-onboarding-design.md` — Phase 3
 
 **Independent of:** Phases 1 and 2 (voice works for any authenticated user)
+
+**Existing voice infrastructure (DO NOT duplicate):**
+- `apps/web/src/hooks/useVoiceInput.ts` — hook with `ISpeechRecognitionProvider` abstraction
+- `apps/web/src/hooks/useVoiceOutput.ts` — SpeechSynthesis management
+- `apps/web/src/lib/voice/types.ts` — provider types
+- `apps/web/src/lib/voice/providers/provider-factory.ts` — provider creation
+- `apps/web/src/lib/voice/providers/web-speech-provider.ts` — Web Speech API provider
 
 ---
 
@@ -34,15 +41,16 @@
 ### Frontend — New Files
 | File | Responsibility |
 |------|---------------|
-| `components/chat/VoiceChatButton.tsx` | Mic toggle button with recording state |
-| `hooks/useAudioRecorder.ts` | MediaRecorder hook |
-| `lib/services/SpeechService.ts` | Whisper + Web Speech API abstraction |
+| `components/chat/VoiceChatButton.tsx` | Mic toggle button with recording state + quality indicator badge |
+| `lib/voice/providers/whisper-provider.ts` | Implements existing `ISpeechRecognitionProvider` using MediaRecorder + backend Whisper proxy |
 | `components/chat/TextToSpeechButton.tsx` | Speaker button per message |
-| `hooks/useTextToSpeech.ts` | SpeechSynthesis hook |
 
 ### Frontend — Modified Files
 | File | Change |
 |------|--------|
+| `lib/voice/providers/provider-factory.ts` | Add tier-based provider selection (`createProvider(userTier)`) |
+| `hooks/useVoiceOutput.ts` | Extend with language auto-detection from response content |
+| `lib/voice/types.ts` | Add `WhisperProvider` type to provider union |
 | `components/ui/meeple/chat-message.tsx` | Add TTS speaker button |
 | Chat input component (find exact path) | Add mic button next to send |
 
@@ -54,9 +62,10 @@
 ### Tests
 | File | Scope |
 |------|-------|
-| `Api.Tests/KnowledgeBase/Commands/TranscribeAudioCommandTests.cs` | Unit: tier gating, handler |
-| `apps/web/__tests__/chat/VoiceChatButton.test.tsx` | Frontend: mic states |
-| `apps/web/__tests__/chat/SpeechService.test.ts` | Frontend: fallback logic |
+| `apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Commands/Speech/TranscribeAudioCommandHandlerTests.cs` | Unit: tier gating, handler |
+| `apps/web/src/__tests__/components/chat-unified/VoiceChatButton.test.tsx` | Frontend: mic states, quality badge |
+| `apps/web/src/__tests__/components/chat-unified/WhisperProvider.test.ts` | Frontend: provider + fallback logic |
+| `apps/web/src/__tests__/components/chat-unified/VoiceOutput.test.ts` | Frontend: TTS + language auto-detect |
 
 ---
 
@@ -149,9 +158,9 @@ internal record TranscribeAudioCommand(
     string FileName,
     Guid UserId,
     string UserTier
-) : ICommand<TranscriptionResult>;
+) : IRequest<TranscriptionResult>;
 
-internal class TranscribeAudioCommandHandler : ICommandHandler<TranscribeAudioCommand, TranscriptionResult>
+internal class TranscribeAudioCommandHandler : IRequestHandler<TranscribeAudioCommand, TranscriptionResult>
 {
     private readonly ITranscriptionService _transcriptionService;
 
@@ -189,87 +198,97 @@ internal class TranscribeAudioCommandHandler : ICommandHandler<TranscribeAudioCo
 
 ## Chunk 2: Frontend (Mic button + STT + TTS)
 
-### Task 5: Create useAudioRecorder hook
+### Task 5: Create WhisperProvider
 
-- [ ] **Step 1: Write hook**
+> **IMPORTANT:** The codebase already has voice infrastructure at `hooks/useVoiceInput.ts` (with `ISpeechRecognitionProvider` abstraction), `hooks/useVoiceOutput.ts`, and `lib/voice/` (types, provider-factory, web-speech-provider). This task extends it — do NOT duplicate.
+
+- [ ] **Step 1: Write WhisperProvider** at `lib/voice/providers/whisper-provider.ts`
 
 ```typescript
-import { useState, useRef, useCallback } from 'react';
+import type { ISpeechRecognitionProvider, RecognitionResult } from '../types';
 
-interface AudioRecorderState {
-  isRecording: boolean;
-  duration: number;
-  audioBlob: Blob | null;
-  error: string | null;
-}
+/**
+ * Implements ISpeechRecognitionProvider using MediaRecorder to capture audio
+ * and the backend Whisper proxy endpoint (POST /api/v1/speech/transcribe)
+ * for cloud-based transcription. Used for Normal/Premium tier users.
+ */
+export class WhisperProvider implements ISpeechRecognitionProvider {
+  private mediaRecorder: MediaRecorder | null = null;
+  private chunks: Blob[] = [];
+  private stream: MediaStream | null = null;
 
-export function useAudioRecorder(maxDurationMs = 30000) {
-  const [state, setState] = useState<AudioRecorderState>({
-    isRecording: false, duration: 0, audioBlob: null, error: null,
-  });
-  const mediaRecorderRef = useRef<MediaRecorder | null>(null);
-  const chunksRef = useRef<Blob[]>([]);
-  const timerRef = useRef<NodeJS.Timeout | null>(null);
-  const startTimeRef = useRef<number>(0);
+  readonly id = 'whisper' as const;
 
-  const startRecording = useCallback(async () => {
+  async start(onResult: (result: RecognitionResult) => void, onError: (error: Error) => void): Promise<void> {
     try {
-      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
-      const mediaRecorder = new MediaRecorder(stream, { mimeType: 'audio/webm' });
-      mediaRecorderRef.current = mediaRecorder;
-      chunksRef.current = [];
-      startTimeRef.current = Date.now();
+      this.stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      this.mediaRecorder = new MediaRecorder(this.stream, { mimeType: 'audio/webm' });
+      this.chunks = [];
 
-      mediaRecorder.ondataavailable = (e) => { if (e.data.size > 0) chunksRef.current.push(e.data); };
-      mediaRecorder.onstop = () => {
-        const blob = new Blob(chunksRef.current, { type: 'audio/webm' });
-        setState(prev => ({ ...prev, isRecording: false, audioBlob: blob }));
-        stream.getTracks().forEach(t => t.stop());
+      this.mediaRecorder.ondataavailable = (e) => {
+        if (e.data.size > 0) this.chunks.push(e.data);
       };
 
-      mediaRecorder.start();
-      setState(prev => ({ ...prev, isRecording: true, error: null, audioBlob: null }));
+      this.mediaRecorder.onstop = async () => {
+        const blob = new Blob(this.chunks, { type: 'audio/webm' });
+        this.stream?.getTracks().forEach(t => t.stop());
+        try {
+          const formData = new FormData();
+          formData.append('audio', blob, 'recording.webm');
+          const res = await fetch('/api/v1/speech/transcribe', { method: 'POST', body: formData });
+          if (!res.ok) throw new Error(`Transcription failed: ${res.status}`);
+          const data = await res.json();
+          onResult({ text: data.text, language: data.language, isFinal: true });
+        } catch (err) {
+          onError(err instanceof Error ? err : new Error('Transcription failed'));
+        }
+      };
 
-      // Auto-stop after max duration
-      timerRef.current = setInterval(() => {
-        const elapsed = Date.now() - startTimeRef.current;
-        setState(prev => ({ ...prev, duration: Math.floor(elapsed / 1000) }));
-        if (elapsed >= maxDurationMs) stopRecording();
-      }, 1000);
+      this.mediaRecorder.start();
     } catch (err) {
-      setState(prev => ({ ...prev, error: 'Permesso microfono necessario' }));
+      onError(err instanceof Error ? err : new Error('Permesso microfono necessario'));
     }
-  }, [maxDurationMs]);
+  }
 
-  const stopRecording = useCallback(() => {
-    if (mediaRecorderRef.current?.state === 'recording') {
-      mediaRecorderRef.current.stop();
+  stop(): void {
+    if (this.mediaRecorder?.state === 'recording') {
+      this.mediaRecorder.stop();
     }
-    if (timerRef.current) clearInterval(timerRef.current);
-  }, []);
+  }
 
-  return { ...state, startRecording, stopRecording };
+  isSupported(): boolean {
+    return typeof navigator !== 'undefined'
+      && !!navigator.mediaDevices?.getUserMedia
+      && typeof MediaRecorder !== 'undefined';
+  }
 }
 ```
 
-- [ ] **Step 2: Test + commit**
+- [ ] **Step 2: Add `'whisper'` to provider type union in `lib/voice/types.ts`**
+- [ ] **Step 3: Test + commit**
 
-### Task 6: Create SpeechService
+### Task 6: Update provider-factory.ts with tier-based selection
 
-- [ ] **Step 1: Write service class** with Whisper → Web Speech API fallback
-- [ ] **Step 2: Test fallback logic + commit**
+> **Extends existing** `lib/voice/providers/provider-factory.ts` — do NOT create a new `SpeechService`.
+
+- [ ] **Step 1: Add `createProvider(userTier)` function** — returns `WhisperProvider` for `Normal`/`Premium` tiers, `WebSpeechProvider` for `Free` tier
+- [ ] **Step 2: Test tier-based selection logic + commit**
 
 ### Task 7: Create VoiceChatButton component
 
 - [ ] **Step 1: Write component** — idle (mic icon) → recording (red pulse + timer) → transcribing (spinner)
-- [ ] **Step 2: Write test + commit**
+- [ ] **Step 2: Add quality indicator badge** — display "HD" badge when using WhisperProvider, or browser icon when using WebSpeechProvider (free tier)
+- [ ] **Step 3: Add tooltip for free users** — "Trascrizione base — Upgrade per qualita HD"
+- [ ] **Step 4: Write test + commit**
 
-### Task 8: Create TTS components
+### Task 8: Extend useVoiceOutput.ts with language auto-detection
 
-- [ ] **Step 1: Write useTextToSpeech hook** — wraps SpeechSynthesis API
-- [ ] **Step 2: Write TextToSpeechButton** — speaker icon on agent messages
+> **Extends existing** `hooks/useVoiceOutput.ts` — do NOT create a new `useTextToSpeech.ts` hook.
+
+- [ ] **Step 1: Add language auto-detection** — detect language from agent response content and set appropriate `SpeechSynthesisUtterance.lang`
+- [ ] **Step 2: Write TextToSpeechButton** — speaker icon on agent messages, uses extended `useVoiceOutput`
 - [ ] **Step 3: Add auto-read toggle in chat header**
-- [ ] **Step 4: Test + commit**
+- [ ] **Step 4: Test TTS + language detection + commit**
 
 ### Task 9: Integrate into existing chat
 

--- a/docs/superpowers/plans/2026-03-11-phase4-admin-audit-management.md
+++ b/docs/superpowers/plans/2026-03-11-phase4-admin-audit-management.md
@@ -12,6 +12,16 @@
 
 **Independent of:** Phases 1-3 (audit system is self-contained)
 
+> **Existing `AuditLog` entity:** `Administration/Domain/Entities/AuditLog.cs` already exists with similar fields. `AuditLogEntry` is a more comprehensive replacement with event-driven population, JSONB details, and typed `AuditAction` enum. The existing `AuditLog` will be deprecated after migration.
+
+> **Existing endpoints:** `Routing/AdminAuditLogEndpoints.cs` already has basic `GET /admin/audit-log` and `GET /admin/audit-log/export`. This plan extends these rather than creating new ones.
+
+> **Existing frontend schema:** `admin.schemas.ts` defines `AuditLogEntrySchema` (line 617). New audit schemas will extend/replace this.
+
+> **Existing AuditTab:** `app/admin/(dashboard)/monitor/operations/AuditTab.tsx` exists. The new `/admin/monitor/audit` page is the enhanced replacement.
+
+> **Cross-context events:** `RoleChangedEvent` is `internal sealed` in Authentication. The `RoleChangedAuditHandler` should either live in Authentication context, or the event should be made `public sealed`.
+
 ---
 
 ## File Structure
@@ -23,14 +33,14 @@
 | `Administration/Domain/Enums/AuditAction.cs` | 26-value enum |
 | `Administration/Domain/Repositories/IAuditLogRepository.cs` | Repository interface |
 | `Administration/Infrastructure/Repositories/AuditLogRepository.cs` | EF Core implementation |
-| `Administration/Infrastructure/Configuration/AuditLogEntryConfiguration.cs` | EF config with indexes |
+| `Administration/Infrastructure/Persistence/Configurations/AuditLogEntryConfiguration.cs` | EF config with indexes |
 | `Administration/Application/Commands/ChangeUserRoleCommand.cs` | Dedicated role change |
 | `Administration/Application/Queries/GetAuditLogQuery.cs` | Paginated + filtered |
 | `Administration/Application/Queries/GetUserAuditLogQuery.cs` | Per-user filtered |
 | `Administration/Application/Queries/ExportAuditLogQuery.cs` | CSV export |
 | `Administration/Application/EventHandlers/AuditLogEventHandler.cs` | Centralized audit writer |
 | `Administration/Infrastructure/Jobs/AuditLogCleanupJob.cs` | Quartz: 90-day retention |
-| `Routing/AdminAuditEndpoints.cs` | Audit log endpoints |
+| `Routing/AdminAuditLogEndpoints.cs` | **Modified** — extend existing audit log endpoints |
 
 ### Backend — Modified Files
 | File | Change |
@@ -44,20 +54,20 @@
 ### Frontend — New Files
 | File | Responsibility |
 |------|---------------|
-| `components/admin/users/InlineRoleSelect.tsx` | Dropdown + confirmation modal |
-| `components/admin/users/UserActivityTimeline.tsx` | Per-user event timeline |
-| `app/admin/(dashboard)/monitor/audit/page.tsx` | Audit log page |
-| `components/admin/audit/AuditLogTable.tsx` | Filterable table |
-| `components/admin/audit/AuditLogFilters.tsx` | Filter controls |
-| `components/admin/audit/AuditLogExport.tsx` | CSV export button |
-| `lib/api/clients/auditClient.ts` | API client |
-| `lib/api/schemas/audit.schemas.ts` | Zod schemas |
+| `src/components/admin/users/InlineRoleSelect.tsx` | Dropdown + confirmation modal |
+| `src/components/admin/users/UserActivityTimeline.tsx` | Per-user event timeline |
+| `src/app/admin/(dashboard)/monitor/audit/page.tsx` | Audit log page |
+| `src/components/admin/audit/AuditLogTable.tsx` | Filterable table |
+| `src/components/admin/audit/AuditLogFilters.tsx` | Filter controls |
+| `src/components/admin/audit/AuditLogExport.tsx` | CSV export button |
+| `src/lib/api/clients/auditClient.ts` | API client |
+| `src/lib/api/schemas/audit.schemas.ts` | Zod schemas |
 
 ### Frontend — Modified Files
 | File | Change |
 |------|--------|
-| `lib/api/index.ts` | Register auditClient |
-| `components/admin/users/activity-table.tsx` | Wire to real API (currently mock data) |
+| `src/lib/api/index.ts` | Register auditClient |
+| `src/components/admin/users/activity-table.tsx` | Wire to real API (currently mock data) |
 | Admin user detail page | Add "Activity" tab |
 
 ### Tests
@@ -67,8 +77,12 @@
 | `Api.Tests/Administration/Commands/ChangeUserRoleCommandTests.cs` | Unit: handler |
 | `Api.Tests/Administration/Queries/GetAuditLogQueryTests.cs` | Unit: query handler |
 | `Api.Tests/Administration/EventHandlers/AuditLogEventHandlerTests.cs` | Unit: event handler |
-| `apps/web/__tests__/admin/audit/AuditLogTable.test.tsx` | Frontend: table |
-| `apps/web/__tests__/admin/users/InlineRoleSelect.test.tsx` | Frontend: role change |
+| `Api.Tests/Administration/Queries/ExportAuditLogQueryTests.cs` | Unit: export handler |
+| `Api.Tests/Administration/Queries/GetUserAuditLogQueryTests.cs` | Unit: per-user query handler |
+| `Api.Tests/Administration/Jobs/AuditLogCleanupJobTests.cs` | Unit: retention job |
+| `apps/web/src/__tests__/admin/audit/AuditLogTable.test.tsx` | Frontend: table |
+| `apps/web/src/__tests__/admin/users/InlineRoleSelect.test.tsx` | Frontend: role change |
+| `apps/web/src/__tests__/admin/users/UserActivityTimeline.test.tsx` | Frontend: activity timeline |
 
 ### Migration
 | File | Description |
@@ -149,7 +163,7 @@ public sealed class AuditLogEntry : Entity<Guid>
 
 ### Task 3: Create repository + EF config
 
-- [ ] **Step 1: Write IAuditLogRepository** — methods: AddAsync, GetPagedAsync(filters), GetByUserIdAsync, GetForExportAsync
+- [ ] **Step 1: Write IAuditLogRepository** — methods: AddAsync, GetPagedAsync(filters), GetByUserIdAsync, GetForExportAsync, DeleteOlderThanAsync(DateTime cutoff, CancellationToken ct)
 - [ ] **Step 2: Write AuditLogRepository** — EF Core with filter predicates
 - [ ] **Step 3: Write EF configuration** with 3 indexes:
   - `IX_AuditLogEntry_CreatedAt` (for retention cleanup)
@@ -169,6 +183,7 @@ public sealed class AuditLogEntry : Entity<Guid>
 
 ### Task 5: Add ChangedById to RoleChangedEvent
 
+- [ ] **Step 0: Grep for `UpdateRole` calls** to identify all callers that need the new `changedById` parameter
 - [ ] **Step 1: Read RoleChangedEvent.cs** (Authentication/Domain/Events/)
 - [ ] **Step 2: Add `ChangedById` property**
 
@@ -284,6 +299,12 @@ internal sealed class AuditLogCleanupJob : IJob
 - [ ] **Step 2: Write handler** generating CSV string
 - [ ] **Step 3: Commit**
 
+### Task 10b: Create GetUserAuditLogQuery
+
+- [ ] **Step 1: Write query** with userId filter + pagination (limit, offset, dateFrom, dateTo)
+- [ ] **Step 2: Write handler** calling `IAuditLogRepository.GetByUserIdAsync`
+- [ ] **Step 3: Test + commit**
+
 ### Task 11: Create AdminAuditEndpoints
 
 - [ ] **Step 1: Write endpoints**
@@ -322,14 +343,15 @@ interface InlineRoleSelectProps {
 
 - [ ] **Step 1: Write component** — chronological event list with icons per action type
 - [ ] **Step 2: Wire to GET /admin/users/{id}/audit-log**
-- [ ] **Step 3: Add as tab in admin user detail page**
-- [ ] **Step 4: Test + commit**
+- [ ] **Step 3: Add pagination/infinite scroll** — useInfiniteQuery with cursor-based loading for long activity histories
+- [ ] **Step 4: Add as tab in admin user detail page**
+- [ ] **Step 5: Test + commit**
 
 ### Task 15: Create Audit Log page
 
 - [ ] **Step 1: Write page** at `/admin/monitor/audit/page.tsx`
 - [ ] **Step 2: Write AuditLogTable** — filterable table with action badges
-- [ ] **Step 3: Write AuditLogFilters** — user picker, action dropdown, date range
+- [ ] **Step 3: Write AuditLogFilters** — user picker, action dropdown, date range, full-text search input (searches details JSONB and user/actor names)
 - [ ] **Step 4: Write AuditLogExport** — CSV download button
 - [ ] **Step 5: Add to admin navigation** in `config/admin-dashboard-navigation.ts`
 - [ ] **Step 6: Test + commit**

--- a/docs/superpowers/specs/2026-03-11-admin-invite-onboarding-design.md
+++ b/docs/superpowers/specs/2026-03-11-admin-invite-onboarding-design.md
@@ -1,8 +1,8 @@
 # User Invitation System & Onboarding Wizard — Design Spec
 
 > **Date:** 2026-03-11
-> **Status:** Approved
-> **Scope:** Admin user invitation flow (single + bulk), accept-invite with onboarding wizard, forced password change
+> **Status:** Approved (spec review v2)
+> **Scope:** Admin user invitation flow (single + bulk), accept-invite with onboarding wizard
 
 ---
 
@@ -12,7 +12,6 @@ Administrators need to invite users to MeepleAI by email. Currently, user creati
 
 - Sending invitation emails with a secure token link
 - Allowing invited users to set their own password
-- Forcing password change on first login
 - Guided onboarding for new users
 
 ## Design Decisions
@@ -23,11 +22,13 @@ Administrators need to invite users to MeepleAI by email. Currently, user creati
 | Token storage | SHA256 hash only | Same pattern as PasswordReset; plaintext only in email |
 | Token expiry | 7 days | Longer than password reset (24h) since invites need more time |
 | Resend behavior | New token, old marked Expired | One active invite per email at a time |
-| Revoke | No explicit revoke | Token expires naturally in 7 days |
+| Revoke | No explicit revoke | Token expires naturally in 7 days; admin can resend (which expires old token) to effectively cancel+renew |
 | Admin UI | B+C: inline in user list + dedicated page | Quick visibility + full management power |
 | Onboarding | 5-step wizard, only password mandatory | Low friction; user can skip and explore later |
 | Bounded context | Authentication (token + accept) + Administration (admin endpoints) | Follows existing separation |
 | Bulk invite | CSV upload (email,role per row), max 100 per batch | Matches existing BulkImportUsersCommand pattern |
+| MustChangePassword | NOT used for invitation flow | User sets their own password in Step 1 — no "default password" to change. Flag reserved for future admin-forced password resets. |
+| Role storage | `string` (not enum) | Matches existing `UserEntity.Role` convention; `UserRole` enum is domain logic only |
 
 ---
 
@@ -39,7 +40,7 @@ Administrators need to invite users to MeepleAI by email. Currently, user creati
 |-------|------|-------------|
 | `Id` | `Guid` | PK |
 | `Email` | `string` | Required, max 256, normalized lowercase |
-| `Role` | `UserRole` | Required (User, Editor, Admin) |
+| `Role` | `string` | Required, stored as string (matches `UserEntity.Role` convention) |
 | `TokenHash` | `string` | Required, unique index, SHA256 of plaintext token |
 | `InvitedByUserId` | `Guid` | FK → Users, required |
 | `Status` | `InvitationStatus` | Required, default `Pending` |
@@ -55,16 +56,11 @@ Administrators need to invite users to MeepleAI by email. Currently, user creati
 - Resend = mark old as `Expired`, create new with fresh token
 - Token validated by: hash match + status == `Pending` + `ExpiresAt > now`
 - SuperAdmin role cannot be assigned via invitation (admin-only escalation)
+- Allowed roles for invitation: `"User"`, `"Editor"`, `"Admin"` (validated as strings matching `AllowedRoles` array)
 
-### Modified Entity: `UserEntity`
+### UserEntity — No Modifications
 
-Add field:
-
-| Field | Type | Default | Purpose |
-|-------|------|---------|---------|
-| `MustChangePassword` | `bool` | `false` | Set `true` on invitation accept; forces redirect to `/change-password` |
-
-**Guard behavior:** Authenticated layout middleware checks `user.mustChangePassword`. If `true`, redirect to `/change-password`. The change-password page clears the flag on success via existing `ChangePasswordCommand` (modified to set `MustChangePassword = false`).
+The invitation flow does **not** add `MustChangePassword` to `UserEntity`. The user sets their own password during the wizard's Step 1 (`AcceptInvitationCommand`). There is no "default password" to force-change. A `MustChangePassword` feature for admin-forced resets is out of scope and can be added independently in the future.
 
 ---
 
@@ -74,8 +70,8 @@ Add field:
 
 #### `SendInvitationCommand`
 - **Input:** `Email`, `Role`
-- **Auth:** Admin+ role required
-- **Validation:** Valid email format, role != SuperAdmin, no existing Pending invite for email, no existing active user with email
+- **Auth:** Admin+ role required. `InvitedByUserId` extracted from authenticated session in the handler (not part of command record).
+- **Validation:** Valid email format, role in `["User", "Editor", "Admin"]` (string match), no existing Pending invite for email, no existing active user with email
 - **Handler:**
   1. Generate cryptographically random token (32 bytes, base64url)
   2. Create `InvitationToken` entity with `SHA256(token)` as `TokenHash`
@@ -84,7 +80,7 @@ Add field:
 - **Audit:** `[AuditableAction]`
 
 #### `BulkSendInvitationsCommand`
-- **Input:** `CsvContent` (string) or `CsvFile` (IFormFile)
+- **Input:** `CsvContent` (string only — endpoint layer converts `IFormFile` to string before dispatching)
 - **Auth:** Admin+ role required
 - **CSV format:** `email,role` per row (header optional)
 - **Validation:** Each row validated individually; max 100 invites per batch
@@ -95,32 +91,34 @@ Add field:
 - **Audit:** `[AuditableAction]` with batch metadata
 
 #### `AcceptInvitationCommand`
-- **Input:** `Token` (plaintext from URL), `Password`, `ConfirmPassword`
+- **Input:** `Token` (plaintext from request body), `Password`, `ConfirmPassword`
 - **Auth:** Unauthenticated (public endpoint)
 - **Validation:** Password min 8 chars, upper + lower + digit, passwords match, token not empty
 - **Handler:**
   1. Hash token with SHA256, find `InvitationToken` by hash
   2. Validate: status == `Pending`, `ExpiresAt > now`
-  3. Create `UserEntity` with email from invitation, hashed password, assigned role, `MustChangePassword = true`
+  3. Create `UserEntity` with email from invitation, hashed password, assigned role, `EmailVerified = true` (admin-supplied email is trusted)
   4. Mark invitation as `Accepted`, set `AcceptedAt` and `AcceptedByUserId`
   5. Create session (auto-login) — return auth cookie + user data
-- **Audit:** `[AuditableAction]`
+- **Audit:** `[AuditableAction]` — note: audit record will have `adminUserId = null` since this is an unauthenticated endpoint. The `InvitedByUserId` on the `InvitationToken` entity provides the audit trail to the inviting admin. This is expected and acceptable.
 
 #### `ResendInvitationCommand`
 - **Input:** `InvitationId` (Guid)
 - **Auth:** Admin+ role required
+- **Validation:** Invitation must exist. Status must be `Pending` or `Expired` (not `Accepted`). No active user must exist for the invitation's email.
 - **Handler:**
   1. Find existing invitation by Id
-  2. Mark as `Expired`
-  3. Generate new token, create new `InvitationToken` for same email + role
-  4. Send email
-  5. Return new `InvitationDto`
+  2. Validate status and email (see above)
+  3. Mark as `Expired`
+  4. Generate new token, create new `InvitationToken` for same email + role
+  5. Send email
+  6. Return new `InvitationDto`
 - **Audit:** `[AuditableAction]`
 
 ### New Queries
 
 #### `GetInvitationsQuery`
-- **Input:** `Status?` (filter), `Page`, `PageSize`
+- **Input:** `Status?` (filter), `Page`, `PageSize`, `SortBy` (default: `CreatedAt DESC`)
 - **Auth:** Admin+
 - **Returns:** `PaginatedResult<InvitationDto>`
 
@@ -129,9 +127,9 @@ Add field:
 - **Returns:** `{ pending: int, accepted: int, expired: int, total: int }`
 
 #### `ValidateInvitationTokenQuery`
-- **Input:** `Token` (plaintext)
+- **Input:** `Token` (plaintext, sent in POST body — not GET query param, to avoid server log exposure)
 - **Auth:** Unauthenticated
-- **Returns:** `{ valid: bool, email: string?, role: string?, expiresAt: DateTime? }`
+- **Returns:** `{ valid: bool, role: string?, expiresAt: DateTime? }` — **email is NOT returned** to prevent user-enumeration via forwarded invite links. The email is shown to the user only after they complete `AcceptInvitationCommand`.
 
 ---
 
@@ -141,7 +139,7 @@ Add field:
 
 ```
 POST   /api/v1/admin/users/invite                    → SendInvitationCommand
-POST   /api/v1/admin/users/bulk/invite                → BulkSendInvitationsCommand
+POST   /api/v1/admin/users/bulk/invite                → BulkSendInvitationsCommand (endpoint reads IFormFile, converts to string CsvContent)
 POST   /api/v1/admin/users/invitations/{id}/resend    → ResendInvitationCommand
 GET    /api/v1/admin/users/invitations                → GetInvitationsQuery
 GET    /api/v1/admin/users/invitations/stats           → GetInvitationStatsQuery
@@ -150,8 +148,8 @@ GET    /api/v1/admin/users/invitations/stats           → GetInvitationStatsQue
 ### Public Auth Endpoints (AuthenticationEndpoints.cs)
 
 ```
-POST   /api/v1/auth/accept-invitation                 → AcceptInvitationCommand
-GET    /api/v1/auth/validate-invitation?token=X        → ValidateInvitationTokenQuery
+POST   /api/v1/auth/accept-invitation                 → AcceptInvitationCommand (token in body)
+POST   /api/v1/auth/validate-invitation               → ValidateInvitationTokenQuery (token in body, POST to avoid server log exposure)
 ```
 
 ---
@@ -174,47 +172,51 @@ GET    /api/v1/auth/validate-invitation?token=X        → ValidateInvitationTok
 
 ## 5. Frontend: Accept Invitation & Onboarding
 
-### Route: `/accept-invite` (auth route group, unauthenticated)
+### Route: `/accept-invite` — new `(onboarding)` route group
+
+The accept-invite page and onboarding wizard live in a **new `(onboarding)` route group** with its own full-width layout. The `(auth)` group layout (max-width ~450px centered card) is too narrow for game search and agent creation steps.
+
+**`(onboarding)/layout.tsx`:** Minimal header (logo only), full-width content area (max-width 768px centered), no sidebar, no navigation.
 
 **Entry flow:**
 1. URL: `/accept-invite?token=xxx`
-2. Call `ValidateInvitationTokenQuery` to check token
-3. If invalid/expired → error page with "Contact your administrator" message
+2. Extract token from URL, call `ValidateInvitationTokenQuery` (POST with token in body)
+3. If invalid/expired → error page with "This invitation has expired or is invalid. Contact your administrator." message
 4. If valid → show `OnboardingWizard`
 
 ### OnboardingWizard (5 steps)
 
-| Step | Required | Component | API Call |
-|------|----------|-----------|----------|
-| 1. Set Password | Yes | `PasswordStep` | `AcceptInvitationCommand` (creates user + auto-login) |
-| 2. Profile | Skippable | `ProfileStep` | `UpdateUserProfileCommand` |
-| 3. Interests | Skippable | `InterestsStep` | `UpdateUserPreferencesCommand` (or new) |
-| 4. First Game | Skippable | `FirstGameStep` | `AddGameToLibraryCommand` |
-| 5. First Agent | Skippable | `FirstAgentStep` | `CreateAgentDefinitionCommand` |
+| Step | Required | Component | API Call | Notes |
+|------|----------|-----------|----------|-------|
+| 1. Set Password | Yes | `PasswordStep` | `AcceptInvitationCommand` (creates user + auto-login) | After this step, user is authenticated |
+| 2. Profile | Skippable | `ProfileStep` | `UpdateUserProfileCommand` | Display name + avatar |
+| 3. Interests | Skippable | `InterestsStep` | `SaveUserInterestsCommand` (new) | See Section 5A |
+| 4. First Game | Skippable | `FirstGameStep` | `AddGameToLibraryCommand` | Search catalog |
+| 5. First Agent | Skippable/Auto-skip | `FirstAgentStep` | `CreateAgentDefinitionCommand` | Only shown if game added in step 4 |
 
 **Step 1 (Password)** is the critical step — it calls `AcceptInvitationCommand` which creates the user and returns an auth session. Steps 2-5 execute as authenticated API calls.
 
+**Progress bar behavior:** Shows total step count dynamically. If step 5 is auto-skipped (no game added in step 4), the progress bar shows 4 steps total, not 5 with one greyed out. Implementation: `totalSteps` is computed from wizard state — `hasGame ? 5 : 4`.
+
 **Components:**
-- `OnboardingWizard` — stepper with progress bar, skip/next/back navigation
+- `OnboardingWizard` — stepper with dynamic progress bar, skip/next/back navigation. "Skip wizard" link in header (skips remaining steps, redirects to home).
 - `PasswordStep` — password + confirm fields, strength meter, validation rules display (reuse pattern from `/reset-password`)
 - `ProfileStep` — display name input + avatar upload
 - `InterestsStep` — checkbox grid with game category icons (Strategy, Party, Cooperative, Family, Thematic, Abstract, Card, Dice, Miniatures)
 - `FirstGameStep` — search bar with debounce → catalog results as cards → click to add
-- `FirstAgentStep` — conditional: if game was added in step 4, show "Create an AI assistant for {GameName}?" toggle + agent name input. If no game, auto-skip.
+- `FirstAgentStep` — conditional render: shown only if game was added in step 4. Toggle "Create an AI assistant for {GameName}?" + agent name input.
 
 **Post-completion:** redirect to `/` (home dashboard)
 
-### MustChangePassword Guard
+### Section 5A: User Interests (New Backend)
 
-**Location:** `(authenticated)/layout.tsx` or middleware
+**New command: `SaveUserInterestsCommand`**
+- **Input:** `Interests` (string array — category names)
+- **Auth:** Authenticated user
+- **Handler:** Saves interests as JSONB on UserEntity
+- **Migration:** Add `Interests` column (`jsonb`, nullable, default `null`) to `Users` table — included in the same migration as `InvitationTokens` table.
 
-**Logic:**
-- If `user.mustChangePassword === true` AND current path is NOT `/change-password` → redirect to `/change-password`
-- The `/change-password` page already exists (uses `ChangePasswordCommand`)
-- Add a banner: "You must change your password to continue"
-- Modify `ChangePasswordCommand` handler: after successful change, set `MustChangePassword = false`
-
-**Note:** The guard is a safety net. Normal invite flow goes through the wizard (step 1 sets password). The guard catches edge cases: user bookmarks the app, session persists, etc.
+**UserEntity change:** Add `Interests` property (`List<string>?`) with JSONB backing field (same pattern as `AgentDefinition.KbCardIds`).
 
 ---
 
@@ -229,16 +231,16 @@ GET    /api/v1/auth/validate-invitation?token=X        → ValidateInvitationTok
   - Status badge: "Invited" in amber
   - Subtitle: "Invited X ago · expires in Xd Xh"
 - Actions: "Resend" button inline
-- Data source: pending invitations mixed into user list query (or separate query merged client-side)
+- Data source: pending invitations fetched via separate `getInvitations({ status: 'Pending' })` call, merged client-side into user list
 
 ### B) Dedicated Page (`/admin/users/invitations`)
 
 - **Sidebar entry:** "Invitations" under Users section with pending count badge
 - **Header:** title + "Invite User" button + "Bulk Invite (CSV)" button
-- **Filter tabs:** All / Pending / Accepted / Expired (with counts)
+- **Filter tabs:** All / Pending / Accepted / Expired (with counts from `getInvitationStats()`)
 - **Table columns:** Email, Role (badge), Status (badge), Sent date, Expires/Accepted date, Actions
-- **Actions per row:** Resend (for Pending and Expired)
-- **Bulk invite dialog:** CSV file upload (drag & drop), preview table with per-row validation, confirm send, results summary
+- **Actions per row:** Resend (for Pending and Expired rows)
+- **Bulk invite dialog:** CSV file upload (drag & drop), preview table with per-row validation, confirm send, results summary (success/failure counts)
 
 ### Shared Components
 
@@ -253,18 +255,20 @@ New sub-client `createInvitationsClient()` registered in `createApiClient()`:
 
 ```typescript
 sendInvitation(email: string, role: string): Promise<InvitationDto>
-bulkSendInvitations(csv: File): Promise<BulkInviteResult>
+bulkSendInvitations(csvContent: string): Promise<BulkInviteResult>
 resendInvitation(id: string): Promise<InvitationDto>
 getInvitations(filters: InvitationFilters): Promise<PaginatedResult<InvitationDto>>
 getInvitationStats(): Promise<InvitationStats>
 validateInvitationToken(token: string): Promise<TokenValidation>
 ```
 
+Note: `bulkSendInvitations` receives `string` (the endpoint component reads the file and sends content). The `BulkInviteDialog` component reads the `File` to string client-side before calling the API.
+
 ---
 
 ## 7. Database Migration
 
-**Migration name:** `AddInvitationTokenAndMustChangePassword`
+**Migration name:** `AddInvitationTokensAndUserInterests`
 
 **Changes:**
 1. New table `InvitationTokens`:
@@ -275,7 +279,7 @@ validateInvitationToken(token: string): Promise<TokenValidation>
    - Composite index on `(Email, Status)` for fast lookup
    - Index on `ExpiresAt` for cleanup queries
 2. Alter table `Users`:
-   - Add column `MustChangePassword` (`bool`, NOT NULL, DEFAULT false)
+   - Add column `Interests` (`jsonb`, nullable, default `null`)
 
 ---
 
@@ -283,25 +287,25 @@ validateInvitationToken(token: string): Promise<TokenValidation>
 
 | Layer | Test Scope | Tool | Count (est.) |
 |-------|-----------|------|--------------|
-| Unit | `SendInvitationCommandHandler` — creates token, hashes, calls email | xUnit | 5-6 |
-| Unit | `AcceptInvitationCommandHandler` — validates token, creates user, sets MustChangePassword | xUnit | 6-8 |
-| Unit | `ResendInvitationCommandHandler` — expires old, creates new | xUnit | 3-4 |
-| Unit | `BulkSendInvitationsCommandHandler` — CSV parsing, validation, batch results | xUnit | 5-6 |
-| Unit | `ValidateInvitationTokenQueryHandler` — valid/expired/invalid cases | xUnit | 3-4 |
+| Unit | `SendInvitationCommandHandler` — creates token, hashes, calls email, extracts admin from session | xUnit | 5-6 |
+| Unit | `AcceptInvitationCommandHandler` — validates token, creates user, sets EmailVerified=true, null audit context | xUnit | 6-8 |
+| Unit | `ResendInvitationCommandHandler` — expires old, creates new, rejects if Accepted, rejects if user exists | xUnit | 5-6 |
+| Unit | `BulkSendInvitationsCommandHandler` — CSV parsing, validation, batch results, max 100 limit | xUnit | 5-6 |
+| Unit | `ValidateInvitationTokenQueryHandler` — valid/expired/invalid cases, no email in response | xUnit | 3-4 |
+| Unit | `SaveUserInterestsCommandHandler` — saves JSONB, validates categories | xUnit | 2-3 |
 | Unit | `InvitationStatusBadge`, `InviteUserDialog`, `BulkInviteDialog` rendering | Vitest | 8-10 |
 | Unit | `invitationsClient` — all API methods, error handling | Vitest | 6-8 |
-| Unit | `OnboardingWizard` — step navigation, skip, back, completion | Vitest | 8-10 |
+| Unit | `OnboardingWizard` — step navigation, skip, back, completion, auto-skip step 5, dynamic progress bar | Vitest | 10-12 |
 | Unit | `PasswordStep`, `ProfileStep`, `InterestsStep`, `FirstGameStep`, `FirstAgentStep` | Vitest | 10-12 |
-| Integration | Token expiry enforcement, resend invalidation, unique constraint | xUnit + Testcontainers | 4-5 |
-| Integration | MustChangePassword flag lifecycle (set on accept, clear on change) | xUnit + Testcontainers | 2-3 |
-| E2E | Admin: invite single user, verify in list + dedicated page | Playwright | 2-3 |
-| E2E | Admin: bulk CSV invite, verify results | Playwright | 1-2 |
+| Integration | Token expiry enforcement, resend invalidation, unique constraint, resend-already-expired idempotency | xUnit + Testcontainers | 5-6 |
+| E2E | Admin: invite single user, verify in user list (amber row) + dedicated page | Playwright | 2-3 |
+| E2E | Admin: bulk CSV invite, verify results summary | Playwright | 1-2 |
 | E2E | Admin: resend expired invitation | Playwright | 1 |
 | E2E | User: accept invite → password → skip onboarding → lands on home | Playwright | 1-2 |
 | E2E | User: accept invite → full onboarding (all 5 steps) | Playwright | 1-2 |
 | E2E | User: expired token → error page | Playwright | 1 |
 
-**Estimated total:** 60-80 tests
+**Estimated total:** 65-85 tests
 **Coverage target:** 90%+ backend, 85%+ frontend
 
 ---
@@ -309,22 +313,52 @@ validateInvitationToken(token: string): Promise<TokenValidation>
 ## 9. Security Considerations
 
 - **Token:** 32 bytes cryptographically random, base64url encoded, stored as SHA256 hash only
+- **Token transmission:** Always in POST body, never in GET query params (prevents server log/referrer/browser history exposure). Note: the initial email link uses `?token=xxx` in the URL for UX — the frontend extracts it and sends via POST to the API.
 - **Rate limit:** Max 10 invitations per minute per admin session (prevent spam)
+- **Validate endpoint rate limit:** Max 5 attempts per minute per IP (prevent brute force)
 - **Email validation:** Normalize to lowercase, validate format before sending
-- **Role escalation:** Cannot invite as SuperAdmin (validator rejects)
+- **Role escalation:** Cannot invite as SuperAdmin (validator rejects; string match against allowlist)
 - **Token reuse:** One-time use; marked Accepted after first use
-- **Brute force:** Rate limit on `/auth/accept-invitation` endpoint (5 attempts per minute per IP)
-- **CSRF:** AcceptInvitationCommand is POST with token in body (not query param for logging safety)
+- **User enumeration:** `ValidateInvitationTokenQuery` does NOT return email — prevents enumeration via forwarded links
+- **Audit trail:** `AcceptInvitationCommand` audit records have `adminUserId = null` (unauthenticated context); the inviting admin is traceable via `InvitationToken.InvitedByUserId`
 
 ---
 
 ## 10. Out of Scope
 
 - Email template editor/customizer (use hardcoded HTML template)
-- Invitation revoke/cancel (expires naturally in 7 days)
+- Invitation revoke/cancel button (expires naturally in 7 days; resend effectively cancels+renews)
 - Custom expiry per invitation (always 7 days)
 - Invitation analytics/reporting beyond basic stats
 - SSO/SAML invitation integration
+- `MustChangePassword` / forced password change feature (separate future feature — not needed for invitation flow since user sets own password)
+- `/change-password` standalone page (not needed without `MustChangePassword`)
 - Voice features (already implemented: `useVoiceInput`, `useVoiceOutput`, Web Speech API)
 - Audit log system (already implemented: `AuditLoggingBehavior` pipeline)
 - Role management UI (already implemented: `ChangeUserRoleCommand`)
+
+---
+
+## Appendix: Spec Review Fixes Applied (v2)
+
+Issues found during automated spec review and their resolutions:
+
+| # | Severity | Issue | Resolution |
+|---|----------|-------|------------|
+| 1 | CRITICAL | `MustChangePassword` deadlock — user sets password in Step 1 but flag forces redirect to nonexistent `/change-password` | Removed `MustChangePassword` from invitation flow entirely. User sets own password — no forced change needed. |
+| 2 | CRITICAL | `AcceptInvitationCommand` sets `MustChangePassword = true` immediately after user chose password | Same as above — flag removed from this flow |
+| 3 | HIGH | `UpdateUserPreferencesCommand` does not exist | Specified new `SaveUserInterestsCommand` with JSONB `Interests` field on UserEntity (Section 5A) |
+| 4 | HIGH | `/change-password` page does not exist | Removed from scope — not needed without `MustChangePassword` |
+| 5 | HIGH | `AcceptInvitationCommand` audit has null adminUserId | Documented as expected; `InvitedByUserId` provides admin audit trail |
+| 6 | HIGH | `ValidateInvitationTokenQuery` returns email (user enumeration risk) | Removed `email` from response — only `valid`, `role`, `expiresAt` returned |
+| 7 | HIGH | `IFormFile` in MediatR command violates CQRS | Endpoint converts `IFormFile` → `string`; command receives only `CsvContent: string` |
+| 8 | MEDIUM | `ResendInvitationCommand` doesn't check if invitation was Accepted | Added validation: status must be `Pending` or `Expired`, and no active user for email |
+| 9 | MEDIUM | Resend-already-expired case not explicitly tested | Added to integration test scope |
+| 10 | MEDIUM | Auto-skip step 5 creates hidden navigation branch | Documented: `totalSteps` computed dynamically; progress bar shows 4 or 5 steps |
+| 11 | MEDIUM | `UserRole` enum vs string mismatch | Changed `InvitationToken.Role` to `string`; documented enum is domain logic only |
+| 12 | MEDIUM | `(auth)` route group too narrow for wizard | Created new `(onboarding)` route group with full-width layout |
+| 13 | MEDIUM | GET validate endpoint logs token in server logs | Changed to POST with token in body (consistent with accept endpoint) |
+| 14 | LOW | `InvitedByUserId` not in command inputs | Documented: extracted from authenticated session in handler |
+| 15 | LOW | `GetInvitationsQuery` missing sort order | Added `SortBy` param with default `CreatedAt DESC` |
+| 16 | LOW | No documentation on how to cancel a pending invite | Added note: resend effectively cancels (expires old token) + renews |
+| 17 | LOW | `[AuditableAction]` on unauthenticated command | Documented: null adminUserId is expected and acceptable |

--- a/docs/superpowers/specs/2026-03-11-admin-invite-onboarding-design.md
+++ b/docs/superpowers/specs/2026-03-11-admin-invite-onboarding-design.md
@@ -1,398 +1,330 @@
-# Admin Invite, Onboarding, Voice Chat & User Management
+# User Invitation System & Onboarding Wizard — Design Spec
 
-**Date**: 2026-03-11
-**Status**: Draft
-**Approach**: Incremental (4 independent phases)
+> **Date:** 2026-03-11
+> **Status:** Approved
+> **Scope:** Admin user invitation flow (single + bulk), accept-invite with onboarding wizard, forced password change
 
-## Overview
+---
 
-End-to-end flow: admin invites users via email → forced password change → guided onboarding wizard → voice-enabled agent chat → admin role management with full audit logging.
+## Problem Statement
 
-### Decisions Summary
+Administrators need to invite users to MeepleAI by email. Currently, user creation (`CreateUserCommand`) requires setting a password at creation time with no invitation workflow. There is no mechanism for:
+
+- Sending invitation emails with a secure token link
+- Allowing invited users to set their own password
+- Forcing password change on first login
+- Guided onboarding for new users
+
+## Design Decisions
 
 | Decision | Choice | Rationale |
 |----------|--------|-----------|
-| Invite mechanism | Token-based link (no password in email) | Security — reuses password-reset pattern |
-| Onboarding | Step-by-step wizard (skippable) | Guided but not blocking |
-| Voice STT | Whisper API + Web Speech API fallback | Quality + resilience |
-| Voice TTS | Browser-native SpeechSynthesis | Free, sufficient quality |
-| Paid features | Whisper (cloud STT) gated by UserTier | Free users get browser-native STT |
-| Admin UX | Inline role change + dedicated audit page | Quick ops + deep analysis |
-| Audit scope | Everything (auth, activity, API, errors) | Full visibility, integrates with Epic #124 |
-| Architecture | 4 independent phases | Low risk, incremental value |
+| Password handling | No default password — token-based invite | More secure; no password in transit; reuses existing token patterns |
+| Token storage | SHA256 hash only | Same pattern as PasswordReset; plaintext only in email |
+| Token expiry | 7 days | Longer than password reset (24h) since invites need more time |
+| Resend behavior | New token, old marked Expired | One active invite per email at a time |
+| Revoke | No explicit revoke | Token expires naturally in 7 days |
+| Admin UI | B+C: inline in user list + dedicated page | Quick visibility + full management power |
+| Onboarding | 5-step wizard, only password mandatory | Low friction; user can skip and explore later |
+| Bounded context | Authentication (token + accept) + Administration (admin endpoints) | Follows existing separation |
+| Bulk invite | CSV upload (email,role per row), max 100 per batch | Matches existing BulkImportUsersCommand pattern |
 
-### Open Issues Check
+---
 
-No duplicate issues found among 70+ open issues. Related:
-- **#33** "Epic: Email, Notifiche & Calendario" — email infra exists, no invite flow
-- **#130** "Audit Trail Viewer tab" — will be covered by Phase 4
-- **#124** "Epic: Admin Infrastructure Panel" — audit log integrates with this
+## 1. Domain Model
 
-## Existing Infrastructure
+### New Entity: `InvitationToken` (Authentication BC)
 
-| Component | Status | Location |
-|-----------|--------|----------|
-| `CreateUserCommand` | Exists | `Administration/Application/Commands/` |
-| Email template system | Exists | `UserNotifications/` (queue + templates + event handlers) |
-| Password reset flow | Exists | `Authentication/Application/Commands/` + `/reset-password` page |
-| 5-tier role hierarchy | Exists | `SharedKernel/Domain/ValueObjects/Role.cs` (user/editor/creator/admin/superadmin) |
-| `UserTier` on User | Exists | `Authentication/Domain/Entities/User.cs` |
-| Agent builder modal | Exists | `components/admin/shared-games/AgentBuilderModal.tsx` |
-| Chat with agent (SSE) | Exists | KnowledgeBase endpoints |
-| `PUT /admin/users/{id}` (general update) | Exists | `Routing/AdminUserEndpoints.cs` |
-| `POST /admin/users/bulk/role-change` | Exists | `Routing/AdminUserEndpoints.cs` |
-| `GET /admin/users/{id}/role-history` | Exists | `Routing/AdminUserEndpoints.cs` |
-| `PUT /admin/users/{id}/role` (dedicated) | **Needed** | Must be created in Phase 4 |
-| Voice/speech features | None | Zero speech-to-text in codebase |
-| Invite system | None | No invitation entity or flow |
-| Forced password change | None | No `MustChangePassword` flag |
-| Onboarding wizard | None | Welcome page auto-redirects to dashboard |
+| Field | Type | Constraints |
+|-------|------|-------------|
+| `Id` | `Guid` | PK |
+| `Email` | `string` | Required, max 256, normalized lowercase |
+| `Role` | `UserRole` | Required (User, Editor, Admin) |
+| `TokenHash` | `string` | Required, unique index, SHA256 of plaintext token |
+| `InvitedByUserId` | `Guid` | FK → Users, required |
+| `Status` | `InvitationStatus` | Required, default `Pending` |
+| `ExpiresAt` | `DateTime` | Required, CreatedAt + 7 days |
+| `AcceptedAt` | `DateTime?` | Set when user completes password step |
+| `AcceptedByUserId` | `Guid?` | FK → Users, set on accept |
+| `CreatedAt` | `DateTime` | Audit |
 
-## Phase 1: Admin Invite System
+**`InvitationStatus` enum:** `Pending`, `Accepted`, `Expired`
 
-### Backend
+**Domain rules:**
+- Max 1 `Pending` invitation per email at any time
+- Resend = mark old as `Expired`, create new with fresh token
+- Token validated by: hash match + status == `Pending` + `ExpiresAt > now`
+- SuperAdmin role cannot be assigned via invitation (admin-only escalation)
 
-#### New Entity: `UserInvitation` (Authentication bounded context)
+### Modified Entity: `UserEntity`
+
+Add field:
+
+| Field | Type | Default | Purpose |
+|-------|------|---------|---------|
+| `MustChangePassword` | `bool` | `false` | Set `true` on invitation accept; forces redirect to `/change-password` |
+
+**Guard behavior:** Authenticated layout middleware checks `user.mustChangePassword`. If `true`, redirect to `/change-password`. The change-password page clears the flag on success via existing `ChangePasswordCommand` (modified to set `MustChangePassword = false`).
+
+---
+
+## 2. Backend: Commands & Handlers
+
+### New Commands (Authentication BC)
+
+#### `SendInvitationCommand`
+- **Input:** `Email`, `Role`
+- **Auth:** Admin+ role required
+- **Validation:** Valid email format, role != SuperAdmin, no existing Pending invite for email, no existing active user with email
+- **Handler:**
+  1. Generate cryptographically random token (32 bytes, base64url)
+  2. Create `InvitationToken` entity with `SHA256(token)` as `TokenHash`
+  3. Call `IEmailService.SendInvitationEmailAsync(email, adminName, role, inviteUrl, expiresAt)`
+  4. Return `InvitationDto` (id, email, role, status, expiresAt)
+- **Audit:** `[AuditableAction]`
+
+#### `BulkSendInvitationsCommand`
+- **Input:** `CsvContent` (string) or `CsvFile` (IFormFile)
+- **Auth:** Admin+ role required
+- **CSV format:** `email,role` per row (header optional)
+- **Validation:** Each row validated individually; max 100 invites per batch
+- **Handler:**
+  1. Parse CSV, validate each row
+  2. For each valid row: execute `SendInvitationCommand` logic
+  3. Collect results: `{ successful: InvitationDto[], failed: { email, error }[] }`
+- **Audit:** `[AuditableAction]` with batch metadata
+
+#### `AcceptInvitationCommand`
+- **Input:** `Token` (plaintext from URL), `Password`, `ConfirmPassword`
+- **Auth:** Unauthenticated (public endpoint)
+- **Validation:** Password min 8 chars, upper + lower + digit, passwords match, token not empty
+- **Handler:**
+  1. Hash token with SHA256, find `InvitationToken` by hash
+  2. Validate: status == `Pending`, `ExpiresAt > now`
+  3. Create `UserEntity` with email from invitation, hashed password, assigned role, `MustChangePassword = true`
+  4. Mark invitation as `Accepted`, set `AcceptedAt` and `AcceptedByUserId`
+  5. Create session (auto-login) — return auth cookie + user data
+- **Audit:** `[AuditableAction]`
+
+#### `ResendInvitationCommand`
+- **Input:** `InvitationId` (Guid)
+- **Auth:** Admin+ role required
+- **Handler:**
+  1. Find existing invitation by Id
+  2. Mark as `Expired`
+  3. Generate new token, create new `InvitationToken` for same email + role
+  4. Send email
+  5. Return new `InvitationDto`
+- **Audit:** `[AuditableAction]`
+
+### New Queries
+
+#### `GetInvitationsQuery`
+- **Input:** `Status?` (filter), `Page`, `PageSize`
+- **Auth:** Admin+
+- **Returns:** `PaginatedResult<InvitationDto>`
+
+#### `GetInvitationStatsQuery`
+- **Auth:** Admin+
+- **Returns:** `{ pending: int, accepted: int, expired: int, total: int }`
+
+#### `ValidateInvitationTokenQuery`
+- **Input:** `Token` (plaintext)
+- **Auth:** Unauthenticated
+- **Returns:** `{ valid: bool, email: string?, role: string?, expiresAt: DateTime? }`
+
+---
+
+## 3. Backend: Endpoints
+
+### Admin Endpoints (AdminUserEndpoints.cs)
 
 ```
-UserInvitation
-├── Id: Guid
-├── Email: string
-├── Role: string
-├── DisplayName: string
-├── InvitationToken: string (hashed)
-├── ExpiresAt: DateTime (48h from creation)
-├── Status: InvitationStatus (Pending | Accepted | Expired | Revoked)
-├── CreatedBy: Guid (admin userId)
-├── AcceptedAt: DateTime?
-├── CreatedAt: DateTime
-└── UpdatedAt: DateTime
+POST   /api/v1/admin/users/invite                    → SendInvitationCommand
+POST   /api/v1/admin/users/bulk/invite                → BulkSendInvitationsCommand
+POST   /api/v1/admin/users/invitations/{id}/resend    → ResendInvitationCommand
+GET    /api/v1/admin/users/invitations                → GetInvitationsQuery
+GET    /api/v1/admin/users/invitations/stats           → GetInvitationStatsQuery
 ```
 
-#### Modifications to `User` entity
-
-- `MustChangePassword: bool` (default: false)
-- `InvitedBy: Guid?` (nullable — tracks who invited)
-
-#### Flow
-
-1. Admin calls `POST /admin/users/invite` with `{email, role, displayName}`
-2. Handler validates: reject if email already registered (409 Conflict). Reject if pending invitation exists for same email (409 Conflict with "invitation already pending" message). Creates `UserInvitation` only — **no User record yet**.
-3. Email sent via new `SendInvitationEmailCommand` (MediatR, not direct service injection — `IEmailTemplateService` is `internal` to UserNotifications). Template data: `{inviteLink, adminName, expiresAt, displayName}`.
-4. Email contains link: `/accept-invite?token=xxx`
-5. User clicks → `POST /auth/accept-invite` validates token (checks: not expired, not already accepted, not revoked — single-use enforcement). Creates `User` record at this point (with random password, `MustChangePassword = true`, `OnboardingCompleted = false`, `EmailVerified = true` — admin-supplied email is trusted). Marks invitation as `Accepted`. Creates temporary session → redirect to `/change-password`.
-6. User changes password via `UpdatePassword` (admin-path, no current password required — NOT `ChangePassword` which requires current password verification) → `MustChangePassword = false` → redirect to onboarding wizard.
-
-#### Invitation cleanup
-
-- Expired invitations: background job marks `Pending` → `Expired` after 48h. No ghost User records exist (User created only at acceptance).
-- Revoked invitations: admin action, only affects `UserInvitation` status. No User cleanup needed.
-- Re-invite: admin can create new invitation for same email after previous one is Expired or Revoked.
-
-#### Login guard
-
-On every login, if `MustChangePassword == true`, redirect to `/change-password`. No access to other pages. Enforced server-side: all authenticated endpoints (except `/change-password` and `/logout`) return 403 with `must_change_password` error code.
-
-#### New Commands
-
-- `InviteUserCommand(Email, Role, DisplayName)` → validates uniqueness, creates invitation only (no User yet), sends email via `SendInvitationEmailCommand`
-- `AcceptInvitationCommand(Token)` → validates token (not expired, not used, not revoked), creates User, marks invitation accepted, creates session
-- `RevokeInvitationCommand(InvitationId)` → marks as revoked (admin action)
-- `SendInvitationEmailCommand(Email, TemplateData)` → new command in UserNotifications for invitation-specific emails (avoids abusing `EnqueueEmailCommand` which has document-processing schema: `FileName`, `DocumentUrl`, `ErrorMessage`)
-
-#### New Queries
-
-- `GetPendingInvitationsQuery` → list for admin UI
-- `GetInvitationByTokenQuery(Token)` → for accept-invite page
-
-#### New Endpoints
-
-- `POST /admin/users/invite` → InviteUserCommand
-- `POST /auth/accept-invite` → AcceptInvitationCommand
-- `DELETE /admin/users/invitations/{id}` → RevokeInvitationCommand
-- `GET /admin/users/invitations` → GetPendingInvitationsQuery
-
-### Frontend
-
-#### Admin UI
-
-- Button "Invita Utente" in the user list page → opens modal
-- Modal fields: Email, DisplayName, Role (dropdown: user/editor/creator/admin)
-- Pending invitations table (with revoke action)
-
-#### Auth Pages
-
-- New page `/accept-invite` — validates token, shows welcome message, redirects to `/change-password`
-- Modified `/change-password` — handles invite flow (post-change redirects to `/onboarding` instead of dashboard)
-
-#### Email Template
-
-- Template "invitation" — contains: admin name who invited, link to accept, expiration notice
-- Sent via new `SendInvitationEmailCommand` (not `EnqueueEmailCommand` which has incompatible schema)
-- Template rendered by a new `RenderInvitationEmail` method on a new or extended template service
-
-## Phase 2: Onboarding Wizard
-
-### Backend
-
-#### Modifications to `User` entity
-
-- `OnboardingCompleted: bool` (default: true for existing users, false for invited)
-- `OnboardingCompletedAt: DateTime?`
-- `OnboardingSkipped: bool` (default: false — for analytics)
-
-#### New Command
-
-- `CompleteOnboardingCommand(SkippedSteps: string[]?)` → sets `OnboardingCompleted = true`, records skipped steps in `AuditLogEntry.Details` (JSONB) when Phase 4 is active. Also stored in User entity for analytics queries.
-
-#### Existing endpoints used (no changes needed)
-
-- `POST /api/v1/user-library/games` — add game to collection
-- `POST /api/v1/agent-definitions` — create agent
-- Chat SSE endpoint — talk to agent
-
-### Frontend
-
-#### Wizard (`/onboarding`) — 3 steps
-
-**Step 1: "Aggiungi il tuo primo gioco"**
-- Search SharedGame catalog
-- Click to add to collection
-- Shows preview of selected game
-- "Salta questo step →" link bottom-right
-
-**Step 2: "Crea il tuo primo agente"**
-- Simplified form (name auto-generated from game, KB cards pre-selected)
-- Streamlined version of AgentBuilderModal
-- "Salta questo step →" link bottom-right
-
-**Step 3: "Prova a chiedergli qualcosa"**
-- Inline mini-chat with the agent just created
-- Pre-filled suggestions: "Qual è lo scopo del gioco?" / "Descrivi un turno di gioco"
-- "Completa" button to finish
-- "Salta questo step →" link bottom-right
-
-#### Skip controls
-
-- **Per-step skip**: "Salta questo step →" link on each step. Step marked as "skipped" (not "completed").
-- **Skip all**: "Salta il wizard" link in header top-right. Confirmation: "Puoi trovare queste funzionalità nella dashboard quando vuoi". Sets `OnboardingCompleted = true`, `OnboardingSkipped = true`.
-
-#### Navigation guard
-
-- Next.js middleware: if `onboardingCompleted === false`, redirect to `/onboarding`
-- Exceptions: `/change-password`, `/logout`, `/accept-invite`, `/api/*`
-- **Interaction with email verification**: invited users have `EmailVerified = true` set at acceptance time (admin-supplied email is trusted), so the email verification guard does not interfere with onboarding
-
-#### Dashboard reminder
-
-- If user skipped onboarding, show dismissible banner: "Non hai completato il setup — riprendi da dove eri rimasto"
-- Dismiss stored in localStorage, does not reappear
-
-#### Visual design
-
-- Progress bar at top: 3 dots with current step highlighted
-- Glassmorphic style consistent with design system (bg-white/70, backdrop-blur-md, amber accents)
-- Font: Quicksand headings, Nunito body
-
-## Phase 3: Voice in Chat
-
-### Backend
-
-#### New endpoint (proxy for Whisper)
-
-- `POST /api/v1/speech/transcribe`
-  - Receives: audio blob (webm/ogg)
-  - Sends to: OpenAI Whisper API
-  - Returns: `{ text: string, language: string, duration: number }`
-  - Auth: requires valid session
-  - **Tier gating**: free users → `403 Forbidden` with message
-  - Rate limit: max 60 requests/hour per user (paid tier)
-
-#### Configuration
-
-- New secret file: `infra/secrets/speech.secret`
-  ```
-  WHISPER_API_KEY=sk-...
-  WHISPER_MODEL=whisper-1
-  ```
-- Priority: optional (speech features degrade gracefully)
-
-### Frontend
-
-#### Mic button in chat input
-
-- `Mic` icon (Lucide) next to Send button
-- Click → starts recording (`MediaRecorder API`)
-- Icon turns red + pulses + shows duration
-- Click again (or auto-stop after 30s) → sends audio
-
-#### STT flow
-
-1. Check user tier
-2. If paid → try `POST /api/v1/speech/transcribe` (Whisper)
-3. If free OR Whisper fails (503, timeout, no API key) → fallback to `webkitSpeechRecognition` / `SpeechRecognition`
-4. Transcribed text appears in input field → user can edit before sending
-5. Visual indicator: "🎙️ HD" (Whisper, paid) or "🎙️" (browser, free)
-
-#### TTS for responses
-
-- When user sent last message via mic, agent response is read aloud via `SpeechSynthesis API` (browser-native, free for all tiers)
-- Speaker 🔊 button on each agent message for manual replay
-- Global toggle "Auto-lettura" in chat header (default: on when using mic)
-- Language auto-detect from response (Italian/English)
-
-#### Tier gating rule
-
-- Cloud APIs (Whisper STT, future cloud TTS) → paid tier only (tier `Normal` or `Premium` — NOT `Free`)
-- Browser-native features (Web Speech API, SpeechSynthesis) → all tiers including `Free`
-- Tier check: backend `tier != "free"`, frontend reads `user.tier` from session
-- Tooltip for free users on mic: "Trascrizione base — Upgrade per qualità HD"
-
-#### Browser permissions
-
-- First mic click → requests microphone permission
-- If denied → toast: "Permesso microfono necessario" with link to settings
-
-#### New components
-
-- `VoiceChatButton` — toggle recording, shows state (idle/recording/transcribing)
-- `useAudioRecorder()` hook — manages MediaRecorder + audio blob
-- `SpeechService` class — abstracts Whisper vs Web Speech API with automatic fallback
-- `TextToSpeechButton` — speaker button on single message
-- `useTextToSpeech()` hook — manages SpeechSynthesis lifecycle
-
-## Phase 4: Admin User Management + Audit
-
-### Backend
-
-#### New Entity: `AuditLogEntry` (Administration bounded context)
+### Public Auth Endpoints (AuthenticationEndpoints.cs)
 
 ```
-AuditLogEntry
-├── Id: Guid
-├── UserId: Guid (subject — who was affected)
-├── ActorId: Guid (who performed the action)
-├── Action: AuditAction (enum)
-├── Details: string (JSONB — flexible payload per event type)
-├── IpAddress: string?
-├── UserAgent: string?
-├── CreatedAt: DateTime
+POST   /api/v1/auth/accept-invitation                 → AcceptInvitationCommand
+GET    /api/v1/auth/validate-invitation?token=X        → ValidateInvitationTokenQuery
 ```
 
-#### `AuditAction` enum
+---
 
+## 4. Email Template
+
+**Method:** `IEmailService.SendInvitationEmailAsync(email, inviterName, role, inviteUrl, expiresAt)`
+
+**Email content:**
+- **Subject:** "You're invited to MeepleAI"
+- **Body:** HTML branded template following existing email style
+  - Logo header
+  - "{InviterName} has invited you to join MeepleAI as {Role}"
+  - CTA button: "Accept Invitation" → `{Frontend:BaseUrl}/accept-invite?token={token}`
+  - Expiry notice: "This invitation expires on {expiresAt:format}"
+  - Fallback: plaintext link below button
+  - Footer: "If you didn't expect this invitation, you can safely ignore this email."
+
+---
+
+## 5. Frontend: Accept Invitation & Onboarding
+
+### Route: `/accept-invite` (auth route group, unauthenticated)
+
+**Entry flow:**
+1. URL: `/accept-invite?token=xxx`
+2. Call `ValidateInvitationTokenQuery` to check token
+3. If invalid/expired → error page with "Contact your administrator" message
+4. If valid → show `OnboardingWizard`
+
+### OnboardingWizard (5 steps)
+
+| Step | Required | Component | API Call |
+|------|----------|-----------|----------|
+| 1. Set Password | Yes | `PasswordStep` | `AcceptInvitationCommand` (creates user + auto-login) |
+| 2. Profile | Skippable | `ProfileStep` | `UpdateUserProfileCommand` |
+| 3. Interests | Skippable | `InterestsStep` | `UpdateUserPreferencesCommand` (or new) |
+| 4. First Game | Skippable | `FirstGameStep` | `AddGameToLibraryCommand` |
+| 5. First Agent | Skippable | `FirstAgentStep` | `CreateAgentDefinitionCommand` |
+
+**Step 1 (Password)** is the critical step — it calls `AcceptInvitationCommand` which creates the user and returns an auth session. Steps 2-5 execute as authenticated API calls.
+
+**Components:**
+- `OnboardingWizard` — stepper with progress bar, skip/next/back navigation
+- `PasswordStep` — password + confirm fields, strength meter, validation rules display (reuse pattern from `/reset-password`)
+- `ProfileStep` — display name input + avatar upload
+- `InterestsStep` — checkbox grid with game category icons (Strategy, Party, Cooperative, Family, Thematic, Abstract, Card, Dice, Miniatures)
+- `FirstGameStep` — search bar with debounce → catalog results as cards → click to add
+- `FirstAgentStep` — conditional: if game was added in step 4, show "Create an AI assistant for {GameName}?" toggle + agent name input. If no game, auto-skip.
+
+**Post-completion:** redirect to `/` (home dashboard)
+
+### MustChangePassword Guard
+
+**Location:** `(authenticated)/layout.tsx` or middleware
+
+**Logic:**
+- If `user.mustChangePassword === true` AND current path is NOT `/change-password` → redirect to `/change-password`
+- The `/change-password` page already exists (uses `ChangePasswordCommand`)
+- Add a banner: "You must change your password to continue"
+- Modify `ChangePasswordCommand` handler: after successful change, set `MustChangePassword = false`
+
+**Note:** The guard is a safety net. Normal invite flow goes through the wizard (step 1 sets password). The guard catches edge cases: user bookmarks the app, session persists, etc.
+
+---
+
+## 6. Frontend: Admin Invitation UI
+
+### C) Inline in User List (`/admin/users`)
+
+- Pending invitations appear as rows in the existing users table
+- Visual differentiation:
+  - Row background: `bg-amber-50`
+  - Avatar: mail icon with dashed amber border (instead of initials circle)
+  - Status badge: "Invited" in amber
+  - Subtitle: "Invited X ago · expires in Xd Xh"
+- Actions: "Resend" button inline
+- Data source: pending invitations mixed into user list query (or separate query merged client-side)
+
+### B) Dedicated Page (`/admin/users/invitations`)
+
+- **Sidebar entry:** "Invitations" under Users section with pending count badge
+- **Header:** title + "Invite User" button + "Bulk Invite (CSV)" button
+- **Filter tabs:** All / Pending / Accepted / Expired (with counts)
+- **Table columns:** Email, Role (badge), Status (badge), Sent date, Expires/Accepted date, Actions
+- **Actions per row:** Resend (for Pending and Expired)
+- **Bulk invite dialog:** CSV file upload (drag & drop), preview table with per-row validation, confirm send, results summary
+
+### Shared Components
+
+- `InviteUserDialog` — modal form: email input + role select dropdown → shared between user list and invitations page
+- `BulkInviteDialog` — CSV upload with drag & drop, preview table, validation feedback, send confirmation
+- `InvitationStatusBadge` — Pending (amber), Accepted (green), Expired (red)
+- `InvitationRow` — reusable table row component for both views
+
+### Admin API Client
+
+New sub-client `createInvitationsClient()` registered in `createApiClient()`:
+
+```typescript
+sendInvitation(email: string, role: string): Promise<InvitationDto>
+bulkSendInvitations(csv: File): Promise<BulkInviteResult>
+resendInvitation(id: string): Promise<InvitationDto>
+getInvitations(filters: InvitationFilters): Promise<PaginatedResult<InvitationDto>>
+getInvitationStats(): Promise<InvitationStats>
+validateInvitationToken(token: string): Promise<TokenValidation>
 ```
-RoleChanged, UserInvited, InviteAccepted, InviteRevoked,
-PasswordChanged, Login, LoginFailed, Logout,
-AccountSuspended, AccountUnlocked, AccountBanned,
-TierChanged, OnboardingCompleted, OnboardingSkipped,
-GameAdded, GameRemoved, AgentCreated, AgentDeleted,
-ChatMessage, PdfUploaded, PdfDeleted,
-VoiceTranscription, SettingsChanged,
-ApiError, RateLimitExceeded
-```
 
-#### Event-driven architecture
+---
 
-Each bounded context publishes domain events → a centralized handler in Administration writes `AuditLogEntry`. **Exception**: `RoleChangedEvent` in Authentication bounded context must be modified to include `ChangedById: Guid` (currently only has `UserId`, `OldRole`, `NewRole`). The `User.AssignRole`/`User.UpdateRole` methods must accept and forward the actor ID.
+## 7. Database Migration
 
-#### New Endpoints
+**Migration name:** `AddInvitationTokenAndMustChangePassword`
 
-- `PUT /admin/users/{id}/role` → `ChangeUserRoleCommand(UserId, NewRole)` — dedicated role change endpoint (currently only bulk `POST /admin/users/bulk/role-change` exists)
-- `GET /admin/audit-log` — paginated list, filters: userId, action, dateFrom, dateTo, actorId, search
-- `GET /admin/audit-log/export` — CSV export
-- `GET /admin/users/{id}/audit-log` — filtered log for single user
+**Changes:**
+1. New table `InvitationTokens`:
+   - All fields from domain model (Section 1)
+   - FK `InvitedByUserId` → `Users(Id)` (ON DELETE RESTRICT)
+   - FK `AcceptedByUserId` → `Users(Id)` (ON DELETE SET NULL)
+   - Unique index on `TokenHash`
+   - Composite index on `(Email, Status)` for fast lookup
+   - Index on `ExpiresAt` for cleanup queries
+2. Alter table `Users`:
+   - Add column `MustChangePassword` (`bool`, NOT NULL, DEFAULT false)
 
-#### Domain event: `RoleChangedEvent` (modification)
+---
 
-- **Existing** in Authentication bounded context — must add `ChangedById: Guid` property
-- Updated payload: userId, oldRole, newRole, changedById
+## 8. Testing Strategy
 
-#### Retention
+| Layer | Test Scope | Tool | Count (est.) |
+|-------|-----------|------|--------------|
+| Unit | `SendInvitationCommandHandler` — creates token, hashes, calls email | xUnit | 5-6 |
+| Unit | `AcceptInvitationCommandHandler` — validates token, creates user, sets MustChangePassword | xUnit | 6-8 |
+| Unit | `ResendInvitationCommandHandler` — expires old, creates new | xUnit | 3-4 |
+| Unit | `BulkSendInvitationsCommandHandler` — CSV parsing, validation, batch results | xUnit | 5-6 |
+| Unit | `ValidateInvitationTokenQueryHandler` — valid/expired/invalid cases | xUnit | 3-4 |
+| Unit | `InvitationStatusBadge`, `InviteUserDialog`, `BulkInviteDialog` rendering | Vitest | 8-10 |
+| Unit | `invitationsClient` — all API methods, error handling | Vitest | 6-8 |
+| Unit | `OnboardingWizard` — step navigation, skip, back, completion | Vitest | 8-10 |
+| Unit | `PasswordStep`, `ProfileStep`, `InterestsStep`, `FirstGameStep`, `FirstAgentStep` | Vitest | 10-12 |
+| Integration | Token expiry enforcement, resend invalidation, unique constraint | xUnit + Testcontainers | 4-5 |
+| Integration | MustChangePassword flag lifecycle (set on accept, clear on change) | xUnit + Testcontainers | 2-3 |
+| E2E | Admin: invite single user, verify in list + dedicated page | Playwright | 2-3 |
+| E2E | Admin: bulk CSV invite, verify results | Playwright | 1-2 |
+| E2E | Admin: resend expired invitation | Playwright | 1 |
+| E2E | User: accept invite → password → skip onboarding → lands on home | Playwright | 1-2 |
+| E2E | User: accept invite → full onboarding (all 5 steps) | Playwright | 1-2 |
+| E2E | User: expired token → error page | Playwright | 1 |
 
-- 90 days default, configurable via SystemConfiguration
-- Background job for cleanup: `AuditLogCleanupJob` (Quartz)
+**Estimated total:** 60-80 tests
+**Coverage target:** 90%+ backend, 85%+ frontend
 
-### Frontend
+---
 
-#### Inline role change (existing user list)
+## 9. Security Considerations
 
-- Role dropdown directly in user table row
-- Change → confirmation modal: "Cambiare il ruolo di {nome} da {old} a {new}?"
-- Success/error toast
+- **Token:** 32 bytes cryptographically random, base64url encoded, stored as SHA256 hash only
+- **Rate limit:** Max 10 invitations per minute per admin session (prevent spam)
+- **Email validation:** Normalize to lowercase, validate format before sending
+- **Role escalation:** Cannot invite as SuperAdmin (validator rejects)
+- **Token reuse:** One-time use; marked Accepted after first use
+- **Brute force:** Rate limit on `/auth/accept-invitation` endpoint (5 attempts per minute per IP)
+- **CSRF:** AcceptInvitationCommand is POST with token in body (not query param for logging safety)
 
-#### "Activity" tab in user detail
+---
 
-- New tab in admin user detail page
-- Chronological timeline of user events (login, actions, role changes)
-- Filter by event type
-- Infinite scroll or pagination
+## 10. Out of Scope
 
-#### Dedicated Audit Log page (`/admin/monitor/audit`)
-
-- Full-width table with all cross-user events
-- Filters: user, event type, date range, actor
-- Full-text search in details
-- CSV export button
-- Integrates with Epic #124 (#130 Audit Trail Viewer) — replaces that issue's scope
-
-### Integration with existing issues
-
-- **#130** "Audit Trail Viewer" → covered by this implementation, can be closed
-- **#140** "Log Viewer" → remains separate (application logs, not audit)
-- **#124** "Epic: Admin Infrastructure Panel" → audit becomes part of this epic
-
-## Cross-Phase Concerns
-
-### Database Migrations
-
-Each phase adds its own migration:
-- Phase 1: `AddUserInvitations` + `AddMustChangePasswordToUser`
-- Phase 2: `AddOnboardingFieldsToUser`
-- Phase 3: No migration (only new secret file)
-- Phase 4: `AddAuditLogEntries` — **must include indexes**: `IX_AuditLogEntry_CreatedAt` (for retention cleanup job), `IX_AuditLogEntry_UserId_CreatedAt` (for per-user queries), `IX_AuditLogEntry_Action` (for event type filtering)
-
-### Testing Strategy
-
-| Phase | Unit Tests | Integration Tests | E2E Tests |
-|-------|-----------|-------------------|-----------|
-| 1 | Invitation commands, validators, handlers | DB: create/accept/revoke invitation | Full invite → accept → change password flow |
-| 2 | Wizard step logic, skip handling | Onboarding completion command | Wizard 3-step walkthrough + skip |
-| 3 | SpeechService fallback logic, tier gating | Whisper proxy endpoint | Mic → transcribe → send → TTS response |
-| 4 | Audit event handlers, role change | Audit query filters, pagination | Role change → verify audit log entry |
-
-### Security Considerations
-
-- Invitation tokens: cryptographically random, hashed in DB, single-use, 48h expiry
-- `MustChangePassword` enforced server-side (not just frontend redirect)
-- Whisper proxy validates session + tier before forwarding audio
-- Audit log entries are immutable (no update/delete endpoints)
-- Audio blobs not stored — transcribed and discarded
-- Rate limiting on voice endpoint (60/hour)
-
-### Git Workflow
-
-Each phase = separate feature branch → PR to `main-dev`:
-- `feature/issue-XXX-admin-invite-system`
-- `feature/issue-XXX-onboarding-wizard`
-- `feature/issue-XXX-voice-chat`
-- `feature/issue-XXX-admin-audit-management`
-
-After creating each branch: `git config branch.<feature>.parent main-dev` to ensure PRs target correct base.
-
-## Spec Review Fixes Applied
-
-Issues found during automated spec review (10 total, all resolved):
-
-| # | Issue | Fix |
-|---|-------|-----|
-| 1 | `EnqueueEmailCommand` incompatible schema | New `SendInvitationEmailCommand` introduced |
-| 2 | `RoleChangedEvent` missing `ActorId` | Spec now requires modification to add `ChangedById` |
-| 3 | `POST /admin/users/{id}/role` doesn't exist | Corrected infra table; new `PUT` endpoint in Phase 4 |
-| 4 | `ChangePassword` requires current password | Flow now uses `UpdatePassword` (admin-path) |
-| 5 | Onboarding guard conflicts with email verification | Invited users get `EmailVerified = true`; `/accept-invite` added to exceptions |
-| 6 | Missing edge cases (duplicate email, token reuse) | Full validation rules + single-use enforcement documented |
-| 7 | `IEmailTemplateService` is `internal` | Uses MediatR command (not direct service injection) |
-| 8 | "Paid tier" not mapped to enum values | Explicitly: `Normal` or `Premium` = paid, `Free` = gated |
-| 9 | No DB indexes on AuditLogEntry | 3 indexes specified in migration |
-| 10 | Ghost user accounts at invite-send | User created at acceptance time only, not at invite-send |
+- Email template editor/customizer (use hardcoded HTML template)
+- Invitation revoke/cancel (expires naturally in 7 days)
+- Custom expiry per invitation (always 7 days)
+- Invitation analytics/reporting beyond basic stats
+- SSO/SAML invitation integration
+- Voice features (already implemented: `useVoiceInput`, `useVoiceOutput`, Web Speech API)
+- Audit log system (already implemented: `AuditLoggingBehavior` pipeline)
+- Role management UI (already implemented: `ChangeUserRoleCommand`)


### PR DESCRIPTION
## Summary
- **Auto-refresh toggle** with configurable interval (15/30/60s) and visual countdown
- **Uptime % badges** per service (green >99%, yellow >95%, red <95%) — estimated from current health state
- **Response time trend indicators** (up/down/stable arrows) comparing last 2 checks
- **Last incident timestamp** per service (shown in expanded view)
- **Status transition animation** (smooth color change on status dot)
- **Compact vs expanded view toggle** (hides Last Incident + Error columns)
- **Services grouped by category** with collapsible sections (Core Infrastructure, AI Services, External APIs, Monitoring)
- **Prometheus metrics KPI row** displaying API requests, avg latency, error rate, and LLM cost
- **Backend endpoint** `GET /api/v1/admin/infrastructure/services/dashboard` with MediatR CQRS pattern
- **New route**: `/admin/monitor/services`

## Files Changed (14 files, +1800 lines)

### Backend
- `DTOs/EnhancedServiceDashboardDto.cs` — 3 sealed record DTOs
- `GetServiceDashboardQuery.cs` + `GetServiceDashboardQueryHandler.cs` — MediatR handler enriching health data
- `MonitoringEndpoints.cs` — New `/admin/infrastructure/services/dashboard` endpoint
- `GetServiceDashboardQueryHandlerTests.cs` — 11 unit tests

### Frontend
- `ServicesDashboard.tsx` — Main component with all UI features
- `NavConfig.tsx` — ActionBar registration
- `page.tsx` — Route page
- `ServicesDashboard.test.tsx` — 18 unit tests
- `adminClient.ts` + `admin.schemas.ts` — API client + Zod schemas
- `admin-dashboard-navigation.ts` — Sidebar nav entry

## Known Limitations
- Uptime % is estimated from current state (99.9/97/85), not from real 24h poll history (no historical storage yet)
- Response time trends default to "stable" on backend (no previous check storage); frontend handles all 3 states

## Test plan
- [x] 18 frontend tests pass (ServicesDashboard)
- [x] 11 backend tests pass (GetServiceDashboardQueryHandler)
- [x] `next build` passes
- [x] `dotnet build` passes
- [ ] Manual verification on `/admin/monitor/services`

Closes #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)