### PR TITLE
feat(admin): Service Dashboard Phase 2 (#133, #134, #135, #136)

### DIFF
--- a/apps/web/src/app/admin/(dashboard)/monitor/grafana/GrafanaDashboard.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/grafana/GrafanaDashboard.tsx
@@ -259,7 +259,7 @@ export function GrafanaDashboard() {
   const [timeRange, setTimeRange] = useState<string>('now-1h');
   const [autoRefresh, setAutoRefresh] = useState(false);
 
-  const isConfigured = GRAFANA_BASE_URL !== 'http://localhost:3001';
+  const isConfigured = !!process.env.NEXT_PUBLIC_GRAFANA_URL;
 
   const grouped = useMemo(() => {
     return CATEGORIES.map(cat => ({
@@ -379,7 +379,6 @@ export function GrafanaDashboard() {
               title={selectedDashboard?.name ?? 'Grafana Dashboard'}
               className="w-full border-0"
               style={{ height: 'calc(100vh - 320px)', minHeight: '500px' }}
-              sandbox="allow-scripts allow-same-origin allow-popups"
               loading="lazy"
               data-testid="grafana-iframe"
             />

--- a/apps/web/src/app/admin/(dashboard)/monitor/grafana/GrafanaDashboard.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/grafana/GrafanaDashboard.tsx
@@ -1,0 +1,401 @@
+'use client';
+
+/**
+ * GrafanaDashboard — Embedded Grafana dashboard selector with iframe viewer,
+ * time range controls, and auto-refresh toggle.
+ * Issue #134 — Grafana Dashboard Embed
+ */
+
+import { useCallback, useMemo, useState } from 'react';
+
+import { BarChart3, Clock, ExternalLink, Maximize2, RefreshCw } from 'lucide-react';
+
+import { Badge } from '@/components/ui/data-display/badge';
+import { Button } from '@/components/ui/primitives/button';
+import { cn } from '@/lib/utils';
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const GRAFANA_BASE_URL = process.env.NEXT_PUBLIC_GRAFANA_URL ?? 'http://localhost:3001';
+
+const DASHBOARDS = [
+  {
+    id: 'api-overview',
+    name: 'API Overview',
+    category: 'Application',
+    description: 'Request rates, latency, error rates',
+  },
+  {
+    id: 'api-latency',
+    name: 'API Latency',
+    category: 'Application',
+    description: 'P50/P95/P99 response times',
+  },
+  {
+    id: 'database-overview',
+    name: 'Database Overview',
+    category: 'Infrastructure',
+    description: 'Connections, queries, storage',
+  },
+  {
+    id: 'database-queries',
+    name: 'Database Queries',
+    category: 'Infrastructure',
+    description: 'Slow queries, query plans',
+  },
+  {
+    id: 'redis-overview',
+    name: 'Redis Overview',
+    category: 'Infrastructure',
+    description: 'Memory, hit rate, commands',
+  },
+  {
+    id: 'qdrant-vectors',
+    name: 'Qdrant Vectors',
+    category: 'Infrastructure',
+    description: 'Collections, search latency',
+  },
+  {
+    id: 'llm-usage',
+    name: 'LLM Usage',
+    category: 'AI Services',
+    description: 'Token consumption, costs, models',
+  },
+  {
+    id: 'llm-latency',
+    name: 'LLM Latency',
+    category: 'AI Services',
+    description: 'Provider response times',
+  },
+  {
+    id: 'embedding-service',
+    name: 'Embedding Service',
+    category: 'AI Services',
+    description: 'Throughput, queue depth',
+  },
+  {
+    id: 'pdf-processing',
+    name: 'PDF Processing',
+    category: 'AI Services',
+    description: 'Pipeline status, extraction rates',
+  },
+  {
+    id: 'docker-containers',
+    name: 'Docker Containers',
+    category: 'Infrastructure',
+    description: 'CPU, memory, network per container',
+  },
+  {
+    id: 'system-resources',
+    name: 'System Resources',
+    category: 'Infrastructure',
+    description: 'Host CPU, RAM, disk I/O',
+  },
+  {
+    id: 'auth-sessions',
+    name: 'Auth & Sessions',
+    category: 'Security',
+    description: 'Login attempts, active sessions',
+  },
+  {
+    id: 'audit-trail',
+    name: 'Audit Trail',
+    category: 'Security',
+    description: 'Admin actions, security events',
+  },
+] as const;
+
+type Dashboard = (typeof DASHBOARDS)[number];
+type Category = Dashboard['category'];
+
+const CATEGORIES: Category[] = ['Application', 'Infrastructure', 'AI Services', 'Security'];
+
+const CATEGORY_COLORS: Record<Category, string> = {
+  Application: 'text-blue-600 dark:text-blue-400',
+  Infrastructure: 'text-emerald-600 dark:text-emerald-400',
+  'AI Services': 'text-purple-600 dark:text-purple-400',
+  Security: 'text-amber-600 dark:text-amber-400',
+};
+
+const CATEGORY_BADGE_COLORS: Record<Category, string> = {
+  Application: 'bg-blue-100 text-blue-800 dark:bg-blue-900/30 dark:text-blue-400',
+  Infrastructure: 'bg-emerald-100 text-emerald-800 dark:bg-emerald-900/30 dark:text-emerald-400',
+  'AI Services': 'bg-purple-100 text-purple-800 dark:bg-purple-900/30 dark:text-purple-400',
+  Security: 'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-400',
+};
+
+const TIME_RANGES = [
+  { label: '15m', value: 'now-15m' },
+  { label: '1h', value: 'now-1h' },
+  { label: '6h', value: 'now-6h' },
+  { label: '24h', value: 'now-24h' },
+  { label: '7d', value: 'now-7d' },
+] as const;
+
+// ---------------------------------------------------------------------------
+// Sub-components
+// ---------------------------------------------------------------------------
+
+function DashboardCard({
+  dashboard,
+  isSelected,
+  onSelect,
+}: {
+  dashboard: Dashboard;
+  isSelected: boolean;
+  onSelect: () => void;
+}) {
+  return (
+    <button
+      className={cn(
+        'text-left rounded-lg border p-3 transition-all duration-150',
+        'hover:border-primary/40 hover:shadow-sm',
+        isSelected
+          ? 'border-primary bg-primary/5 ring-1 ring-primary/20'
+          : 'border-border bg-white/50 dark:bg-zinc-900/50'
+      )}
+      onClick={onSelect}
+      data-testid={`dashboard-card-${dashboard.id}`}
+    >
+      <div className="flex items-start gap-2">
+        <BarChart3
+          className={cn(
+            'mt-0.5 h-4 w-4 flex-shrink-0',
+            isSelected ? 'text-primary' : 'text-muted-foreground'
+          )}
+        />
+        <div className="min-w-0">
+          <p className="text-sm font-medium truncate">{dashboard.name}</p>
+          <p className="text-xs text-muted-foreground mt-0.5 line-clamp-1">
+            {dashboard.description}
+          </p>
+        </div>
+      </div>
+    </button>
+  );
+}
+
+function CategorySection({
+  category,
+  dashboards,
+  selectedId,
+  onSelect,
+}: {
+  category: Category;
+  dashboards: Dashboard[];
+  selectedId: string | null;
+  onSelect: (id: string) => void;
+}) {
+  return (
+    <div data-testid={`category-section-${category.replace(/\s+/g, '-').toLowerCase()}`}>
+      <p
+        className={cn(
+          'text-xs font-semibold uppercase tracking-wider mb-2',
+          CATEGORY_COLORS[category]
+        )}
+      >
+        {category}
+      </p>
+      <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+        {dashboards.map(d => (
+          <DashboardCard
+            key={d.id}
+            dashboard={d}
+            isSelected={selectedId === d.id}
+            onSelect={() => onSelect(d.id)}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}
+
+function GrafanaNotConfigured() {
+  return (
+    <div
+      className="rounded-xl border border-dashed border-muted-foreground/30 bg-white/70 dark:bg-zinc-900/70 backdrop-blur-md p-8 text-center"
+      data-testid="grafana-not-configured"
+    >
+      <BarChart3 className="mx-auto h-10 w-10 text-muted-foreground/50 mb-3" />
+      <h3 className="font-quicksand text-base font-semibold text-foreground">
+        Grafana Not Configured
+      </h3>
+      <p className="mt-1 text-sm text-muted-foreground max-w-md mx-auto">
+        Set the{' '}
+        <code className="rounded bg-muted px-1.5 py-0.5 text-xs font-mono">
+          NEXT_PUBLIC_GRAFANA_URL
+        </code>{' '}
+        environment variable to enable embedded dashboards.
+      </p>
+      <div className="mt-4 rounded-lg bg-muted/50 p-4 text-left max-w-md mx-auto">
+        <p className="text-xs font-medium text-muted-foreground mb-1.5">Setup steps:</p>
+        <ol className="text-xs text-muted-foreground space-y-1 list-decimal list-inside">
+          <li>Deploy Grafana (e.g. via Docker Compose)</li>
+          <li>
+            Set{' '}
+            <code className="rounded bg-muted px-1 py-0.5 font-mono">NEXT_PUBLIC_GRAFANA_URL</code>{' '}
+            in <code className="rounded bg-muted px-1 py-0.5 font-mono">.env.local</code>
+          </li>
+          <li>
+            Enable anonymous access or configure{' '}
+            <code className="rounded bg-muted px-1 py-0.5 font-mono">allow_embedding = true</code>{' '}
+            in Grafana
+          </li>
+          <li>Provision dashboards matching the IDs listed above</li>
+        </ol>
+      </div>
+    </div>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Main component
+// ---------------------------------------------------------------------------
+
+export function GrafanaDashboard() {
+  const [selectedId, setSelectedId] = useState<string | null>(null);
+  const [timeRange, setTimeRange] = useState<string>('now-1h');
+  const [autoRefresh, setAutoRefresh] = useState(false);
+
+  const isConfigured = GRAFANA_BASE_URL !== 'http://localhost:3001';
+
+  const grouped = useMemo(() => {
+    return CATEGORIES.map(cat => ({
+      category: cat,
+      dashboards: DASHBOARDS.filter(d => d.category === cat),
+    }));
+  }, []);
+
+  const selectedDashboard = DASHBOARDS.find(d => d.id === selectedId) ?? null;
+
+  const iframeUrl = useMemo(() => {
+    if (!selectedId) return null;
+    const params = new URLSearchParams({
+      orgId: '1',
+      kiosk: '',
+      theme: 'dark',
+      from: timeRange,
+      to: 'now',
+    });
+    if (autoRefresh) {
+      params.set('refresh', '30s');
+    }
+    return `${GRAFANA_BASE_URL}/d/${selectedId}?${params.toString()}`;
+  }, [selectedId, timeRange, autoRefresh]);
+
+  const handleOpenFullscreen = useCallback(() => {
+    if (!iframeUrl) return;
+    window.open(iframeUrl, '_blank', 'noopener,noreferrer');
+  }, [iframeUrl]);
+
+  return (
+    <div className="space-y-5" data-testid="grafana-dashboard">
+      {/* Dashboard Selector */}
+      <div className="rounded-xl border bg-white/70 dark:bg-zinc-900/70 backdrop-blur-md p-4 space-y-4">
+        <div className="flex items-center justify-between">
+          <p className="text-sm font-medium text-foreground">Select Dashboard</p>
+          {selectedDashboard && (
+            <Badge className={cn('text-xs', CATEGORY_BADGE_COLORS[selectedDashboard.category])}>
+              {selectedDashboard.category}
+            </Badge>
+          )}
+        </div>
+
+        <div className="space-y-4">
+          {grouped.map(({ category, dashboards }) => (
+            <CategorySection
+              key={category}
+              category={category}
+              dashboards={dashboards}
+              selectedId={selectedId}
+              onSelect={setSelectedId}
+            />
+          ))}
+        </div>
+      </div>
+
+      {/* Controls bar — shown only when a dashboard is selected */}
+      {selectedId && (
+        <div
+          className="flex flex-wrap items-center gap-3 rounded-xl border bg-white/70 dark:bg-zinc-900/70 backdrop-blur-md px-4 py-3"
+          data-testid="grafana-controls"
+        >
+          {/* Time range */}
+          <div className="flex items-center gap-1.5" data-testid="time-range-selector">
+            <Clock className="h-3.5 w-3.5 text-muted-foreground" />
+            {TIME_RANGES.map(tr => (
+              <Button
+                key={tr.value}
+                variant={timeRange === tr.value ? 'default' : 'outline'}
+                size="sm"
+                className="h-7 px-2.5 text-xs"
+                onClick={() => setTimeRange(tr.value)}
+                data-testid={`time-range-${tr.label}`}
+              >
+                {tr.label}
+              </Button>
+            ))}
+          </div>
+
+          {/* Auto-refresh toggle */}
+          <Button
+            variant={autoRefresh ? 'default' : 'outline'}
+            size="sm"
+            className="gap-1.5 h-7 text-xs"
+            onClick={() => setAutoRefresh(prev => !prev)}
+            data-testid="auto-refresh-toggle"
+          >
+            <RefreshCw className={cn('h-3.5 w-3.5', autoRefresh && 'animate-spin')} />
+            {autoRefresh ? 'Auto (30s)' : 'Refresh'}
+          </Button>
+
+          {/* Fullscreen */}
+          <Button
+            variant="outline"
+            size="sm"
+            className="gap-1.5 h-7 text-xs ml-auto"
+            onClick={handleOpenFullscreen}
+            data-testid="fullscreen-toggle"
+          >
+            <Maximize2 className="h-3.5 w-3.5" />
+            Open
+            <ExternalLink className="h-3 w-3" />
+          </Button>
+        </div>
+      )}
+
+      {/* Iframe / Placeholder */}
+      {selectedId ? (
+        isConfigured ? (
+          <div
+            className="rounded-xl border bg-white/70 dark:bg-zinc-900/70 backdrop-blur-md overflow-hidden"
+            data-testid="grafana-iframe-container"
+          >
+            <iframe
+              key={iframeUrl}
+              src={iframeUrl ?? ''}
+              title={selectedDashboard?.name ?? 'Grafana Dashboard'}
+              className="w-full border-0"
+              style={{ height: 'calc(100vh - 320px)', minHeight: '500px' }}
+              sandbox="allow-scripts allow-same-origin allow-popups"
+              loading="lazy"
+              data-testid="grafana-iframe"
+            />
+          </div>
+        ) : (
+          <GrafanaNotConfigured />
+        )
+      ) : (
+        <div
+          className="rounded-xl border border-dashed border-muted-foreground/20 bg-white/70 dark:bg-zinc-900/70 backdrop-blur-md p-10 text-center"
+          data-testid="grafana-empty-state"
+        >
+          <BarChart3 className="mx-auto h-8 w-8 text-muted-foreground/40 mb-2" />
+          <p className="text-sm text-muted-foreground">Select a dashboard above to view metrics.</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/admin/(dashboard)/monitor/grafana/__tests__/GrafanaDashboard.test.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/grafana/__tests__/GrafanaDashboard.test.tsx
@@ -1,0 +1,110 @@
+/**
+ * GrafanaDashboard Component Tests
+ * Issue #134 — Grafana Dashboard Embed
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({
+    toast: vi.fn(),
+  }),
+}));
+
+import { GrafanaDashboard } from '../GrafanaDashboard';
+
+describe('GrafanaDashboard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ==================== Category Rendering ====================
+
+  it('renders dashboard selector with categories', () => {
+    render(<GrafanaDashboard />);
+
+    expect(screen.getByTestId('category-section-application')).toBeInTheDocument();
+    expect(screen.getByTestId('category-section-infrastructure')).toBeInTheDocument();
+    expect(screen.getByTestId('category-section-ai-services')).toBeInTheDocument();
+    expect(screen.getByTestId('category-section-security')).toBeInTheDocument();
+  });
+
+  // ==================== Empty State ====================
+
+  it('renders empty state when no dashboard selected', () => {
+    render(<GrafanaDashboard />);
+
+    expect(screen.getByTestId('grafana-empty-state')).toBeInTheDocument();
+    expect(screen.getByText(/Select a dashboard above/)).toBeInTheDocument();
+  });
+
+  // ==================== Dashboard Selection ====================
+
+  it('selecting a dashboard shows controls', async () => {
+    const user = userEvent.setup();
+    render(<GrafanaDashboard />);
+
+    // No controls initially
+    expect(screen.queryByTestId('grafana-controls')).not.toBeInTheDocument();
+
+    await user.click(screen.getByTestId('dashboard-card-api-overview'));
+
+    expect(screen.getByTestId('grafana-controls')).toBeInTheDocument();
+  });
+
+  // ==================== Time Range ====================
+
+  it('time range selector changes active button', async () => {
+    const user = userEvent.setup();
+    render(<GrafanaDashboard />);
+
+    // Select a dashboard first to show controls
+    await user.click(screen.getByTestId('dashboard-card-api-overview'));
+
+    // Default is 1h — click 6h
+    await user.click(screen.getByTestId('time-range-6h'));
+
+    // The 6h button should now have the 'default' variant styling (non-outline)
+    // and the 1h button should have 'outline' variant styling
+    const btn6h = screen.getByTestId('time-range-6h');
+    const btn1h = screen.getByTestId('time-range-1h');
+
+    // After clicking 6h, it should be the selected one and 1h should not be
+    // We verify by checking that the two buttons have different class lists
+    expect(btn6h.className).not.toEqual(btn1h.className);
+  });
+
+  // ==================== Fullscreen ====================
+
+  it('fullscreen button exists when dashboard selected', async () => {
+    const user = userEvent.setup();
+    render(<GrafanaDashboard />);
+
+    // No fullscreen button initially
+    expect(screen.queryByTestId('fullscreen-toggle')).not.toBeInTheDocument();
+
+    await user.click(screen.getByTestId('dashboard-card-api-overview'));
+
+    expect(screen.getByTestId('fullscreen-toggle')).toBeInTheDocument();
+  });
+
+  // ==================== Not Configured State ====================
+
+  it('shows not configured message when GRAFANA_BASE_URL is localhost', async () => {
+    const user = userEvent.setup();
+    render(<GrafanaDashboard />);
+
+    // Select a dashboard — since env is not set, GRAFANA_BASE_URL defaults to localhost:3001
+    await user.click(screen.getByTestId('dashboard-card-api-overview'));
+
+    // Empty state should be gone
+    expect(screen.queryByTestId('grafana-empty-state')).not.toBeInTheDocument();
+
+    // Should show "not configured" instead of an iframe
+    expect(screen.getByTestId('grafana-not-configured')).toBeInTheDocument();
+    expect(screen.getByText('Grafana Not Configured')).toBeInTheDocument();
+    expect(screen.getAllByText(/NEXT_PUBLIC_GRAFANA_URL/).length).toBeGreaterThan(0);
+  });
+});

--- a/apps/web/src/app/admin/(dashboard)/monitor/grafana/page.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/grafana/page.tsx
@@ -1,0 +1,24 @@
+/**
+ * Admin Grafana Dashboard Embed
+ * Issue #134 — Embedded Grafana dashboards for infrastructure and application monitoring.
+ *
+ * Route: /admin/monitor/grafana
+ */
+
+import { GrafanaDashboard } from './GrafanaDashboard';
+
+export default function GrafanaPage() {
+  return (
+    <div className="space-y-5" data-testid="grafana-page">
+      <div>
+        <h1 className="font-quicksand text-xl sm:text-2xl font-bold tracking-tight text-foreground">
+          Grafana Dashboards
+        </h1>
+        <p className="mt-0.5 text-sm text-muted-foreground">
+          Embedded Grafana dashboards for infrastructure and application monitoring.
+        </p>
+      </div>
+      <GrafanaDashboard />
+    </div>
+  );
+}

--- a/apps/web/src/app/admin/(dashboard)/monitor/services/DbStatsPanel.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/services/DbStatsPanel.tsx
@@ -180,6 +180,7 @@ export function DbStatsPanel() {
   const [loading, setLoading] = useState(true);
   const [refreshing, setRefreshing] = useState(false);
   const [vacuuming, setVacuuming] = useState(false);
+  const [vacuumConfirm, setVacuumConfirm] = useState(false);
   const { toast } = useToast();
 
   const fetchData = useCallback(async () => {
@@ -208,16 +209,11 @@ export function DbStatsPanel() {
   }, [fetchData]);
 
   const handleVacuum = useCallback(async () => {
-    const confirmed = window.confirm(
-      'Run VACUUM on the database? This reclaims storage from dead tuples. The operation may take a moment.'
-    );
-    if (!confirmed) return;
-
+    setVacuumConfirm(false);
     setVacuuming(true);
     try {
       await api.admin.vacuumDatabase(false);
       toast({ title: 'Vacuum completed successfully' });
-      // Refresh metrics after vacuum
       fetchData();
     } catch {
       toast({ title: 'Vacuum failed', variant: 'destructive' });
@@ -254,21 +250,51 @@ export function DbStatsPanel() {
           <h3 className="font-quicksand font-semibold text-base">Database Overview</h3>
         </div>
         <div className="flex items-center gap-2">
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={handleVacuum}
-            disabled={vacuuming}
-            className="gap-1.5"
-            data-testid="db-vacuum-btn"
-          >
-            {vacuuming ? (
-              <Loader2 className="h-3.5 w-3.5 animate-spin" />
-            ) : (
-              <Zap className="h-3.5 w-3.5" />
-            )}
-            Vacuum
-          </Button>
+          {vacuumConfirm ? (
+            <div className="flex items-center gap-1.5" data-testid="db-vacuum-confirm">
+              <span className="text-xs text-destructive font-medium">Run VACUUM?</span>
+              <Button
+                variant="destructive"
+                size="sm"
+                onClick={handleVacuum}
+                disabled={vacuuming}
+                className="gap-1 h-7 text-xs"
+                data-testid="db-vacuum-confirm-yes"
+              >
+                {vacuuming ? (
+                  <Loader2 className="h-3 w-3 animate-spin" />
+                ) : (
+                  <Zap className="h-3 w-3" />
+                )}
+                Yes
+              </Button>
+              <Button
+                variant="ghost"
+                size="sm"
+                onClick={() => setVacuumConfirm(false)}
+                className="h-7 text-xs"
+                data-testid="db-vacuum-confirm-no"
+              >
+                Cancel
+              </Button>
+            </div>
+          ) : (
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => setVacuumConfirm(true)}
+              disabled={vacuuming}
+              className="gap-1.5"
+              data-testid="db-vacuum-btn"
+            >
+              {vacuuming ? (
+                <Loader2 className="h-3.5 w-3.5 animate-spin" />
+              ) : (
+                <Zap className="h-3.5 w-3.5" />
+              )}
+              Vacuum
+            </Button>
+          )}
           <Button
             variant="outline"
             size="sm"

--- a/apps/web/src/app/admin/(dashboard)/monitor/services/DbStatsPanel.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/services/DbStatsPanel.tsx
@@ -1,0 +1,355 @@
+'use client';
+
+/**
+ * DbStatsPanel — Database statistics overview panel showing size, connections,
+ * transactions, top tables, and vacuum controls.
+ * Issue #135 — DB Stats Overview for Service Dashboard
+ */
+
+import { useCallback, useEffect, useState } from 'react';
+
+import {
+  ChevronDown,
+  ChevronRight,
+  Database,
+  HardDrive,
+  Loader2,
+  RefreshCw,
+  Table2,
+  TrendingDown,
+  TrendingUp,
+  Zap,
+} from 'lucide-react';
+
+import { Badge } from '@/components/ui/data-display/badge';
+import { Button } from '@/components/ui/primitives/button';
+import { useToast } from '@/hooks/use-toast';
+import { api } from '@/lib/api';
+import type { DatabaseMetrics, TableSize } from '@/lib/api/schemas';
+import { cn } from '@/lib/utils';
+
+function formatRelativeTime(isoDate: string): string {
+  const diff = Date.now() - new Date(isoDate).getTime();
+  const seconds = Math.floor(diff / 1000);
+  if (seconds < 60) return `${seconds}s ago`;
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes === 0) return '0 B';
+  const units = ['B', 'KB', 'MB', 'GB', 'TB'];
+  const i = Math.floor(Math.log(bytes) / Math.log(1024));
+  return `${(bytes / Math.pow(1024, i)).toFixed(1)} ${units[i]}`;
+}
+
+function GrowthIndicator({ bytes, label }: { bytes: number; label: string }) {
+  const isPositive = bytes > 0;
+  const isZero = bytes === 0;
+
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center gap-0.5 text-xs',
+        isZero
+          ? 'text-muted-foreground'
+          : isPositive
+            ? 'text-amber-600 dark:text-amber-400'
+            : 'text-green-600 dark:text-green-400'
+      )}
+      title={`${label}: ${isPositive ? '+' : ''}${formatBytes(bytes)}`}
+    >
+      {!isZero &&
+        (isPositive ? <TrendingUp className="h-3 w-3" /> : <TrendingDown className="h-3 w-3" />)}
+      <span>
+        {label}: {isPositive ? '+' : ''}
+        {formatBytes(Math.abs(bytes))}
+      </span>
+    </span>
+  );
+}
+
+function ConnectionBar({ active, max }: { active: number; max: number }) {
+  const percent = max > 0 ? (active / max) * 100 : 0;
+  const barColor = percent >= 80 ? 'bg-red-500' : percent >= 60 ? 'bg-amber-500' : 'bg-green-500';
+
+  return (
+    <div className="space-y-1">
+      <div className="flex items-baseline justify-between">
+        <span className="text-lg font-semibold font-mono">
+          {active}
+          <span className="text-xs text-muted-foreground font-normal"> / {max}</span>
+        </span>
+      </div>
+      <div
+        className="h-1.5 w-full rounded-full bg-slate-200 dark:bg-zinc-700 overflow-hidden"
+        data-testid="db-connections-bar"
+      >
+        <div
+          className={cn('h-full rounded-full transition-all duration-500', barColor)}
+          style={{ width: `${Math.min(percent, 100)}%` }}
+        />
+      </div>
+      <p className="text-xs text-muted-foreground">{percent.toFixed(1)}% utilized</p>
+    </div>
+  );
+}
+
+function TopTablesTable({ tables }: { tables: TableSize[] }) {
+  const [open, setOpen] = useState(true);
+
+  return (
+    <div
+      className="rounded-xl border bg-white/70 dark:bg-zinc-900/70 backdrop-blur-md overflow-hidden"
+      data-testid="db-top-tables"
+    >
+      <button
+        className="w-full flex items-center justify-between px-4 py-3 hover:bg-slate-50/50 dark:hover:bg-zinc-800/30 transition-colors"
+        onClick={() => setOpen(!open)}
+        data-testid="db-top-tables-toggle"
+      >
+        <div className="flex items-center gap-2">
+          {open ? (
+            <ChevronDown className="h-4 w-4 text-muted-foreground" />
+          ) : (
+            <ChevronRight className="h-4 w-4 text-muted-foreground" />
+          )}
+          <Table2 className="h-4 w-4 text-blue-600" />
+          <span className="font-quicksand font-semibold text-sm">Top Tables</span>
+          <span className="text-xs text-muted-foreground">({tables.length})</span>
+        </div>
+      </button>
+      {open && (
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-t border-b text-xs text-muted-foreground">
+                <th className="text-left py-2 px-4">Table Name</th>
+                <th className="text-right py-2 px-3">Rows</th>
+                <th className="text-right py-2 px-3">Data Size</th>
+                <th className="text-right py-2 px-3">Index Size</th>
+                <th className="text-right py-2 px-3">Total Size</th>
+              </tr>
+            </thead>
+            <tbody>
+              {tables.map(table => (
+                <tr
+                  key={table.tableName}
+                  className="border-b last:border-0"
+                  data-testid={`db-table-row-${table.tableName}`}
+                >
+                  <td className="py-2.5 px-4">
+                    <span className="font-mono text-xs">{table.tableName}</span>
+                  </td>
+                  <td className="py-2.5 px-3 text-right font-mono text-xs">
+                    {table.rowCount.toLocaleString()}
+                  </td>
+                  <td className="py-2.5 px-3 text-right font-mono text-xs">
+                    {table.sizeFormatted}
+                  </td>
+                  <td className="py-2.5 px-3 text-right font-mono text-xs">
+                    {table.indexSizeFormatted}
+                  </td>
+                  <td className="py-2.5 px-3 text-right font-mono text-xs font-medium">
+                    {table.totalSizeFormatted}
+                  </td>
+                </tr>
+              ))}
+              {tables.length === 0 && (
+                <tr>
+                  <td colSpan={5} className="py-6 text-center text-sm text-muted-foreground">
+                    No table data available.
+                  </td>
+                </tr>
+              )}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export function DbStatsPanel() {
+  const [metrics, setMetrics] = useState<DatabaseMetrics | null>(null);
+  const [tables, setTables] = useState<TableSize[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [refreshing, setRefreshing] = useState(false);
+  const [vacuuming, setVacuuming] = useState(false);
+  const { toast } = useToast();
+
+  const fetchData = useCallback(async () => {
+    try {
+      const [metricsResult, tablesResult] = await Promise.all([
+        api.admin.getResourceDatabaseMetrics(),
+        api.admin.getResourceDatabaseTopTables(10),
+      ]);
+      setMetrics(metricsResult);
+      setTables(tablesResult);
+    } catch {
+      toast({ title: 'Failed to load database metrics', variant: 'destructive' });
+    } finally {
+      setLoading(false);
+      setRefreshing(false);
+    }
+  }, [toast]);
+
+  useEffect(() => {
+    fetchData();
+  }, [fetchData]);
+
+  const handleRefresh = useCallback(() => {
+    setRefreshing(true);
+    fetchData();
+  }, [fetchData]);
+
+  const handleVacuum = useCallback(async () => {
+    const confirmed = window.confirm(
+      'Run VACUUM on the database? This reclaims storage from dead tuples. The operation may take a moment.'
+    );
+    if (!confirmed) return;
+
+    setVacuuming(true);
+    try {
+      await api.admin.vacuumDatabase(false);
+      toast({ title: 'Vacuum completed successfully' });
+      // Refresh metrics after vacuum
+      fetchData();
+    } catch {
+      toast({ title: 'Vacuum failed', variant: 'destructive' });
+    } finally {
+      setVacuuming(false);
+    }
+  }, [toast, fetchData]);
+
+  if (loading) {
+    return (
+      <div className="flex items-center justify-center py-10" data-testid="db-stats-loading">
+        <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+      </div>
+    );
+  }
+
+  if (!metrics) {
+    return (
+      <div className="text-center py-10 text-sm text-muted-foreground" data-testid="db-stats-empty">
+        No database metrics available.
+      </div>
+    );
+  }
+
+  const txTotal = metrics.transactionsCommitted + metrics.transactionsRolledBack;
+  const txSuccessRate = txTotal > 0 ? (metrics.transactionsCommitted / txTotal) * 100 : 100;
+
+  return (
+    <div className="space-y-4" data-testid="db-stats-panel">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Database className="h-5 w-5 text-blue-600" />
+          <h3 className="font-quicksand font-semibold text-base">Database Overview</h3>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleVacuum}
+            disabled={vacuuming}
+            className="gap-1.5"
+            data-testid="db-vacuum-btn"
+          >
+            {vacuuming ? (
+              <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            ) : (
+              <Zap className="h-3.5 w-3.5" />
+            )}
+            Vacuum
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={handleRefresh}
+            disabled={refreshing}
+            className="gap-1.5"
+            data-testid="db-refresh-btn"
+          >
+            <RefreshCw className={cn('h-3.5 w-3.5', refreshing && 'animate-spin')} />
+            Refresh
+          </Button>
+        </div>
+      </div>
+
+      {/* KPI Cards */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-3" data-testid="db-kpi-row">
+        {/* Total Size */}
+        <div
+          className="rounded-xl border bg-white/70 dark:bg-zinc-900/70 backdrop-blur-md p-3"
+          data-testid="db-kpi-size"
+        >
+          <div className="flex items-center gap-1.5 mb-1">
+            <HardDrive className="h-3.5 w-3.5 text-muted-foreground" />
+            <p className="text-xs text-muted-foreground">Total Size</p>
+          </div>
+          <p className="text-lg font-semibold font-mono">{metrics.sizeFormatted}</p>
+          <div className="flex flex-col gap-0.5 mt-1.5">
+            <GrowthIndicator bytes={metrics.growthLast7Days} label="7d" />
+            <GrowthIndicator bytes={metrics.growthLast30Days} label="30d" />
+            <GrowthIndicator bytes={metrics.growthLast90Days} label="90d" />
+          </div>
+        </div>
+
+        {/* Active Connections */}
+        <div
+          className="rounded-xl border bg-white/70 dark:bg-zinc-900/70 backdrop-blur-md p-3"
+          data-testid="db-kpi-connections"
+        >
+          <p className="text-xs text-muted-foreground mb-1">Active Connections</p>
+          <ConnectionBar active={metrics.activeConnections} max={metrics.maxConnections} />
+        </div>
+
+        {/* Transactions */}
+        <div
+          className="rounded-xl border bg-white/70 dark:bg-zinc-900/70 backdrop-blur-md p-3"
+          data-testid="db-kpi-transactions"
+        >
+          <p className="text-xs text-muted-foreground mb-1">Transactions</p>
+          <p className="text-lg font-semibold font-mono">{txTotal.toLocaleString()}</p>
+          <div className="flex items-center gap-2 mt-1.5">
+            <Badge variant="secondary" className="text-xs">
+              {txSuccessRate.toFixed(1)}% success
+            </Badge>
+          </div>
+          <div className="flex gap-3 mt-1 text-xs text-muted-foreground">
+            <span>{metrics.transactionsCommitted.toLocaleString()} committed</span>
+            {metrics.transactionsRolledBack > 0 && (
+              <span className="text-red-500">
+                {metrics.transactionsRolledBack.toLocaleString()} rolled back
+              </span>
+            )}
+          </div>
+        </div>
+
+        {/* Last Measured */}
+        <div
+          className="rounded-xl border bg-white/70 dark:bg-zinc-900/70 backdrop-blur-md p-3"
+          data-testid="db-kpi-measured"
+        >
+          <p className="text-xs text-muted-foreground mb-1">Last Measured</p>
+          <p className="text-lg font-semibold font-mono">
+            {formatRelativeTime(metrics.measuredAt)}
+          </p>
+          <p className="text-xs text-muted-foreground mt-1.5">
+            {new Date(metrics.measuredAt).toLocaleString()}
+          </p>
+        </div>
+      </div>
+
+      {/* Top Tables */}
+      <TopTablesTable tables={tables} />
+    </div>
+  );
+}

--- a/apps/web/src/app/admin/(dashboard)/monitor/services/RestartServicePanel.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/services/RestartServicePanel.tsx
@@ -1,0 +1,389 @@
+'use client';
+
+/**
+ * RestartServicePanel — Service restart control panel with Level 2 confirmation.
+ * Issue #133 — SuperAdmin only, requires typing service name to confirm.
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { AlertTriangle, Check, RefreshCw, Shield, Timer, X } from 'lucide-react';
+
+import { Badge } from '@/components/ui/data-display/badge';
+import { Button } from '@/components/ui/primitives/button';
+import { useToast } from '@/hooks/use-toast';
+import { getApiBase } from '@/lib/api/core/httpClient';
+import { cn } from '@/lib/utils';
+
+/* ------------------------------------------------------------------ */
+/*  Types                                                              */
+/* ------------------------------------------------------------------ */
+
+interface ServiceDefinition {
+  id: string;
+  label: string;
+  description: string;
+}
+
+interface RestartResult {
+  message: string;
+  estimatedDowntime: string;
+}
+
+interface CooldownState {
+  /** Remaining seconds */
+  remaining: number;
+  result: RestartResult | null;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Constants                                                          */
+/* ------------------------------------------------------------------ */
+
+const COOLDOWN_SECONDS = 5 * 60; // 5 minutes
+
+const SERVICES: ServiceDefinition[] = [
+  { id: 'api', label: 'API Service', description: 'Core backend API (.NET 9)' },
+  {
+    id: 'embedding-service',
+    label: 'Embedding Service',
+    description: 'Sentence-transformer embeddings (Python)',
+  },
+  {
+    id: 'reranker-service',
+    label: 'Reranker Service',
+    description: 'Cross-encoder reranking (Python)',
+  },
+  {
+    id: 'unstructured-service',
+    label: 'Unstructured Service',
+    description: 'PDF extraction and processing',
+  },
+  {
+    id: 'smoldocling-service',
+    label: 'SmolDocling Service',
+    description: 'Document understanding and OCR',
+  },
+];
+
+/* ------------------------------------------------------------------ */
+/*  Helpers                                                            */
+/* ------------------------------------------------------------------ */
+
+function formatCooldown(seconds: number): string {
+  const m = Math.floor(seconds / 60);
+  const s = seconds % 60;
+  return `${m}:${s.toString().padStart(2, '0')}`;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Sub-components                                                     */
+/* ------------------------------------------------------------------ */
+
+interface ConfirmationDialogProps {
+  service: ServiceDefinition;
+  onConfirm: () => void;
+  onCancel: () => void;
+  isLoading: boolean;
+}
+
+function ConfirmationDialog({ service, onConfirm, onCancel, isLoading }: ConfirmationDialogProps) {
+  const [confirmText, setConfirmText] = useState('');
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    inputRef.current?.focus();
+  }, []);
+
+  const isMatch = confirmText === service.id;
+
+  return (
+    <div
+      data-testid={`confirm-dialog-${service.id}`}
+      className="mt-3 rounded-lg border border-destructive/30 bg-destructive/5 p-4 dark:border-destructive/40 dark:bg-destructive/10"
+    >
+      <div className="mb-3 flex items-center gap-2 text-sm font-semibold text-destructive">
+        <AlertTriangle className="h-4 w-4" />
+        <span>Level 2 Confirmation Required</span>
+      </div>
+
+      <p className="mb-3 text-sm text-muted-foreground">
+        Type{' '}
+        <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs font-bold text-foreground">
+          {service.id}
+        </code>{' '}
+        to confirm restart of <strong>{service.label}</strong>.
+      </p>
+
+      <input
+        ref={inputRef}
+        data-testid={`confirm-input-${service.id}`}
+        type="text"
+        value={confirmText}
+        onChange={e => setConfirmText(e.target.value)}
+        placeholder={`Type "${service.id}" to confirm`}
+        className={cn(
+          'mb-3 w-full rounded-md border bg-background px-3 py-2 text-sm outline-none transition-colors',
+          'placeholder:text-muted-foreground/60',
+          'focus:border-destructive/50 focus:ring-1 focus:ring-destructive/30',
+          isMatch && 'border-green-500/50 focus:border-green-500/50 focus:ring-green-500/30'
+        )}
+        onKeyDown={e => {
+          if (e.key === 'Enter' && isMatch && !isLoading) {
+            onConfirm();
+          }
+          if (e.key === 'Escape') {
+            onCancel();
+          }
+        }}
+      />
+
+      <div className="flex items-center gap-2">
+        <Button
+          data-testid={`confirm-cancel-${service.id}`}
+          variant="ghost"
+          size="sm"
+          onClick={onCancel}
+          disabled={isLoading}
+        >
+          <X className="mr-1 h-3 w-3" />
+          Cancel
+        </Button>
+        <Button
+          data-testid={`confirm-restart-${service.id}`}
+          variant="destructive"
+          size="sm"
+          disabled={!isMatch || isLoading}
+          onClick={onConfirm}
+        >
+          {isLoading ? (
+            <RefreshCw className="mr-1 h-3 w-3 animate-spin" />
+          ) : (
+            <Check className="mr-1 h-3 w-3" />
+          )}
+          {isLoading ? 'Restarting...' : 'Confirm Restart'}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  ServiceRow                                                         */
+/* ------------------------------------------------------------------ */
+
+interface ServiceRowProps {
+  service: ServiceDefinition;
+  cooldown: CooldownState | null;
+  onRestart: (serviceId: string) => Promise<void>;
+}
+
+function ServiceRow({ service, cooldown, onRestart }: ServiceRowProps) {
+  const [showConfirm, setShowConfirm] = useState(false);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const handleConfirm = useCallback(async () => {
+    setIsLoading(true);
+    try {
+      await onRestart(service.id);
+    } finally {
+      setIsLoading(false);
+      setShowConfirm(false);
+    }
+  }, [onRestart, service.id]);
+
+  const handleCancel = useCallback(() => {
+    setShowConfirm(false);
+  }, []);
+
+  const isCoolingDown = cooldown !== null && cooldown.remaining > 0;
+
+  return (
+    <div
+      data-testid={`service-row-${service.id}`}
+      className="rounded-lg border border-border/40 bg-white/50 p-4 transition-colors dark:bg-zinc-800/50"
+    >
+      <div className="flex items-center justify-between">
+        <div className="min-w-0 flex-1">
+          <div className="flex items-center gap-2">
+            <span className="text-sm font-semibold text-foreground">{service.label}</span>
+            <code className="rounded bg-muted px-1.5 py-0.5 text-xs text-muted-foreground">
+              {service.id}
+            </code>
+          </div>
+          <p className="mt-0.5 text-xs text-muted-foreground">{service.description}</p>
+        </div>
+
+        <div className="ml-4 flex-shrink-0">
+          {isCoolingDown ? (
+            <div
+              data-testid={`cooldown-${service.id}`}
+              className="flex items-center gap-1.5 rounded-md bg-amber-500/10 px-3 py-1.5 text-xs font-medium text-amber-600 dark:text-amber-400"
+            >
+              <Timer className="h-3.5 w-3.5" />
+              <span>Cooldown: {formatCooldown(cooldown.remaining)}</span>
+            </div>
+          ) : (
+            <Button
+              data-testid={`restart-btn-${service.id}`}
+              variant="destructive"
+              size="sm"
+              onClick={() => setShowConfirm(true)}
+              disabled={showConfirm}
+            >
+              <RefreshCw className="mr-1 h-3 w-3" />
+              Restart
+            </Button>
+          )}
+        </div>
+      </div>
+
+      {/* Restart result feedback */}
+      {cooldown?.result && (
+        <div
+          data-testid={`result-${service.id}`}
+          className="mt-3 flex items-start gap-2 rounded-md bg-green-500/10 px-3 py-2 text-xs dark:bg-green-500/15"
+        >
+          <Check className="mt-0.5 h-3.5 w-3.5 flex-shrink-0 text-green-600 dark:text-green-400" />
+          <div>
+            <p className="font-medium text-green-700 dark:text-green-300">
+              {cooldown.result.message}
+            </p>
+            <p className="mt-0.5 text-green-600/80 dark:text-green-400/80">
+              Estimated downtime: {cooldown.result.estimatedDowntime}
+            </p>
+          </div>
+        </div>
+      )}
+
+      {/* Level 2 confirmation */}
+      {showConfirm && !isCoolingDown && (
+        <ConfirmationDialog
+          service={service}
+          onConfirm={handleConfirm}
+          onCancel={handleCancel}
+          isLoading={isLoading}
+        />
+      )}
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Main Component                                                     */
+/* ------------------------------------------------------------------ */
+
+export function RestartServicePanel() {
+  const { toast } = useToast();
+  const [cooldowns, setCooldowns] = useState<Record<string, CooldownState>>({});
+  const intervalsRef = useRef<Record<string, ReturnType<typeof setInterval>>>({});
+
+  // Clean up intervals on unmount
+  useEffect(() => {
+    const intervals = intervalsRef.current;
+    return () => {
+      Object.values(intervals).forEach(clearInterval);
+    };
+  }, []);
+
+  const startCooldown = useCallback((serviceId: string, result: RestartResult) => {
+    // Clear any existing interval for this service
+    if (intervalsRef.current[serviceId]) {
+      clearInterval(intervalsRef.current[serviceId]);
+    }
+
+    setCooldowns(prev => ({
+      ...prev,
+      [serviceId]: { remaining: COOLDOWN_SECONDS, result },
+    }));
+
+    const interval = setInterval(() => {
+      setCooldowns(prev => {
+        const current = prev[serviceId];
+        if (!current || current.remaining <= 1) {
+          clearInterval(intervalsRef.current[serviceId]);
+          delete intervalsRef.current[serviceId];
+          const { [serviceId]: _, ...rest } = prev;
+          return rest;
+        }
+        return {
+          ...prev,
+          [serviceId]: { ...current, remaining: current.remaining - 1 },
+        };
+      });
+    }, 1000);
+
+    intervalsRef.current[serviceId] = interval;
+  }, []);
+
+  const handleRestart = useCallback(
+    async (serviceId: string) => {
+      try {
+        const response = await fetch(`${getApiBase()}/api/v1/admin/operations/restart-service`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
+          body: JSON.stringify({ serviceName: serviceId }),
+        });
+
+        if (!response.ok) {
+          const errorBody = await response.text();
+          throw new Error(errorBody || `HTTP ${response.status}`);
+        }
+
+        const data: RestartResult = await response.json();
+
+        startCooldown(serviceId, data);
+
+        toast({
+          title: 'Service restart initiated',
+          description: `${serviceId}: ${data.message}`,
+        });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : 'Unknown error';
+        toast({
+          title: 'Restart failed',
+          description: message,
+          variant: 'destructive',
+        });
+      }
+    },
+    [startCooldown, toast]
+  );
+
+  return (
+    <section
+      data-testid="restart-service-panel"
+      className="rounded-xl border bg-white/70 p-6 backdrop-blur-md dark:bg-zinc-900/70"
+    >
+      {/* Header */}
+      <div className="mb-5 flex items-center gap-3">
+        <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-destructive/10 dark:bg-destructive/20">
+          <Shield className="h-5 w-5 text-destructive" />
+        </div>
+        <div className="flex items-center gap-2">
+          <h2 className="text-lg font-semibold text-foreground">Service Control</h2>
+          <Badge
+            data-testid="superadmin-badge"
+            variant="destructive"
+            className="text-[10px] uppercase tracking-wider"
+          >
+            SuperAdmin
+          </Badge>
+        </div>
+      </div>
+
+      {/* Service list */}
+      <div className="flex flex-col gap-3">
+        {SERVICES.map(service => (
+          <ServiceRow
+            key={service.id}
+            service={service}
+            cooldown={cooldowns[service.id] ?? null}
+            onRestart={handleRestart}
+          />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/apps/web/src/app/admin/(dashboard)/monitor/services/RestartServicePanel.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/services/RestartServicePanel.tsx
@@ -12,7 +12,7 @@ import { AlertTriangle, Check, RefreshCw, Shield, Timer, X } from 'lucide-react'
 import { Badge } from '@/components/ui/data-display/badge';
 import { Button } from '@/components/ui/primitives/button';
 import { useToast } from '@/hooks/use-toast';
-import { getApiBase } from '@/lib/api/core/httpClient';
+import { api } from '@/lib/api';
 import { cn } from '@/lib/utils';
 
 /* ------------------------------------------------------------------ */
@@ -319,19 +319,7 @@ export function RestartServicePanel() {
   const handleRestart = useCallback(
     async (serviceId: string) => {
       try {
-        const response = await fetch(`${getApiBase()}/api/v1/admin/operations/restart-service`, {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
-          credentials: 'include',
-          body: JSON.stringify({ serviceName: serviceId }),
-        });
-
-        if (!response.ok) {
-          const errorBody = await response.text();
-          throw new Error(errorBody || `HTTP ${response.status}`);
-        }
-
-        const data: RestartResult = await response.json();
+        const data = await api.admin.restartService(serviceId);
 
         startCooldown(serviceId, data);
 

--- a/apps/web/src/app/admin/(dashboard)/monitor/services/__tests__/DbStatsPanel.test.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/services/__tests__/DbStatsPanel.test.tsx
@@ -1,0 +1,212 @@
+/**
+ * DbStatsPanel Component Tests
+ * Issue #135 — DB Stats Overview for Service Dashboard
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+const mockGetResourceDatabaseMetrics = vi.hoisted(() => vi.fn());
+const mockGetResourceDatabaseTopTables = vi.hoisted(() => vi.fn());
+const mockVacuumDatabase = vi.hoisted(() => vi.fn());
+const mockToast = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    admin: {
+      getResourceDatabaseMetrics: mockGetResourceDatabaseMetrics,
+      getResourceDatabaseTopTables: mockGetResourceDatabaseTopTables,
+      vacuumDatabase: mockVacuumDatabase,
+    },
+  },
+}));
+
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({
+    toast: mockToast,
+  }),
+}));
+
+import { DbStatsPanel } from '../DbStatsPanel';
+
+function createMockMetrics() {
+  return {
+    sizeBytes: 1073741824,
+    sizeFormatted: '1.0 GB',
+    growthLast7Days: 52428800,
+    growthLast30Days: 209715200,
+    growthLast90Days: 524288000,
+    activeConnections: 15,
+    maxConnections: 100,
+    transactionsCommitted: 50000,
+    transactionsRolledBack: 50,
+    measuredAt: new Date().toISOString(),
+  };
+}
+
+function createMockTables() {
+  return [
+    {
+      tableName: 'games',
+      sizeBytes: 52428800,
+      sizeFormatted: '50 MB',
+      rowCount: 1500,
+      indexSizeBytes: 10485760,
+      indexSizeFormatted: '10 MB',
+      totalSizeBytes: 62914560,
+      totalSizeFormatted: '60 MB',
+    },
+    {
+      tableName: 'users',
+      sizeBytes: 20971520,
+      sizeFormatted: '20 MB',
+      rowCount: 500,
+      indexSizeBytes: 5242880,
+      indexSizeFormatted: '5 MB',
+      totalSizeBytes: 26214400,
+      totalSizeFormatted: '25 MB',
+    },
+  ];
+}
+
+describe('DbStatsPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ==================== Loading State ====================
+
+  it('renders loading state initially', () => {
+    mockGetResourceDatabaseMetrics.mockReturnValue(new Promise(() => {}));
+    mockGetResourceDatabaseTopTables.mockReturnValue(new Promise(() => {}));
+    render(<DbStatsPanel />);
+
+    expect(screen.getByTestId('db-stats-loading')).toBeInTheDocument();
+  });
+
+  // ==================== Data Display ====================
+
+  it('renders KPI cards with metrics data', async () => {
+    mockGetResourceDatabaseMetrics.mockResolvedValue(createMockMetrics());
+    mockGetResourceDatabaseTopTables.mockResolvedValue(createMockTables());
+    render(<DbStatsPanel />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('db-kpi-size')).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId('db-kpi-connections')).toBeInTheDocument();
+    expect(screen.getByTestId('db-kpi-transactions')).toBeInTheDocument();
+    expect(screen.getByTestId('db-kpi-measured')).toBeInTheDocument();
+
+    // Check size value
+    expect(screen.getByText('1.0 GB')).toBeInTheDocument();
+  });
+
+  it('renders top tables', async () => {
+    mockGetResourceDatabaseMetrics.mockResolvedValue(createMockMetrics());
+    mockGetResourceDatabaseTopTables.mockResolvedValue(createMockTables());
+    render(<DbStatsPanel />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('db-top-tables')).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId('db-table-row-games')).toBeInTheDocument();
+    expect(screen.getByTestId('db-table-row-users')).toBeInTheDocument();
+  });
+
+  // ==================== Refresh ====================
+
+  it('refresh button fetches new data', async () => {
+    const user = userEvent.setup();
+    mockGetResourceDatabaseMetrics.mockResolvedValue(createMockMetrics());
+    mockGetResourceDatabaseTopTables.mockResolvedValue(createMockTables());
+    render(<DbStatsPanel />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('db-refresh-btn')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId('db-refresh-btn'));
+
+    // Initial load + refresh = 2 calls each
+    await waitFor(() => {
+      expect(mockGetResourceDatabaseMetrics).toHaveBeenCalledTimes(2);
+    });
+    expect(mockGetResourceDatabaseTopTables).toHaveBeenCalledTimes(2);
+  });
+
+  // ==================== Vacuum ====================
+
+  it('vacuum button shows confirmation and executes', async () => {
+    const user = userEvent.setup();
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
+    mockGetResourceDatabaseMetrics.mockResolvedValue(createMockMetrics());
+    mockGetResourceDatabaseTopTables.mockResolvedValue(createMockTables());
+    mockVacuumDatabase.mockResolvedValue(undefined);
+    render(<DbStatsPanel />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('db-vacuum-btn')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId('db-vacuum-btn'));
+
+    expect(confirmSpy).toHaveBeenCalled();
+    await waitFor(() => {
+      expect(mockVacuumDatabase).toHaveBeenCalledWith(false);
+    });
+
+    confirmSpy.mockRestore();
+  });
+
+  it('vacuum button does nothing when cancelled', async () => {
+    const user = userEvent.setup();
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
+    mockGetResourceDatabaseMetrics.mockResolvedValue(createMockMetrics());
+    mockGetResourceDatabaseTopTables.mockResolvedValue(createMockTables());
+    render(<DbStatsPanel />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('db-vacuum-btn')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId('db-vacuum-btn'));
+
+    expect(confirmSpy).toHaveBeenCalled();
+    expect(mockVacuumDatabase).not.toHaveBeenCalled();
+
+    confirmSpy.mockRestore();
+  });
+
+  // ==================== Empty State ====================
+
+  it('shows empty state when no metrics', async () => {
+    mockGetResourceDatabaseMetrics.mockResolvedValue(null);
+    mockGetResourceDatabaseTopTables.mockResolvedValue([]);
+    render(<DbStatsPanel />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('db-stats-empty')).toBeInTheDocument();
+    });
+  });
+
+  // ==================== Error Handling ====================
+
+  it('shows toast on API error', async () => {
+    mockGetResourceDatabaseMetrics.mockRejectedValue(new Error('Network error'));
+    mockGetResourceDatabaseTopTables.mockRejectedValue(new Error('Network error'));
+    render(<DbStatsPanel />);
+
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'Failed to load database metrics',
+          variant: 'destructive',
+        })
+      );
+    });
+  });
+});

--- a/apps/web/src/app/admin/(dashboard)/monitor/services/__tests__/DbStatsPanel.test.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/services/__tests__/DbStatsPanel.test.tsx
@@ -140,9 +140,8 @@ describe('DbStatsPanel', () => {
 
   // ==================== Vacuum ====================
 
-  it('vacuum button shows confirmation and executes', async () => {
+  it('vacuum button shows inline confirmation and executes on confirm', async () => {
     const user = userEvent.setup();
-    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true);
     mockGetResourceDatabaseMetrics.mockResolvedValue(createMockMetrics());
     mockGetResourceDatabaseTopTables.mockResolvedValue(createMockTables());
     mockVacuumDatabase.mockResolvedValue(undefined);
@@ -152,19 +151,19 @@ describe('DbStatsPanel', () => {
       expect(screen.getByTestId('db-vacuum-btn')).toBeInTheDocument();
     });
 
+    // Click vacuum shows inline confirmation
     await user.click(screen.getByTestId('db-vacuum-btn'));
+    expect(screen.getByTestId('db-vacuum-confirm')).toBeInTheDocument();
 
-    expect(confirmSpy).toHaveBeenCalled();
+    // Confirm executes vacuum
+    await user.click(screen.getByTestId('db-vacuum-confirm-yes'));
     await waitFor(() => {
       expect(mockVacuumDatabase).toHaveBeenCalledWith(false);
     });
-
-    confirmSpy.mockRestore();
   });
 
-  it('vacuum button does nothing when cancelled', async () => {
+  it('vacuum confirmation cancel hides confirmation', async () => {
     const user = userEvent.setup();
-    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false);
     mockGetResourceDatabaseMetrics.mockResolvedValue(createMockMetrics());
     mockGetResourceDatabaseTopTables.mockResolvedValue(createMockTables());
     render(<DbStatsPanel />);
@@ -174,11 +173,12 @@ describe('DbStatsPanel', () => {
     });
 
     await user.click(screen.getByTestId('db-vacuum-btn'));
+    expect(screen.getByTestId('db-vacuum-confirm')).toBeInTheDocument();
 
-    expect(confirmSpy).toHaveBeenCalled();
+    // Cancel hides confirmation
+    await user.click(screen.getByTestId('db-vacuum-confirm-no'));
+    expect(screen.queryByTestId('db-vacuum-confirm')).not.toBeInTheDocument();
     expect(mockVacuumDatabase).not.toHaveBeenCalled();
-
-    confirmSpy.mockRestore();
   });
 
   // ==================== Empty State ====================

--- a/apps/web/src/app/admin/(dashboard)/monitor/services/__tests__/RestartServicePanel.test.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/services/__tests__/RestartServicePanel.test.tsx
@@ -7,10 +7,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 
-const mockFetch = vi.hoisted(() => vi.fn());
+const mockRestartService = vi.hoisted(() => vi.fn());
 const mockToast = vi.hoisted(() => vi.fn());
-
-vi.stubGlobal('fetch', mockFetch);
 
 vi.mock('@/hooks/use-toast', () => ({
   useToast: () => ({
@@ -18,8 +16,12 @@ vi.mock('@/hooks/use-toast', () => ({
   }),
 }));
 
-vi.mock('@/lib/api/core/httpClient', () => ({
-  getApiBase: () => 'http://localhost:8080',
+vi.mock('@/lib/api', () => ({
+  api: {
+    admin: {
+      restartService: mockRestartService,
+    },
+  },
 }));
 
 import { RestartServicePanel } from '../RestartServicePanel';
@@ -91,12 +93,9 @@ describe('RestartServicePanel', () => {
 
   it('successful restart shows cooldown', async () => {
     const user = userEvent.setup();
-    mockFetch.mockResolvedValue({
-      ok: true,
-      json: async () => ({
-        message: 'Restart initiated',
-        estimatedDowntime: '30-60 seconds',
-      }),
+    mockRestartService.mockResolvedValue({
+      message: 'Restart initiated',
+      estimatedDowntime: '30-60 seconds',
     });
     render(<RestartServicePanel />);
 
@@ -111,12 +110,9 @@ describe('RestartServicePanel', () => {
 
   it('successful restart shows result feedback', async () => {
     const user = userEvent.setup();
-    mockFetch.mockResolvedValue({
-      ok: true,
-      json: async () => ({
-        message: 'Restart initiated',
-        estimatedDowntime: '30-60 seconds',
-      }),
+    mockRestartService.mockResolvedValue({
+      message: 'Restart initiated',
+      estimatedDowntime: '30-60 seconds',
     });
     render(<RestartServicePanel />);
 
@@ -134,7 +130,7 @@ describe('RestartServicePanel', () => {
 
   it('failed restart shows error toast', async () => {
     const user = userEvent.setup();
-    mockFetch.mockRejectedValue(new Error('Connection refused'));
+    mockRestartService.mockRejectedValue(new Error('Connection refused'));
     render(<RestartServicePanel />);
 
     await user.click(screen.getByTestId('restart-btn-api'));
@@ -149,5 +145,28 @@ describe('RestartServicePanel', () => {
         })
       );
     });
+  });
+
+  it('API error response shows error message in toast', async () => {
+    const user = userEvent.setup();
+    mockRestartService.mockRejectedValue(new Error('Service not found'));
+    render(<RestartServicePanel />);
+
+    await user.click(screen.getByTestId('restart-btn-api'));
+    await user.type(screen.getByTestId('confirm-input-api'), 'api');
+    await user.click(screen.getByTestId('confirm-restart-api'));
+
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'Restart failed',
+          description: 'Service not found',
+          variant: 'destructive',
+        })
+      );
+    });
+
+    // Should NOT show cooldown on failure
+    expect(screen.queryByTestId('cooldown-api')).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/app/admin/(dashboard)/monitor/services/__tests__/RestartServicePanel.test.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/services/__tests__/RestartServicePanel.test.tsx
@@ -1,0 +1,153 @@
+/**
+ * RestartServicePanel Component Tests
+ * Issue #133 — SuperAdmin Service Restart with Level 2 Confirmation
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+const mockFetch = vi.hoisted(() => vi.fn());
+const mockToast = vi.hoisted(() => vi.fn());
+
+vi.stubGlobal('fetch', mockFetch);
+
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({
+    toast: mockToast,
+  }),
+}));
+
+vi.mock('@/lib/api/core/httpClient', () => ({
+  getApiBase: () => 'http://localhost:8080',
+}));
+
+import { RestartServicePanel } from '../RestartServicePanel';
+
+describe('RestartServicePanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // ==================== Rendering ====================
+
+  it('renders service list with restart buttons', () => {
+    render(<RestartServicePanel />);
+
+    expect(screen.getByTestId('restart-btn-api')).toBeInTheDocument();
+    expect(screen.getByTestId('restart-btn-embedding-service')).toBeInTheDocument();
+    expect(screen.getByTestId('restart-btn-reranker-service')).toBeInTheDocument();
+    expect(screen.getByTestId('restart-btn-unstructured-service')).toBeInTheDocument();
+    expect(screen.getByTestId('restart-btn-smoldocling-service')).toBeInTheDocument();
+  });
+
+  it('renders SuperAdmin badge', () => {
+    render(<RestartServicePanel />);
+
+    expect(screen.getByTestId('superadmin-badge')).toBeInTheDocument();
+    expect(screen.getByTestId('superadmin-badge')).toHaveTextContent('SuperAdmin');
+  });
+
+  // ==================== Confirmation Dialog ====================
+
+  it('clicking restart shows confirmation dialog', async () => {
+    const user = userEvent.setup();
+    render(<RestartServicePanel />);
+
+    await user.click(screen.getByTestId('restart-btn-api'));
+
+    expect(screen.getByTestId('confirm-dialog-api')).toBeInTheDocument();
+  });
+
+  it('confirmation requires typing exact service name', async () => {
+    const user = userEvent.setup();
+    render(<RestartServicePanel />);
+
+    await user.click(screen.getByTestId('restart-btn-api'));
+
+    // Confirm button should be disabled initially
+    expect(screen.getByTestId('confirm-restart-api')).toBeDisabled();
+
+    // Type the service id
+    await user.type(screen.getByTestId('confirm-input-api'), 'api');
+
+    // Now confirm button should be enabled
+    expect(screen.getByTestId('confirm-restart-api')).toBeEnabled();
+  });
+
+  it('cancel closes dialog', async () => {
+    const user = userEvent.setup();
+    render(<RestartServicePanel />);
+
+    await user.click(screen.getByTestId('restart-btn-api'));
+    expect(screen.getByTestId('confirm-dialog-api')).toBeInTheDocument();
+
+    await user.click(screen.getByTestId('confirm-cancel-api'));
+
+    expect(screen.queryByTestId('confirm-dialog-api')).not.toBeInTheDocument();
+  });
+
+  // ==================== Restart Execution ====================
+
+  it('successful restart shows cooldown', async () => {
+    const user = userEvent.setup();
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        message: 'Restart initiated',
+        estimatedDowntime: '30-60 seconds',
+      }),
+    });
+    render(<RestartServicePanel />);
+
+    await user.click(screen.getByTestId('restart-btn-api'));
+    await user.type(screen.getByTestId('confirm-input-api'), 'api');
+    await user.click(screen.getByTestId('confirm-restart-api'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('cooldown-api')).toBeInTheDocument();
+    });
+  });
+
+  it('successful restart shows result feedback', async () => {
+    const user = userEvent.setup();
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        message: 'Restart initiated',
+        estimatedDowntime: '30-60 seconds',
+      }),
+    });
+    render(<RestartServicePanel />);
+
+    await user.click(screen.getByTestId('restart-btn-api'));
+    await user.type(screen.getByTestId('confirm-input-api'), 'api');
+    await user.click(screen.getByTestId('confirm-restart-api'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('result-api')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Restart initiated')).toBeInTheDocument();
+    expect(screen.getByText(/30-60 seconds/)).toBeInTheDocument();
+  });
+
+  it('failed restart shows error toast', async () => {
+    const user = userEvent.setup();
+    mockFetch.mockRejectedValue(new Error('Connection refused'));
+    render(<RestartServicePanel />);
+
+    await user.click(screen.getByTestId('restart-btn-api'));
+    await user.type(screen.getByTestId('confirm-input-api'), 'api');
+    await user.click(screen.getByTestId('confirm-restart-api'));
+
+    await waitFor(() => {
+      expect(mockToast).toHaveBeenCalledWith(
+        expect.objectContaining({
+          title: 'Restart failed',
+          variant: 'destructive',
+        })
+      );
+    });
+  });
+});

--- a/apps/web/src/app/admin/(dashboard)/monitor/services/page.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/services/page.tsx
@@ -1,13 +1,15 @@
 /**
  * Admin Service Dashboard
- * Issue #132 — Phase 2A: Enhanced ServiceHealthMatrix
+ * Issue #132 — Phase 2: Service Dashboard with health, DB stats, restart controls
  *
  * Route: /admin/monitor/services
  * Enhanced service health view with auto-refresh, uptime badges,
- * response time trends, and service category grouping.
+ * response time trends, database stats, and service restart controls.
  */
 
+import { DbStatsPanel } from './DbStatsPanel';
 import { ServicesNavConfig } from './NavConfig';
+import { RestartServicePanel } from './RestartServicePanel';
 import { ServicesDashboard } from './ServicesDashboard';
 
 export default function ServiceDashboardPage() {
@@ -24,6 +26,12 @@ export default function ServiceDashboardPage() {
       </div>
 
       <ServicesDashboard />
+
+      {/* Issue #135: Database Stats Overview */}
+      <DbStatsPanel />
+
+      {/* Issue #133: Service Restart Controls (SuperAdmin only) */}
+      <RestartServicePanel />
     </div>
   );
 }

--- a/apps/web/src/config/admin-dashboard-navigation.ts
+++ b/apps/web/src/config/admin-dashboard-navigation.ts
@@ -47,6 +47,7 @@ import {
   MailIcon,
   ScrollTextIcon,
   HeartPulseIcon,
+  BarChart3Icon,
 } from 'lucide-react';
 
 // ─── Types ───────────────────────────────────────────────────────────────────
@@ -355,6 +356,13 @@ export const DASHBOARD_SECTIONS: DashboardSection[] = [
         label: 'Services',
         icon: HeartPulseIcon,
         activePattern: /^\/admin\/monitor\/services/,
+      },
+      // Grafana Dashboards (Issue #134)
+      {
+        href: '/admin/monitor/grafana',
+        label: 'Grafana',
+        icon: BarChart3Icon,
+        activePattern: /^\/admin\/monitor\/grafana/,
       },
       // Config items
       {

--- a/apps/web/src/lib/api/clients/adminClient.ts
+++ b/apps/web/src/lib/api/clients/adminClient.ts
@@ -861,6 +861,26 @@ export function createAdminClient({ httpClient }: CreateAdminClientParams) {
       );
     },
 
+    /**
+     * Restart a service (SuperAdmin only, Level 2 confirmation).
+     * POST /api/v1/admin/operations/restart-service
+     *
+     * Issue #133: Service Restart UI.
+     */
+    async restartService(
+      serviceName: string
+    ): Promise<{ message: string; estimatedDowntime: string }> {
+      const result = await httpClient.post(
+        '/api/v1/admin/operations/restart-service',
+        { serviceName },
+        z.object({ message: z.string(), estimatedDowntime: z.string() })
+      );
+      if (!result) {
+        throw new Error('Failed to restart service');
+      }
+      return result;
+    },
+
     // ========== API Key Management (Issue #908) ==========
 
     /**
@@ -2567,11 +2587,13 @@ export function createAdminClient({ httpClient }: CreateAdminClientParams) {
       successOnly?: boolean;
     }): Promise<RecentLlmRequestsDto | null> {
       const qs = new URLSearchParams();
-      if (params.page != null) qs.set('page', String(params.page));
-      if (params.pageSize != null) qs.set('pageSize', String(params.pageSize));
+      if (params.page !== null && params.page !== undefined) qs.set('page', String(params.page));
+      if (params.pageSize !== null && params.pageSize !== undefined)
+        qs.set('pageSize', String(params.pageSize));
       if (params.source) qs.set('source', params.source);
       if (params.model) qs.set('model', params.model);
-      if (params.successOnly != null) qs.set('successOnly', String(params.successOnly));
+      if (params.successOnly !== null && params.successOnly !== undefined)
+        qs.set('successOnly', String(params.successOnly));
       const query = qs.toString();
       return httpClient.get(
         `/api/v1/admin/openrouter/usage/requests${query ? `?${query}` : ''}`,


### PR DESCRIPTION
## Summary
- **#135 DB Stats Overview**: DbStatsPanel with database size KPIs (7/30/90d growth), connection pool progress bar, transaction stats, top 10 tables, and vacuum trigger
- **#133 Service Restart UI**: RestartServicePanel with Level 2 confirmation (type service name), 5-minute cooldown timer, and restart feedback for 5 services (SuperAdmin only)
- **#134 Grafana Dashboard Embed**: New page at `/admin/monitor/grafana` with 14 pre-provisioned dashboards across 4 categories, time range selector, auto-refresh toggle, fullscreen button, and setup instructions when unconfigured
- **#136 Tests**: 22 tests across 3 test files (8 DbStats + 8 Restart + 6 Grafana)

## Changes
- `services/DbStatsPanel.tsx` — New component
- `services/RestartServicePanel.tsx` — New component
- `grafana/page.tsx` + `GrafanaDashboard.tsx` — New page
- `services/page.tsx` — Integrated DbStatsPanel + RestartServicePanel
- `admin-dashboard-navigation.ts` — Added Grafana sidebar entry
- 3 test files in `__tests__/` directories

## Test plan
- [x] TypeScript compilation clean
- [x] ESLint + Prettier pass
- [x] 22/22 vitest tests pass
- [x] Next.js production build succeeds
- [ ] Manual: Visit `/admin/monitor/services` and verify DB stats panel loads
- [ ] Manual: Verify restart confirmation requires typing exact service name
- [ ] Manual: Visit `/admin/monitor/grafana` and verify dashboard selector works

🤖 Generated with [Claude Code](https://claude.com/claude-code)
