### PR TITLE
feat: Admin RAG Dashboard - single-page setup for shared games

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -206,3 +206,4 @@ apps/docs/screenshots/.test-output/chromatic-archives/archive/_next/static/chunk
 apps/docs/screenshots/.test-output/chromatic-archives/archive/_next/static/media/4a7551bcc3548e67-s.p.717db902.woff2
 apps/web/next-env.d.ts
 .superpowers/
+.worktrees/

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/CreateAgentWithSetupCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/CreateAgentWithSetupCommand.cs
@@ -5,7 +5,8 @@ namespace Api.BoundedContexts.KnowledgeBase.Application.Commands;
 
 /// <summary>
 /// Orchestrated agent creation: validates slots, optionally adds game to library,
-/// creates the agent, and creates an initial chat thread.
+/// creates the agent, creates an initial chat thread, and optionally links to a
+/// SharedGame and attaches selected documents.
 /// Issue #4772: Agent Creation Orchestration Flow.
 /// </summary>
 internal record CreateAgentWithSetupCommand(
@@ -18,4 +19,17 @@ internal record CreateAgentWithSetupCommand(
     string? AgentName,
     string? StrategyName,
     IDictionary<string, object>? StrategyParameters
-) : IRequest<AgentCreationResultDto>;
+) : IRequest<AgentCreationResultDto>
+{
+    /// <summary>
+    /// Optional SharedGame ID to link the agent to a community shared game.
+    /// When provided, sends LinkAgentToSharedGameCommand after agent creation.
+    /// </summary>
+    public Guid? SharedGameId { get; init; }
+
+    /// <summary>
+    /// Optional list of document IDs to attach to the agent's knowledge base.
+    /// When provided, sends UpdateAgentDocumentsCommand after agent creation.
+    /// </summary>
+    public List<Guid>? DocumentIds { get; init; }
+}

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/DTOs/AgentCostEstimateDto.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/DTOs/AgentCostEstimateDto.cs
@@ -1,0 +1,14 @@
+namespace Api.BoundedContexts.KnowledgeBase.Application.DTOs;
+
+/// <summary>
+/// DTO for pre-chat agent cost estimation.
+/// Provides token and cost estimates before an admin starts a RAG chat session.
+/// </summary>
+internal record AgentCostEstimateDto(
+    int TotalChunks,
+    int EstimatedEmbeddingTokens,
+    decimal EstimatedCostPerQuery,
+    string Currency,
+    string Model,
+    string Note
+);

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Handlers/CreateAgentWithSetupCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Handlers/CreateAgentWithSetupCommandHandler.cs
@@ -5,6 +5,7 @@ using Api.BoundedContexts.KnowledgeBase.Domain;
 using Api.BoundedContexts.KnowledgeBase.Domain.Entities;
 using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
 using Api.BoundedContexts.KnowledgeBase.Domain.ValueObjects;
+using Api.BoundedContexts.SharedGameCatalog.Application.Commands;
 using Api.BoundedContexts.UserLibrary.Domain.Entities;
 using Api.BoundedContexts.UserLibrary.Domain.Repositories;
 using Api.Infrastructure;
@@ -32,6 +33,7 @@ internal sealed class CreateAgentWithSetupCommandHandler
     private readonly IUserLibraryRepository _libraryRepository;
     private readonly IUnitOfWork _unitOfWork;
     private readonly MeepleAiDbContext _db;
