### PR TITLE
feat(admin): inline role change, per-user audit log, live activity table (#124)

### DIFF
--- a/apps/api/src/Api/Routing/AdminAuditLogEndpoints.cs
+++ b/apps/api/src/Api/Routing/AdminAuditLogEndpoints.cs
@@ -71,6 +71,43 @@ internal static class AdminAuditLogEndpoints
             return Results.File(exportResult.Content, exportResult.ContentType, exportResult.FileName);
         });
 
+        // Per-user audit log - Issue #124
+        group.MapGet("/admin/users/{userId:guid}/audit-log", async (
+            Guid userId,
+            HttpContext context,
+            IMediator mediator,
+            int? limit,
+            int? offset,
+            string? action,
+            string? resource,
+            string? result,
+            DateTime? startDate,
+            DateTime? endDate,
+            CancellationToken ct) =>
+        {
+            var (authorized, _, error) = context.RequireAdminSession();
+            if (!authorized) return error!;
+
+            var query = new GetAuditLogsQuery(
+                Limit: limit ?? 50,
+                Offset: offset ?? 0,
+                AdminUserId: userId,
+                Action: action,
+                Resource: resource,
+                Result: result,
+                StartDate: startDate,
+                EndDate: endDate);
+
+            var queryResult = await mediator.Send(query, ct).ConfigureAwait(false);
+            return Results.Ok(queryResult);
+        })
+        .WithName("GetUserAuditLog")
+        .WithTags("Admin", "AuditLog")
+        .WithSummary("Get audit log filtered by user")
+        .WithDescription("Returns audit log entries for a specific user. Issue #124.")
+        .Produces(StatusCodes.Status200OK)
+        .Produces(StatusCodes.Status403Forbidden);
+
         return group;
     }
 }

--- a/apps/api/src/Api/Routing/AdminUserEndpoints.cs
+++ b/apps/api/src/Api/Routing/AdminUserEndpoints.cs
@@ -48,6 +48,7 @@ internal static class AdminUserEndpoints
         MapUserDetailEndpoint(group);
         MapUserRoleHistoryEndpoint(group);
         MapUserQuickActionsEndpoints(group);
+        MapUserRoleChangeEndpoint(group);
         MapUserImpersonateEndpoint(group);
         MapEndImpersonationEndpoint(group);
         // ISSUE-124: Invitation endpoints
@@ -920,6 +921,57 @@ internal static class AdminUserEndpoints
             .Produces(StatusCodes.Status404NotFound);
     }
 
