### PR TITLE
perf(ci): optimize integration test speed with parallel sharding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,7 +151,7 @@ jobs:
         continue-on-error: true
 
   # Backend Integration Tests (requires service containers, runs in parallel with unit tests)
-  # Phase 3: 3-shard matrix for ~3x wall-clock speedup
+  # Phase 2+3: 8 parallel threads per shard, 3-shard matrix for ~8-24x total speedup
   backend-integration:
     name: Backend - Integration (${{ matrix.shard.name }})
     runs-on: ubuntu-latest


### PR DESCRIPTION
## Summary
- **Phase 1**: Enable xUnit parallel test collections (was 100% sequential)
- **Phase 2**: Increase maxParallelThreads to 8 (budget: 40/500 connections per shard)
- **Phase 3**: Split integration tests into 3 parallel CI shards:
  - **KnowledgeBase**: KB + DocProcessing + Auth (742 tests, 37%)
  - **Games**: SharedGameCatalog + GameMgmt + Admin (707 tests, 36%)
  - **Core**: Remaining contexts (545 tests, 27%)

## Expected Impact
- **Before**: ~28min sequential, single CI job
- **After**: ~3-5min wall-clock (8x thread parallelism + 3x shard parallelism)
- Timeout reduced from 45min to 20min per shard

## Test plan
- [ ] All 3 shard jobs complete successfully
- [ ] No test failures from parallelism (DB isolation is per-class)
- [ ] Coverage uploads work for each shard
- [ ] Total test count matches (~1,984 integration tests)
- [ ] Wall-clock time under 10 minutes

🤖 Generated with [Claude Code](https://claude.com/claude-code)