+    private readonly IMediator _mediator;
     private readonly ILogger<CreateAgentWithSetupCommandHandler> _logger;
 
     public CreateAgentWithSetupCommandHandler(
@@ -40,6 +42,7 @@ internal sealed class CreateAgentWithSetupCommandHandler
         IUserLibraryRepository libraryRepository,
         IUnitOfWork unitOfWork,
         MeepleAiDbContext db,
+        IMediator mediator,
         ILogger<CreateAgentWithSetupCommandHandler> logger)
     {
         _agentRepository = agentRepository ?? throw new ArgumentNullException(nameof(agentRepository));
@@ -47,6 +50,7 @@ internal sealed class CreateAgentWithSetupCommandHandler
         _libraryRepository = libraryRepository ?? throw new ArgumentNullException(nameof(libraryRepository));
         _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
         _db = db ?? throw new ArgumentNullException(nameof(db));
+        _mediator = mediator ?? throw new ArgumentNullException(nameof(mediator));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -163,6 +167,31 @@ internal sealed class CreateAgentWithSetupCommandHandler
             _logger.LogInformation(
                 "Orchestrated agent creation: Agent {AgentId} ({AgentType}) + Thread {ThreadId} for user {UserId}, game {GameId}",
                 agent.Id, agentType.Value, chatThread.Id, request.UserId, request.GameId);
+
+            // Step 6: Post-creation orchestration (outside main transaction)
+            // Link to SharedGame if provided
+            if (request.SharedGameId.HasValue)
+            {
+                await _mediator.Send(
+                    new LinkAgentToSharedGameCommand(request.SharedGameId.Value, agent.Id),
+                    cancellationToken).ConfigureAwait(false);
+
+                _logger.LogInformation(
+                    "Linked agent {AgentId} to shared game {SharedGameId}",
+                    agent.Id, request.SharedGameId.Value);
+            }
+
+            // Attach selected documents if provided
+            if (request.DocumentIds is { Count: > 0 })
+            {
+                await _mediator.Send(
+                    new UpdateAgentDocumentsCommand(agent.Id, request.DocumentIds),
+                    cancellationToken).ConfigureAwait(false);
+
+                _logger.LogInformation(
+                    "Attached {DocumentCount} documents to agent {AgentId}",
+                    request.DocumentIds.Count, agent.Id);
+            }
 
             return new AgentCreationResultDto(
                 AgentId: agent.Id,

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/EstimateAgentCost/EstimateAgentCostQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/EstimateAgentCost/EstimateAgentCostQuery.cs
@@ -1,0 +1,14 @@
+using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
+using MediatR;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.EstimateAgentCost;
+
+/// <summary>
+/// Query to estimate the token cost before an admin starts chatting with an agent.
+/// Calculates cost based on documents that will be used for RAG retrieval.
+/// </summary>
+internal sealed record EstimateAgentCostQuery(
+    Guid GameId,
+    List<Guid> DocumentIds,
+    string StrategyName = "HybridSearch"
+) : IRequest<AgentCostEstimateDto>;

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/EstimateAgentCost/EstimateAgentCostQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/EstimateAgentCost/EstimateAgentCostQueryHandler.cs
@@ -1,0 +1,119 @@
+using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
+using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.EstimateAgentCost;
+
+/// <summary>
+/// Handler for EstimateAgentCostQuery.
+/// Estimates token cost based on document chunks, model pricing, and retrieval strategy.
+/// </summary>
+internal sealed class EstimateAgentCostQueryHandler
+    : IRequestHandler<EstimateAgentCostQuery, AgentCostEstimateDto>
+{
+    // Hardcoded pricing table (per token)
+    // nomic-embed-text: $0.0001 / 1K tokens = $0.0000001 per token
+    private const decimal EmbeddingPricePerToken = 0.0000001m;
+    // gpt-4o-mini: $0.15 / 1M input tokens = $0.00000015 per token
+    private const decimal CompletionInputPricePerToken = 0.00000015m;
+    // gpt-4o-mini output: $0.60 / 1M output tokens = $0.0000006 per token
+    private const decimal CompletionOutputPricePerToken = 0.0000006m;
+
+    // Retrieval estimation constants
+    private const int DefaultTopK = 5;
+    private const int AvgChunkSizeTokens = 500;
+    private const int PromptOverheadTokens = 200;
+    private const int ResponseTokens = 500;
+
+    private const string EmbeddingModel = "nomic-embed-text";
+    private const string CompletionModel = "gpt-4o-mini";
+
+    private readonly IVectorDocumentRepository _vectorDocumentRepository;
+    private readonly ILogger<EstimateAgentCostQueryHandler> _logger;
+
+    public EstimateAgentCostQueryHandler(
+        IVectorDocumentRepository vectorDocumentRepository,
+        ILogger<EstimateAgentCostQueryHandler> logger)
+    {
+        _vectorDocumentRepository = vectorDocumentRepository ?? throw new ArgumentNullException(nameof(vectorDocumentRepository));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<AgentCostEstimateDto> Handle(
+        EstimateAgentCostQuery request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        // Get all vector documents for the game
+        var vectorDocuments = await _vectorDocumentRepository
+            .GetByGameIdAsync(request.GameId, cancellationToken)
+            .ConfigureAwait(false);
+
+        // Filter to only requested document IDs (match by PdfDocumentId)
+        var matchingDocuments = vectorDocuments
+            .Where(vd => request.DocumentIds.Contains(vd.PdfDocumentId))
+            .ToList();
+
+        var totalChunks = matchingDocuments.Sum(vd => vd.TotalChunks);
+
+        if (totalChunks == 0)
+        {
+            _logger.LogDebug(
+                "No chunks found for GameId {GameId} with DocumentIds [{DocumentIds}]",
+                request.GameId,
+                string.Join(", ", request.DocumentIds));
+
+            return new AgentCostEstimateDto(
+                TotalChunks: 0,
+                EstimatedEmbeddingTokens: 0,
+                EstimatedCostPerQuery: 0m,
+                Currency: "USD",
+                Model: $"{EmbeddingModel} + {CompletionModel}",
+                Note: "No indexed chunks found for the selected documents."
+            );
+        }
+
+        // Estimate tokens per query:
+        // - Embedding: query text (~50 tokens) for search
+        // - Retrieved context: min(top-k, totalChunks) * avg chunk size
+        // - Prompt overhead + response tokens
+        var retrievedChunks = Math.Min(DefaultTopK, totalChunks);
+        var embeddingTokens = 50; // query embedding tokens
+        var contextTokens = retrievedChunks * AvgChunkSizeTokens;
+        var inputTokens = contextTokens + PromptOverheadTokens;
+        var totalEstimatedTokens = embeddingTokens + inputTokens + ResponseTokens;
+
+        // Calculate cost
+        var embeddingCost = embeddingTokens * EmbeddingPricePerToken;
+        var completionInputCost = inputTokens * CompletionInputPricePerToken;
+        var completionOutputCost = ResponseTokens * CompletionOutputPricePerToken;
+        var totalCostPerQuery = embeddingCost + completionInputCost + completionOutputCost;
+
+        // Include search cost for HybridSearch strategy (vector + keyword search)
+        var isHybridSearch = string.Equals(request.StrategyName, "HybridSearch", StringComparison.OrdinalIgnoreCase);
+        if (isHybridSearch)
+        {
+            // HybridSearch runs embedding twice (vector search + reranking)
+            totalCostPerQuery += embeddingCost;
+        }
+
+        _logger.LogDebug(
+            "Cost estimate for GameId {GameId}: {TotalChunks} chunks, {EstTokens} est. tokens, ${Cost:F8}/query ({Strategy})",
+            request.GameId, totalChunks, totalEstimatedTokens, totalCostPerQuery, request.StrategyName);
+
+        var note = isHybridSearch
+            ? $"Estimate based on top-{retrievedChunks} retrieval from {totalChunks} chunks. HybridSearch includes vector search and reranking costs."
+            : $"Estimate based on top-{retrievedChunks} retrieval from {totalChunks} chunks.";
+
+        return new AgentCostEstimateDto(
+            TotalChunks: totalChunks,
+            EstimatedEmbeddingTokens: totalEstimatedTokens,
+            EstimatedCostPerQuery: Math.Round(totalCostPerQuery, 8),
+            Currency: "USD",
+            Model: $"{EmbeddingModel} + {CompletionModel}",
+            Note: note
+        );
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/EstimateAgentCost/EstimateAgentCostQueryValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Queries/EstimateAgentCost/EstimateAgentCostQueryValidator.cs
@@ -1,0 +1,29 @@
+using FluentValidation;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Queries.EstimateAgentCost;
+
+/// <summary>
+/// Validator for EstimateAgentCostQuery.
+/// Ensures GameId and DocumentIds are provided with reasonable limits.
+/// </summary>
+internal sealed class EstimateAgentCostQueryValidator : AbstractValidator<EstimateAgentCostQuery>
+{
+    private const int MaxDocumentIds = 10;
+
+    public EstimateAgentCostQueryValidator()
+    {
+        RuleFor(x => x.GameId)
+            .NotEqual(Guid.Empty).WithMessage("GameId is required");
+
+        RuleFor(x => x.DocumentIds)
+            .NotEmpty().WithMessage("DocumentIds is required")
+            .Must(ids => ids.Count <= MaxDocumentIds)
+            .WithMessage($"DocumentIds cannot exceed {MaxDocumentIds} items");
+
+        RuleForEach(x => x.DocumentIds)
+            .NotEqual(Guid.Empty).WithMessage("Each DocumentId must be a valid GUID");
+
+        RuleFor(x => x.StrategyName)
+            .NotEmpty().WithMessage("StrategyName is required");
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Validators/CreateAgentWithSetupCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Validators/CreateAgentWithSetupCommandValidator.cs
@@ -1,0 +1,49 @@
+using Api.BoundedContexts.KnowledgeBase.Application.Commands;
+using FluentValidation;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Validators;
+
+/// <summary>
+/// Validator for CreateAgentWithSetupCommand.
+/// Issue #4772: Agent Creation Orchestration Flow.
+/// </summary>
+internal sealed class CreateAgentWithSetupCommandValidator : AbstractValidator<CreateAgentWithSetupCommand>
+{
+    private const int MaxDocumentIds = 10;
+
+    public CreateAgentWithSetupCommandValidator()
+    {
+        RuleFor(x => x.UserId)
+            .NotEqual(Guid.Empty).WithMessage("UserId is required");
+
+        RuleFor(x => x.GameId)
+            .NotEqual(Guid.Empty).WithMessage("GameId is required");
+
+        RuleFor(x => x.AgentType)
+            .NotEmpty().WithMessage("AgentType is required");
+
+        RuleFor(x => x.UserTier)
+            .NotEmpty().WithMessage("UserTier is required");
+
+        RuleFor(x => x.UserRole)
+            .NotEmpty().WithMessage("UserRole is required");
+
+        // Optional: SharedGameId must not be Guid.Empty when provided
+        RuleFor(x => x.SharedGameId)
+            .NotEqual(Guid.Empty)
+            .When(x => x.SharedGameId.HasValue)
+            .WithMessage("SharedGameId must not be empty when provided");
+
+        // Optional: DocumentIds validation when provided
+        When(x => x.DocumentIds is { Count: > 0 }, () =>
+        {
+            RuleFor(x => x.DocumentIds!.Count)
+                .LessThanOrEqualTo(MaxDocumentIds)
+                .WithMessage($"Cannot attach more than {MaxDocumentIds} documents at once");
+
+            RuleForEach(x => x.DocumentIds)
+                .NotEqual(Guid.Empty)
+                .WithMessage("Each DocumentId must not be empty");
+        });
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/DTOs/GameRagReadinessDto.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/DTOs/GameRagReadinessDto.cs
@@ -1,0 +1,41 @@
+namespace Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
+
+/// <summary>
+/// Aggregated RAG readiness status for a shared game across
+/// SharedGameCatalog, DocumentProcessing, and KnowledgeBase bounded contexts.
+/// </summary>
+public record GameRagReadinessDto(
+    Guid GameId,
+    string GameTitle,
+    string GameStatus,
+    int TotalDocuments,
+    int ReadyDocuments,
+    int ProcessingDocuments,
+    int FailedDocuments,
+    List<DocumentStatusDto> Documents,
+    AgentInfoDto? LinkedAgent,
+    string OverallReadiness
+);
+
+/// <summary>
+/// Processing status of a single PDF document in the RAG pipeline.
+/// </summary>
+public record DocumentStatusDto(
+    Guid DocumentId,
+    string FileName,
+    string ProcessingState,
+    int ProgressPercentage,
+    bool IsActiveForRag,
+    string? ErrorMessage
+);
+
+/// <summary>
+/// Linked AI agent information for RAG readiness assessment.
+/// </summary>
+public record AgentInfoDto(
+    Guid AgentId,
+    string Name,
+    string Type,
+    bool IsActive,
+    bool IsReady
+);

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetGameRagReadiness/GetGameRagReadinessQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetGameRagReadiness/GetGameRagReadinessQuery.cs
@@ -1,0 +1,9 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
+using MediatR;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Queries.GetGameRagReadiness;
+
+/// <summary>
+/// Query to aggregate RAG readiness status across bounded contexts for a shared game.
+/// </summary>
+public record GetGameRagReadinessQuery(Guid GameId) : IRequest<GameRagReadinessDto>;

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetGameRagReadiness/GetGameRagReadinessQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetGameRagReadiness/GetGameRagReadinessQueryHandler.cs
@@ -1,0 +1,161 @@
+using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
+using Api.BoundedContexts.DocumentProcessing.Domain.Repositories;
+using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
+using Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.Middleware.Exceptions;
+using MediatR;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Queries.GetGameRagReadiness;
+
+/// <summary>
+/// Handler for GetGameRagReadinessQuery.
+/// Aggregates RAG readiness status across SharedGameCatalog, DocumentProcessing,
+/// and KnowledgeBase bounded contexts.
+/// </summary>
+internal sealed class GetGameRagReadinessQueryHandler
+    : IRequestHandler<GetGameRagReadinessQuery, GameRagReadinessDto>
+{
+    private readonly ISharedGameRepository _sharedGameRepository;
+    private readonly ISharedGameDocumentRepository _documentRepository;
+    private readonly IPdfDocumentRepository _pdfDocumentRepository;
+    private readonly IAgentDefinitionRepository _agentDefinitionRepository;
+    private readonly ILogger<GetGameRagReadinessQueryHandler> _logger;
+
+    public GetGameRagReadinessQueryHandler(
+        ISharedGameRepository sharedGameRepository,
+        ISharedGameDocumentRepository documentRepository,
+        IPdfDocumentRepository pdfDocumentRepository,
+        IAgentDefinitionRepository agentDefinitionRepository,
+        ILogger<GetGameRagReadinessQueryHandler> logger)
+    {
+        _sharedGameRepository = sharedGameRepository ?? throw new ArgumentNullException(nameof(sharedGameRepository));
+        _documentRepository = documentRepository ?? throw new ArgumentNullException(nameof(documentRepository));
+        _pdfDocumentRepository = pdfDocumentRepository ?? throw new ArgumentNullException(nameof(pdfDocumentRepository));
+        _agentDefinitionRepository = agentDefinitionRepository ?? throw new ArgumentNullException(nameof(agentDefinitionRepository));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<GameRagReadinessDto> Handle(
+        GetGameRagReadinessQuery request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        // Step 1: Get SharedGame
+        var game = await _sharedGameRepository.GetByIdAsync(request.GameId, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (game is null)
+        {
+            throw new NotFoundException("SharedGame", request.GameId.ToString());
+        }
+
+        // Step 2: Get SharedGameDocuments linked to this game
+        var sharedGameDocuments = await _documentRepository.GetBySharedGameIdAsync(request.GameId, cancellationToken)
+            .ConfigureAwait(false);
+
+        // Step 3: Get PdfDocument entities for processing status
+        var pdfDocumentIds = sharedGameDocuments.Select(d => d.PdfDocumentId).Distinct().ToList();
+        var pdfDocuments = pdfDocumentIds.Count > 0
+            ? await _pdfDocumentRepository.GetByIdsAsync(pdfDocumentIds, cancellationToken).ConfigureAwait(false)
+            : [];
+
+        // Build a lookup by PdfDocument ID
+        var pdfLookup = pdfDocuments.ToDictionary(p => p.Id);
+
+        // Step 4: Map documents to DTOs
+        var documentDtos = new List<DocumentStatusDto>();
+        foreach (var sharedDoc in sharedGameDocuments)
+        {
+            if (pdfLookup.TryGetValue(sharedDoc.PdfDocumentId, out var pdf))
+            {
+                documentDtos.Add(new DocumentStatusDto(
+                    DocumentId: pdf.Id,
+                    FileName: pdf.FileName.Value,
+                    ProcessingState: pdf.ProcessingState.ToString(),
+                    ProgressPercentage: pdf.ProgressPercentage,
+                    IsActiveForRag: pdf.IsActiveForRag,
+                    ErrorMessage: pdf.ProcessingError
+                ));
+            }
+        }
+
+        // Step 5: Get linked agent if present
+        AgentInfoDto? agentInfo = null;
+        if (game.AgentDefinitionId.HasValue)
+        {
+            var agentDef = await _agentDefinitionRepository.GetByIdAsync(
+                game.AgentDefinitionId.Value, cancellationToken).ConfigureAwait(false);
+
+            if (agentDef is not null)
+            {
+                agentInfo = new AgentInfoDto(
+                    AgentId: agentDef.Id,
+                    Name: agentDef.Name,
+                    Type: agentDef.Type.Value,
+                    IsActive: agentDef.IsActive,
+                    IsReady: agentDef.IsActive
+                );
+            }
+            else
+            {
+                _logger.LogWarning(
+                    "GetGameRagReadiness: AgentDefinition {AgentDefinitionId} not found for game {GameId}",
+                    game.AgentDefinitionId, request.GameId);
+            }
+        }
+
+        // Step 6: Calculate readiness metrics
+        var totalDocuments = documentDtos.Count;
+        var readyDocuments = documentDtos.Count(d =>
+            string.Equals(d.ProcessingState, PdfProcessingState.Ready.ToString(), StringComparison.Ordinal));
+        var processingDocuments = documentDtos.Count(d =>
+            !string.Equals(d.ProcessingState, PdfProcessingState.Ready.ToString(), StringComparison.Ordinal) &&
+            !string.Equals(d.ProcessingState, PdfProcessingState.Failed.ToString(), StringComparison.Ordinal));
+        var failedDocuments = documentDtos.Count(d =>
+            string.Equals(d.ProcessingState, PdfProcessingState.Failed.ToString(), StringComparison.Ordinal));
+
+        // Step 7: Determine overall readiness
+        var overallReadiness = CalculateOverallReadiness(
+            totalDocuments, readyDocuments, processingDocuments, failedDocuments, agentInfo);
+
+        return new GameRagReadinessDto(
+            GameId: game.Id,
+            GameTitle: game.Title,
+            GameStatus: game.Status.ToString(),
+            TotalDocuments: totalDocuments,
+            ReadyDocuments: readyDocuments,
+            ProcessingDocuments: processingDocuments,
+            FailedDocuments: failedDocuments,
+            Documents: documentDtos,
+            LinkedAgent: agentInfo,
+            OverallReadiness: overallReadiness
+        );
+    }
+
+    private static string CalculateOverallReadiness(
+        int totalDocuments,
+        int readyDocuments,
+        int processingDocuments,
+        int failedDocuments,
+        AgentInfoDto? agent)
+    {
+        if (totalDocuments == 0)
+            return "no_documents";
+
+        if (processingDocuments > 0)
+            return "documents_processing";
+
+        if (failedDocuments == totalDocuments)
+            return "documents_failed";
+
+        if (readyDocuments > 0 && agent is null)
+            return "ready_for_agent";
+
+        if (readyDocuments > 0 && agent is not null)
+            return "fully_operational";
+
+        return "no_documents";
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetGameRagReadiness/GetGameRagReadinessQueryValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetGameRagReadiness/GetGameRagReadinessQueryValidator.cs
@@ -1,0 +1,16 @@
+using FluentValidation;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Queries.GetGameRagReadiness;
+
+/// <summary>
+/// Validator for GetGameRagReadinessQuery.
+/// </summary>
+public sealed class GetGameRagReadinessQueryValidator : AbstractValidator<GetGameRagReadinessQuery>
+{
+    public GetGameRagReadinessQueryValidator()
+    {
+        RuleFor(x => x.GameId)
+            .NotEmpty()
+            .WithMessage("GameId is required.");
+    }
+}

--- a/apps/api/src/Api/Routing/AdminKnowledgeBaseEndpoints.cs
+++ b/apps/api/src/Api/Routing/AdminKnowledgeBaseEndpoints.cs
@@ -1,8 +1,11 @@
 using Api.BoundedContexts.DocumentProcessing.Application.Queries.Queue;
+using Api.BoundedContexts.KnowledgeBase.Application.DTOs;
+using Api.BoundedContexts.KnowledgeBase.Application.Queries.EstimateAgentCost;
 using Api.BoundedContexts.SharedGameCatalog.Application.Queries;
 using Api.Filters;
 using Api.Services;
 using MediatR;
+using Microsoft.AspNetCore.Mvc;
 
 namespace Api.Routing;
 
@@ -101,6 +104,25 @@ internal static class AdminKnowledgeBaseEndpoints
             return Results.Ok(result);
         });
 
+        // POST /api/v1/admin/kb/agents/estimate-cost - Pre-chat cost estimation
+        kbGroup.MapPost("/agents/estimate-cost", async (
+            [FromBody] EstimateAgentCostByDocumentsRequest request,
+            IMediator mediator,
+            CancellationToken cancellationToken) =>
+        {
+            var query = new EstimateAgentCostQuery(
+                request.GameId,
+                request.DocumentIds,
+                request.StrategyName ?? "HybridSearch");
+
+            var result = await mediator.Send(query, cancellationToken).ConfigureAwait(false);
+            return Results.Ok(result);
+        })
+        .WithName("EstimateAgentCost")
+        .WithSummary("Estimate token cost before starting a RAG chat session")
+        .WithDescription("Calculates estimated cost per query based on document chunks, model pricing, and retrieval strategy.")
+        .Produces<AgentCostEstimateDto>();
+
         // GET /api/v1/admin/shared-games (extended for admin - #4654, #4785)
         var gamesGroup = group.MapGroup("/admin/shared-games")
             .WithTags("Admin", "SharedGames")
@@ -132,3 +154,12 @@ internal static class AdminKnowledgeBaseEndpoints
         return $"{len:0.##} {sizes[order]}";
     }
 }
+
+/// <summary>
+/// Request model for pre-chat agent cost estimation by document selection.
+/// </summary>
+internal record EstimateAgentCostByDocumentsRequest(
+    Guid GameId,
+    List<Guid> DocumentIds,
+    string? StrategyName
+);

--- a/apps/api/src/Api/Routing/SharedGameCatalogEndpoints.cs
+++ b/apps/api/src/Api/Routing/SharedGameCatalogEndpoints.cs
@@ -16,6 +16,7 @@ using Api.BoundedContexts.SharedGameCatalog.Application.Queries.GetUserBadges;
 using Api.BoundedContexts.SharedGameCatalog.Application.Queries.GetBadgeLeaderboard;
 using Api.BoundedContexts.SharedGameCatalog.Application.Queries.GetMyActiveReviews;
 using Api.BoundedContexts.SharedGameCatalog.Application.Queries.CheckPrivateGameDuplicates;
+using Api.BoundedContexts.SharedGameCatalog.Application.Queries.GetGameRagReadiness;
 using Api.BoundedContexts.SharedGameCatalog.Application.Commands.ToggleBadgeDisplay;
 using Api.BoundedContexts.SharedGameCatalog.Application.Commands.ApproveGameProposal;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
@@ -456,6 +457,15 @@ internal static class SharedGameCatalogEndpoints
             .WithSummary("Activate game state template version (Admin/Editor)")
             .WithDescription("Sets the specified template version as active. Deactivates all other versions for this game.")
             .Produces(StatusCodes.Status204NoContent)
+            .Produces(StatusCodes.Status404NotFound);
+
+        // RAG Readiness aggregation (cross-BC: SharedGameCatalog + DocumentProcessing + KnowledgeBase)
+        group.MapGet("/admin/shared-games/{id:guid}/rag-readiness", HandleGetGameRagReadiness)
+            .RequireAuthorization("AdminOrEditorPolicy")
+            .WithName("GetGameRagReadiness")
+            .WithSummary("Get RAG readiness status for a shared game (Admin/Editor)")
+            .WithDescription("Aggregates document processing status and agent linkage across bounded contexts to determine if a game is RAG-ready.")
+            .Produces<GameRagReadinessDto>()
             .Produces(StatusCodes.Status404NotFound);
     }
 
@@ -1399,6 +1409,16 @@ internal static class SharedGameCatalogEndpoints
         CancellationToken ct)
     {
         var query = new GetActiveDocumentsQuery(id);
+        var result = await mediator.Send(query, ct).ConfigureAwait(false);
+        return Results.Ok(result);
+    }
+
+    private static async Task<IResult> HandleGetGameRagReadiness(
+        Guid id,
+        IMediator mediator,
+        CancellationToken ct)
+    {
+        var query = new GetGameRagReadinessQuery(id);
         var result = await mediator.Send(query, ct).ConfigureAwait(false);
         return Results.Ok(result);
     }

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/CreateAgentWithSetupCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/CreateAgentWithSetupCommandHandlerTests.cs
@@ -3,6 +3,7 @@ using Api.BoundedContexts.KnowledgeBase.Application.Handlers;
 using Api.BoundedContexts.KnowledgeBase.Domain.Entities;
 using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
 using Api.BoundedContexts.KnowledgeBase.Domain.ValueObjects;
+using Api.BoundedContexts.SharedGameCatalog.Application.Commands;
 using Api.BoundedContexts.UserLibrary.Domain.Entities;
 using Api.BoundedContexts.UserLibrary.Domain.Repositories;
 using Api.Infrastructure;
@@ -31,6 +32,7 @@ public class CreateAgentWithSetupCommandHandlerTests
     private readonly Mock<IUserLibraryRepository> _mockLibraryRepo;
     private readonly Mock<IUnitOfWork> _mockUnitOfWork;
     private readonly MeepleAiDbContext _db;
+    private readonly Mock<IMediator> _mockMediator;
     private readonly Mock<ILogger<CreateAgentWithSetupCommandHandler>> _mockLogger;
     private readonly CreateAgentWithSetupCommandHandler _handler;
 
@@ -43,6 +45,7 @@ public class CreateAgentWithSetupCommandHandlerTests
         _mockChatRepo = new Mock<IChatThreadRepository>();
         _mockLibraryRepo = new Mock<IUserLibraryRepository>();
         _mockUnitOfWork = new Mock<IUnitOfWork>();
+        _mockMediator = new Mock<IMediator>();
         _mockLogger = new Mock<ILogger<CreateAgentWithSetupCommandHandler>>();
 
         var options = new DbContextOptionsBuilder<MeepleAiDbContext>()
@@ -56,6 +59,7 @@ public class CreateAgentWithSetupCommandHandlerTests
             _mockLibraryRepo.Object,
             _mockUnitOfWork.Object,
             _db,
+            _mockMediator.Object,
             _mockLogger.Object);
 
         // Default: no existing agents, name doesn't exist
@@ -298,12 +302,126 @@ public class CreateAgentWithSetupCommandHandlerTests
         Assert.Equal(201, result.SlotUsed);
     }
 
+    [Fact]
+    public async Task Handle_WithSharedGameId_SendsLinkCommand()
+    {
+        // Arrange
+        var sharedGameId = Guid.NewGuid();
+        _mockMediator
+            .Setup(m => m.Send(It.IsAny<LinkAgentToSharedGameCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Unit.Value);
+
+        var command = CreateCommand(sharedGameId: sharedGameId);
+
+        // Act
+        var result = await _handler.Handle(command, TestContext.Current.CancellationToken);
+
+        // Assert
+        _mockMediator.Verify(
+            m => m.Send(
+                It.Is<LinkAgentToSharedGameCommand>(cmd =>
+                    cmd.GameId == sharedGameId && cmd.AgentId == result.AgentId),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_WithDocumentIds_SendsUpdateDocumentsCommand()
+    {
+        // Arrange
+        var documentIds = new List<Guid> { Guid.NewGuid(), Guid.NewGuid() };
+        _mockMediator
+            .Setup(m => m.Send(It.IsAny<UpdateAgentDocumentsCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new UpdateAgentDocumentsResult(true, "ok", Guid.NewGuid(), 2));
+
+        var command = CreateCommand(documentIds: documentIds);
+
+        // Act
+        var result = await _handler.Handle(command, TestContext.Current.CancellationToken);
+
+        // Assert
+        _mockMediator.Verify(
+            m => m.Send(
+                It.Is<UpdateAgentDocumentsCommand>(cmd =>
+                    cmd.AgentId == result.AgentId &&
+                    cmd.DocumentIds.Count == 2),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_WithoutOptionalFields_DoesNotSendExtraCommands()
+    {
+        // Arrange
+        var command = CreateCommand();
+
+        // Act
+        await _handler.Handle(command, TestContext.Current.CancellationToken);
+
+        // Assert
+        _mockMediator.Verify(
+            m => m.Send(It.IsAny<LinkAgentToSharedGameCommand>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _mockMediator.Verify(
+            m => m.Send(It.IsAny<UpdateAgentDocumentsCommand>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_WithEmptyDocumentIds_DoesNotSendUpdateCommand()
+    {
+        // Arrange
+        var command = CreateCommand(documentIds: new List<Guid>());
+
+        // Act
+        await _handler.Handle(command, TestContext.Current.CancellationToken);
+
+        // Assert
+        _mockMediator.Verify(
+            m => m.Send(It.IsAny<UpdateAgentDocumentsCommand>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_WithBothOptionalFields_SendsBothCommands()
+    {
+        // Arrange
+        var sharedGameId = Guid.NewGuid();
+        var documentIds = new List<Guid> { Guid.NewGuid() };
+
+        _mockMediator
+            .Setup(m => m.Send(It.IsAny<LinkAgentToSharedGameCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(Unit.Value);
+        _mockMediator
+            .Setup(m => m.Send(It.IsAny<UpdateAgentDocumentsCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new UpdateAgentDocumentsResult(true, "ok", Guid.NewGuid(), 1));
+
+        var command = CreateCommand(sharedGameId: sharedGameId, documentIds: documentIds);
+
+        // Act
+        var result = await _handler.Handle(command, TestContext.Current.CancellationToken);
+
+        // Assert
+        _mockMediator.Verify(
+            m => m.Send(
+                It.Is<LinkAgentToSharedGameCommand>(cmd => cmd.GameId == sharedGameId),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+        _mockMediator.Verify(
+            m => m.Send(
+                It.Is<UpdateAgentDocumentsCommand>(cmd => cmd.AgentId == result.AgentId),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
     private CreateAgentWithSetupCommand CreateCommand(
         string tier = "free",
         string role = "user",
         bool addToCollection = false,
         string agentName = null!,
-        string? strategyName = null)
+        string? strategyName = null,
+        Guid? sharedGameId = null,
+        List<Guid>? documentIds = null)
     {
         return new CreateAgentWithSetupCommand(
             UserId: _userId,
@@ -314,7 +432,11 @@ public class CreateAgentWithSetupCommandHandlerTests
             AgentType: "RAG",
             AgentName: agentName,
             StrategyName: strategyName,
-            StrategyParameters: null);
+            StrategyParameters: null)
+        {
+            SharedGameId = sharedGameId,
+            DocumentIds = documentIds
+        };
     }
 
     private static Agent CreateAgent(string name, bool isActive = true)

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/EstimateAgentCost/EstimateAgentCostQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Queries/EstimateAgentCost/EstimateAgentCostQueryHandlerTests.cs
@@ -1,0 +1,135 @@
+using Api.BoundedContexts.KnowledgeBase.Application.Queries.EstimateAgentCost;
+using Api.BoundedContexts.KnowledgeBase.Domain.Entities;
+using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
+using Api.Tests.Constants;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.KnowledgeBase.Application.Queries.EstimateAgentCost;
+
+/// <summary>
+/// Tests for EstimateAgentCostQueryHandler.
+/// Validates pre-chat cost estimation logic for RAG agent sessions.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+public class EstimateAgentCostQueryHandlerTests
+{
+    private readonly Mock<IVectorDocumentRepository> _mockVectorDocumentRepository;
+    private readonly Mock<ILogger<EstimateAgentCostQueryHandler>> _mockLogger;
+    private readonly EstimateAgentCostQueryHandler _handler;
+
+    public EstimateAgentCostQueryHandlerTests()
+    {
+        _mockVectorDocumentRepository = new Mock<IVectorDocumentRepository>();
+        _mockLogger = new Mock<ILogger<EstimateAgentCostQueryHandler>>();
+        _handler = new EstimateAgentCostQueryHandler(
+            _mockVectorDocumentRepository.Object,
+            _mockLogger.Object);
+    }
+
+    [Fact]
+    public async Task Handle_NoDocuments_ReturnsZeroCost()
+    {
+        // Arrange
+        var gameId = Guid.NewGuid();
+        var documentIds = new List<Guid> { Guid.NewGuid() };
+        var query = new EstimateAgentCostQuery(gameId, documentIds);
+
+        _mockVectorDocumentRepository
+            .Setup(r => r.GetByGameIdAsync(gameId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<VectorDocument>());
+
+        // Act
+        var result = await _handler.Handle(query, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(0, result.TotalChunks);
+        Assert.Equal(0, result.EstimatedEmbeddingTokens);
+        Assert.Equal(0m, result.EstimatedCostPerQuery);
+        Assert.Equal("USD", result.Currency);
+        Assert.Contains("No indexed chunks found", result.Note);
+
+        _mockVectorDocumentRepository.Verify(
+            r => r.GetByGameIdAsync(gameId, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_WithDocuments_ReturnsCalculatedCost()
+    {
+        // Arrange
+        var gameId = Guid.NewGuid();
+        var pdfDocId1 = Guid.NewGuid();
+        var pdfDocId2 = Guid.NewGuid();
+        var documentIds = new List<Guid> { pdfDocId1, pdfDocId2 };
+
+        var vectorDoc1 = new VectorDocument(
+            id: Guid.NewGuid(),
+            gameId: gameId,
+            pdfDocumentId: pdfDocId1,
+            language: "en",
+            totalChunks: 20);
+
+        var vectorDoc2 = new VectorDocument(
+            id: Guid.NewGuid(),
+            gameId: gameId,
+            pdfDocumentId: pdfDocId2,
+            language: "en",
+            totalChunks: 30);
+
+        var query = new EstimateAgentCostQuery(gameId, documentIds, "VectorSearch");
+
+        _mockVectorDocumentRepository
+            .Setup(r => r.GetByGameIdAsync(gameId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<VectorDocument> { vectorDoc1, vectorDoc2 });
+
+        // Act
+        var result = await _handler.Handle(query, TestContext.Current.CancellationToken);
+
+        // Assert
+        Assert.NotNull(result);
+        Assert.Equal(50, result.TotalChunks); // 20 + 30
+        Assert.True(result.EstimatedEmbeddingTokens > 0);
+        Assert.True(result.EstimatedCostPerQuery > 0m);
+        Assert.Equal("USD", result.Currency);
+        Assert.Contains("nomic-embed-text", result.Model);
+        Assert.Contains("gpt-4o-mini", result.Model);
+        Assert.Contains("top-5", result.Note);
+        Assert.Contains("50 chunks", result.Note);
+    }
+
+    [Fact]
+    public async Task Handle_HybridSearchStrategy_IncludesSearchCost()
+    {
+        // Arrange
+        var gameId = Guid.NewGuid();
+        var pdfDocId = Guid.NewGuid();
+        var documentIds = new List<Guid> { pdfDocId };
+
+        var vectorDoc = new VectorDocument(
+            id: Guid.NewGuid(),
+            gameId: gameId,
+            pdfDocumentId: pdfDocId,
+            language: "en",
+            totalChunks: 10);
+
+        _mockVectorDocumentRepository
+            .Setup(r => r.GetByGameIdAsync(gameId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<VectorDocument> { vectorDoc });
+
+        var hybridQuery = new EstimateAgentCostQuery(gameId, documentIds, "HybridSearch");
+        var vectorQuery = new EstimateAgentCostQuery(gameId, documentIds, "VectorSearch");
+
+        // Act
+        var hybridResult = await _handler.Handle(hybridQuery, TestContext.Current.CancellationToken);
+        var vectorResult = await _handler.Handle(vectorQuery, TestContext.Current.CancellationToken);
+
+        // Assert - HybridSearch should cost more due to reranking
+        Assert.True(hybridResult.EstimatedCostPerQuery > vectorResult.EstimatedCostPerQuery,
+            "HybridSearch should have higher cost than VectorSearch due to reranking");
+        Assert.Contains("HybridSearch", hybridResult.Note);
+        Assert.Contains("reranking", hybridResult.Note);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Queries/GetGameRagReadiness/GetGameRagReadinessQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Queries/GetGameRagReadiness/GetGameRagReadinessQueryHandlerTests.cs
@@ -1,0 +1,298 @@
+using Api.BoundedContexts.DocumentProcessing.Domain.Entities;
+using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
+using Api.BoundedContexts.DocumentProcessing.Domain.Repositories;
+using Api.BoundedContexts.DocumentProcessing.Domain.ValueObjects;
+using Api.BoundedContexts.KnowledgeBase.Domain.Entities;
+using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
+using Api.BoundedContexts.KnowledgeBase.Domain.ValueObjects;
+using Api.BoundedContexts.SharedGameCatalog.Application.Queries.GetGameRagReadiness;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.Middleware.Exceptions;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Queries.GetGameRagReadiness;
+
+/// <summary>
+/// Unit tests for GetGameRagReadinessQueryHandler.
+/// Tests cross-BC aggregation of RAG readiness status.
+/// </summary>
+public sealed class GetGameRagReadinessQueryHandlerTests
+{
+    private readonly Mock<ISharedGameRepository> _gameRepositoryMock;
+    private readonly Mock<ISharedGameDocumentRepository> _documentRepositoryMock;
+    private readonly Mock<IPdfDocumentRepository> _pdfDocumentRepositoryMock;
+    private readonly Mock<IAgentDefinitionRepository> _agentDefinitionRepositoryMock;
+    private readonly GetGameRagReadinessQueryHandler _sut;
+
+    public GetGameRagReadinessQueryHandlerTests()
+    {
+        _gameRepositoryMock = new Mock<ISharedGameRepository>();
+        _documentRepositoryMock = new Mock<ISharedGameDocumentRepository>();
+        _pdfDocumentRepositoryMock = new Mock<IPdfDocumentRepository>();
+        _agentDefinitionRepositoryMock = new Mock<IAgentDefinitionRepository>();
+
+        _sut = new GetGameRagReadinessQueryHandler(
+            _gameRepositoryMock.Object,
+            _documentRepositoryMock.Object,
+            _pdfDocumentRepositoryMock.Object,
+            _agentDefinitionRepositoryMock.Object,
+            NullLogger<GetGameRagReadinessQueryHandler>.Instance);
+    }
+
+    [Fact]
+    public async Task Handle_GameNotFound_ThrowsNotFoundException()
+    {
+        // Arrange
+        var gameId = Guid.NewGuid();
+        var query = new GetGameRagReadinessQuery(gameId);
+
+        _gameRepositoryMock
+            .Setup(x => x.GetByIdAsync(gameId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SharedGame?)null);
+
+        // Act and Assert
+        var exception = await Assert.ThrowsAsync<NotFoundException>(
+            () => _sut.Handle(query, CancellationToken.None));
+
+        Assert.Equal("SharedGame", exception.ResourceType);
+        Assert.Equal(gameId.ToString(), exception.ResourceId);
+    }
+
+    [Fact]
+    public async Task Handle_NoDocuments_ReturnsNoDocumentsReadiness()
+    {
+        // Arrange
+        var gameId = Guid.NewGuid();
+        var query = new GetGameRagReadinessQuery(gameId);
+
+        var game = CreateSharedGame(gameId);
+        _gameRepositoryMock
+            .Setup(x => x.GetByIdAsync(gameId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(game);
+
+        _documentRepositoryMock
+            .Setup(x => x.GetBySharedGameIdAsync(gameId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<SharedGameDocument>());
+
+        // Act
+        var result = await _sut.Handle(query, CancellationToken.None);
+
+        // Assert
+        Assert.Equal(gameId, result.GameId);
+        Assert.Equal("no_documents", result.OverallReadiness);
+        Assert.Equal(0, result.TotalDocuments);
+        Assert.Empty(result.Documents);
+        Assert.Null(result.LinkedAgent);
+    }
+
+    [Fact]
+    public async Task Handle_ProcessingDocuments_ReturnsDocumentsProcessingReadiness()
+    {
+        // Arrange
+        var gameId = Guid.NewGuid();
+        var pdfId = Guid.NewGuid();
+        var query = new GetGameRagReadinessQuery(gameId);
+
+        var game = CreateSharedGame(gameId);
+        _gameRepositoryMock
+            .Setup(x => x.GetByIdAsync(gameId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(game);
+
+        var sharedDoc = CreateSharedGameDocument(gameId, pdfId);
+        _documentRepositoryMock
+            .Setup(x => x.GetBySharedGameIdAsync(gameId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<SharedGameDocument> { sharedDoc });
+
+        var pdfDoc = CreatePdfDocument(pdfId, gameId, PdfProcessingState.Extracting);
+        _pdfDocumentRepositoryMock
+            .Setup(x => x.GetByIdsAsync(It.Is<IEnumerable<Guid>>(ids => ids.Contains(pdfId)), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<PdfDocument> { pdfDoc });
+
+        // Act
+        var result = await _sut.Handle(query, CancellationToken.None);
+
+        // Assert
+        Assert.Equal("documents_processing", result.OverallReadiness);
+        Assert.Equal(1, result.TotalDocuments);
+        Assert.Equal(0, result.ReadyDocuments);
+        Assert.Equal(1, result.ProcessingDocuments);
+        Assert.Single(result.Documents);
+        Assert.Equal("Extracting", result.Documents[0].ProcessingState);
+    }
+
+    [Fact]
+    public async Task Handle_AllDocsReady_NoAgent_ReturnsReadyForAgent()
+    {
+        // Arrange
+        var gameId = Guid.NewGuid();
+        var pdfId = Guid.NewGuid();
+        var query = new GetGameRagReadinessQuery(gameId);
+
+        var game = CreateSharedGame(gameId, agentDefinitionId: null);
+        _gameRepositoryMock
+            .Setup(x => x.GetByIdAsync(gameId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(game);
+
+        var sharedDoc = CreateSharedGameDocument(gameId, pdfId);
+        _documentRepositoryMock
+            .Setup(x => x.GetBySharedGameIdAsync(gameId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<SharedGameDocument> { sharedDoc });
+
+        var pdfDoc = CreatePdfDocument(pdfId, gameId, PdfProcessingState.Ready);
+        _pdfDocumentRepositoryMock
+            .Setup(x => x.GetByIdsAsync(It.Is<IEnumerable<Guid>>(ids => ids.Contains(pdfId)), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<PdfDocument> { pdfDoc });
+
+        // Act
+        var result = await _sut.Handle(query, CancellationToken.None);
+
+        // Assert
+        Assert.Equal("ready_for_agent", result.OverallReadiness);
+        Assert.Equal(1, result.ReadyDocuments);
+        Assert.Null(result.LinkedAgent);
+    }
+
+    [Fact]
+    public async Task Handle_AllDocsReady_AgentLinked_ReturnsFullyOperational()
+    {
+        // Arrange
+        var gameId = Guid.NewGuid();
+        var pdfId = Guid.NewGuid();
+        var agentId = Guid.NewGuid();
+        var query = new GetGameRagReadinessQuery(gameId);
+
+        var game = CreateSharedGame(gameId, agentDefinitionId: agentId);
+        _gameRepositoryMock
+            .Setup(x => x.GetByIdAsync(gameId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(game);
+
+        var sharedDoc = CreateSharedGameDocument(gameId, pdfId);
+        _documentRepositoryMock
+            .Setup(x => x.GetBySharedGameIdAsync(gameId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<SharedGameDocument> { sharedDoc });
+
+        var pdfDoc = CreatePdfDocument(pdfId, gameId, PdfProcessingState.Ready);
+        _pdfDocumentRepositoryMock
+            .Setup(x => x.GetByIdsAsync(It.Is<IEnumerable<Guid>>(ids => ids.Contains(pdfId)), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<PdfDocument> { pdfDoc });
+
+        var agentDef = CreateAgentDefinition(agentId);
+        _agentDefinitionRepositoryMock
+            .Setup(x => x.GetByIdAsync(agentId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(agentDef);
+
+        // Act
+        var result = await _sut.Handle(query, CancellationToken.None);
+
+        // Assert
+        Assert.Equal("fully_operational", result.OverallReadiness);
+        Assert.Equal(1, result.ReadyDocuments);
+        Assert.NotNull(result.LinkedAgent);
+        Assert.Equal(agentId, result.LinkedAgent.AgentId);
+        Assert.True(result.LinkedAgent.IsActive);
+    }
+
+    // ==========================================
+    // Factory helpers
+    // ==========================================
+
+    private static SharedGame CreateSharedGame(Guid gameId, Guid? agentDefinitionId = null)
+    {
+        var game = SharedGame.Create(
+            title: "Test Game",
+            yearPublished: 2024,
+            description: "A test board game for unit testing.",
+            minPlayers: 2,
+            maxPlayers: 4,
+            playingTimeMinutes: 60,
+            minAge: 10,
+            complexityRating: 2.5m,
+            averageRating: 7.5m,
+            imageUrl: "https://example.com/image.jpg",
+            thumbnailUrl: "https://example.com/thumb.jpg",
+            rules: null,
+            createdBy: Guid.NewGuid());
+
+        // Use reflection to set Id and AgentDefinitionId since they are private
+        SetPrivateField(game, "_id", gameId);
+        if (agentDefinitionId.HasValue)
+        {
+            SetPrivateField(game, "_agentDefinitionId", agentDefinitionId);
+        }
+
+        return game;
+    }
+
+    private static SharedGameDocument CreateSharedGameDocument(Guid sharedGameId, Guid pdfDocumentId)
+    {
+        return new SharedGameDocument(
+            id: Guid.NewGuid(),
+            sharedGameId: sharedGameId,
+            pdfDocumentId: pdfDocumentId,
+            documentType: SharedGameDocumentType.Rulebook,
+            version: "1.0",
+            isActive: true,
+            tags: null,
+            createdAt: DateTime.UtcNow,
+            createdBy: Guid.NewGuid());
+    }
+
+    private static PdfDocument CreatePdfDocument(Guid id, Guid gameId, PdfProcessingState state)
+    {
+        return PdfDocument.Reconstitute(
+            id: id,
+            gameId: gameId,
+            fileName: new FileName("test-rulebook.pdf"),
+            filePath: "/uploads/test-rulebook.pdf",
+            fileSize: new FileSize(1024),
+            uploadedByUserId: Guid.NewGuid(),
+            uploadedAt: DateTime.UtcNow,
+            processingStatus: state == PdfProcessingState.Ready ? "completed" : "processing",
+            processedAt: state == PdfProcessingState.Ready ? DateTime.UtcNow : null,
+            pageCount: state == PdfProcessingState.Ready ? 10 : null,
+            processingError: null,
+            language: LanguageCode.English,
+            processingState: state,
+            isActiveForRag: true);
+    }
+
+    private static AgentDefinition CreateAgentDefinition(Guid id)
+    {
+        var agent = AgentDefinition.Create(
+            name: "Test Agent",
+            description: "A test AI agent",
+            type: AgentType.Custom("rag", "RAG Agent"),
+            config: AgentDefinitionConfig.Create("gpt-4", 4096, 0.7f));
+
+        // Set the Id via reflection since Create generates a new one
+        SetPropertyValue(agent, "Id", id);
+        return agent;
+    }
+
+    private static void SetPrivateField(object obj, string fieldName, object? value)
+    {
+        var field = obj.GetType().GetField(fieldName,
+            System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+        field?.SetValue(obj, value);
+    }
+
+    private static void SetPropertyValue(object obj, string propertyName, object? value)
+    {
+        var type = obj.GetType();
+        while (type is not null)
+        {
+            var prop = type.GetProperty(propertyName,
+                System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance);
+            if (prop is not null && prop.CanWrite)
+            {
+                prop.SetValue(obj, value);
+                return;
+            }
+            type = type.BaseType;
+        }
+    }
+}

--- a/apps/web/src/app/admin/(dashboard)/shared-games/[id]/client.tsx
+++ b/apps/web/src/app/admin/(dashboard)/shared-games/[id]/client.tsx
@@ -20,6 +20,7 @@ import {
   FileText,
   Link2,
   MoreHorizontal,
+  Settings2,
   Trash2,
   Unlink,
   Wand2,
@@ -308,9 +309,17 @@ export function GameDetailClient({ params }: GameDetailClientProps) {
           </div>
         </div>
 
-        <Button variant="outline" size="sm" disabled title="Edit functionality coming soon">
-          Edit Game
-        </Button>
+        <div className="flex items-center gap-2">
+          <Link href={`/admin/shared-games/${gameId}/rag-setup`}>
+            <Button variant="outline" size="sm" className="gap-2">
+              <Settings2 className="h-4 w-4" />
+              RAG Setup
+            </Button>
+          </Link>
+          <Button variant="outline" size="sm" disabled title="Edit functionality coming soon">
+            Edit Game
+          </Button>
+        </div>
       </div>
 
       {/* Tabs */}

--- a/apps/web/src/app/admin/(dashboard)/shared-games/[id]/rag-setup/client.tsx
+++ b/apps/web/src/app/admin/(dashboard)/shared-games/[id]/rag-setup/client.tsx
@@ -1,0 +1,149 @@
+/**
+ * RAG Setup Dashboard Client - Admin Dashboard
+ *
+ * 4-panel single-page dashboard layout:
+ * ┌──────────────────────────────────────┐
+ * │ Header: Back + Game title + Readiness│
+ * ├──────────────┬───────────────────────┤
+ * │ Left Column  │ Right Column          │
+ * │ 1. PDF Upload│ 3. Agent Setup        │
+ * │ 2. Doc List  │ 4. Chat               │
+ * │   + Status   │                       │
+ * └──────────────┴───────────────────────┘
+ */
+
+'use client';
+
+import { use, useState } from 'react';
+
+import { ArrowLeft, FileText } from 'lucide-react';
+import Link from 'next/link';
+
+import { PdfIndexingStatus } from '@/components/admin/shared-games/PdfIndexingStatus';
+import { PdfUploadSection } from '@/components/admin/shared-games/PdfUploadSection';
+import { AgentSetupPanel } from '@/components/admin/shared-games/rag-setup/AgentSetupPanel';
+import { InlineChatPanel } from '@/components/admin/shared-games/rag-setup/InlineChatPanel';
+import { RagReadinessIndicator } from '@/components/admin/shared-games/rag-setup/RagReadinessIndicator';
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/data-display/card';
+import { Skeleton } from '@/components/ui/feedback/skeleton';
+import { Button } from '@/components/ui/primitives/button';
+import { useGameRagReadiness } from '@/hooks/queries/useGameRagReadiness';
+
+interface RagSetupClientProps {
+  params: Promise<{ id: string }>;
+}
+
+export function RagSetupClient({ params }: RagSetupClientProps) {
+  const { id: gameId } = use(params);
+  const { data: readiness, isLoading } = useGameRagReadiness(gameId);
+  const [agentInfo, setAgentInfo] = useState<{
+    agentId: string;
+    chatThreadId: string;
+  } | null>(null);
+
+  // Derive active agent/thread from either new creation or existing linked agent
+  const activeAgentId =
+    agentInfo?.agentId ?? readiness?.linkedAgent?.agentId ?? null;
+  const activeChatThreadId = agentInfo?.chatThreadId ?? null;
+
+  if (isLoading) {
+    return (
+      <div className="space-y-6">
+        <Skeleton className="h-8 w-64" />
+        <Skeleton className="h-16 w-full rounded-xl" />
+        <div className="grid gap-6 lg:grid-cols-2">
+          <Skeleton className="h-96 w-full rounded-xl" />
+          <Skeleton className="h-96 w-full rounded-xl" />
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center gap-4">
+        <Link href={`/admin/shared-games/${gameId}`}>
+          <Button variant="ghost" size="icon">
+            <ArrowLeft className="h-5 w-5" />
+          </Button>
+        </Link>
+        <div className="flex-1">
+          <h1 className="text-2xl font-bold">
+            RAG Setup: {readiness?.gameTitle ?? 'Gioco'}
+          </h1>
+          <p className="text-sm text-muted-foreground">
+            Configura documenti, agente e chat per questo gioco
+          </p>
+        </div>
+      </div>
+
+      {/* Readiness Indicator */}
+      {readiness && <RagReadinessIndicator readiness={readiness} />}
+
+      {/* Two-column layout */}
+      <div className="grid gap-6 lg:grid-cols-2">
+        {/* Left Column: Documents */}
+        <div className="space-y-6">
+          {/* PDF Upload */}
+          <PdfUploadSection gameId={gameId} />
+
+          {/* Document List with Status */}
+          {readiness && readiness.documents.length > 0 && (
+            <Card>
+              <CardHeader>
+                <CardTitle className="flex items-center gap-2 text-base">
+                  <FileText className="h-5 w-5" />
+                  Documenti ({readiness.readyDocuments}/{readiness.totalDocuments}{' '}
+                  pronti)
+                </CardTitle>
+              </CardHeader>
+              <CardContent className="space-y-3">
+                {readiness.documents.map((doc) => (
+                  <div
+                    key={doc.documentId}
+                    className="flex items-center justify-between rounded-lg border p-3"
+                  >
+                    <div className="min-w-0 flex-1">
+                      <p className="truncate text-sm font-medium">
+                        {doc.fileName}
+                      </p>
+                    </div>
+                    <PdfIndexingStatus
+                      pdfId={doc.documentId}
+                      fileName={doc.fileName}
+                      compact
+                    />
+                  </div>
+                ))}
+              </CardContent>
+            </Card>
+          )}
+        </div>
+
+        {/* Right Column: Agent + Chat */}
+        <div className="space-y-6">
+          {/* Agent Setup */}
+          <AgentSetupPanel
+            gameId={gameId}
+            gameTitle={readiness?.gameTitle ?? ''}
+            documents={readiness?.documents ?? []}
+            existingAgent={readiness?.linkedAgent ?? null}
+            onAgentCreated={(info) => setAgentInfo(info)}
+          />
+
+          {/* Inline Chat */}
+          <InlineChatPanel
+            agentId={activeAgentId}
+            chatThreadId={activeChatThreadId}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/admin/(dashboard)/shared-games/[id]/rag-setup/page.tsx
+++ b/apps/web/src/app/admin/(dashboard)/shared-games/[id]/rag-setup/page.tsx
@@ -1,0 +1,57 @@
+/**
+ * RAG Setup Page - Admin Dashboard
+ *
+ * Route: /admin/shared-games/[id]/rag-setup
+ * Single-page dashboard for RAG configuration:
+ * upload PDFs, monitor embedding, create agent, test chat.
+ */
+
+import { Suspense } from 'react';
+
+import { type Metadata } from 'next';
+
+import { Skeleton } from '@/components/ui/feedback/skeleton';
+
+import { RagSetupClient } from './client';
+
+interface RagSetupPageProps {
+  params: Promise<{ id: string }>;
+}
+
+export const metadata: Metadata = {
+  title: 'RAG Setup',
+  description: 'Configura RAG per un gioco condiviso',
+};
+
+function LoadingSkeleton() {
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center gap-4">
+        <Skeleton className="h-9 w-9 rounded-md" />
+        <div className="space-y-2">
+          <Skeleton className="h-8 w-64" />
+          <Skeleton className="h-4 w-48" />
+        </div>
+      </div>
+      <Skeleton className="h-16 w-full rounded-xl" />
+      <div className="grid gap-6 lg:grid-cols-2">
+        <div className="space-y-6">
+          <Skeleton className="h-64 w-full rounded-xl" />
+          <Skeleton className="h-48 w-full rounded-xl" />
+        </div>
+        <div className="space-y-6">
+          <Skeleton className="h-80 w-full rounded-xl" />
+          <Skeleton className="h-[480px] w-full rounded-xl" />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export default function RagSetupPage({ params }: RagSetupPageProps) {
+  return (
+    <Suspense fallback={<LoadingSkeleton />}>
+      <RagSetupClient params={params} />
+    </Suspense>
+  );
+}

--- a/apps/web/src/components/admin/shared-games/rag-setup/AgentSetupPanel.tsx
+++ b/apps/web/src/components/admin/shared-games/rag-setup/AgentSetupPanel.tsx
@@ -1,0 +1,269 @@
+/**
+ * Agent Setup Panel - Admin RAG Dashboard
+ *
+ * Allows admin to create a RAG agent with selected Ready documents.
+ * Shows cost estimation and document selection checklist.
+ */
+
+'use client';
+
+import { useState, useMemo } from 'react';
+
+import { Bot, CheckCircle2, Loader2, DollarSign } from 'lucide-react';
+import { toast } from 'sonner';
+
+import { Badge } from '@/components/ui/data-display/badge';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/data-display/card';
+import { Button } from '@/components/ui/primitives/button';
+import { Checkbox } from '@/components/ui/primitives/checkbox';
+import { Input } from '@/components/ui/primitives/input';
+import { Label } from '@/components/ui/primitives/label';
+import { useEstimateAgentCost } from '@/hooks/queries/useEstimateAgentCost';
+import { api } from '@/lib/api';
+import type { DocumentStatus, AgentInfo } from '@/lib/api/schemas/rag-setup.schemas';
+
+interface AgentSetupPanelProps {
+  gameId: string;
+  gameTitle: string;
+  documents: DocumentStatus[];
+  existingAgent: AgentInfo | null;
+  onAgentCreated: (info: { agentId: string; chatThreadId: string }) => void;
+}
+
+export function AgentSetupPanel({
+  gameId,
+  gameTitle,
+  documents,
+  existingAgent,
+  onAgentCreated,
+}: AgentSetupPanelProps) {
+  const [agentName, setAgentName] = useState(`${gameTitle} Assistant`);
+  const [selectedDocIds, setSelectedDocIds] = useState<string[]>(() =>
+    documents
+      .filter((d) => d.processingState === 'Ready' && d.isActiveForRag)
+      .map((d) => d.documentId)
+  );
+  const [creating, setCreating] = useState(false);
+
+  const readyDocs = useMemo(
+    () => documents.filter((d) => d.processingState === 'Ready'),
+    [documents]
+  );
+
+  const { data: costEstimate, isLoading: costLoading } = useEstimateAgentCost(
+    gameId,
+    selectedDocIds,
+    selectedDocIds.length > 0
+  );
+
+  const toggleDoc = (docId: string) => {
+    setSelectedDocIds((prev) =>
+      prev.includes(docId) ? prev.filter((id) => id !== docId) : [...prev, docId]
+    );
+  };
+
+  const handleCreate = async () => {
+    if (selectedDocIds.length === 0) return;
+
+    setCreating(true);
+    try {
+      const result = await api.agents.createAgentWithSetup({
+        userId: '', // Set by backend from session
+        userTier: 'premium',
+        userRole: 'admin',
+        gameId,
+        addToCollection: false,
+        agentType: 'RAG',
+        agentName: agentName.trim() || undefined,
+        strategyName: 'HybridSearch',
+        sharedGameId: gameId,
+        documentIds: selectedDocIds,
+      });
+
+      if (result) {
+        toast.success('Agente creato con successo!');
+        onAgentCreated({
+          agentId: result.agentId,
+          chatThreadId: result.threadId,
+        });
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Errore sconosciuto';
+      toast.error(`Creazione fallita: ${message}`);
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  // Show existing agent info if already linked
+  if (existingAgent) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-base">
+            <Bot className="h-5 w-5" />
+            Agente RAG
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="flex items-center justify-between rounded-lg border border-green-200 bg-green-50 p-4 dark:border-green-800 dark:bg-green-900/20">
+            <div className="flex items-center gap-3">
+              <CheckCircle2 className="h-5 w-5 text-green-600 dark:text-green-400" />
+              <div>
+                <p className="font-medium text-green-900 dark:text-green-100">
+                  {existingAgent.name}
+                </p>
+                <p className="text-sm text-green-700 dark:text-green-300">
+                  {existingAgent.type} •{' '}
+                  {existingAgent.isActive ? 'Attivo' : 'Inattivo'}
+                </p>
+              </div>
+            </div>
+            <Badge
+              variant="default"
+              className={
+                existingAgent.isReady
+                  ? 'bg-green-600 hover:bg-green-700'
+                  : 'bg-amber-600 hover:bg-amber-700'
+              }
+            >
+              {existingAgent.isReady ? 'Pronto' : 'Non pronto'}
+            </Badge>
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2 text-base">
+          <Bot className="h-5 w-5" />
+          Crea Agente RAG
+        </CardTitle>
+        <CardDescription>
+          Seleziona i documenti indicizzati e crea un agente per la chat
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        {/* Agent Name */}
+        <div className="space-y-2">
+          <Label htmlFor="agent-name">Nome Agente</Label>
+          <Input
+            id="agent-name"
+            value={agentName}
+            onChange={(e) => setAgentName(e.target.value)}
+            placeholder="es. Catan Assistant"
+          />
+        </div>
+
+        {/* Document Selection */}
+        <div className="space-y-2">
+          <Label>Documenti per RAG</Label>
+          {documents.length === 0 ? (
+            <p className="text-sm text-muted-foreground">
+              Nessun documento caricato. Carica un PDF per iniziare.
+            </p>
+          ) : (
+            <div className="space-y-2">
+              {documents.map((doc) => {
+                const isReady = doc.processingState === 'Ready';
+                const isSelected = selectedDocIds.includes(doc.documentId);
+
+                return (
+                  <label
+                    key={doc.documentId}
+                    className="flex items-center gap-3 rounded-lg border p-3 transition-colors hover:bg-muted/50"
+                  >
+                    <Checkbox
+                      checked={isSelected}
+                      onCheckedChange={() => toggleDoc(doc.documentId)}
+                      disabled={!isReady}
+                    />
+                    <span
+                      className={`flex-1 truncate text-sm ${
+                        isReady ? 'font-medium' : 'text-muted-foreground'
+                      }`}
+                    >
+                      {doc.fileName}
+                    </span>
+                    <Badge
+                      variant={isReady ? 'default' : 'secondary'}
+                      className={
+                        isReady
+                          ? 'bg-green-600 text-xs hover:bg-green-700'
+                          : 'text-xs'
+                      }
+                    >
+                      {isReady ? 'Pronto' : doc.processingState}
+                    </Badge>
+                  </label>
+                );
+              })}
+            </div>
+          )}
+        </div>
+
+        {/* Cost Estimation */}
+        {selectedDocIds.length > 0 && (
+          <div className="rounded-lg border bg-muted/30 p-3">
+            <div className="flex items-center gap-2 text-sm font-medium">
+              <DollarSign className="h-4 w-4" />
+              Stima Costi
+            </div>
+            {costLoading ? (
+              <div className="mt-2 flex items-center gap-2 text-xs text-muted-foreground">
+                <Loader2 className="h-3 w-3 animate-spin" />
+                Calcolo in corso...
+              </div>
+            ) : costEstimate ? (
+              <div className="mt-2 space-y-1 text-xs text-muted-foreground">
+                <p>
+                  Chunks totali: <strong>{costEstimate.totalChunks}</strong>
+                </p>
+                <p>
+                  Costo per query:{' '}
+                  <strong>
+                    ${costEstimate.estimatedCostPerQuery.toFixed(6)}{' '}
+                    {costEstimate.currency}
+                  </strong>
+                </p>
+                <p>Modello: {costEstimate.model}</p>
+                <p className="italic">{costEstimate.note}</p>
+              </div>
+            ) : null}
+          </div>
+        )}
+
+        {/* Create Button */}
+        <Button
+          onClick={handleCreate}
+          disabled={
+            creating || selectedDocIds.length === 0 || readyDocs.length === 0
+          }
+          className="w-full"
+        >
+          {creating ? (
+            <>
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              Creazione in corso...
+            </>
+          ) : (
+            <>
+              <Bot className="mr-2 h-4 w-4" />
+              Crea Agente ({selectedDocIds.length} doc
+              {selectedDocIds.length !== 1 ? 'umenti' : 'umento'})
+            </>
+          )}
+        </Button>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/components/admin/shared-games/rag-setup/InlineChatPanel.tsx
+++ b/apps/web/src/components/admin/shared-games/rag-setup/InlineChatPanel.tsx
@@ -1,0 +1,225 @@
+/**
+ * Inline Chat Panel - Admin RAG Dashboard
+ *
+ * Private chat interface for admin to test RAG agent.
+ * Uses SSE streaming via useAgentChatStream hook.
+ */
+
+'use client';
+
+import { useState, useRef, useEffect } from 'react';
+
+import { Bot, MessageSquare, Send, Loader2, User } from 'lucide-react';
+
+import {
+  Card,
+  CardContent,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/data-display/card';
+import { Button } from '@/components/ui/primitives/button';
+import { Textarea } from '@/components/ui/primitives/textarea';
+import { useAgentChatStream } from '@/hooks/useAgentChatStream';
+import { cn } from '@/lib/utils';
+
+interface ChatMessage {
+  id: string;
+  role: 'user' | 'assistant';
+  content: string;
+  timestamp: Date;
+}
+
+interface InlineChatPanelProps {
+  agentId: string | null;
+  chatThreadId: string | null;
+}
+
+export function InlineChatPanel({ agentId, chatThreadId }: InlineChatPanelProps) {
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [input, setInput] = useState('');
+  const [threadId, setThreadId] = useState(chatThreadId);
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+
+  const { state, sendMessage, stopStreaming } = useAgentChatStream({
+    onComplete: (answer, metadata) => {
+      setMessages((prev) => [
+        ...prev,
+        {
+          id: `assistant-${Date.now()}`,
+          role: 'assistant',
+          content: answer,
+          timestamp: new Date(),
+        },
+      ]);
+      if (metadata.chatThreadId) {
+        setThreadId(metadata.chatThreadId);
+      }
+    },
+  });
+
+  // Auto-scroll to bottom on new messages
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages, state.currentAnswer]);
+
+  const handleSend = () => {
+    if (!input.trim() || !agentId || state.isStreaming) return;
+
+    const userMessage: ChatMessage = {
+      id: `user-${Date.now()}`,
+      role: 'user',
+      content: input.trim(),
+      timestamp: new Date(),
+    };
+
+    setMessages((prev) => [...prev, userMessage]);
+    sendMessage(agentId, input.trim(), threadId ?? undefined);
+    setInput('');
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      handleSend();
+    }
+  };
+
+  // Empty state when no agent
+  if (!agentId) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-base">
+            <MessageSquare className="h-5 w-5" />
+            Chat di Test
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="flex flex-col items-center justify-center py-12 text-center text-muted-foreground">
+            <Bot className="mb-3 h-10 w-10 opacity-30" />
+            <p className="font-medium">Crea un agente per avviare la chat</p>
+            <p className="mt-1 text-sm">
+              Prima carica documenti e crea un agente RAG
+            </p>
+          </div>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <Card className="flex flex-col">
+      <CardHeader className="pb-3">
+        <CardTitle className="flex items-center gap-2 text-base">
+          <MessageSquare className="h-5 w-5" />
+          Chat di Test (Privata)
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="flex flex-1 flex-col space-y-3">
+        {/* Messages area */}
+        <div className="flex h-[400px] flex-col gap-3 overflow-y-auto rounded-lg border bg-muted/20 p-3">
+          {messages.length === 0 && !state.isStreaming && (
+            <div className="flex flex-1 items-center justify-center text-sm text-muted-foreground">
+              Scrivi un messaggio per testare l&apos;agente RAG
+            </div>
+          )}
+
+          {messages.map((msg) => (
+            <div
+              key={msg.id}
+              className={cn(
+                'flex gap-2',
+                msg.role === 'user' ? 'justify-end' : 'justify-start'
+              )}
+            >
+              {msg.role === 'assistant' && (
+                <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-primary/10">
+                  <Bot className="h-4 w-4 text-primary" />
+                </div>
+              )}
+              <div
+                className={cn(
+                  'max-w-[80%] rounded-lg px-3 py-2 text-sm',
+                  msg.role === 'user'
+                    ? 'bg-primary text-primary-foreground'
+                    : 'bg-muted'
+                )}
+              >
+                <p className="whitespace-pre-wrap">{msg.content}</p>
+              </div>
+              {msg.role === 'user' && (
+                <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-muted">
+                  <User className="h-4 w-4" />
+                </div>
+              )}
+            </div>
+          ))}
+
+          {/* Streaming response */}
+          {state.isStreaming && state.currentAnswer && (
+            <div className="flex gap-2">
+              <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-primary/10">
+                <Bot className="h-4 w-4 text-primary" />
+              </div>
+              <div className="max-w-[80%] rounded-lg bg-muted px-3 py-2 text-sm">
+                <p className="whitespace-pre-wrap">{state.currentAnswer}</p>
+                <Loader2 className="mt-1 inline h-3 w-3 animate-spin text-muted-foreground" />
+              </div>
+            </div>
+          )}
+
+          {/* Status message */}
+          {state.isStreaming && !state.currentAnswer && state.statusMessage && (
+            <div className="flex items-center justify-center gap-2 text-xs text-muted-foreground">
+              <Loader2 className="h-3 w-3 animate-spin" />
+              {state.statusMessage}
+            </div>
+          )}
+
+          {/* Error message */}
+          {state.error && (
+            <div className="rounded-lg border border-destructive/20 bg-destructive/5 p-2 text-xs text-destructive">
+              {state.error}
+            </div>
+          )}
+
+          <div ref={messagesEndRef} />
+        </div>
+
+        {/* Input area */}
+        <div className="flex gap-2">
+          <Textarea
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={handleKeyDown}
+            placeholder="Scrivi un messaggio per testare il RAG..."
+            className="min-h-[44px] resize-none"
+            rows={1}
+            disabled={state.isStreaming}
+          />
+          {state.isStreaming ? (
+            <Button
+              variant="outline"
+              size="icon"
+              onClick={stopStreaming}
+              className="shrink-0"
+            >
+              <span className="sr-only">Stop</span>
+              <div className="h-3 w-3 rounded-sm bg-foreground" />
+            </Button>
+          ) : (
+            <Button
+              size="icon"
+              onClick={handleSend}
+              disabled={!input.trim()}
+              className="shrink-0"
+            >
+              <Send className="h-4 w-4" />
+              <span className="sr-only">Invia</span>
+            </Button>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/components/admin/shared-games/rag-setup/RagReadinessIndicator.tsx
+++ b/apps/web/src/components/admin/shared-games/rag-setup/RagReadinessIndicator.tsx
@@ -1,0 +1,216 @@
+/**
+ * RAG Readiness Indicator - Admin RAG Dashboard
+ *
+ * Horizontal stepper showing cross-BC readiness status:
+ * 📄 Documenti → ⚙️ Elaborazione → 🤖 Agente → 💬 Chat
+ */
+
+'use client';
+
+import {
+  FileText,
+  Loader2,
+  CheckCircle2,
+  XCircle,
+  Bot,
+  MessageSquare,
+  AlertTriangle,
+} from 'lucide-react';
+
+import { Badge } from '@/components/ui/data-display/badge';
+import { Card, CardContent } from '@/components/ui/data-display/card';
+import { Progress } from '@/components/ui/feedback/progress';
+import type { GameRagReadiness } from '@/lib/api/schemas/rag-setup.schemas';
+import { READINESS_STATES } from '@/lib/api/schemas/rag-setup.schemas';
+import { cn } from '@/lib/utils';
+
+interface RagReadinessIndicatorProps {
+  readiness: GameRagReadiness;
+}
+
+const STEPS = [
+  { id: 'documents', label: 'Documenti', icon: FileText },
+  { id: 'processing', label: 'Elaborazione', icon: Loader2 },
+  { id: 'agent', label: 'Agente', icon: Bot },
+  { id: 'chat', label: 'Chat', icon: MessageSquare },
+] as const;
+
+function getActiveStep(overallReadiness: string): number {
+  switch (overallReadiness) {
+    case READINESS_STATES.NO_DOCUMENTS:
+      return 0;
+    case READINESS_STATES.DOCUMENTS_PROCESSING:
+      return 1;
+    case READINESS_STATES.DOCUMENTS_FAILED:
+      return 1;
+    case READINESS_STATES.READY_FOR_AGENT:
+      return 2;
+    case READINESS_STATES.FULLY_OPERATIONAL:
+      return 4; // all complete
+    default:
+      return 0;
+  }
+}
+
+function getStatusBadge(overallReadiness: string) {
+  switch (overallReadiness) {
+    case READINESS_STATES.NO_DOCUMENTS:
+      return (
+        <Badge variant="secondary">
+          <FileText className="mr-1 h-3 w-3" />
+          Nessun documento
+        </Badge>
+      );
+    case READINESS_STATES.DOCUMENTS_PROCESSING:
+      return (
+        <Badge variant="secondary" className="animate-pulse">
+          <Loader2 className="mr-1 h-3 w-3 animate-spin" />
+          Elaborazione in corso
+        </Badge>
+      );
+    case READINESS_STATES.DOCUMENTS_FAILED:
+      return (
+        <Badge variant="destructive">
+          <XCircle className="mr-1 h-3 w-3" />
+          Elaborazione fallita
+        </Badge>
+      );
+    case READINESS_STATES.READY_FOR_AGENT:
+      return (
+        <Badge variant="default" className="bg-amber-600 hover:bg-amber-700">
+          <Bot className="mr-1 h-3 w-3" />
+          Pronto per agente
+        </Badge>
+      );
+    case READINESS_STATES.FULLY_OPERATIONAL:
+      return (
+        <Badge variant="default" className="bg-green-600 hover:bg-green-700">
+          <CheckCircle2 className="mr-1 h-3 w-3" />
+          Operativo
+        </Badge>
+      );
+    default:
+      return <Badge variant="secondary">Sconosciuto</Badge>;
+  }
+}
+
+export function RagReadinessIndicator({ readiness }: RagReadinessIndicatorProps) {
+  const activeStep = getActiveStep(readiness.overallReadiness);
+  const isFailed = readiness.overallReadiness === READINESS_STATES.DOCUMENTS_FAILED;
+
+  return (
+    <Card>
+      <CardContent className="py-4">
+        {/* Status badge */}
+        <div className="mb-4 flex items-center justify-between">
+          <span className="text-sm font-medium text-muted-foreground">Stato RAG</span>
+          {getStatusBadge(readiness.overallReadiness)}
+        </div>
+
+        {/* Horizontal stepper */}
+        <div className="flex items-center gap-2">
+          {STEPS.map((step, index) => {
+            const Icon = step.icon;
+            const isComplete = index < activeStep;
+            const isCurrent = index === activeStep && activeStep < 4;
+            const isFailedStep = isFailed && index === 1;
+
+            return (
+              <div key={step.id} className="flex flex-1 items-center gap-2">
+                <div
+                  className={cn(
+                    'flex h-9 w-9 shrink-0 items-center justify-center rounded-full border-2 transition-colors',
+                    isComplete &&
+                      'border-green-500 bg-green-50 text-green-600 dark:bg-green-900/30 dark:text-green-400',
+                    isCurrent &&
+                      !isFailedStep &&
+                      'border-amber-500 bg-amber-50 text-amber-600 dark:bg-amber-900/30 dark:text-amber-400',
+                    isFailedStep &&
+                      'border-destructive bg-destructive/10 text-destructive',
+                    !isComplete &&
+                      !isCurrent &&
+                      !isFailedStep &&
+                      'border-muted text-muted-foreground'
+                  )}
+                >
+                  {isComplete ? (
+                    <CheckCircle2 className="h-4 w-4" />
+                  ) : isFailedStep ? (
+                    <AlertTriangle className="h-4 w-4" />
+                  ) : isCurrent && step.id === 'processing' ? (
+                    <Loader2 className="h-4 w-4 animate-spin" />
+                  ) : (
+                    <Icon className="h-4 w-4" />
+                  )}
+                </div>
+                <span
+                  className={cn(
+                    'text-xs font-medium',
+                    isComplete && 'text-green-600 dark:text-green-400',
+                    isCurrent && !isFailedStep && 'text-amber-600 dark:text-amber-400',
+                    isFailedStep && 'text-destructive',
+                    !isComplete && !isCurrent && !isFailedStep && 'text-muted-foreground'
+                  )}
+                >
+                  {step.label}
+                </span>
+                {index < STEPS.length - 1 && (
+                  <div
+                    className={cn(
+                      'h-0.5 flex-1',
+                      isComplete ? 'bg-green-500' : 'bg-muted'
+                    )}
+                  />
+                )}
+              </div>
+            );
+          })}
+        </div>
+
+        {/* Per-document progress (when processing) */}
+        {readiness.processingDocuments > 0 && (
+          <div className="mt-4 space-y-2">
+            {readiness.documents
+              .filter(
+                (d) => d.processingState !== 'Ready' && d.processingState !== 'Failed'
+              )
+              .map((doc) => (
+                <div key={doc.documentId} className="flex items-center gap-3">
+                  <span className="min-w-0 flex-1 truncate text-xs text-muted-foreground">
+                    {doc.fileName}
+                  </span>
+                  <Progress
+                    value={doc.progressPercentage}
+                    className="h-1.5 w-24"
+                  />
+                  <span className="text-xs font-medium tabular-nums">
+                    {doc.progressPercentage}%
+                  </span>
+                </div>
+              ))}
+          </div>
+        )}
+
+        {/* Failed documents warning */}
+        {readiness.failedDocuments > 0 && (
+          <div className="mt-3 flex items-center gap-2 rounded-lg border border-destructive/20 bg-destructive/5 p-2 text-xs text-destructive">
+            <XCircle className="h-3.5 w-3.5 shrink-0" />
+            <span>
+              {readiness.failedDocuments} documento/i fallito/i
+              {readiness.documents
+                .filter((d) => d.processingState === 'Failed')
+                .map((d) => d.errorMessage)
+                .filter(Boolean)
+                .length > 0 &&
+                `: ${readiness.documents
+                  .filter((d) => d.processingState === 'Failed')
+                  .map((d) => d.errorMessage)
+                  .filter(Boolean)
+                  .join(', ')}`}
+            </span>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/hooks/queries/useEstimateAgentCost.ts
+++ b/apps/web/src/hooks/queries/useEstimateAgentCost.ts
@@ -1,0 +1,35 @@
+/**
+ * React Query hook for agent cost estimation.
+ *
+ * Only fetches when at least one document ID is provided.
+ * Results are cached for 1 minute (cost doesn't change frequently).
+ */
+
+import { useQuery } from '@tanstack/react-query';
+
+import { api } from '@/lib/api';
+import type { AgentCostEstimate } from '@/lib/api/schemas/rag-setup.schemas';
+
+export const agentCostKeys = {
+  all: ['agentCostEstimate'] as const,
+  estimate: (gameId: string, documentIds: string[]) =>
+    [...agentCostKeys.all, gameId, ...documentIds.sort()] as const,
+};
+
+export function useEstimateAgentCost(
+  gameId: string,
+  documentIds: string[],
+  enabled = true
+) {
+  return useQuery<AgentCostEstimate | null, Error>({
+    queryKey: agentCostKeys.estimate(gameId, documentIds),
+    queryFn: () =>
+      api.agents.estimateAgentCost({
+        gameId,
+        documentIds,
+        strategyName: 'HybridSearch',
+      }),
+    enabled: enabled && !!gameId && documentIds.length > 0,
+    staleTime: 60_000, // 1 minute
+  });
+}

--- a/apps/web/src/hooks/queries/useGameRagReadiness.ts
+++ b/apps/web/src/hooks/queries/useGameRagReadiness.ts
@@ -1,0 +1,33 @@
+/**
+ * React Query hook for cross-BC RAG readiness status.
+ *
+ * Auto-refreshes every 5s while documents are processing,
+ * stops polling when all documents reach a terminal state.
+ */
+
+import { useQuery } from '@tanstack/react-query';
+
+import { api } from '@/lib/api';
+import type { GameRagReadiness } from '@/lib/api/schemas/rag-setup.schemas';
+
+export const ragReadinessKeys = {
+  all: ['ragReadiness'] as const,
+  byGame: (gameId: string) => [...ragReadinessKeys.all, gameId] as const,
+};
+
+export function useGameRagReadiness(gameId: string, enabled = true) {
+  return useQuery<GameRagReadiness | null, Error>({
+    queryKey: ragReadinessKeys.byGame(gameId),
+    queryFn: () => api.sharedGames.getGameRagReadiness(gameId),
+    enabled: enabled && !!gameId,
+    staleTime: 10_000, // 10s
+    refetchInterval: (query) => {
+      const data = query.state.data;
+      // Auto-refresh while documents are processing
+      if (data?.processingDocuments && data.processingDocuments > 0) {
+        return 5_000; // 5s while processing
+      }
+      return false; // Stop polling when stable
+    },
+  });
+}

--- a/apps/web/src/lib/api/clients/agentsClient.ts
+++ b/apps/web/src/lib/api/clients/agentsClient.ts
@@ -41,6 +41,10 @@ import type {
   BackendAgentConfigurationDto,
   UpdateAgentConfigurationRequest,
 } from '../schemas/agent-config.schemas';
+import {
+  AgentCostEstimateSchema,
+  type AgentCostEstimate,
+} from '../schemas/rag-setup.schemas';
 
 export interface CreateAgentsClientParams {
   httpClient: HttpClient;
@@ -677,6 +681,40 @@ export function createAgentsClient({ httpClient }: CreateAgentsClientParams) {
         throw new Error('Failed to update agent configuration: no response from server');
       }
       return response;
+    },
+
+    // ========== RAG Setup (Admin) ==========
+
+    /** Estimate cost for agent with selected documents */
+    async estimateAgentCost(request: {
+      gameId: string;
+      documentIds: string[];
+      strategyName?: string;
+    }): Promise<AgentCostEstimate | null> {
+      return httpClient.post(
+        '/api/v1/admin/agents/estimate-cost',
+        request,
+        AgentCostEstimateSchema
+      );
+    },
+
+    /** Create agent with auto-link to SharedGame and document attachment */
+    async createAgentWithSetup(request: {
+      userId: string;
+      userTier: string;
+      userRole: string;
+      gameId: string;
+      addToCollection: boolean;
+      agentType: string;
+      agentName?: string;
+      strategyName?: string;
+      sharedGameId: string;
+      documentIds: string[];
+    }): Promise<{ agentId: string; agentName: string; threadId: string; slotUsed: number; gameAddedToCollection: boolean } | null> {
+      return httpClient.post(
+        '/api/v1/agents/setup',
+        request
+      );
     },
   };
 }

--- a/apps/web/src/lib/api/clients/agentsClient.ts
+++ b/apps/web/src/lib/api/clients/agentsClient.ts
@@ -34,6 +34,11 @@ import {
   type Typology, // Added for AGT-012
 } from '../schemas';
 
+import {
+  AgentCostEstimateSchema,
+  type AgentCostEstimate,
+} from '../schemas/rag-setup.schemas';
+
 import type { HttpClient } from '../core/httpClient';
 import type {
   BackendModelDto,
@@ -41,10 +46,6 @@ import type {
   BackendAgentConfigurationDto,
   UpdateAgentConfigurationRequest,
 } from '../schemas/agent-config.schemas';
-import {
-  AgentCostEstimateSchema,
-  type AgentCostEstimate,
-} from '../schemas/rag-setup.schemas';
 
 export interface CreateAgentsClientParams {
   httpClient: HttpClient;

--- a/apps/web/src/lib/api/clients/sharedGamesClient.ts
+++ b/apps/web/src/lib/api/clients/sharedGamesClient.ts
@@ -15,6 +15,10 @@ import {
   type KbCardDto,
 } from '../schemas/agent-definitions.schemas';
 import {
+  GameRagReadinessSchema,
+  type GameRagReadiness,
+} from '../schemas/rag-setup.schemas';
+import {
   SharedGameDetailSchema,
   PagedSharedGamesSchema,
   GameCategorySchema,
@@ -831,6 +835,16 @@ export function createSharedGamesClient({ httpClient }: CreateSharedGamesClientP
         xhr.open('POST', `/api/v1/admin/shared-games/${gameId}/documents/upload`);
         xhr.send(formData);
       });
+    },
+
+    // ========== RAG Readiness ==========
+
+    /** Get cross-BC RAG readiness status for a shared game (Admin only) */
+    async getGameRagReadiness(gameId: string): Promise<GameRagReadiness | null> {
+      return httpClient.get(
+        `/api/v1/admin/shared-games/${gameId}/rag-readiness`,
+        GameRagReadinessSchema
+      );
     },
   };
 }

--- a/apps/web/src/lib/api/schemas/rag-setup.schemas.ts
+++ b/apps/web/src/lib/api/schemas/rag-setup.schemas.ts
@@ -1,0 +1,74 @@
+/**
+ * RAG Setup Schemas - Admin RAG Dashboard
+ *
+ * Zod schemas for cross-BC readiness aggregation and cost estimation DTOs.
+ */
+
+import { z } from 'zod';
+
+// ========== Document Status ==========
+
+export const DocumentStatusSchema = z.object({
+  documentId: z.string(),
+  fileName: z.string(),
+  processingState: z.string(),
+  progressPercentage: z.number(),
+  isActiveForRag: z.boolean(),
+  errorMessage: z.string().nullable().optional(),
+});
+
+export type DocumentStatus = z.infer<typeof DocumentStatusSchema>;
+
+// ========== Agent Info ==========
+
+export const AgentInfoSchema = z.object({
+  agentId: z.string(),
+  name: z.string(),
+  type: z.string(),
+  isActive: z.boolean(),
+  isReady: z.boolean(),
+});
+
+export type AgentInfo = z.infer<typeof AgentInfoSchema>;
+
+// ========== Game RAG Readiness ==========
+
+export const GameRagReadinessSchema = z.object({
+  gameId: z.string(),
+  gameTitle: z.string(),
+  gameStatus: z.string(),
+  totalDocuments: z.number(),
+  readyDocuments: z.number(),
+  processingDocuments: z.number(),
+  failedDocuments: z.number(),
+  documents: z.array(DocumentStatusSchema),
+  linkedAgent: AgentInfoSchema.nullable(),
+  overallReadiness: z.string(),
+});
+
+export type GameRagReadiness = z.infer<typeof GameRagReadinessSchema>;
+
+// ========== Agent Cost Estimate ==========
+
+export const AgentCostEstimateSchema = z.object({
+  totalChunks: z.number(),
+  estimatedEmbeddingTokens: z.number(),
+  estimatedCostPerQuery: z.number(),
+  currency: z.string(),
+  model: z.string(),
+  note: z.string(),
+});
+
+export type AgentCostEstimate = z.infer<typeof AgentCostEstimateSchema>;
+
+// ========== Overall Readiness States ==========
+
+export const READINESS_STATES = {
+  NO_DOCUMENTS: 'no_documents',
+  DOCUMENTS_PROCESSING: 'documents_processing',
+  DOCUMENTS_FAILED: 'documents_failed',
+  READY_FOR_AGENT: 'ready_for_agent',
+  FULLY_OPERATIONAL: 'fully_operational',
+} as const;
+
+export type ReadinessState = (typeof READINESS_STATES)[keyof typeof READINESS_STATES];


### PR DESCRIPTION
## Summary

- **Single-page RAG dashboard** at `/admin/shared-games/[id]/rag-setup` with 4-panel layout
- **2 backend queries**: `GetGameRagReadinessQuery` (cross-BC status aggregation) and `EstimateAgentCostQuery` (pre-chat cost estimation)
- **1 backend enhancement**: `CreateAgentWithSetupCommand` now supports `SharedGameId` + `DocumentIds` for auto-linking
- **3 frontend components**: `RagReadinessIndicator` (horizontal stepper), `AgentSetupPanel` (doc selection + cost), `InlineChatPanel` (SSE chat)
- **2 React Query hooks**: `useGameRagReadiness` (auto-polling while processing) and `useEstimateAgentCost`
- **RAG Setup button** added to game detail page header

### Admin Flow
1. Navigate to shared game → click "RAG Setup"
2. Upload PDFs (drag-drop, progress tracking)
3. Monitor embedding progress (auto-refreshing stepper)
4. Documents become RAG-eligible when processing reaches Ready state
5. Create RAG agent with selected Ready documents + cost estimate
6. Test agent with private inline chat (SSE streaming)

## Test plan
- [ ] Navigate to `/admin/shared-games/[id]/rag-setup` for an existing game
- [ ] Upload a PDF and verify progress polling shows embedding stages
- [ ] Wait for document to reach Ready state, verify readiness indicator updates
- [ ] Create agent with selected documents, verify cost estimation displays
- [ ] Send test message in inline chat, verify SSE streaming works
- [ ] Verify "RAG Setup" button appears on game detail page
- [ ] TypeScript check passes (`pnpm typecheck`)
- [ ] Backend builds successfully (`dotnet build`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)