+    private static void MapUserRoleChangeEndpoint(RouteGroupBuilder group)
+    {
+        group.MapPut("/admin/users/{userId:guid}/role", HandleChangeUserRole)
+            .RequireAdminSession()
+            .WithName("ChangeUserRole")
+            .WithTags("Admin", "Users")
+            .WithSummary("Change a single user's role")
+            .WithDescription(@"Change a user's role. Automatically audited via [AuditableAction].
+
+**Authorization**: Admin session required
+
+**Valid Roles**: Admin, Editor, User
+
+**Issue**: #124 - Admin Infrastructure Panel")
+            .Produces<Api.Models.UserDto>(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status400BadRequest)
+            .Produces(StatusCodes.Status403Forbidden)
+            .Produces(StatusCodes.Status404NotFound);
+    }
+
+    private static async Task<IResult> HandleChangeUserRole(
+        Guid userId,
+        ChangeUserRoleRequest request,
+        HttpContext context,
+        IMediator mediator,
+        ILogger<Program> logger,
+        CancellationToken ct)
+    {
+        var (authorized, session, error) = context.RequireAdminSession();
+        if (!authorized) return error!;
+
+        logger.LogInformation("Admin {AdminId} changing role for user {UserId} to {NewRole}",
+            session!.User!.Id, userId, request.NewRole);
+
+        try
+        {
+            var command = new ChangeUserRoleCommand(userId.ToString(), request.NewRole);
+            var result = await mediator.Send(command, ct).ConfigureAwait(false);
+
+            logger.LogInformation("Role changed for user {UserId} to {NewRole} by admin {AdminId}",
+                userId, request.NewRole, session.User.Id);
+
+            return Results.Ok(result);
+        }
+        catch (DomainException ex)
+        {
+            logger.LogWarning(ex, "Failed to change role for user {UserId}", userId);
+            return Results.BadRequest(new { error = ex.Message });
+        }
+    }
+
     private static async Task<IResult> HandleResetUserPassword(
         Guid userId,
         ResetUserPasswordRequest request,
@@ -1307,3 +1359,8 @@ internal record SendUserEmailRequest(string Subject, string Body);
 /// Request payload for sending an invitation (Issue #124).
 /// </summary>
 internal record SendInvitationRequest(string Email, string Role);
+
+/// <summary>
+/// Request payload for changing a user's role (Issue #124).
+/// </summary>
+internal record ChangeUserRoleRequest(string NewRole);

--- a/apps/web/src/app/admin/(dashboard)/users/activity/page.tsx
+++ b/apps/web/src/app/admin/(dashboard)/users/activity/page.tsx
@@ -1,24 +1,14 @@
-import { Suspense } from 'react';
+'use client';
 
-import { type Metadata } from 'next';
+import { useState } from 'react';
 
 import { ActivityFilters } from '@/components/admin/users/activity-filters';
 import { ActivityTable } from '@/components/admin/users/activity-table';
 
-export const metadata: Metadata = {
-  title: 'Activity Log',
-  description: 'Monitor user actions and system events',
-};
-
-function CardSkeleton({ height = 'h-[400px]' }: { height?: string }) {
-  return (
-    <div
-      className={`${height} bg-white/40 dark:bg-zinc-800/40 backdrop-blur-sm rounded-2xl border border-slate-200/60 dark:border-zinc-700/40 animate-pulse`}
-    />
-  );
-}
-
 export default function UserActivityPage() {
+  const [actionFilter, setActionFilter] = useState('all');
+  const [dateRange, setDateRange] = useState('24h');
+
   return (
     <div className="space-y-6">
       {/* Page Header */}
@@ -32,14 +22,13 @@ export default function UserActivityPage() {
       </div>
 
       {/* Filters */}
-      <Suspense fallback={<CardSkeleton height="h-[120px]" />}>
-        <ActivityFilters />
-      </Suspense>
+      <ActivityFilters
+        onActionTypeChange={setActionFilter}
+        onDateRangeChange={setDateRange}
+      />
 
       {/* Activity Table */}
-      <Suspense fallback={<CardSkeleton height="h-[600px]" />}>
-        <ActivityTable />
-      </Suspense>
+      <ActivityTable actionFilter={actionFilter} dateRange={dateRange} />
     </div>
   );
 }

--- a/apps/web/src/app/admin/(dashboard)/users/page.tsx
+++ b/apps/web/src/app/admin/(dashboard)/users/page.tsx
@@ -15,6 +15,7 @@ import { toast } from 'sonner';
 
 import { InvitationStatusBadge } from '@/components/admin/invitations/InvitationStatusBadge';
 import { InviteUserDialog } from '@/components/admin/invitations/InviteUserDialog';
+import { InlineRoleSelect } from '@/components/admin/users/InlineRoleSelect';
 import { Badge } from '@/components/ui/data-display/badge';
 import { Button } from '@/components/ui/primitives/button';
 import { useSetNavConfig } from '@/hooks/useSetNavConfig';
@@ -168,7 +169,11 @@ export default function AdminUsersPage() {
                     </div>
                   </td>
                   <td className="px-3 py-2">
-                    <Badge variant="secondary">{u.role}</Badge>
+                    <InlineRoleSelect
+                      userId={u.id}
+                      currentRole={u.role}
+                      userName={u.displayName || u.email}
+                    />
                   </td>
                   <td className="px-3 py-2">
                     <Badge

--- a/apps/web/src/components/admin/users/InlineRoleSelect.tsx
+++ b/apps/web/src/components/admin/users/InlineRoleSelect.tsx
@@ -1,0 +1,114 @@
+'use client';
+
+import { useState } from 'react';
+
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/overlays/alert-dialog-primitives';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { api } from '@/lib/api';
+
+const AVAILABLE_ROLES = ['User', 'Editor', 'Admin'] as const;
+
+interface InlineRoleSelectProps {
+  userId: string;
+  currentRole: string;
+  userName: string;
+  onRoleChanged?: () => void;
+}
+
+export function InlineRoleSelect({
+  userId,
+  currentRole,
+  userName,
+  onRoleChanged,
+}: InlineRoleSelectProps) {
+  const queryClient = useQueryClient();
+  const [pendingRole, setPendingRole] = useState<string | null>(null);
+
+  const mutation = useMutation({
+    mutationFn: (newRole: string) => api.admin.changeUserRole(userId, newRole),
+    onSuccess: (_data, newRole) => {
+      toast.success(`Role changed to ${newRole} for ${userName}`);
+      queryClient.invalidateQueries({ queryKey: ['admin', 'users'] });
+      onRoleChanged?.();
+    },
+    onError: (err) => {
+      toast.error(
+        err instanceof Error ? err.message : 'Failed to change role'
+      );
+    },
+  });
+
+  function handleSelect(value: string) {
+    if (value !== currentRole) {
+      setPendingRole(value);
+    }
+  }
+
+  function handleConfirm() {
+    if (pendingRole) {
+      mutation.mutate(pendingRole);
+      setPendingRole(null);
+    }
+  }
+
+  return (
+    <>
+      <Select
+        value={currentRole}
+        onValueChange={handleSelect}
+        disabled={mutation.isPending}
+      >
+        <SelectTrigger className="h-7 w-[100px] text-xs">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          {AVAILABLE_ROLES.map((role) => (
+            <SelectItem key={role} value={role}>
+              {role}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+
+      <AlertDialog
+        open={pendingRole !== null}
+        onOpenChange={(open) => !open && setPendingRole(null)}
+      >
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Change Role</AlertDialogTitle>
+            <AlertDialogDescription>
+              Change the role of <strong>{userName}</strong> from{' '}
+              <strong>{currentRole}</strong> to{' '}
+              <strong>{pendingRole}</strong>?
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={handleConfirm}>
+              Confirm
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </>
+  );
+}

--- a/apps/web/src/components/admin/users/__tests__/activity-table.test.tsx
+++ b/apps/web/src/components/admin/users/__tests__/activity-table.test.tsx
@@ -1,51 +1,105 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
 import { ActivityTable } from '../activity-table';
 
+// Mock the API module
+vi.mock('@/lib/api', () => ({
+  api: {
+    admin: {
+      getAuditLogs: vi.fn().mockResolvedValue({
+        entries: [
+          {
+            id: '00000000-0000-0000-0000-000000000001',
+            adminUserId: '00000000-0000-0000-0000-000000000010',
+            action: 'UserRoleChange',
+            resource: 'User',
+            resourceId: '123',
+            result: 'Success',
+            details: null,
+            ipAddress: '192.168.1.45',
+            createdAt: '2026-03-12T14:35:22Z',
+            userName: 'Sarah Chen',
+            userEmail: 'sarah@meepleai.com',
+          },
+          {
+            id: '00000000-0000-0000-0000-000000000002',
+            adminUserId: null,
+            action: 'DomainEvent.InvitationAcceptedEvent',
+            resource: 'InvitationAcceptedEvent',
+            resourceId: null,
+            result: 'Error',
+            details: null,
+            ipAddress: null,
+            createdAt: '2026-03-12T13:22:17Z',
+            userName: null,
+            userEmail: null,
+          },
+        ],
+        totalCount: 2,
+        limit: 50,
+        offset: 0,
+      }),
+    },
+  },
+}));
+
+function renderWithQuery(ui: React.ReactElement) {
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>
+  );
+}
+
 describe('ActivityTable', () => {
-  it('renders activity table with mock data', () => {
-    render(<ActivityTable />);
+  it('renders table headers', async () => {
+    renderWithQuery(<ActivityTable />);
 
-    // Check table headers
-    expect(screen.getByText('Timestamp')).toBeInTheDocument();
-    expect(screen.getByText('User')).toBeInTheDocument();
-    expect(screen.getByText('Action')).toBeInTheDocument();
-    expect(screen.getByText('Target')).toBeInTheDocument();
-    expect(screen.getByText('IP Address')).toBeInTheDocument();
-    expect(screen.getByText('Status')).toBeInTheDocument();
+    expect(await screen.findByText('Timestamp')).toBeInTheDocument();
+    // "User" appears in both header and data cells, so use role selector
+    const headers = screen.getAllByRole('columnheader');
+    const headerTexts = headers.map((h) => h.textContent);
+    expect(headerTexts).toContain('User');
+    expect(headerTexts).toContain('Action');
+    expect(headerTexts).toContain('Resource');
+    expect(headerTexts).toContain('IP Address');
+    expect(headerTexts).toContain('Result');
   });
 
-  it('displays user information with avatars', () => {
-    render(<ActivityTable />);
+  it('displays user information from API', async () => {
+    renderWithQuery(<ActivityTable />);
 
-    // Check at least one user name is visible (Sarah Chen appears twice in mock data)
-    const users = screen.getAllByText('Sarah Chen');
-    expect(users.length).toBeGreaterThan(0);
-    // Email appears multiple times in mock data, use getAllByText
-    const emails = screen.getAllByText('sarah@meepleai.com');
-    expect(emails.length).toBeGreaterThan(0);
+    expect(await screen.findByText('Sarah Chen')).toBeInTheDocument();
+    expect(screen.getByText('sarah@meepleai.com')).toBeInTheDocument();
   });
 
-  it('shows action badges', () => {
-    render(<ActivityTable />);
+  it('shows action badges', async () => {
+    renderWithQuery(<ActivityTable />);
 
-    // Check for action text (appears multiple times in mock data)
-    const actions = screen.getAllByText('Approved game');
-    expect(actions.length).toBeGreaterThan(0);
+    expect(await screen.findByText('User Role Change')).toBeInTheDocument();
   });
 
-  it('displays success and error statuses', () => {
-    render(<ActivityTable />);
+  it('displays success and error results', async () => {
+    renderWithQuery(<ActivityTable />);
 
-    const successBadges = screen.getAllByText('Success');
-    expect(successBadges.length).toBeGreaterThan(0);
+    expect(await screen.findByText('Success')).toBeInTheDocument();
+    expect(screen.getByText('Error')).toBeInTheDocument();
   });
 
-  it('formats timestamps correctly', () => {
-    const { container } = render(<ActivityTable />);
+  it('shows system when no user name', async () => {
+    renderWithQuery(<ActivityTable />);
 
-    // Check for font-mono class on timestamp cells
+    expect(await screen.findByText('System')).toBeInTheDocument();
+  });
+
+  it('formats timestamps correctly', async () => {
+    const { container } = renderWithQuery(<ActivityTable />);
+
+    // Wait for data to load, then check for font-mono class on timestamp cells
+    await screen.findByText('Sarah Chen');
     const timestamps = container.querySelectorAll('.font-mono');
     expect(timestamps.length).toBeGreaterThan(0);
   });

--- a/apps/web/src/components/admin/users/activity-table.tsx
+++ b/apps/web/src/components/admin/users/activity-table.tsx
@@ -1,118 +1,72 @@
 'use client';
 
-import { Badge } from '@/components/ui/badge';
+import { useQuery } from '@tanstack/react-query';
 
-interface ActivityEntry {
-  id: string;
-  timestamp: string;
-  user: {
-    name: string;
-    email: string;
-    avatar?: string;
-  };
-  action: string;
-  actionType: 'login' | 'edit' | 'approve' | 'config' | 'delete';
-  target: string;
-  ipAddress: string;
-  status: 'success' | 'error';
+import { Badge } from '@/components/ui/badge';
+import { api } from '@/lib/api';
+import type { AuditLogEntry } from '@/lib/api/schemas/admin.schemas';
+
+interface ActivityTableProps {
+  actionFilter?: string;
+  dateRange?: string;
 }
 
-// Mock data
-const MOCK_ACTIVITIES: ActivityEntry[] = [
-  {
-    id: '1',
-    timestamp: '2026-02-18 14:35:22',
-    user: { name: 'Sarah Chen', email: 'sarah@meepleai.com', avatar: undefined },
-    action: 'Approved game',
-    actionType: 'approve',
-    target: 'Catan (ID: 789)',
-    ipAddress: '192.168.1.45',
-    status: 'success',
-  },
-  {
-    id: '2',
-    timestamp: '2026-02-18 14:12:05',
-    user: { name: 'Mike Johnson', email: 'mike@meepleai.com', avatar: undefined },
-    action: 'Updated AI model',
-    actionType: 'config',
-    target: 'GPT-4 Turbo settings',
-    ipAddress: '10.0.0.12',
-    status: 'success',
-  },
-  {
-    id: '3',
-    timestamp: '2026-02-18 13:48:33',
-    user: { name: 'Admin User', email: 'admin@meepleai.com', avatar: undefined },
-    action: 'Deleted user',
-    actionType: 'delete',
-    target: 'spam_account@test.com',
-    ipAddress: '192.168.1.1',
-    status: 'success',
-  },
-  {
-    id: '4',
-    timestamp: '2026-02-18 13:22:17',
-    user: { name: 'Emily Rodriguez', email: 'emily@meepleai.com', avatar: undefined },
-    action: 'Edited category',
-    actionType: 'edit',
-    target: 'Strategy Games',
-    ipAddress: '192.168.1.88',
-    status: 'success',
-  },
-  {
-    id: '5',
-    timestamp: '2026-02-18 12:55:44',
-    user: { name: 'John Smith', email: 'john@meepleai.com', avatar: undefined },
-    action: 'Failed login',
-    actionType: 'login',
-    target: 'Web Portal',
-    ipAddress: '203.0.113.42',
-    status: 'error',
-  },
-  {
-    id: '6',
-    timestamp: '2026-02-18 12:30:11',
-    user: { name: 'Sarah Chen', email: 'sarah@meepleai.com', avatar: undefined },
-    action: 'Login',
-    actionType: 'login',
-    target: 'Admin Dashboard',
-    ipAddress: '192.168.1.45',
-    status: 'success',
-  },
-  {
-    id: '7',
-    timestamp: '2026-02-18 11:45:29',
-    user: { name: 'Mike Johnson', email: 'mike@meepleai.com', avatar: undefined },
-    action: 'Approved game',
-    actionType: 'approve',
-    target: 'Wingspan (ID: 456)',
-    ipAddress: '10.0.0.12',
-    status: 'success',
-  },
-  {
-    id: '8',
-    timestamp: '2026-02-18 11:15:03',
-    user: { name: 'Emily Rodriguez', email: 'emily@meepleai.com', avatar: undefined },
-    action: 'Updated category',
-    actionType: 'edit',
-    target: 'Family Games',
-    ipAddress: '192.168.1.88',
-    status: 'success',
-  },
-];
-
-const actionTypeColors = {
-  login: 'bg-blue-100 text-blue-900 dark:bg-blue-900/30 dark:text-blue-300',
-  edit: 'bg-amber-100 text-amber-900 dark:bg-amber-900/30 dark:text-amber-300',
-  approve: 'bg-green-100 text-green-900 dark:bg-green-900/30 dark:text-green-300',
-  config: 'bg-purple-100 text-purple-900 dark:bg-purple-900/30 dark:text-purple-300',
-  delete: 'bg-red-100 text-red-900 dark:bg-red-900/30 dark:text-red-300',
+const actionTypeColors: Record<string, string> = {
+  UserRoleChange:
+    'bg-purple-100 text-purple-900 dark:bg-purple-900/30 dark:text-purple-300',
+  'DomainEvent.RoleChangedEvent':
+    'bg-purple-100 text-purple-900 dark:bg-purple-900/30 dark:text-purple-300',
+  'DomainEvent.UserInvitedEvent':
+    'bg-blue-100 text-blue-900 dark:bg-blue-900/30 dark:text-blue-300',
+  'DomainEvent.InvitationAcceptedEvent':
+    'bg-green-100 text-green-900 dark:bg-green-900/30 dark:text-green-300',
+  email_sent:
+    'bg-amber-100 text-amber-900 dark:bg-amber-900/30 dark:text-amber-300',
 };
 
-const statusColors = {
-  success: 'bg-green-100 text-green-900 dark:bg-green-900/30 dark:text-green-300',
-  error: 'bg-red-100 text-red-900 dark:bg-red-900/30 dark:text-red-300',
+const resultColors: Record<string, string> = {
+  Success:
+    'bg-green-100 text-green-900 dark:bg-green-900/30 dark:text-green-300',
+  Error: 'bg-red-100 text-red-900 dark:bg-red-900/30 dark:text-red-300',
+  Denied:
+    'bg-amber-100 text-amber-900 dark:bg-amber-900/30 dark:text-amber-300',
 };
+
+function getDateRange(range?: string): { startDate?: string; endDate?: string } {
+  if (!range || range === 'all') return {};
+  const now = new Date();
+  const end = now.toISOString();
+  let start: Date;
+  switch (range) {
+    case '24h':
+      start = new Date(now.getTime() - 24 * 60 * 60 * 1000);
+      break;
+    case '7d':
+      start = new Date(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+      break;
+    case '30d':
+      start = new Date(now.getTime() - 30 * 24 * 60 * 60 * 1000);
+      break;
+    default:
+      return {};
+  }
+  return { startDate: start.toISOString(), endDate: end };
+}
+
+function formatTimestamp(iso: string): string {
+  try {
+    return new Date(iso).toLocaleString('it-IT', {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+    });
+  } catch {
+    return iso;
+  }
+}
 
 function getUserInitials(name: string): string {
   return name
@@ -123,7 +77,46 @@ function getUserInitials(name: string): string {
     .slice(0, 2);
 }
 
-export function ActivityTable() {
+function formatAction(action: string): string {
+  return action
+    .replace('DomainEvent.', '')
+    .replace(/Event$/, '')
+    .replace(/([A-Z])/g, ' $1')
+    .trim();
+}
+
+export function ActivityTable({ actionFilter, dateRange }: ActivityTableProps) {
+  const dateParams = getDateRange(dateRange);
+
+  const { data, isLoading, isError } = useQuery({
+    queryKey: ['admin', 'audit-log', 'activity', actionFilter, dateRange],
+    queryFn: () =>
+      api.admin.getAuditLogs({
+        limit: 50,
+        action: actionFilter && actionFilter !== 'all' ? actionFilter : undefined,
+        ...dateParams,
+      }),
+    staleTime: 30_000,
+  });
+
+  const entries: AuditLogEntry[] = data?.entries ?? [];
+
+  if (isLoading) {
+    return (
+      <div className="bg-white/70 dark:bg-zinc-800/70 backdrop-blur-md border border-amber-200/50 dark:border-zinc-700/50 rounded-lg p-8 text-center text-muted-foreground">
+        Loading activity log...
+      </div>
+    );
+  }
+
+  if (isError) {
+    return (
+      <div className="bg-white/70 dark:bg-zinc-800/70 backdrop-blur-md border border-amber-200/50 dark:border-zinc-700/50 rounded-lg p-8 text-center text-red-600">
+        Failed to load activity log.
+      </div>
+    );
+  }
+
   return (
     <div className="bg-white/70 dark:bg-zinc-800/70 backdrop-blur-md border border-amber-200/50 dark:border-zinc-700/50 rounded-lg overflow-hidden">
       <div className="overflow-x-auto">
@@ -140,55 +133,92 @@ export function ActivityTable() {
                 Action
               </th>
               <th className="text-left py-3 px-4 text-sm font-bold text-amber-900 dark:text-amber-400 uppercase tracking-wider">
-                Target
+                Resource
               </th>
               <th className="text-left py-3 px-4 text-sm font-bold text-amber-900 dark:text-amber-400 uppercase tracking-wider">
                 IP Address
               </th>
               <th className="text-right py-3 px-4 text-sm font-bold text-amber-900 dark:text-amber-400 uppercase tracking-wider">
-                Status
+                Result
               </th>
             </tr>
           </thead>
           <tbody className="divide-y divide-slate-200 dark:divide-zinc-700">
-            {MOCK_ACTIVITIES.map((activity) => (
-              <tr key={activity.id} className="hover:bg-slate-50/50 dark:hover:bg-zinc-900/50 transition-colors">
-                <td className="py-3 px-4 font-mono text-sm text-slate-600 dark:text-zinc-400">
-                  {activity.timestamp}
-                </td>
-                <td className="py-3 px-4">
-                  <div className="flex items-center gap-3">
-                    <div className="h-8 w-8 rounded-full bg-amber-100 dark:bg-amber-900/30 flex items-center justify-center text-xs font-semibold text-amber-900 dark:text-amber-300">
-                      {getUserInitials(activity.user.name)}
-                    </div>
-                    <div>
-                      <div className="font-medium text-slate-900 dark:text-zinc-100">
-                        {activity.user.name}
-                      </div>
-                      <div className="text-xs text-slate-500 dark:text-zinc-400">
-                        {activity.user.email}
-                      </div>
-                    </div>
-                  </div>
-                </td>
-                <td className="py-3 px-4">
-                  <Badge variant="outline" className={actionTypeColors[activity.actionType]}>
-                    {activity.action}
-                  </Badge>
-                </td>
-                <td className="py-3 px-4 text-slate-700 dark:text-zinc-300">
-                  {activity.target}
-                </td>
-                <td className="py-3 px-4 font-mono text-sm text-slate-600 dark:text-zinc-400">
-                  {activity.ipAddress}
-                </td>
-                <td className="py-3 px-4 text-right">
-                  <Badge variant="outline" className={statusColors[activity.status]}>
-                    {activity.status === 'success' ? 'Success' : 'Error'}
-                  </Badge>
+            {entries.length === 0 ? (
+              <tr>
+                <td
+                  colSpan={6}
+                  className="py-12 text-center text-muted-foreground"
+                >
+                  No activity found.
                 </td>
               </tr>
-            ))}
+            ) : (
+              entries.map((entry) => (
+                <tr
+                  key={entry.id}
+                  className="hover:bg-slate-50/50 dark:hover:bg-zinc-900/50 transition-colors"
+                >
+                  <td className="py-3 px-4 font-mono text-sm text-slate-600 dark:text-zinc-400">
+                    {formatTimestamp(entry.createdAt)}
+                  </td>
+                  <td className="py-3 px-4">
+                    {entry.userName ? (
+                      <div className="flex items-center gap-3">
+                        <div className="h-8 w-8 rounded-full bg-amber-100 dark:bg-amber-900/30 flex items-center justify-center text-xs font-semibold text-amber-900 dark:text-amber-300">
+                          {getUserInitials(entry.userName)}
+                        </div>
+                        <div>
+                          <div className="font-medium text-slate-900 dark:text-zinc-100">
+                            {entry.userName}
+                          </div>
+                          {entry.userEmail && (
+                            <div className="text-xs text-slate-500 dark:text-zinc-400">
+                              {entry.userEmail}
+                            </div>
+                          )}
+                        </div>
+                      </div>
+                    ) : (
+                      <span className="text-slate-400 text-sm">System</span>
+                    )}
+                  </td>
+                  <td className="py-3 px-4">
+                    <Badge
+                      variant="outline"
+                      className={
+                        actionTypeColors[entry.action] ??
+                        'bg-slate-100 text-slate-900 dark:bg-slate-900/30 dark:text-slate-300'
+                      }
+                    >
+                      {formatAction(entry.action)}
+                    </Badge>
+                  </td>
+                  <td className="py-3 px-4 text-slate-700 dark:text-zinc-300">
+                    {entry.resource}
+                    {entry.resourceId && (
+                      <span className="text-xs text-slate-400 ml-1">
+                        ({entry.resourceId})
+                      </span>
+                    )}
+                  </td>
+                  <td className="py-3 px-4 font-mono text-sm text-slate-600 dark:text-zinc-400">
+                    {entry.ipAddress ?? '—'}
+                  </td>
+                  <td className="py-3 px-4 text-right">
+                    <Badge
+                      variant="outline"
+                      className={
+                        resultColors[entry.result] ??
+                        'bg-slate-100 text-slate-900'
+                      }
+                    >
+                      {entry.result}
+                    </Badge>
+                  </td>
+                </tr>
+              ))
+            )}
           </tbody>
         </table>
       </div>

--- a/apps/web/src/lib/api/clients/adminClient.ts
+++ b/apps/web/src/lib/api/clients/adminClient.ts
@@ -316,6 +316,20 @@ export function createAdminClient({ httpClient }: CreateAdminClientParams) {
     },
 
     /**
+     * Change user role (admin only) - Issue #124
+     * PUT /api/v1/admin/users/{userId}/role
+     */
+    async changeUserRole(userId: string, newRole: string): Promise<AdminUser> {
+      const result = await httpClient.put<AdminUser>(
+        `/api/v1/admin/users/${encodeURIComponent(userId)}/role`,
+        { newRole },
+        AdminUserSchema
+      );
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      return result!;
+    },
+
+    /**
      * Get all users (admin only) - Issue #903
      * GET /api/v1/admin/users
      */

--- a/docs/superpowers/specs/2026-03-11-admin-invite-onboarding-design.md
+++ b/docs/superpowers/specs/2026-03-11-admin-invite-onboarding-design.md
@@ -1,8 +1,9 @@
 # Admin Invite, Onboarding, Voice Chat & User Management
 
 **Date**: 2026-03-11
-**Status**: Draft
+**Status**: In Progress (Phases 1-2 completed, Phase 4 in progress, Phase 3 pending)
 **Approach**: Incremental (4 independent phases)
+**PR History**: Phase 1+2 merged via PR #225 → `main-dev` (2026-03-12)
 
 ## Overview
 
@@ -48,7 +49,7 @@ No duplicate issues found among 70+ open issues. Related:
 | Forced password change | None | No `MustChangePassword` flag |
 | Onboarding wizard | None | Welcome page auto-redirects to dashboard |
 
-## Phase 1: Admin Invite System
+## Phase 1: Admin Invite System ✅ COMPLETED (PR #225)
 
 ### Backend
 
@@ -131,7 +132,7 @@ On every login, if `MustChangePassword == true`, redirect to `/change-password`.
 - Sent via new `SendInvitationEmailCommand` (not `EnqueueEmailCommand` which has incompatible schema)
 - Template rendered by a new `RenderInvitationEmail` method on a new or extended template service
 
-## Phase 2: Onboarding Wizard
+## Phase 2: Onboarding Wizard ✅ COMPLETED (PR #225)
 
 ### Backend
 


### PR DESCRIPTION
## Summary
- Add `PUT /admin/users/{id}/role` endpoint for single-user role changes (was only bulk before)
- Add `GET /admin/users/{id}/audit-log` endpoint for per-user audit log filtering
- Create `InlineRoleSelect` component with confirmation modal — replaces static badge in user list
- Wire `ActivityTable` to real audit log API, replacing 8 hardcoded mock entries
- Connect `ActivityFilters` (action type, date range) to table queries
- Add `changeUserRole` method to admin API client

Phase 4 of the admin invite/onboarding design (Epic #124). Backend audit infrastructure (entity, repository, retention job, event handlers, query endpoints) was already in place — this PR adds the missing frontend integration and dedicated role-change endpoint.

## Test Plan
- [x] Backend builds with 0 errors
- [x] Frontend typecheck passes
- [x] Activity table unit tests pass (6/6)
- [ ] Manual: change user role via dropdown → confirm modal → verify toast + audit log entry
- [ ] Manual: visit `/admin/users/activity` → verify real audit data loads with filters

🤖 Generated with [Claude Code](https://claude.com/claude-code)