### PR TITLE
chore(ci): upgrade GitHub Actions to Node.js 24

### DIFF
--- a/.github/workflows/auto-validate.yml
+++ b/.github/workflows/auto-validate.yml
@@ -21,10 +21,10 @@ jobs:
     runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
 

--- a/.github/workflows/backend-e2e-tests.yml
+++ b/.github/workflows/backend-e2e-tests.yml
@@ -27,7 +27,7 @@ jobs:
     outputs:
       e2e-needed: ${{ steps.filter.outputs.e2e }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v3
         id: filter
         with:
@@ -48,7 +48,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup .NET
         uses: actions/setup-dotnet@v5
@@ -56,7 +56,7 @@ jobs:
           dotnet-version: '9.0.x'
 
       - name: Cache NuGet packages
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.nuget/packages
           key: ${{ runner.os }}-${{ runner.arch }}-nuget-${{ hashFiles('**/*.csproj') }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
       python: ${{ steps.filter.outputs.python }}
       infra: ${{ steps.filter.outputs.infra }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v3
         id: filter
         with:
@@ -58,7 +58,7 @@ jobs:
         working-directory: apps/web
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Frontend
         uses: ./.github/actions/setup-frontend
@@ -92,7 +92,7 @@ jobs:
 
       - name: Upload Coverage
         if: always()
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           files: apps/web/coverage/lcov.info
           flags: frontend
@@ -153,7 +153,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install PDF Dependencies
         run: sudo apt-get update && sudo apt-get install -y libgdiplus
@@ -165,7 +165,7 @@ jobs:
           working-directory: apps/api
 
       - name: Cache Docker Images
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-${{ runner.arch }}-docker-${{ hashFiles('**/Dockerfile', 'docker-compose*.yml') }}
@@ -274,7 +274,7 @@ jobs:
 
       - name: Upload Coverage
         if: always()
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           files: |
             apps/api/coverage/unit-coverage.xml
@@ -294,7 +294,7 @@ jobs:
         working-directory: apps/orchestration-service
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Python
         uses: actions/setup-python@v5
@@ -323,7 +323,7 @@ jobs:
 
       - name: Upload Python Coverage
         if: always()
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           files: apps/orchestration-service/coverage.xml
           flags: python,arbitro
@@ -381,7 +381,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # ===== Backend Setup =====
       - name: Wait for Services

--- a/.github/workflows/deploy-production.yml
+++ b/.github/workflows/deploy-production.yml
@@ -124,7 +124,7 @@ jobs:
       version: ${{ steps.version.outputs.version }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0  # Full history for version detection
 
@@ -324,7 +324,7 @@ jobs:
       url: https://meepleai.com
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Create Deployment Record
         run: |
@@ -412,7 +412,7 @@ jobs:
     needs: [deploy, snapshot-baseline]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Deep Health Check
         run: |

--- a/.github/workflows/deploy-staging.yml
+++ b/.github/workflows/deploy-staging.yml
@@ -52,7 +52,7 @@ jobs:
       deploy_api: ${{ steps.decision.outputs.deploy_api }}
       deploy_web: ${{ steps.decision.outputs.deploy_web }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 2
 
@@ -100,7 +100,7 @@ jobs:
     timeout-minutes: 15
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Verify CI passed on this commit
         env:
@@ -166,7 +166,7 @@ jobs:
       web_built: ${{ needs.detect-changes.outputs.deploy_web }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Generate Version
         id: version
@@ -358,7 +358,7 @@ jobs:
       url: https://meepleai.app
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # Option 1: SSH Deploy (VPS/Dedicated Server)
       - name: Deploy via SSH
@@ -440,7 +440,7 @@ jobs:
     needs: [deploy, snapshot-baseline]
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Deep Health Check
         run: |
@@ -638,7 +638,7 @@ jobs:
     timeout-minutes: 10
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Frontend
         uses: ./.github/actions/setup-frontend
@@ -659,7 +659,7 @@ jobs:
 
       - name: Upload Test Report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: staging-e2e-report
           path: apps/web/playwright-report/

--- a/.github/workflows/epic-4068-ci.yml
+++ b/.github/workflows/epic-4068-ci.yml
@@ -42,10 +42,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
@@ -84,7 +84,7 @@ jobs:
             apps/api/src/Api/TestResults/*/coverage.cobertura.xml
 
       - name: Code Coverage Report
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           files: ./apps/api/src/Api/TestResults/*/coverage.cobertura.xml
           flags: backend,permission-system
@@ -122,10 +122,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup .NET
-        uses: actions/setup-dotnet@v4
+        uses: actions/setup-dotnet@v5
         with:
           dotnet-version: ${{ env.DOTNET_VERSION }}
 
@@ -158,10 +158,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
 
@@ -191,7 +191,7 @@ jobs:
           pnpm test -- Permission --verbose
 
       - name: Upload Coverage
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           files: ./apps/web/coverage/lcov.info
           flags: frontend,epic-4068
@@ -203,10 +203,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node & pnpm
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
 
@@ -235,8 +235,8 @@ jobs:
     runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
       - uses: pnpm/action-setup@v4
@@ -253,8 +253,8 @@ jobs:
     needs: [frontend-unit-tests, frontend-typecheck]
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
       - uses: pnpm/action-setup@v4
@@ -287,8 +287,8 @@ jobs:
     needs: frontend-unit-tests
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
       - uses: pnpm/action-setup@v4
@@ -332,8 +332,8 @@ jobs:
     needs: [frontend-unit-tests, backend-unit-tests]
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
       - uses: pnpm/action-setup@v4
@@ -377,8 +377,8 @@ jobs:
     needs: frontend-unit-tests
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
+      - uses: actions/checkout@v6
+      - uses: actions/setup-node@v6
         with:
           node-version: ${{ env.NODE_VERSION }}
       - uses: pnpm/action-setup@v4
@@ -413,7 +413,7 @@ jobs:
     runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Run Trivy (Backend)
         uses: aquasecurity/trivy-action@master
@@ -444,7 +444,7 @@ jobs:
     if: github.event_name == 'pull_request'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Deploy to Vercel
         uses: amondnet/vercel-action@v25
@@ -457,7 +457,7 @@ jobs:
             epic-4068-pr-${{ github.event.pull_request.number }}.vercel.app
 
       - name: Comment Preview URL
-        uses: actions/github-script@v7
+        uses: actions/github-script@v8
         with:
           script: |
             github.rest.issues.createComment({

--- a/.github/workflows/generate-diagrams.yml
+++ b/.github/workflows/generate-diagrams.yml
@@ -14,12 +14,12 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'

--- a/.github/workflows/security-pentest.yml
+++ b/.github/workflows/security-pentest.yml
@@ -70,7 +70,7 @@ jobs:
       security: ${{ steps.filter.outputs.security }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -99,7 +99,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 1
 

--- a/.github/workflows/security-review.yml
+++ b/.github/workflows/security-review.yml
@@ -20,7 +20,7 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Calculate Quarter
         id: quarter

--- a/.github/workflows/security-scan.yml
+++ b/.github/workflows/security-scan.yml
@@ -26,7 +26,7 @@ jobs:
         language: ['csharp', 'javascript']
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3
@@ -61,7 +61,7 @@ jobs:
     runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # .NET dependencies
       - name: Setup .NET
@@ -89,7 +89,7 @@ jobs:
           version: 10
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: pnpm
@@ -121,7 +121,7 @@ jobs:
     runs-on: ${{ vars.RUNNER || 'ubuntu-latest' }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Install Semgrep
         run: |

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -41,7 +41,7 @@ jobs:
     outputs:
       e2e-needed: ${{ steps.filter.outputs.e2e }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v3
         id: filter
         with:
@@ -109,7 +109,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       # ===== Backend Setup =====
       - name: Wait for Services
@@ -193,7 +193,7 @@ jobs:
           working-directory: apps/web
 
       - name: Cache Playwright Browsers
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-${{ runner.arch }}-playwright-${{ hashFiles('apps/web/pnpm-lock.yaml') }}
@@ -356,7 +356,7 @@ jobs:
 
       - name: Upload Merged Coverage
         if: always()
-        uses: codecov/codecov-action@v4
+        uses: codecov/codecov-action@v5
         with:
           files: coverage-merged/lcov.info
           flags: e2e
@@ -450,7 +450,7 @@ jobs:
         project: [desktop-chrome, desktop-firefox, desktop-safari, mobile-chrome, mobile-safari, tablet-chrome]
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       # ===== Backend Setup =====
       - name: Wait for Services

--- a/.github/workflows/test-performance.yml
+++ b/.github/workflows/test-performance.yml
@@ -81,7 +81,7 @@ jobs:
       api: ${{ steps.filter.outputs.api || 'true' }}
       k6: ${{ steps.filter.outputs.k6 || 'true' }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v3
         id: filter
         if: github.event_name == 'pull_request'
@@ -147,7 +147,7 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup backend environment
         uses: ./.github/actions/setup-backend
@@ -394,7 +394,7 @@ jobs:
         working-directory: apps/web
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup frontend environment
         uses: ./.github/actions/setup-frontend
@@ -408,7 +408,7 @@ jobs:
         run: cp .env.test.example .env.test
 
       - name: Cache Next.js build
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: apps/web/.next/cache
           key: ${{ runner.os }}-${{ runner.arch }}-nextjs-${{ hashFiles('apps/web/pnpm-lock.yaml') }}-${{ hashFiles('apps/web/src/**') }}
@@ -440,7 +440,7 @@ jobs:
         working-directory: apps/web
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
 
@@ -602,7 +602,7 @@ jobs:
       issues: write
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Create GitHub issue on failure
         uses: actions/github-script@v8

--- a/.github/workflows/test-visual.yml
+++ b/.github/workflows/test-visual.yml
@@ -25,7 +25,7 @@ jobs:
     outputs:
       web: ${{ steps.filter.outputs.web }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dorny/paths-filter@v3
         id: filter
         with:
@@ -50,7 +50,7 @@ jobs:
         working-directory: apps/web
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Frontend
         uses: ./.github/actions/setup-frontend

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/CreateAgentWithSetupCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Handlers/CreateAgentWithSetupCommandHandlerTests.cs
@@ -309,7 +309,7 @@ public class CreateAgentWithSetupCommandHandlerTests
         var sharedGameId = Guid.NewGuid();
         _mockMediator
             .Setup(m => m.Send(It.IsAny<LinkAgentToSharedGameCommand>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(Unit.Value);
+            .ReturnsAsync(MediatR.Unit.Value);
 
         var command = CreateCommand(sharedGameId: sharedGameId);
 
@@ -391,7 +391,7 @@ public class CreateAgentWithSetupCommandHandlerTests
 
         _mockMediator
             .Setup(m => m.Send(It.IsAny<LinkAgentToSharedGameCommand>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync(Unit.Value);
+            .ReturnsAsync(MediatR.Unit.Value);
         _mockMediator
             .Setup(m => m.Send(It.IsAny<UpdateAgentDocumentsCommand>(), It.IsAny<CancellationToken>()))
             .ReturnsAsync(new UpdateAgentDocumentsResult(true, "ok", Guid.NewGuid(), 1));


### PR DESCRIPTION
## Summary
- Upgrade all GitHub Actions to Node.js 24-compatible versions ahead of June 2, 2026 deadline
- Fix pre-existing backend build error (`MediatR.Unit` namespace ambiguity)

## Changes

| Action | Before | After | Occurrences |
|--------|--------|-------|-------------|
| `actions/checkout` | `@v4` | `@v6` | 46 |
| `actions/cache` | `@v4` | `@v5` | 4 |
| `actions/setup-node` | `@v4` | `@v6` | 11 |
| `codecov/codecov-action` | `@v4` | `@v5` | 6 |
| `actions/setup-dotnet` | `@v4` | `@v5` | 2 |
| `actions/github-script` | `@v7` | `@v8` | 1 |
| `actions/upload-artifact` | `@v4` | `@v7` | 1 |

**Kept as-is:**
- `dorny/paths-filter@v3` — no v4 available; v3.0.2 compatible with forced Node.js 24 runners
- `pnpm/action-setup@v4` — already Node.js 24 compatible

**Bonus fix:** `MediatR.Unit.Value` fully qualified in `CreateAgentWithSetupCommandHandlerTests.cs` to resolve pre-existing namespace ambiguity with `Api.Tests.Unit`

## Files Changed
- 13 workflow files in `.github/workflows/`
- 1 test file (pre-existing build fix)

## Test plan
- [x] Frontend build passes (`next build`)
- [x] Backend build passes (`dotnet build` — 0 errors)
- [x] Pre-push hooks pass (both FE + BE)
- [ ] CI workflows run without Node.js 20 deprecation warnings

Closes #230

🤖 Generated with [Claude Code](https://claude.com/claude-code)