### PR TITLE
fix(api): resolve Postgres localhost connectivity (#279)

### DIFF
--- a/apps/api/src/Api/Infrastructure/SecretsHelper.cs
+++ b/apps/api/src/Api/Infrastructure/SecretsHelper.cs
@@ -116,8 +116,6 @@ internal static class SecretsHelper
         IConfiguration config,
         ILogger? logger = null)
     {
-        Console.WriteLine("[DEBUG #2152] SecretsHelper.BuildPostgresConnectionString() called");
-
         // Priority: Environment variable > Configuration > Default
         // This ensures launchSettings.json and SecretLoader env vars work correctly
         var host = Environment.GetEnvironmentVariable("POSTGRES_HOST")
@@ -130,24 +128,29 @@ internal static class SecretsHelper
             ?? config["POSTGRES_DB"]
             ?? config["ConnectionStrings:DefaultDatabase"]
             ?? "meepleai";
-        // Issue #2152: Change default username from 'meeple' to 'postgres' for CI/standard PostgreSQL compatibility
         var username = Environment.GetEnvironmentVariable("POSTGRES_USER")
             ?? config["POSTGRES_USER"]
             ?? "postgres";
 
-        Console.WriteLine($"[DEBUG #2152] SecretsHelper values: Host={host}, Port={port}, DB={database}, User={username}");
+        // Issue #279: Guard against Docker-internal hostnames leaking into local dev.
+        // If POSTGRES_HOST resolved to a Docker service name (e.g. "postgres") but we're
+        // NOT running inside Docker, DNS resolution will fail. Fall back to localhost.
+        if (string.Equals(host, "postgres", StringComparison.OrdinalIgnoreCase)
+            && !IsRunningInDocker())
+        {
+            logger?.LogWarning(
+                "POSTGRES_HOST resolved to Docker service name '{Host}' but not running in Docker. Falling back to localhost.",
+                host);
+            host = "localhost";
+        }
 
         // Get password from secret file or direct config
-        // Issue #2152: Try GetSecretOrValue first, then Environment.GetEnvironmentVariable directly
         var password = GetSecretOrValue(config, "POSTGRES_PASSWORD", logger, required: false)
             ?? Environment.GetEnvironmentVariable("POSTGRES_PASSWORD");
-
-        Console.WriteLine($"[DEBUG #2152] SecretsHelper password source: {(password != null ? "found" : "NULL")}");
 
         // If no password configured, return null to allow fallback to other connection string sources
         if (string.IsNullOrEmpty(password))
         {
-            Console.WriteLine("[DEBUG #2152] SecretsHelper: POSTGRES_PASSWORD not found anywhere, returning null for fallback");
             return null;
         }
 
@@ -161,5 +164,19 @@ internal static class SecretsHelper
         );
 
         return connectionString;
+    }
+
+    /// <summary>
+    /// Detect if the current process is running inside a Docker container.
+    /// </summary>
+    private static bool IsRunningInDocker()
+    {
+        // Standard Docker detection: /.dockerenv file exists
+        if (File.Exists("/.dockerenv"))
+            return true;
+
+        // DOTNET_RUNNING_IN_CONTAINER is set by official .NET Docker images
+        var dotnetInContainer = Environment.GetEnvironmentVariable("DOTNET_RUNNING_IN_CONTAINER");
+        return string.Equals(dotnetInContainer, "true", StringComparison.OrdinalIgnoreCase);
     }
 }


### PR DESCRIPTION
## Summary

- Fix Postgres connectivity from localhost when running `dotnet run` outside Docker
- Remove `POSTGRES_HOST` and `POSTGRES_PORT` from `database.secret` (not secrets — they're environment-specific config)
- Add `IsRunningInDocker()` guard in `SecretsHelper`: if host resolves to Docker service name `postgres` but process is NOT in a container, automatically falls back to `localhost`
- Remove stale `Console.WriteLine("[DEBUG #2152]")` calls

## Root Cause

`SecretLoader` reads `database.secret` → injects `POSTGRES_HOST=postgres` into `IConfiguration` via `AddInMemoryCollection` (highest priority). When `dotnet run` is executed without `launchSettings.json` profile, `Environment.GetEnvironmentVariable("POSTGRES_HOST")` returns null → falls through to `config["POSTGRES_HOST"]` = `"postgres"` → DNS resolution fails on localhost.

## Test plan

- [x] 49 Secret-related unit tests pass
- [x] Build succeeds (0 warnings, 0 errors)
- [ ] `dotnet run` with Docker services → clean startup
- [ ] `dotnet run --no-launch-profile` with Docker services → clean startup (was failing before)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
