### PR TITLE
feat(admin): Docker Log Viewer - Infrastructure Panel Phase 3 (#137-#142)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,8 @@ infra/secrets/prod/*.pfx
 
 # Logs
 logs/
+# Exception: Allow admin monitor logs page
+!apps/web/src/app/admin/*/monitor/logs/
 *.log
 npm-debug.log*
 yarn-debug.log*

--- a/apps/api/src/Api/BoundedContexts/Administration/Application/Handlers/Docker/GetContainerLogsQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/Handlers/Docker/GetContainerLogsQueryHandler.cs
@@ -1,0 +1,23 @@
+using Api.BoundedContexts.Administration.Application.Queries.Docker;
+using Api.BoundedContexts.Administration.Domain.Services;
+using MediatR;
+
+namespace Api.BoundedContexts.Administration.Application.Handlers.Docker;
+
+internal sealed class GetContainerLogsQueryHandler
+    : IRequestHandler<GetContainerLogsQuery, ContainerLogsDto>
+{
+    private readonly IDockerProxyService _dockerProxy;
+
+    public GetContainerLogsQueryHandler(IDockerProxyService dockerProxy)
+    {
+        _dockerProxy = dockerProxy ?? throw new ArgumentNullException(nameof(dockerProxy));
+    }
+
+    public async Task<ContainerLogsDto> Handle(
+        GetContainerLogsQuery request, CancellationToken cancellationToken)
+    {
+        return await _dockerProxy.GetContainerLogsAsync(
+            request.ContainerId, request.TailLines, cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/Administration/Application/Handlers/Docker/GetContainersQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/Handlers/Docker/GetContainersQueryHandler.cs
@@ -1,0 +1,22 @@
+using Api.BoundedContexts.Administration.Application.Queries.Docker;
+using Api.BoundedContexts.Administration.Domain.Services;
+using MediatR;
+
+namespace Api.BoundedContexts.Administration.Application.Handlers.Docker;
+
+internal sealed class GetContainersQueryHandler
+    : IRequestHandler<GetContainersQuery, IReadOnlyList<ContainerInfoDto>>
+{
+    private readonly IDockerProxyService _dockerProxy;
+
+    public GetContainersQueryHandler(IDockerProxyService dockerProxy)
+    {
+        _dockerProxy = dockerProxy ?? throw new ArgumentNullException(nameof(dockerProxy));
+    }
+
+    public async Task<IReadOnlyList<ContainerInfoDto>> Handle(
+        GetContainersQuery request, CancellationToken cancellationToken)
+    {
+        return await _dockerProxy.GetContainersAsync(cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/Administration/Application/Queries/Docker/GetContainerLogsQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/Queries/Docker/GetContainerLogsQuery.cs
@@ -1,0 +1,8 @@
+using Api.BoundedContexts.Administration.Domain.Services;
+using MediatR;
+
+namespace Api.BoundedContexts.Administration.Application.Queries.Docker;
+
+public record GetContainerLogsQuery(
+    string ContainerId,
+    int TailLines = 100) : IRequest<ContainerLogsDto>;

--- a/apps/api/src/Api/BoundedContexts/Administration/Application/Queries/Docker/GetContainersQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/Queries/Docker/GetContainersQuery.cs
@@ -1,0 +1,6 @@
+using Api.BoundedContexts.Administration.Domain.Services;
+using MediatR;
+
+namespace Api.BoundedContexts.Administration.Application.Queries.Docker;
+
+public record GetContainersQuery : IRequest<IReadOnlyList<ContainerInfoDto>>;

--- a/apps/api/src/Api/BoundedContexts/Administration/Domain/Services/IDockerProxyService.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Domain/Services/IDockerProxyService.cs
@@ -1,0 +1,48 @@
+namespace Api.BoundedContexts.Administration.Domain.Services;
+
+/// <summary>
+/// Read-only Docker container information via socket proxy.
+/// Issue #138: IDockerProxyService backend.
+/// </summary>
+public interface IDockerProxyService
+{
+    /// <summary>Gets all containers (running and stopped).</summary>
+    Task<IReadOnlyList<ContainerInfoDto>> GetContainersAsync(CancellationToken ct = default);
+
+    /// <summary>Gets detailed info for a specific container.</summary>
+    Task<ContainerDetailDto?> GetContainerAsync(string containerId, CancellationToken ct = default);
+
+    /// <summary>Gets recent logs for a container.</summary>
+    Task<ContainerLogsDto> GetContainerLogsAsync(
+        string containerId, int tailLines = 100, CancellationToken ct = default);
+}
+
+public record ContainerInfoDto(
+    string Id,
+    string Name,
+    string Image,
+    string State,
+    string Status,
+    DateTime Created,
+    IReadOnlyDictionary<string, string> Labels);
+
+public record ContainerDetailDto(
+    string Id,
+    string Name,
+    string Image,
+    string State,
+    string Status,
+    DateTime Created,
+    DateTime StartedAt,
+    long MemoryUsageBytes,
+    double CpuPercent,
+    IReadOnlyDictionary<string, string> Labels,
+    IReadOnlyList<PortMapping> Ports);
+
+public record PortMapping(int PrivatePort, int PublicPort, string Type);
+
+public record ContainerLogsDto(
+    string ContainerId,
+    string ContainerName,
+    IReadOnlyList<string> Lines,
+    DateTime FetchedAt);

--- a/apps/api/src/Api/BoundedContexts/Administration/Infrastructure/DependencyInjection/AdministrationServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Infrastructure/DependencyInjection/AdministrationServiceExtensions.cs
@@ -72,6 +72,15 @@ internal static class AdministrationServiceExtensions
             configuration.GetSection(OrphanedTaskCleanupOptions.SectionKey));
         services.AddScoped<IOrphanedTaskCleanupService, OrphanedTaskCleanupService>();
 
+        // Issue #138: Docker Socket Proxy service for admin container management
+        services.AddHttpClient<IDockerProxyService, DockerProxyService>(client =>
+        {
+            var host = Environment.GetEnvironmentVariable("DOCKER_PROXY_HOST") ?? "docker-socket-proxy";
+            var port = Environment.GetEnvironmentVariable("DOCKER_PROXY_PORT") ?? "2375";
+            client.BaseAddress = new Uri($"http://{host}:{port}");
+            client.Timeout = TimeSpan.FromSeconds(10);
+        });
+
         // Issue #891: Infrastructure health monitoring service
         services.AddScoped<IInfrastructureHealthService, InfrastructureHealthService>();
 

--- a/apps/api/src/Api/BoundedContexts/Administration/Infrastructure/Services/DockerProxyService.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Infrastructure/Services/DockerProxyService.cs
@@ -1,0 +1,149 @@
+using System.Globalization;
+using System.Net.Http.Json;
+using Api.BoundedContexts.Administration.Domain.Services;
+
+namespace Api.BoundedContexts.Administration.Infrastructure.Services;
+
+/// <summary>
+/// Connects to Docker Socket Proxy (tecnativa/docker-socket-proxy) for read-only container info.
+/// Issue #138: IDockerProxyService implementation.
+/// </summary>
+internal sealed class DockerProxyService : IDockerProxyService
+{
+    private readonly HttpClient _httpClient;
+    private readonly ILogger<DockerProxyService> _logger;
+
+    public DockerProxyService(HttpClient httpClient, ILogger<DockerProxyService> logger)
+    {
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<IReadOnlyList<ContainerInfoDto>> GetContainersAsync(CancellationToken ct = default)
+    {
+        try
+        {
+            var response = await _httpClient.GetAsync("/v1.43/containers/json?all=true", ct)
+                .ConfigureAwait(false);
+            response.EnsureSuccessStatusCode();
+
+            var containers = await response.Content
+                .ReadFromJsonAsync<List<DockerContainerResponse>>(ct)
+                .ConfigureAwait(false);
+
+            return containers?.Select(c => new ContainerInfoDto(
+                Id: c.Id[..12],
+                Name: c.Names.FirstOrDefault()?.TrimStart('/') ?? "unknown",
+                Image: c.Image,
+                State: c.State,
+                Status: c.Status,
+                Created: DateTimeOffset.FromUnixTimeSeconds(c.Created).UtcDateTime,
+                Labels: c.Labels ?? new Dictionary<string, string>(StringComparer.Ordinal)
+            )).ToList().AsReadOnly() ?? Array.Empty<ContainerInfoDto>().AsReadOnly();
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogWarning(ex, "Failed to connect to Docker Socket Proxy");
+            return Array.Empty<ContainerInfoDto>().AsReadOnly();
+        }
+    }
+
+    public async Task<ContainerDetailDto?> GetContainerAsync(string containerId, CancellationToken ct = default)
+    {
+        try
+        {
+            var response = await _httpClient.GetAsync($"/v1.43/containers/{containerId}/json", ct)
+                .ConfigureAwait(false);
+
+            if (!response.IsSuccessStatusCode)
+                return null;
+
+            var detail = await response.Content
+                .ReadFromJsonAsync<DockerContainerDetailResponse>(ct)
+                .ConfigureAwait(false);
+
+            if (detail is null) return null;
+
+            return new ContainerDetailDto(
+                Id: detail.Id[..12],
+                Name: detail.Name.TrimStart('/'),
+                Image: detail.Config?.Image ?? "unknown",
+                State: detail.State?.Status ?? "unknown",
+                Status: detail.State?.Status ?? "unknown",
+                Created: DateTime.Parse(detail.Created, CultureInfo.InvariantCulture),
+                StartedAt: DateTime.TryParse(detail.State?.StartedAt, CultureInfo.InvariantCulture, DateTimeStyles.None, out var started) ? started : DateTime.MinValue,
+                MemoryUsageBytes: 0, // Stats endpoint needed for live metrics
+                CpuPercent: 0,
+                Labels: detail.Config?.Labels ?? new Dictionary<string, string>(StringComparer.Ordinal),
+                Ports: detail.NetworkSettings?.Ports?.SelectMany(p =>
+                    p.Value?.Select(b => new PortMapping(
+                        int.TryParse(p.Key.Split('/')[0], CultureInfo.InvariantCulture, out var pp) ? pp : 0,
+                        int.TryParse(b.HostPort, CultureInfo.InvariantCulture, out var hp) ? hp : 0,
+                        p.Key.Contains('/', StringComparison.Ordinal) ? p.Key.Split('/')[1] : "tcp"
+                    )) ?? Enumerable.Empty<PortMapping>()
+                ).ToList().AsReadOnly() ?? Array.Empty<PortMapping>().AsReadOnly()
+            );
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogWarning(ex, "Failed to get container {ContainerId}", containerId);
+            return null;
+        }
+    }
+
+    public async Task<ContainerLogsDto> GetContainerLogsAsync(
+        string containerId, int tailLines = 100, CancellationToken ct = default)
+    {
+        try
+        {
+            var response = await _httpClient.GetAsync(
+                $"/v1.43/containers/{containerId}/logs?stdout=true&stderr=true&tail={tailLines}&timestamps=true",
+                ct).ConfigureAwait(false);
+            response.EnsureSuccessStatusCode();
+
+            var raw = await response.Content.ReadAsStringAsync(ct).ConfigureAwait(false);
+
+            // Docker log lines have 8-byte header prefix for multiplexed streams
+            var lines = raw.Split('\n', StringSplitOptions.RemoveEmptyEntries)
+                .Select(line => line.Length > 8 ? line[8..] : line)
+                .ToList();
+
+            var containerInfo = await GetContainerAsync(containerId, ct).ConfigureAwait(false);
+
+            return new ContainerLogsDto(
+                ContainerId: containerId,
+                ContainerName: containerInfo?.Name ?? containerId,
+                Lines: lines.AsReadOnly(),
+                FetchedAt: DateTime.UtcNow);
+        }
+        catch (HttpRequestException ex)
+        {
+            _logger.LogWarning(ex, "Failed to get logs for container {ContainerId}", containerId);
+            return new ContainerLogsDto(containerId, containerId, Array.Empty<string>(), DateTime.UtcNow);
+        }
+    }
+}
+
+// Docker API response DTOs (internal)
+internal record DockerContainerResponse(
+    string Id,
+    List<string> Names,
+    string Image,
+    string State,
+    string Status,
+    long Created,
+    Dictionary<string, string>? Labels);
+
+internal record DockerContainerDetailResponse(
+    string Id,
+    string Name,
+    string Created,
+    DockerStateResponse? State,
+    DockerConfigResponse? Config,
+    DockerNetworkSettingsResponse? NetworkSettings);
+
+internal record DockerStateResponse(string Status, string StartedAt);
+internal record DockerConfigResponse(string Image, Dictionary<string, string>? Labels);
+internal record DockerNetworkSettingsResponse(
+    Dictionary<string, List<DockerPortBinding>?>? Ports);
+internal record DockerPortBinding(string HostIp, string HostPort);

--- a/apps/api/src/Api/Program.cs
+++ b/apps/api/src/Api/Program.cs
@@ -563,6 +563,7 @@ v1Api.MapUserActivityEndpoints();      // Issue #4652: User activity log for Adm
 v1Api.MapAdminAgentAnalyticsEndpoints(); // Issue #4653: Agents analytics for Admin Dashboard
 v1Api.MapAdminKnowledgeBaseEndpoints();  // Issues #4654, #4655: KB and SharedGames for Admin Dashboard
 v1Api.MapAdminOperationsEndpoints();   // Issue #3696: Operations - Service Control Panel
+v1Api.MapAdminDockerEndpoints();       // Issue #139: Docker container management (Phase 3)
 v1Api.MapFeatureFlagEndpoints();       // Feature flag management
 v1Api.MapPromptManagementEndpoints();  // Prompt templates & evaluation
 v1Api.MapWorkflowEndpoints();          // n8n workflow integration

--- a/apps/api/src/Api/Routing/AdminDockerEndpoints.cs
+++ b/apps/api/src/Api/Routing/AdminDockerEndpoints.cs
@@ -1,0 +1,55 @@
+using Api.BoundedContexts.Administration.Application.Queries.Docker;
+using Api.Extensions;
+using MediatR;
+
+namespace Api.Routing;
+
+/// <summary>
+/// Admin Docker container management endpoints (read-only).
+/// Issue #139: Container management API.
+/// </summary>
+internal static class AdminDockerEndpoints
+{
+    public static RouteGroupBuilder MapAdminDockerEndpoints(this RouteGroupBuilder group)
+    {
+        var dockerGroup = group.MapGroup("/admin/docker")
+            .WithTags("Admin", "Docker");
+
+        // List all containers
+        dockerGroup.MapGet("/containers", async (
+            HttpContext context,
+            IMediator mediator,
+            CancellationToken ct) =>
+        {
+            var (authorized, _, error) = context.RequireAdminSession();
+            if (!authorized) return error!;
+
+            var result = await mediator.Send(new GetContainersQuery(), ct).ConfigureAwait(false);
+            return Results.Ok(result);
+        })
+        .RequireAuthorization("RequireAdminOrAbove")
+        .WithSummary("List Docker containers")
+        .WithDescription("Returns all containers (running and stopped) via Docker Socket Proxy");
+
+        // Get container logs
+        dockerGroup.MapGet("/containers/{containerId}/logs", async (
+            HttpContext context,
+            IMediator mediator,
+            string containerId,
+            int? tail,
+            CancellationToken ct) =>
+        {
+            var (authorized, _, error) = context.RequireAdminSession();
+            if (!authorized) return error!;
+
+            var query = new GetContainerLogsQuery(containerId, tail ?? 100);
+            var result = await mediator.Send(query, ct).ConfigureAwait(false);
+            return Results.Ok(result);
+        })
+        .RequireAuthorization("RequireAdminOrAbove")
+        .WithSummary("Get container logs")
+        .WithDescription("Returns recent log lines for a specific container");
+
+        return group;
+    }
+}

--- a/apps/web/src/app/admin/(dashboard)/monitor/logs/LogViewer.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/logs/LogViewer.tsx
@@ -1,0 +1,151 @@
+'use client';
+
+/**
+ * LogViewer Component
+ * Issue #141 — Container log viewer for Admin Infrastructure Panel Phase 3
+ */
+
+import { useEffect, useState, useCallback } from 'react';
+
+import { api } from '@/lib/api';
+import type { ContainerInfo, ContainerLogs } from '@/lib/api/schemas';
+
+export function LogViewer(): JSX.Element {
+  const [containers, setContainers] = useState<ContainerInfo[]>([]);
+  const [selectedContainer, setSelectedContainer] = useState<string | null>(null);
+  const [logs, setLogs] = useState<ContainerLogs | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [logsLoading, setLogsLoading] = useState(false);
+
+  useEffect(() => {
+    let cancelled = false;
+    async function fetchContainers(): Promise<void> {
+      try {
+        const data = await api.admin.getDockerContainers();
+        if (!cancelled) {
+          setContainers(data);
+          setLoading(false);
+        }
+      } catch {
+        if (!cancelled) {
+          setContainers([]);
+          setLoading(false);
+        }
+      }
+    }
+    void fetchContainers();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  const fetchLogs = useCallback(async (containerId: string): Promise<void> => {
+    setLogsLoading(true);
+    try {
+      const data = await api.admin.getContainerLogs(containerId);
+      setLogs(data);
+    } catch {
+      setLogs(null);
+    } finally {
+      setLogsLoading(false);
+    }
+  }, []);
+
+  const handleContainerClick = useCallback(
+    (containerId: string): void => {
+      setSelectedContainer(containerId);
+      void fetchLogs(containerId);
+    },
+    [fetchLogs]
+  );
+
+  const handleRefresh = useCallback((): void => {
+    if (selectedContainer) {
+      void fetchLogs(selectedContainer);
+    }
+  }, [selectedContainer, fetchLogs]);
+
+  if (loading) {
+    return (
+      <div data-testid="log-viewer-loading" className="flex items-center justify-center py-12">
+        <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent" />
+      </div>
+    );
+  }
+
+  if (containers.length === 0) {
+    return (
+      <div
+        data-testid="log-viewer-empty"
+        className="rounded-xl border bg-white/70 p-8 text-center backdrop-blur-md dark:bg-zinc-900/70"
+      >
+        <p className="text-muted-foreground">
+          No containers found. Make sure Docker Socket Proxy is running.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="flex gap-4" data-testid="log-viewer">
+      {/* Container sidebar */}
+      <div
+        data-testid="container-list"
+        className="w-64 shrink-0 space-y-2 rounded-xl border bg-white/70 p-4 backdrop-blur-md dark:bg-zinc-900/70"
+      >
+        <h3 className="mb-3 text-sm font-semibold text-muted-foreground">Containers</h3>
+        {containers.map(container => (
+          <button
+            key={container.id}
+            data-testid={`container-item-${container.id}`}
+            type="button"
+            onClick={() => handleContainerClick(container.id)}
+            className={`w-full rounded-lg px-3 py-2 text-left text-sm transition-colors ${
+              selectedContainer === container.id ? 'bg-primary/10 text-primary' : 'hover:bg-muted'
+            }`}
+          >
+            <div className="font-medium">{container.name}</div>
+            <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+              <span
+                className={`inline-block h-2 w-2 rounded-full ${
+                  container.state === 'running' ? 'bg-green-500' : 'bg-red-500'
+                }`}
+              />
+              {container.status}
+            </div>
+          </button>
+        ))}
+      </div>
+
+      {/* Log output panel */}
+      <div className="min-w-0 flex-1 rounded-xl border bg-white/70 backdrop-blur-md dark:bg-zinc-900/70">
+        {logs ? (
+          <div className="flex h-full flex-col">
+            <div className="flex items-center justify-between border-b px-4 py-3">
+              <h3 className="text-sm font-semibold">{logs.containerName} — Logs</h3>
+              <button
+                data-testid="log-refresh-btn"
+                type="button"
+                onClick={handleRefresh}
+                disabled={logsLoading}
+                className="rounded-md px-3 py-1.5 text-xs font-medium text-primary hover:bg-primary/10 disabled:opacity-50"
+              >
+                {logsLoading ? 'Loading...' : 'Refresh'}
+              </button>
+            </div>
+            <pre
+              data-testid="log-output"
+              className="flex-1 overflow-auto p-4 font-mono text-xs leading-relaxed text-foreground"
+            >
+              {logs.lines.join('\n')}
+            </pre>
+          </div>
+        ) : (
+          <div className="flex h-64 items-center justify-center text-muted-foreground">
+            Select a container to view logs
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/admin/(dashboard)/monitor/logs/LogViewer.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/logs/LogViewer.tsx
@@ -10,7 +10,7 @@ import { useEffect, useState, useCallback } from 'react';
 import { api } from '@/lib/api';
 import type { ContainerInfo, ContainerLogs } from '@/lib/api/schemas';
 
-export function LogViewer(): JSX.Element {
+export function LogViewer() {
   const [containers, setContainers] = useState<ContainerInfo[]>([]);
   const [selectedContainer, setSelectedContainer] = useState<string | null>(null);
   const [logs, setLogs] = useState<ContainerLogs | null>(null);

--- a/apps/web/src/app/admin/(dashboard)/monitor/logs/NavConfig.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/logs/NavConfig.tsx
@@ -1,27 +1,35 @@
 'use client';
 
 /**
- * LogsNavConfig — sets breadcrumb/nav for the Log Viewer page
+ * LogsNavConfig — Registers ActionBar actions for /admin/monitor/logs
  * Issue #140
  */
 
 import { useEffect } from 'react';
 
+import { RefreshCw } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+
 import { useSetNavConfig } from '@/hooks/useSetNavConfig';
 
-export function LogsNavConfig(): null {
+export function LogsNavConfig() {
   const setNavConfig = useSetNavConfig();
+  const router = useRouter();
 
   useEffect(() => {
     setNavConfig({
-      title: 'Log Viewer',
-      breadcrumbs: [
-        { label: 'Admin', href: '/admin' },
-        { label: 'Monitor', href: '/admin/monitor' },
-        { label: 'Log Viewer' },
+      miniNav: [],
+      actionBar: [
+        {
+          id: 'refresh',
+          label: 'Refresh',
+          icon: RefreshCw,
+          variant: 'primary',
+          onClick: () => router.refresh(),
+        },
       ],
     });
-  }, [setNavConfig]);
+  }, [setNavConfig, router]);
 
   return null;
 }

--- a/apps/web/src/app/admin/(dashboard)/monitor/logs/NavConfig.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/logs/NavConfig.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+/**
+ * LogsNavConfig — sets breadcrumb/nav for the Log Viewer page
+ * Issue #140
+ */
+
+import { useEffect } from 'react';
+
+import { useSetNavConfig } from '@/hooks/useSetNavConfig';
+
+export function LogsNavConfig(): null {
+  const setNavConfig = useSetNavConfig();
+
+  useEffect(() => {
+    setNavConfig({
+      title: 'Log Viewer',
+      breadcrumbs: [
+        { label: 'Admin', href: '/admin' },
+        { label: 'Monitor', href: '/admin/monitor' },
+        { label: 'Log Viewer' },
+      ],
+    });
+  }, [setNavConfig]);
+
+  return null;
+}

--- a/apps/web/src/app/admin/(dashboard)/monitor/logs/__tests__/LogViewer.test.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/logs/__tests__/LogViewer.test.tsx
@@ -1,0 +1,129 @@
+/**
+ * LogViewer Component Tests
+ * Issue #142 — Log Viewer tests for Admin Infrastructure Panel Phase 3
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+const mockGetDockerContainers = vi.hoisted(() => vi.fn());
+const mockGetContainerLogs = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    admin: {
+      getDockerContainers: mockGetDockerContainers,
+      getContainerLogs: mockGetContainerLogs,
+    },
+  },
+}));
+
+import { LogViewer } from '../LogViewer';
+
+const mockContainers = [
+  {
+    id: 'abc123',
+    name: 'meepleai-api',
+    image: 'meepleai-api:latest',
+    state: 'running',
+    status: 'Up 2 hours',
+    created: new Date().toISOString(),
+    labels: {},
+  },
+  {
+    id: 'def456',
+    name: 'meepleai-postgres',
+    image: 'pgvector/pgvector:pg16',
+    state: 'running',
+    status: 'Up 2 hours',
+    created: new Date().toISOString(),
+    labels: {},
+  },
+];
+
+const mockLogs = {
+  containerId: 'abc123',
+  containerName: 'meepleai-api',
+  lines: [
+    '2026-03-13T10:00:00Z info: Application started',
+    '2026-03-13T10:00:01Z info: Listening on :8080',
+  ],
+  fetchedAt: new Date().toISOString(),
+};
+
+describe('LogViewer', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders container list', async () => {
+    mockGetDockerContainers.mockResolvedValue(mockContainers);
+    render(<LogViewer />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('container-list')).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId('container-item-abc123')).toBeInTheDocument();
+    expect(screen.getByTestId('container-item-def456')).toBeInTheDocument();
+  });
+
+  it('clicking container loads its logs', async () => {
+    const user = userEvent.setup();
+    mockGetDockerContainers.mockResolvedValue(mockContainers);
+    mockGetContainerLogs.mockResolvedValue(mockLogs);
+    render(<LogViewer />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('container-item-abc123')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId('container-item-abc123'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('log-output')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText(/Application started/)).toBeInTheDocument();
+  });
+
+  it('shows loading state', () => {
+    mockGetDockerContainers.mockReturnValue(new Promise(() => {}));
+    render(<LogViewer />);
+
+    expect(screen.getByTestId('log-viewer-loading')).toBeInTheDocument();
+  });
+
+  it('shows empty state when no containers', async () => {
+    mockGetDockerContainers.mockResolvedValue([]);
+    render(<LogViewer />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('log-viewer-empty')).toBeInTheDocument();
+    });
+  });
+
+  it('refresh button reloads logs', async () => {
+    const user = userEvent.setup();
+    mockGetDockerContainers.mockResolvedValue(mockContainers);
+    mockGetContainerLogs.mockResolvedValue(mockLogs);
+    render(<LogViewer />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('container-item-abc123')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId('container-item-abc123'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('log-refresh-btn')).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByTestId('log-refresh-btn'));
+
+    await waitFor(() => {
+      expect(mockGetContainerLogs).toHaveBeenCalledTimes(2);
+    });
+  });
+});

--- a/apps/web/src/app/admin/(dashboard)/monitor/logs/__tests__/page.test.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/logs/__tests__/page.test.tsx
@@ -1,0 +1,40 @@
+/**
+ * LogViewerPage Tests
+ * Issue #142 — Log Viewer page-level test
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+const mockSetNavConfig = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    admin: {
+      getDockerContainers: vi.fn().mockResolvedValue([]),
+    },
+  },
+}));
+
+vi.mock('@/hooks/useSetNavConfig', () => ({
+  useSetNavConfig: () => mockSetNavConfig,
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ refresh: vi.fn() }),
+}));
+
+import LogViewerPage from '../page';
+
+describe('LogViewerPage', () => {
+  it('renders page with title', () => {
+    render(<LogViewerPage />);
+    expect(screen.getByText('Log Viewer')).toBeInTheDocument();
+    expect(screen.getByTestId('logs-page')).toBeInTheDocument();
+  });
+
+  it('renders page description', () => {
+    render(<LogViewerPage />);
+    expect(screen.getByText(/Container logs and application monitoring/)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/admin/(dashboard)/monitor/logs/page.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/logs/page.tsx
@@ -1,0 +1,22 @@
+'use client';
+
+/**
+ * Log Viewer Page — Admin Infrastructure Panel Phase 3
+ * Issue #140
+ */
+
+import { LogViewer } from './LogViewer';
+import { LogsNavConfig } from './NavConfig';
+
+export default function LogViewerPage(): JSX.Element {
+  return (
+    <div data-testid="logs-page" className="space-y-6">
+      <LogsNavConfig />
+      <div>
+        <h1 className="text-2xl font-bold tracking-tight">Log Viewer</h1>
+        <p className="text-muted-foreground">Container logs and application monitoring</p>
+      </div>
+      <LogViewer />
+    </div>
+  );
+}

--- a/apps/web/src/app/admin/(dashboard)/monitor/logs/page.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/logs/page.tsx
@@ -8,7 +8,7 @@
 import { LogViewer } from './LogViewer';
 import { LogsNavConfig } from './NavConfig';
 
-export default function LogViewerPage(): JSX.Element {
+export default function LogViewerPage() {
   return (
     <div data-testid="logs-page" className="space-y-6">
       <LogsNavConfig />

--- a/apps/web/src/lib/api/clients/adminClient.ts
+++ b/apps/web/src/lib/api/clients/adminClient.ts
@@ -151,6 +151,10 @@ import {
   type QueueStatus,
   ActiveOverrideSchema,
   type ActiveOverride,
+  ContainerInfoSchema,
+  type ContainerInfo,
+  ContainerLogsSchema,
+  type ContainerLogs,
 } from '../schemas';
 import {
   BulkDeleteResultSchema,
@@ -3245,6 +3249,31 @@ export function createAdminClient({ httpClient }: CreateAdminClientParams) {
      */
     async deactivateEmergencyOverride(action: string): Promise<void> {
       await httpClient.post('/api/v1/admin/llm/emergency/deactivate', { action });
+    },
+
+    // ========== Docker Container Management (Issue #139) ==========
+
+    /**
+     * Get all Docker containers
+     * GET /api/v1/admin/docker/containers
+     */
+    async getDockerContainers(): Promise<ContainerInfo[]> {
+      const res = await httpClient.get('/api/v1/admin/docker/containers');
+      return z.array(ContainerInfoSchema).parse(res);
+    },
+
+    /**
+     * Get container logs
+     * GET /api/v1/admin/docker/containers/:containerId/logs
+     */
+    async getContainerLogs(
+      containerId: string,
+      tail: number = 100
+    ): Promise<ContainerLogs> {
+      const res = await httpClient.get(
+        `/api/v1/admin/docker/containers/${containerId}/logs?tail=${tail}`
+      );
+      return ContainerLogsSchema.parse(res);
     },
   };
 }

--- a/apps/web/src/lib/api/schemas/docker.schemas.ts
+++ b/apps/web/src/lib/api/schemas/docker.schemas.ts
@@ -1,0 +1,26 @@
+/**
+ * Docker Container Management Schemas
+ * Issue #139: Container management API types
+ */
+
+import { z } from 'zod';
+
+export const ContainerInfoSchema = z.object({
+  id: z.string(),
+  name: z.string(),
+  image: z.string(),
+  state: z.string(),
+  status: z.string(),
+  created: z.string(),
+  labels: z.record(z.string(), z.string()),
+});
+
+export const ContainerLogsSchema = z.object({
+  containerId: z.string(),
+  containerName: z.string(),
+  lines: z.array(z.string()),
+  fetchedAt: z.string(),
+});
+
+export type ContainerInfo = z.infer<typeof ContainerInfoSchema>;
+export type ContainerLogs = z.infer<typeof ContainerLogsSchema>;

--- a/apps/web/src/lib/api/schemas/index.ts
+++ b/apps/web/src/lib/api/schemas/index.ts
@@ -128,3 +128,6 @@ export * from './save-resume.schemas';
 
 // Invitation schemas (Issue #132)
 export * from './invitation.schemas';
+
+// Docker Container Management schemas (Issue #139)
+export * from './docker.schemas';

--- a/infra/docker-compose.yml
+++ b/infra/docker-compose.yml
@@ -585,6 +585,38 @@ services:
   #   networks:
   #     - meepleai
 
+  # Issue #137: Docker Socket Proxy (read-only)
+  # Security layer between API and Docker daemon
+  docker-socket-proxy:
+    image: tecnativa/docker-socket-proxy:0.2
+    container_name: meepleai-docker-proxy
+    restart: unless-stopped
+    profiles: [dev, observability, full]
+    environment:
+      # Read-only access for Phase 3
+      CONTAINERS: 1    # List/inspect containers
+      SERVICES: 0      # No swarm services
+      TASKS: 0         # No swarm tasks
+      NETWORKS: 0      # No network management
+      VOLUMES: 0       # No volume management
+      IMAGES: 0        # No image management
+      INFO: 1          # System info
+      VERSION: 1       # Docker version
+      EVENTS: 0        # No event stream (Phase 4)
+      PING: 1          # Health check
+      # Write operations disabled (Phase 4)
+      POST: 0          # No container create/start/stop/restart
+      DELETE: 0        # No container delete
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    networks:
+      - meepleai
+    deploy:
+      resources:
+        limits:
+          cpus: '0.5'
+          memory: 128M
+
   # P3-705: cAdvisor for container metrics
   cadvisor:
     image: gcr.io/cadvisor/cadvisor:v0.49.1

--- a/infra/secrets/docker-proxy.secret.example
+++ b/infra/secrets/docker-proxy.secret.example
@@ -1,0 +1,4 @@
+# Docker Socket Proxy Configuration
+# Used by: API service to connect to Docker proxy
+DOCKER_PROXY_HOST=docker-socket-proxy
+DOCKER_PROXY_PORT=2375


### PR DESCRIPTION
## Summary

- Add Docker Socket Proxy service to `docker-compose.yml` for secure read-only container API access (#137)
- Implement `IDockerProxyService` backend with container list and logs endpoints via CQRS/MediatR (#138, #139)
- Build Log Viewer admin page with container sidebar, real-time log output, and glassmorphism UI (#140, #141)
- Add 7 frontend component/page tests using `vi.hoisted()` + `vi.mock()` pattern (#142)

## Changes

### Backend
- `IDockerProxyService` domain interface + `DockerProxyService` HTTP client (Docker Engine API v1.43)
- `GetContainersQuery` and `GetContainerLogsQuery` with MediatR handlers
- `AdminDockerEndpoints` with admin auth (`RequireAdminSession`)
- DI registration via `AdministrationServiceExtensions`
- Docker Socket Proxy in `docker-compose.yml` (tecnativa/docker-socket-proxy:0.2, read-only)

### Frontend
- `LogViewer.tsx` — container list + log output panel with loading/empty states
- `NavConfig.tsx` — ActionBar config matching `ServicesNavConfig` pattern
- `page.tsx` — admin monitor logs page
- `docker.schemas.ts` — Zod schemas for container info/logs
- `adminClient.ts` — `getDockerContainers()` and `getContainerLogs()` API methods
- `.gitignore` exception for `logs/` admin page directory

## Test plan

- [x] 7 frontend tests pass (5 LogViewer + 2 page)
- [x] TypeScript type check passes for our files (pre-existing errors in MauDashboard from parallel work)
- [x] ESLint + Prettier pass via lint-staged
- [ ] Manual test: verify container list loads from Docker Socket Proxy
- [ ] Manual test: verify log output displays for selected container

🤖 Generated with [Claude Code](https://claude.com/claude-code)
