### PR TITLE
feat(rag-setup): Admin RAG Dashboard notification toast + unit tests

### DIFF
--- a/apps/web/src/app/admin/(dashboard)/shared-games/[id]/rag-setup/client.tsx
+++ b/apps/web/src/app/admin/(dashboard)/shared-games/[id]/rag-setup/client.tsx
@@ -14,10 +14,11 @@
 
 'use client';
 
-import { use, useState } from 'react';
+import { use, useEffect, useRef, useState } from 'react';
 
 import { ArrowLeft, FileText } from 'lucide-react';
 import Link from 'next/link';
+import { toast } from 'sonner';
 
 import { PdfIndexingStatus } from '@/components/admin/shared-games/PdfIndexingStatus';
 import { PdfUploadSection } from '@/components/admin/shared-games/PdfUploadSection';
@@ -33,6 +34,7 @@ import {
 import { Skeleton } from '@/components/ui/feedback/skeleton';
 import { Button } from '@/components/ui/primitives/button';
 import { useGameRagReadiness } from '@/hooks/queries/useGameRagReadiness';
+import { useNotificationStore } from '@/store/notification/store';
 
 interface RagSetupClientProps {
   params: Promise<{ id: string }>;
@@ -41,10 +43,31 @@ interface RagSetupClientProps {
 export function RagSetupClient({ params }: RagSetupClientProps) {
   const { id: gameId } = use(params);
   const { data: readiness, isLoading } = useGameRagReadiness(gameId);
+  const notifications = useNotificationStore((s) => s.notifications);
+  const seenNotificationIds = useRef<Set<string>>(new Set());
   const [agentInfo, setAgentInfo] = useState<{
     agentId: string;
     chatThreadId: string;
   } | null>(null);
+
+  // Toast when a document processing completes for this game
+  useEffect(() => {
+    for (const n of notifications) {
+      if (seenNotificationIds.current.has(n.id)) continue;
+      seenNotificationIds.current.add(n.id);
+
+      if (n.type !== 'processing_job_completed') continue;
+
+      try {
+        const meta = n.metadata ? JSON.parse(n.metadata) : null;
+        if (meta?.gameId === gameId || meta?.sharedGameId === gameId) {
+          toast.success(n.title ?? 'Documento pronto per RAG!');
+        }
+      } catch {
+        // metadata not valid JSON — skip
+      }
+    }
+  }, [notifications, gameId]);
 
   // Derive active agent/thread from either new creation or existing linked agent
   const activeAgentId =

--- a/apps/web/src/components/admin/shared-games/rag-setup/__tests__/AgentSetupPanel.test.tsx
+++ b/apps/web/src/components/admin/shared-games/rag-setup/__tests__/AgentSetupPanel.test.tsx
@@ -1,0 +1,299 @@
+/**
+ * Tests for AgentSetupPanel component
+ * Admin RAG Dashboard - Issue #4364
+ *
+ * Coverage:
+ * - Existing agent info display (Attivo/Inattivo, Pronto/Non pronto)
+ * - Create agent form rendering (title, agent name input)
+ * - Empty document state
+ * - Document list with checkboxes
+ * - Checkbox disabled for non-Ready documents
+ * - "Pronto" badge for Ready documents
+ */
+
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+
+import type { AgentInfo, DocumentStatus } from '@/lib/api/schemas/rag-setup.schemas';
+
+import { AgentSetupPanel } from '../AgentSetupPanel';
+
+// =========================================================================
+// Mocks
+// =========================================================================
+
+vi.mock('@/hooks/queries/useEstimateAgentCost', () => ({
+  useEstimateAgentCost: () => ({ data: null, isLoading: false }),
+}));
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    agents: {
+      createAgentWithSetup: vi.fn(),
+    },
+  },
+}));
+
+// sonner toast — prevent console noise in tests
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+// =========================================================================
+// Helpers
+// =========================================================================
+
+function createMockDocument(overrides: Partial<DocumentStatus> = {}): DocumentStatus {
+  return {
+    documentId: 'doc-1',
+    fileName: 'rulebook.pdf',
+    processingState: 'Ready',
+    progressPercentage: 100,
+    isActiveForRag: true,
+    errorMessage: null,
+    ...overrides,
+  };
+}
+
+function createMockAgent(overrides: Partial<AgentInfo> = {}): AgentInfo {
+  return {
+    agentId: 'agent-1',
+    name: 'Catan Assistant',
+    type: 'RAG',
+    isActive: true,
+    isReady: true,
+    ...overrides,
+  };
+}
+
+const defaultProps = {
+  gameId: 'game-1',
+  gameTitle: 'Catan',
+  documents: [],
+  existingAgent: null,
+  onAgentCreated: vi.fn(),
+};
+
+// =========================================================================
+// Tests
+// =========================================================================
+
+describe('AgentSetupPanel', () => {
+  // -----------------------------------------------------------------------
+  // Existing agent display
+  // -----------------------------------------------------------------------
+
+  describe('when existingAgent is provided', () => {
+    it('shows agent name', () => {
+      const agent = createMockAgent({ name: 'Catan Assistant' });
+
+      render(<AgentSetupPanel {...defaultProps} existingAgent={agent} />);
+
+      expect(screen.getByText('Catan Assistant')).toBeInTheDocument();
+    });
+
+    it('shows "Attivo" when agent.isActive is true', () => {
+      const agent = createMockAgent({ isActive: true });
+
+      render(<AgentSetupPanel {...defaultProps} existingAgent={agent} />);
+
+      expect(screen.getByText(/Attivo/)).toBeInTheDocument();
+    });
+
+    it('shows "Inattivo" when agent.isActive is false', () => {
+      const agent = createMockAgent({ isActive: false });
+
+      render(<AgentSetupPanel {...defaultProps} existingAgent={agent} />);
+
+      expect(screen.getByText(/Inattivo/)).toBeInTheDocument();
+    });
+
+    it('shows "Pronto" badge when agent.isReady is true', () => {
+      const agent = createMockAgent({ isReady: true });
+
+      render(<AgentSetupPanel {...defaultProps} existingAgent={agent} />);
+
+      expect(screen.getByText('Pronto')).toBeInTheDocument();
+    });
+
+    it('shows "Non pronto" badge when agent.isReady is false', () => {
+      const agent = createMockAgent({ isReady: false });
+
+      render(<AgentSetupPanel {...defaultProps} existingAgent={agent} />);
+
+      expect(screen.getByText('Non pronto')).toBeInTheDocument();
+    });
+
+    it('shows agent type in the agent info paragraph', () => {
+      const agent = createMockAgent({ type: 'RAG' });
+
+      render(<AgentSetupPanel {...defaultProps} existingAgent={agent} />);
+
+      // The agent type appears in "RAG • Attivo" paragraph — use getAllByText since
+      // "Agente RAG" title also contains "RAG"
+      const ragElements = screen.getAllByText(/RAG/);
+      expect(ragElements.length).toBeGreaterThan(0);
+    });
+
+    it('does NOT render "Crea Agente RAG" title when agent already exists', () => {
+      const agent = createMockAgent();
+
+      render(<AgentSetupPanel {...defaultProps} existingAgent={agent} />);
+
+      expect(screen.queryByText('Crea Agente RAG')).not.toBeInTheDocument();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Create agent form (no existing agent)
+  // -----------------------------------------------------------------------
+
+  describe('when no existing agent', () => {
+    it('renders "Crea Agente RAG" title', () => {
+      render(<AgentSetupPanel {...defaultProps} existingAgent={null} />);
+
+      expect(screen.getByText('Crea Agente RAG')).toBeInTheDocument();
+    });
+
+    it('shows agent name input with default value "{gameTitle} Assistant"', () => {
+      render(
+        <AgentSetupPanel {...defaultProps} gameTitle="Catan" existingAgent={null} />
+      );
+
+      const input = screen.getByRole('textbox', { name: /nome agente/i });
+      expect(input).toHaveValue('Catan Assistant');
+    });
+
+    it('uses the provided gameTitle in the default agent name', () => {
+      render(
+        <AgentSetupPanel {...defaultProps} gameTitle="Pandemic" existingAgent={null} />
+      );
+
+      const input = screen.getByRole('textbox', { name: /nome agente/i });
+      expect(input).toHaveValue('Pandemic Assistant');
+    });
+
+    it('shows "Nessun documento caricato" when documents array is empty', () => {
+      render(
+        <AgentSetupPanel {...defaultProps} documents={[]} existingAgent={null} />
+      );
+
+      expect(
+        screen.getByText(/Nessun documento caricato/i)
+      ).toBeInTheDocument();
+    });
+
+    it('renders document list when documents are provided', () => {
+      const documents = [
+        createMockDocument({ documentId: 'doc-1', fileName: 'rules.pdf' }),
+        createMockDocument({ documentId: 'doc-2', fileName: 'faq.pdf' }),
+      ];
+
+      render(
+        <AgentSetupPanel {...defaultProps} documents={documents} existingAgent={null} />
+      );
+
+      expect(screen.getByText('rules.pdf')).toBeInTheDocument();
+      expect(screen.getByText('faq.pdf')).toBeInTheDocument();
+    });
+
+    it('renders a checkbox for each document', () => {
+      const documents = [
+        createMockDocument({ documentId: 'doc-1', fileName: 'rules.pdf' }),
+        createMockDocument({ documentId: 'doc-2', fileName: 'faq.pdf' }),
+      ];
+
+      render(
+        <AgentSetupPanel {...defaultProps} documents={documents} existingAgent={null} />
+      );
+
+      const checkboxes = screen.getAllByRole('checkbox');
+      expect(checkboxes).toHaveLength(2);
+    });
+
+    it('disables checkbox for non-Ready documents', () => {
+      const documents = [
+        createMockDocument({
+          documentId: 'doc-processing',
+          fileName: 'processing.pdf',
+          processingState: 'Processing',
+        }),
+      ];
+
+      render(
+        <AgentSetupPanel {...defaultProps} documents={documents} existingAgent={null} />
+      );
+
+      const checkbox = screen.getByRole('checkbox');
+      expect(checkbox).toBeDisabled();
+    });
+
+    it('does NOT disable checkbox for Ready documents', () => {
+      const documents = [
+        createMockDocument({
+          documentId: 'doc-ready',
+          fileName: 'ready.pdf',
+          processingState: 'Ready',
+        }),
+      ];
+
+      render(
+        <AgentSetupPanel {...defaultProps} documents={documents} existingAgent={null} />
+      );
+
+      const checkbox = screen.getByRole('checkbox');
+      expect(checkbox).not.toBeDisabled();
+    });
+
+    it('shows "Pronto" badge for Ready documents', () => {
+      const documents = [
+        createMockDocument({
+          documentId: 'doc-ready',
+          fileName: 'ready.pdf',
+          processingState: 'Ready',
+        }),
+      ];
+
+      render(
+        <AgentSetupPanel {...defaultProps} documents={documents} existingAgent={null} />
+      );
+
+      expect(screen.getByText('Pronto')).toBeInTheDocument();
+    });
+
+    it('shows processingState as badge text for non-Ready documents', () => {
+      const documents = [
+        createMockDocument({
+          documentId: 'doc-proc',
+          fileName: 'processing.pdf',
+          processingState: 'Processing',
+        }),
+      ];
+
+      render(
+        <AgentSetupPanel {...defaultProps} documents={documents} existingAgent={null} />
+      );
+
+      expect(screen.getByText('Processing')).toBeInTheDocument();
+    });
+
+    it('renders the create button', () => {
+      render(<AgentSetupPanel {...defaultProps} existingAgent={null} />);
+
+      // Button contains "Crea Agente" text
+      expect(screen.getByRole('button', { name: /crea agente/i })).toBeInTheDocument();
+    });
+
+    it('disables create button when no documents are selected', () => {
+      render(
+        <AgentSetupPanel {...defaultProps} documents={[]} existingAgent={null} />
+      );
+
+      const createButton = screen.getByRole('button', { name: /crea agente/i });
+      expect(createButton).toBeDisabled();
+    });
+  });
+});

--- a/apps/web/src/components/admin/shared-games/rag-setup/__tests__/InlineChatPanel.test.tsx
+++ b/apps/web/src/components/admin/shared-games/rag-setup/__tests__/InlineChatPanel.test.tsx
@@ -1,0 +1,131 @@
+/**
+ * Tests for InlineChatPanel component
+ * Admin RAG Dashboard - Issue #4364
+ *
+ * Coverage:
+ * - Empty state when agentId is null
+ * - Chat title rendering when agentId is provided
+ * - Textarea placeholder text
+ * - Send button disabled state when input is empty
+ */
+
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi } from 'vitest';
+
+import { InlineChatPanel } from '../InlineChatPanel';
+
+// =========================================================================
+// Mocks
+// =========================================================================
+
+vi.mock('@/hooks/useAgentChatStream', () => ({
+  useAgentChatStream: () => ({
+    state: {
+      isStreaming: false,
+      currentAnswer: '',
+      statusMessage: '',
+      error: null,
+      followUpQuestions: [],
+      chatThreadId: null,
+      totalTokens: 0,
+      debugSteps: [],
+      modelDowngrade: null,
+      strategyTier: null,
+      executionId: null,
+    },
+    sendMessage: vi.fn(),
+    stopStreaming: vi.fn(),
+    reset: vi.fn(),
+  }),
+}));
+
+// =========================================================================
+// Tests
+// =========================================================================
+
+describe('InlineChatPanel', () => {
+  // -----------------------------------------------------------------------
+  // Empty state (no agent)
+  // -----------------------------------------------------------------------
+
+  describe('when agentId is null', () => {
+    it('shows empty state message "Crea un agente per avviare la chat"', () => {
+      render(<InlineChatPanel agentId={null} chatThreadId={null} />);
+
+      expect(screen.getByText('Crea un agente per avviare la chat')).toBeInTheDocument();
+    });
+
+    it('still renders the "Chat di Test" title', () => {
+      render(<InlineChatPanel agentId={null} chatThreadId={null} />);
+
+      expect(screen.getByText('Chat di Test')).toBeInTheDocument();
+    });
+
+    it('shows instructional sub-text', () => {
+      render(<InlineChatPanel agentId={null} chatThreadId={null} />);
+
+      expect(
+        screen.getByText('Prima carica documenti e crea un agente RAG')
+      ).toBeInTheDocument();
+    });
+
+    it('does NOT render the textarea input', () => {
+      render(<InlineChatPanel agentId={null} chatThreadId={null} />);
+
+      expect(
+        screen.queryByPlaceholderText('Scrivi un messaggio per testare il RAG...')
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Active chat (agentId provided)
+  // -----------------------------------------------------------------------
+
+  describe('when agentId is provided', () => {
+    it('renders "Chat di Test (Privata)" title', () => {
+      render(<InlineChatPanel agentId="agent-123" chatThreadId={null} />);
+
+      expect(screen.getByText('Chat di Test (Privata)')).toBeInTheDocument();
+    });
+
+    it('shows placeholder text in textarea', () => {
+      render(<InlineChatPanel agentId="agent-123" chatThreadId={null} />);
+
+      expect(
+        screen.getByPlaceholderText('Scrivi un messaggio per testare il RAG...')
+      ).toBeInTheDocument();
+    });
+
+    it('disables the send button when input is empty', () => {
+      render(<InlineChatPanel agentId="agent-123" chatThreadId={null} />);
+
+      // The send button has sr-only "Invia" text
+      const sendButton = screen.getByRole('button', { name: /invia/i });
+      expect(sendButton).toBeDisabled();
+    });
+
+    it('renders the message input area', () => {
+      render(<InlineChatPanel agentId="agent-123" chatThreadId={null} />);
+
+      const textarea = screen.getByRole('textbox');
+      expect(textarea).toBeInTheDocument();
+    });
+
+    it('shows empty messages hint when no messages exist', () => {
+      render(<InlineChatPanel agentId="agent-123" chatThreadId={null} />);
+
+      expect(
+        screen.getByText("Scrivi un messaggio per testare l'agente RAG")
+      ).toBeInTheDocument();
+    });
+
+    it('accepts a chatThreadId without errors', () => {
+      render(<InlineChatPanel agentId="agent-123" chatThreadId="thread-456" />);
+
+      expect(
+        screen.getByPlaceholderText('Scrivi un messaggio per testare il RAG...')
+      ).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/src/components/admin/shared-games/rag-setup/__tests__/RagReadinessIndicator.test.tsx
+++ b/apps/web/src/components/admin/shared-games/rag-setup/__tests__/RagReadinessIndicator.test.tsx
@@ -1,0 +1,293 @@
+/**
+ * Tests for RagReadinessIndicator component
+ * Admin RAG Dashboard - Issue #4364
+ *
+ * Coverage:
+ * - Status badge rendering for each readiness state (Italian text)
+ * - Horizontal stepper labels (Documenti, Elaborazione, Agente, Chat)
+ * - Per-document progress bars when processing
+ * - Failed documents warning section
+ */
+
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+
+import type { GameRagReadiness, DocumentStatus } from '@/lib/api/schemas/rag-setup.schemas';
+import { READINESS_STATES } from '@/lib/api/schemas/rag-setup.schemas';
+
+import { RagReadinessIndicator } from '../RagReadinessIndicator';
+
+// =========================================================================
+// Helpers
+// =========================================================================
+
+function createMockDocument(overrides: Partial<DocumentStatus> = {}): DocumentStatus {
+  return {
+    documentId: 'doc-1',
+    fileName: 'rulebook.pdf',
+    processingState: 'Ready',
+    progressPercentage: 100,
+    isActiveForRag: true,
+    errorMessage: null,
+    ...overrides,
+  };
+}
+
+function createMockReadiness(overrides: Partial<GameRagReadiness> = {}): GameRagReadiness {
+  return {
+    gameId: 'game-1',
+    gameTitle: 'Catan',
+    gameStatus: 'Active',
+    totalDocuments: 0,
+    readyDocuments: 0,
+    processingDocuments: 0,
+    failedDocuments: 0,
+    documents: [],
+    linkedAgent: null,
+    overallReadiness: READINESS_STATES.NO_DOCUMENTS,
+    ...overrides,
+  };
+}
+
+// =========================================================================
+// Tests
+// =========================================================================
+
+describe('RagReadinessIndicator', () => {
+  // -----------------------------------------------------------------------
+  // Status badges
+  // -----------------------------------------------------------------------
+
+  describe('Status badge', () => {
+    it('renders "Nessun documento" badge for NO_DOCUMENTS state', () => {
+      const readiness = createMockReadiness({
+        overallReadiness: READINESS_STATES.NO_DOCUMENTS,
+      });
+
+      render(<RagReadinessIndicator readiness={readiness} />);
+
+      expect(screen.getByText('Nessun documento')).toBeInTheDocument();
+    });
+
+    it('renders "Elaborazione in corso" badge for DOCUMENTS_PROCESSING state', () => {
+      const readiness = createMockReadiness({
+        overallReadiness: READINESS_STATES.DOCUMENTS_PROCESSING,
+        processingDocuments: 1,
+        documents: [
+          createMockDocument({
+            processingState: 'Processing',
+            progressPercentage: 50,
+          }),
+        ],
+      });
+
+      render(<RagReadinessIndicator readiness={readiness} />);
+
+      expect(screen.getByText('Elaborazione in corso')).toBeInTheDocument();
+    });
+
+    it('renders "Elaborazione fallita" badge for DOCUMENTS_FAILED state', () => {
+      const readiness = createMockReadiness({
+        overallReadiness: READINESS_STATES.DOCUMENTS_FAILED,
+        failedDocuments: 1,
+        documents: [
+          createMockDocument({
+            processingState: 'Failed',
+            progressPercentage: 0,
+            errorMessage: 'OCR failed',
+          }),
+        ],
+      });
+
+      render(<RagReadinessIndicator readiness={readiness} />);
+
+      expect(screen.getByText('Elaborazione fallita')).toBeInTheDocument();
+    });
+
+    it('renders "Pronto per agente" badge for READY_FOR_AGENT state', () => {
+      const readiness = createMockReadiness({
+        overallReadiness: READINESS_STATES.READY_FOR_AGENT,
+        totalDocuments: 1,
+        readyDocuments: 1,
+        documents: [createMockDocument()],
+      });
+
+      render(<RagReadinessIndicator readiness={readiness} />);
+
+      expect(screen.getByText('Pronto per agente')).toBeInTheDocument();
+    });
+
+    it('renders "Operativo" badge for FULLY_OPERATIONAL state', () => {
+      const readiness = createMockReadiness({
+        overallReadiness: READINESS_STATES.FULLY_OPERATIONAL,
+        totalDocuments: 1,
+        readyDocuments: 1,
+        documents: [createMockDocument()],
+        linkedAgent: {
+          agentId: 'agent-1',
+          name: 'Catan Assistant',
+          type: 'RAG',
+          isActive: true,
+          isReady: true,
+        },
+      });
+
+      render(<RagReadinessIndicator readiness={readiness} />);
+
+      expect(screen.getByText('Operativo')).toBeInTheDocument();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Horizontal stepper
+  // -----------------------------------------------------------------------
+
+  describe('Stepper labels', () => {
+    it('renders all 4 stepper labels', () => {
+      const readiness = createMockReadiness();
+
+      render(<RagReadinessIndicator readiness={readiness} />);
+
+      expect(screen.getByText('Documenti')).toBeInTheDocument();
+      expect(screen.getByText('Elaborazione')).toBeInTheDocument();
+      expect(screen.getByText('Agente')).toBeInTheDocument();
+      expect(screen.getByText('Chat')).toBeInTheDocument();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Per-document progress bars
+  // -----------------------------------------------------------------------
+
+  describe('Per-document progress', () => {
+    it('shows per-document progress section when processingDocuments > 0', () => {
+      const readiness = createMockReadiness({
+        overallReadiness: READINESS_STATES.DOCUMENTS_PROCESSING,
+        processingDocuments: 1,
+        documents: [
+          createMockDocument({
+            documentId: 'doc-processing',
+            fileName: 'rules_v2.pdf',
+            processingState: 'Processing',
+            progressPercentage: 42,
+          }),
+        ],
+      });
+
+      render(<RagReadinessIndicator readiness={readiness} />);
+
+      expect(screen.getByText('rules_v2.pdf')).toBeInTheDocument();
+      expect(screen.getByText('42%')).toBeInTheDocument();
+    });
+
+    it('does NOT show progress section when processingDocuments is 0', () => {
+      const readiness = createMockReadiness({
+        overallReadiness: READINESS_STATES.READY_FOR_AGENT,
+        processingDocuments: 0,
+        documents: [createMockDocument({ fileName: 'should_not_appear.pdf' })],
+      });
+
+      render(<RagReadinessIndicator readiness={readiness} />);
+
+      // The file name should not appear because the progress section is hidden
+      expect(screen.queryByText('should_not_appear.pdf')).not.toBeInTheDocument();
+    });
+
+    it('shows multiple processing documents', () => {
+      const readiness = createMockReadiness({
+        overallReadiness: READINESS_STATES.DOCUMENTS_PROCESSING,
+        processingDocuments: 2,
+        documents: [
+          createMockDocument({
+            documentId: 'doc-a',
+            fileName: 'doc_a.pdf',
+            processingState: 'Processing',
+            progressPercentage: 20,
+          }),
+          createMockDocument({
+            documentId: 'doc-b',
+            fileName: 'doc_b.pdf',
+            processingState: 'Processing',
+            progressPercentage: 75,
+          }),
+        ],
+      });
+
+      render(<RagReadinessIndicator readiness={readiness} />);
+
+      expect(screen.getByText('doc_a.pdf')).toBeInTheDocument();
+      expect(screen.getByText('doc_b.pdf')).toBeInTheDocument();
+      expect(screen.getByText('20%')).toBeInTheDocument();
+      expect(screen.getByText('75%')).toBeInTheDocument();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // Failed documents warning
+  // -----------------------------------------------------------------------
+
+  describe('Failed documents warning', () => {
+    it('shows failed documents warning when failedDocuments > 0', () => {
+      const readiness = createMockReadiness({
+        overallReadiness: READINESS_STATES.DOCUMENTS_FAILED,
+        failedDocuments: 1,
+        documents: [
+          createMockDocument({
+            processingState: 'Failed',
+            progressPercentage: 0,
+            errorMessage: null,
+          }),
+        ],
+      });
+
+      render(<RagReadinessIndicator readiness={readiness} />);
+
+      expect(screen.getByText(/1 documento\/i fallito\/i/)).toBeInTheDocument();
+    });
+
+    it('shows error message in failed documents warning', () => {
+      const errorMessage = 'Impossibile estrarre testo dal PDF';
+      const readiness = createMockReadiness({
+        overallReadiness: READINESS_STATES.DOCUMENTS_FAILED,
+        failedDocuments: 1,
+        documents: [
+          createMockDocument({
+            processingState: 'Failed',
+            progressPercentage: 0,
+            errorMessage,
+          }),
+        ],
+      });
+
+      render(<RagReadinessIndicator readiness={readiness} />);
+
+      expect(screen.getByText(new RegExp(errorMessage))).toBeInTheDocument();
+    });
+
+    it('does NOT show failed documents warning when failedDocuments is 0', () => {
+      const readiness = createMockReadiness({
+        overallReadiness: READINESS_STATES.READY_FOR_AGENT,
+        failedDocuments: 0,
+        documents: [createMockDocument()],
+      });
+
+      render(<RagReadinessIndicator readiness={readiness} />);
+
+      expect(screen.queryByText(/fallito/i)).not.toBeInTheDocument();
+    });
+  });
+
+  // -----------------------------------------------------------------------
+  // General rendering
+  // -----------------------------------------------------------------------
+
+  describe('General rendering', () => {
+    it('renders "Stato RAG" label', () => {
+      const readiness = createMockReadiness();
+
+      render(<RagReadinessIndicator readiness={readiness} />);
+
+      expect(screen.getByText('Stato RAG')).toBeInTheDocument();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
- Add `processing_job_completed` notification listener with toast in RAG Setup dashboard
- Add 42 unit tests across 3 test files for RAG setup components
  - RagReadinessIndicator (13 tests): all readiness states, stepper UI, progress bars
  - InlineChatPanel (10 tests): empty state, chat UI, input handling
  - AgentSetupPanel (19 tests): existing agent display, creation form, document selection

## Test plan
- [x] All 42 unit tests passing
- [x] TypeScript typecheck clean (no new errors)
- [x] ESLint clean (no new warnings)
- [ ] Manual verification of notification toast on document processing completion

Part of Epic #259 (Admin RAG Dashboard)

🤖 Generated with [Claude Code](https://claude.com/claude-code)