### PR TITLE
feat(admin): shared game content management (#236)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/Administration/Application/Queries/GetActiveAiUsersQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/Queries/GetActiveAiUsersQuery.cs
@@ -1,0 +1,36 @@
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.Administration.Application.Queries;
+
+/// <summary>
+/// Query to get Monthly Active AI Users data for monitoring dashboard.
+/// Issue #113: MAU Monitoring Dashboard.
+/// </summary>
+/// <param name="PeriodDays">Analysis period in days (7, 30, 90)</param>
+internal record GetActiveAiUsersQuery(
+    int PeriodDays = 30
+) : IQuery<ActiveAiUsersResult>;
+
+/// <summary>
+/// Result containing MAU data with feature breakdown.
+/// </summary>
+internal record ActiveAiUsersResult(
+    int TotalActiveUsers,
+    int AiChatUsers,
+    int PdfUploadUsers,
+    int AgentUsers,
+    int PeriodDays,
+    DateTime PeriodStart,
+    DateTime PeriodEnd,
+    IReadOnlyList<DailyActiveUsersDto> DailyBreakdown
+);
+
+/// <summary>
+/// Daily active user count for trend analysis.
+/// </summary>
+internal record DailyActiveUsersDto(
+    DateTime Date,
+    int ActiveUsers,
+    int AiChatUsers,
+    int PdfUploadUsers
+);

--- a/apps/api/src/Api/BoundedContexts/Administration/Application/Queries/GetActiveAiUsersQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/Queries/GetActiveAiUsersQueryHandler.cs
@@ -1,0 +1,110 @@
+using Api.Infrastructure;
+using Api.SharedKernel.Application.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.Administration.Application.Queries;
+
+/// <summary>
+/// Handler for GetActiveAiUsersQuery.
+/// Aggregates user activity across AI chat, PDF uploads, and agent interactions.
+/// Issue #113: MAU Monitoring Dashboard.
+/// </summary>
+internal sealed class GetActiveAiUsersQueryHandler
+    : IQueryHandler<GetActiveAiUsersQuery, ActiveAiUsersResult>
+{
+    private readonly MeepleAiDbContext _dbContext;
+    private readonly ILogger<GetActiveAiUsersQueryHandler> _logger;
+
+    public GetActiveAiUsersQueryHandler(
+        MeepleAiDbContext dbContext,
+        ILogger<GetActiveAiUsersQueryHandler> logger)
+    {
+        _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<ActiveAiUsersResult> Handle(
+        GetActiveAiUsersQuery query,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        var periodDays = query.PeriodDays is 7 or 30 or 90 ? query.PeriodDays : 30;
+        var periodEnd = DateTime.UtcNow;
+        var periodStart = periodEnd.AddDays(-periodDays);
+
+        _logger.LogInformation(
+            "Getting active AI users for period {PeriodDays} days ({Start} to {End})",
+            periodDays, periodStart, periodEnd);
+
+        // AI Chat users: users who sent chat messages in the period
+        var aiChatUserIds = await _dbContext.AiRequestLogs
+            .Where(r => r.CreatedAt >= periodStart && r.CreatedAt <= periodEnd && r.UserId != null)
+            .Select(r => r.UserId!.Value)
+            .Distinct()
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        // PDF Upload users: users who uploaded PDFs in the period
+        var pdfUploadUserIds = await _dbContext.PdfDocuments
+            .Where(p => p.UploadedAt >= periodStart && p.UploadedAt <= periodEnd)
+            .Select(p => p.UploadedByUserId)
+            .Distinct()
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        // Agent users: users who interacted with agents (via agent sessions)
+        var agentUserIds = await _dbContext.AgentSessions
+            .Where(s => s.StartedAt >= periodStart && s.StartedAt <= periodEnd)
+            .Select(s => s.UserId)
+            .Distinct()
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        // Total unique active users
+        var allActiveUserIds = aiChatUserIds
+            .Union(pdfUploadUserIds)
+            .Union(agentUserIds)
+            .Distinct()
+            .ToList();
+
+        // Daily breakdown for trend chart
+        var dailyBreakdown = new List<DailyActiveUsersDto>();
+        for (var day = periodStart.Date; day <= periodEnd.Date; day = day.AddDays(1))
+        {
+            var dayEnd = day.AddDays(1);
+
+            var dayAiChatUsers = await _dbContext.AiRequestLogs
+                .Where(r => r.CreatedAt >= day && r.CreatedAt < dayEnd && r.UserId != null)
+                .Select(r => r.UserId!.Value)
+                .Distinct()
+                .CountAsync(cancellationToken)
+                .ConfigureAwait(false);
+
+            var dayPdfUsers = await _dbContext.PdfDocuments
+                .Where(p => p.UploadedAt >= day && p.UploadedAt < dayEnd)
+                .Select(p => p.UploadedByUserId)
+                .Distinct()
+                .CountAsync(cancellationToken)
+                .ConfigureAwait(false);
+
+            var dayTotalUsers = dayAiChatUsers + dayPdfUsers; // Approximate without dedup for perf
+
+            dailyBreakdown.Add(new DailyActiveUsersDto(
+                day,
+                dayTotalUsers,
+                dayAiChatUsers,
+                dayPdfUsers));
+        }
+
+        return new ActiveAiUsersResult(
+            allActiveUserIds.Count,
+            aiChatUserIds.Count,
+            pdfUploadUserIds.Count,
+            agentUserIds.Count,
+            periodDays,
+            periodStart,
+            periodEnd,
+            dailyBreakdown);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/BulkUploadPdfs/BulkUploadPdfsCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/BulkUploadPdfs/BulkUploadPdfsCommand.cs
@@ -1,0 +1,34 @@
+using Api.SharedKernel.Application.Interfaces;
+using Microsoft.AspNetCore.Http;
+
+namespace Api.BoundedContexts.DocumentProcessing.Application.Commands.BulkUploadPdfs;
+
+/// <summary>
+/// Command to bulk upload multiple PDF documents for a shared game.
+/// Issue #117: Bulk PDF Upload for shared game content management.
+/// </summary>
+internal record BulkUploadPdfsCommand(
+    Guid SharedGameId,
+    Guid UserId,
+    IReadOnlyList<IFormFile> Files
+) : ICommand<BulkUploadPdfsResult>;
+
+/// <summary>
+/// Result of a bulk PDF upload operation.
+/// </summary>
+internal record BulkUploadPdfsResult(
+    int TotalRequested,
+    int SuccessCount,
+    int FailedCount,
+    IReadOnlyList<BulkUploadItemResult> Items
+);
+
+/// <summary>
+/// Individual upload result for each file in the bulk operation.
+/// </summary>
+internal record BulkUploadItemResult(
+    string FileName,
+    bool Success,
+    Guid? DocumentId,
+    string? Error
+);

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/BulkUploadPdfs/BulkUploadPdfsCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/BulkUploadPdfs/BulkUploadPdfsCommandHandler.cs
@@ -1,0 +1,81 @@
+using Api.SharedKernel.Application.Interfaces;
+using MediatR;
+
+namespace Api.BoundedContexts.DocumentProcessing.Application.Commands.BulkUploadPdfs;
+
+/// <summary>
+/// Handler for BulkUploadPdfsCommand.
+/// Iterates over files and delegates each to the existing UploadPdfCommand.
+/// Issue #117: Bulk PDF Upload.
+/// </summary>
+internal sealed class BulkUploadPdfsCommandHandler
+    : ICommandHandler<BulkUploadPdfsCommand, BulkUploadPdfsResult>
+{
+    private readonly IMediator _mediator;
+    private readonly ILogger<BulkUploadPdfsCommandHandler> _logger;
+
+    public BulkUploadPdfsCommandHandler(
+        IMediator mediator,
+        ILogger<BulkUploadPdfsCommandHandler> logger)
+    {
+        _mediator = mediator ?? throw new ArgumentNullException(nameof(mediator));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<BulkUploadPdfsResult> Handle(
+        BulkUploadPdfsCommand command,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        _logger.LogInformation(
+            "Bulk uploading {Count} PDFs for shared game {SharedGameId} by user {UserId}",
+            command.Files.Count, command.SharedGameId, command.UserId);
+
+        var items = new List<BulkUploadItemResult>();
+        var successCount = 0;
+        var failedCount = 0;
+
+        foreach (var file in command.Files)
+        {
+            try
+            {
+                var uploadCommand = new UploadPdfCommand(
+                    GameId: command.SharedGameId.ToString(),
+                    Metadata: null,
+                    PrivateGameId: null,
+                    UserId: command.UserId,
+                    File: file);
+
+                var result = await _mediator.Send(uploadCommand, cancellationToken).ConfigureAwait(false);
+
+                if (result.Success && result.Document != null)
+                {
+                    items.Add(new BulkUploadItemResult(file.FileName, true, result.Document.Id, null));
+                    successCount++;
+                }
+                else
+                {
+                    items.Add(new BulkUploadItemResult(file.FileName, false, null, result.Message ?? "Upload failed"));
+                    failedCount++;
+                }
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to upload file {FileName} in bulk operation", file.FileName);
+                items.Add(new BulkUploadItemResult(file.FileName, false, null, ex.Message));
+                failedCount++;
+            }
+        }
+
+        _logger.LogInformation(
+            "Bulk upload complete: {Success}/{Total} succeeded for shared game {SharedGameId}",
+            successCount, command.Files.Count, command.SharedGameId);
+
+        return new BulkUploadPdfsResult(
+            command.Files.Count,
+            successCount,
+            failedCount,
+            items);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetSharedGameDocuments/GetSharedGameDocumentsQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetSharedGameDocuments/GetSharedGameDocumentsQuery.cs
@@ -1,0 +1,44 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Queries.GetSharedGameDocuments;
+
+/// <summary>
+/// Query to get all documents (active and inactive) for a shared game.
+/// Used by admin panel to display full document history with processing status.
+/// Issue #119: Per-SharedGame Document Overview.
+/// </summary>
+/// <param name="SharedGameId">The ID of the shared game</param>
+internal record GetSharedGameDocumentsQuery(
+    Guid SharedGameId
+) : IQuery<GetSharedGameDocumentsResult>;
+
+/// <summary>
+/// Result containing all documents for a shared game with PDF processing details.
+/// </summary>
+internal record GetSharedGameDocumentsResult(
+    Guid SharedGameId,
+    IReadOnlyList<SharedGameDocumentDetailDto> Documents,
+    int TotalCount
+);
+
+/// <summary>
+/// Extended document DTO including PDF processing state details for admin view.
+/// </summary>
+internal record SharedGameDocumentDetailDto(
+    Guid Id,
+    Guid SharedGameId,
+    Guid PdfDocumentId,
+    string DocumentType,
+    string Version,
+    bool IsActive,
+    IReadOnlyList<string> Tags,
+    DateTime CreatedAt,
+    Guid CreatedBy,
+    string ApprovalStatus,
+    // PDF processing details
+    string? FileName,
+    string? ProcessingState,
+    long? FileSizeBytes,
+    DateTime? UploadedAt
+);

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetSharedGameDocuments/GetSharedGameDocumentsQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetSharedGameDocuments/GetSharedGameDocumentsQueryHandler.cs
@@ -1,0 +1,104 @@
+using System.Text.Json;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
+using Api.Infrastructure;
+using Api.SharedKernel.Application.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Queries.GetSharedGameDocuments;
+
+/// <summary>
+/// Handler for GetSharedGameDocumentsQuery.
+/// Joins SharedGameDocuments with PdfDocuments to provide full document details.
+/// Issue #119: Per-SharedGame Document Overview.
+/// </summary>
+internal sealed class GetSharedGameDocumentsQueryHandler
+    : IQueryHandler<GetSharedGameDocumentsQuery, GetSharedGameDocumentsResult>
+{
+    private readonly MeepleAiDbContext _dbContext;
+    private readonly ILogger<GetSharedGameDocumentsQueryHandler> _logger;
+
+    public GetSharedGameDocumentsQueryHandler(
+        MeepleAiDbContext dbContext,
+        ILogger<GetSharedGameDocumentsQueryHandler> logger)
+    {
+        _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<GetSharedGameDocumentsResult> Handle(
+        GetSharedGameDocumentsQuery query,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        _logger.LogInformation(
+            "Getting all documents for shared game {SharedGameId}",
+            query.SharedGameId);
+
+        // Query raw data from DB (two tables joined)
+        var rawDocuments = await _dbContext.SharedGameDocuments
+            .Where(d => d.SharedGameId == query.SharedGameId)
+            .Join(
+                _dbContext.PdfDocuments,
+                doc => doc.PdfDocumentId,
+                pdf => pdf.Id,
+                (doc, pdf) => new
+                {
+                    doc.Id,
+                    doc.SharedGameId,
+                    doc.PdfDocumentId,
+                    doc.DocumentType,
+                    doc.Version,
+                    doc.IsActive,
+                    doc.TagsJson,
+                    doc.CreatedAt,
+                    doc.CreatedBy,
+                    doc.ApprovalStatus,
+                    pdf.FileName,
+                    pdf.ProcessingState,
+                    pdf.FileSizeBytes,
+                    pdf.UploadedAt
+                })
+            .OrderByDescending(d => d.CreatedAt)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        // Project to DTOs in-memory (ParseTags can't be translated by EF)
+        var documents = rawDocuments.Select(d => new SharedGameDocumentDetailDto(
+            d.Id,
+            d.SharedGameId,
+            d.PdfDocumentId,
+            ((SharedGameDocumentType)d.DocumentType).ToString(),
+            d.Version,
+            d.IsActive,
+            ParseTags(d.TagsJson),
+            d.CreatedAt,
+            d.CreatedBy,
+            ((DocumentApprovalStatus)d.ApprovalStatus).ToString(),
+            d.FileName,
+            d.ProcessingState,
+            d.FileSizeBytes,
+            d.UploadedAt
+        )).ToList();
+
+        return new GetSharedGameDocumentsResult(
+            query.SharedGameId,
+            documents,
+            documents.Count);
+    }
+
+    private static IReadOnlyList<string> ParseTags(string? tagsJson)
+    {
+        if (string.IsNullOrWhiteSpace(tagsJson))
+            return Array.Empty<string>();
+
+        try
+        {
+            return JsonSerializer.Deserialize<List<string>>(tagsJson) ?? (IReadOnlyList<string>)Array.Empty<string>();
+        }
+        catch
+        {
+            return Array.Empty<string>();
+        }
+    }
+}

--- a/apps/api/src/Api/Program.cs
+++ b/apps/api/src/Api/Program.cs
@@ -513,6 +513,7 @@ v1Api.MapSessionStatisticsEndpoints(); // P4: Session analytics dashboard
 v1Api.MapSharedGameCatalogEndpoints(); // ISSUE-2371: Shared game catalog Phase 2
 app.MapAdminGameImportWizardEndpoints(); // Issue #4157: Admin game import wizard
 v1Api.MapAdminGameWizardEndpoints();    // Admin Game+PDF+Agent Wizard
+v1Api.MapAdminSharedGameContentEndpoints(); // Issue #236: Admin shared game content + MAU monitoring
 v1Api.MapAdminAgentTestEndpoints();     // Admin Agent Auto-Test Suite
 v1Api.MapAdminOpenRouterEndpoints();    // Issue #5077: OpenRouter usage monitoring dashboard
 v1Api.MapAdminEmergencyControlsEndpoints(); // Issue #5476: LLM emergency controls

--- a/apps/api/src/Api/Routing/AdminSharedGameContentEndpoints.cs
+++ b/apps/api/src/Api/Routing/AdminSharedGameContentEndpoints.cs
@@ -1,0 +1,123 @@
+using Api.BoundedContexts.Administration.Application.Queries;
+using Api.BoundedContexts.DocumentProcessing.Application.Commands.BulkUploadPdfs;
+using Api.Extensions;
+using Api.Filters;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Api.Routing;
+
+/// <summary>
+/// Admin endpoints for shared game content management.
+/// Issues #117, #113: Bulk PDF upload and MAU monitoring.
+/// </summary>
+internal static class AdminSharedGameContentEndpoints
+{
+    public static RouteGroupBuilder MapAdminSharedGameContentEndpoints(this RouteGroupBuilder group)
+    {
+        var contentGroup = group.MapGroup("/admin/shared-games")
+            .WithTags("Admin", "SharedGameContent")
+            .AddEndpointFilter<RequireAdminSessionFilter>();
+
+        // POST /api/v1/admin/shared-games/{gameId}/documents/bulk-upload
+        // Issue #117: Bulk PDF Upload
+        contentGroup.MapPost("/{gameId:guid}/documents/bulk-upload", HandleBulkUploadPdfs)
+            .DisableAntiforgery()
+            .WithMetadata(new RequestSizeLimitAttribute(524_288_000)) // 500 MB for bulk uploads
+            .WithName("BulkUploadPdfsForSharedGame")
+            .WithSummary("Bulk upload PDFs for a shared game (Admin)")
+            .WithDescription("Upload multiple PDF files at once for a shared game. Each file is processed independently.")
+            .Produces<BulkUploadPdfsResult>(StatusCodes.Status200OK)
+            .ProducesProblem(StatusCodes.Status400BadRequest)
+            .ProducesProblem(StatusCodes.Status401Unauthorized)
+            .ProducesProblem(StatusCodes.Status403Forbidden);
+
+        // GET /api/v1/admin/shared-games/mau
+        // Issue #113: MAU Monitoring Dashboard
+        var mauGroup = group.MapGroup("/admin/monitoring")
+            .WithTags("Admin", "Monitoring")
+            .AddEndpointFilter<RequireAdminSessionFilter>();
+
+        mauGroup.MapGet("/mau", HandleGetActiveAiUsers)
+            .WithName("GetActiveAiUsers")
+            .WithSummary("Get Monthly Active AI Users data (Admin)")
+            .WithDescription("Returns MAU data with feature breakdown (AI chat, PDF uploads, agent interactions) and daily trend.")
+            .Produces<ActiveAiUsersResult>(StatusCodes.Status200OK);
+
+        return group;
+    }
+
+    private static async Task<IResult> HandleGetActiveAiUsers(
+        [FromQuery] int period,
+        IMediator mediator,
+        CancellationToken ct)
+    {
+        if (period is not (7 or 30 or 90))
+        {
+            period = 30;
+        }
+
+        var query = new GetActiveAiUsersQuery(period);
+        var result = await mediator.Send(query, ct).ConfigureAwait(false);
+        return Results.Ok(result);
+    }
+
+    private static async Task<IResult> HandleBulkUploadPdfs(
+        Guid gameId,
+        HttpContext context,
+        IMediator mediator,
+        ILogger<Program> logger,
+        CancellationToken ct)
+    {
+        var (authorized, session, error) = context.RequireAdminSession();
+        if (!authorized) return error!;
+
+        var form = await context.Request.ReadFormAsync(ct).ConfigureAwait(false);
+        var files = form.Files;
+
+        if (files.Count == 0)
+        {
+            return Results.BadRequest(new { error = "validation_failed", message = "No files provided" });
+        }
+
+        // Validate all files are PDFs
+        var pdfFiles = new List<Microsoft.AspNetCore.Http.IFormFile>();
+        foreach (var file in files)
+        {
+            if (file.Length == 0)
+            {
+                continue;
+            }
+
+            if (!string.Equals(file.ContentType, "application/pdf", StringComparison.OrdinalIgnoreCase)
+                && !file.FileName.EndsWith(".pdf", StringComparison.OrdinalIgnoreCase))
+            {
+                return Results.BadRequest(new
+                {
+                    error = "validation_failed",
+                    message = $"File '{file.FileName}' is not a PDF"
+                });
+            }
+
+            pdfFiles.Add(file);
+        }
+
+        if (pdfFiles.Count == 0)
+        {
+            return Results.BadRequest(new { error = "validation_failed", message = "No valid PDF files provided" });
+        }
+
+        var command = new BulkUploadPdfsCommand(
+            SharedGameId: gameId,
+            UserId: session!.User!.Id,
+            Files: pdfFiles);
+
+        var result = await mediator.Send(command, ct).ConfigureAwait(false);
+
+        logger.LogInformation(
+            "Bulk upload for game {GameId}: {Success}/{Total} succeeded",
+            gameId, result.SuccessCount, result.TotalRequested);
+
+        return Results.Ok(result);
+    }
+}

--- a/apps/api/src/Api/Routing/SharedGameCatalogEndpoints.cs
+++ b/apps/api/src/Api/Routing/SharedGameCatalogEndpoints.cs
@@ -18,6 +18,7 @@ using Api.BoundedContexts.SharedGameCatalog.Application.Queries.GetBadgeLeaderbo
 using Api.BoundedContexts.SharedGameCatalog.Application.Queries.GetMyActiveReviews;
 using Api.BoundedContexts.SharedGameCatalog.Application.Queries.CheckPrivateGameDuplicates;
 using Api.BoundedContexts.SharedGameCatalog.Application.Queries.GetGameRagReadiness;
+using Api.BoundedContexts.SharedGameCatalog.Application.Queries.GetSharedGameDocuments;
 using Api.BoundedContexts.SharedGameCatalog.Application.Commands.ToggleBadgeDisplay;
 using Api.BoundedContexts.SharedGameCatalog.Application.Commands.ApproveGameProposal;
 using Api.BoundedContexts.SharedGameCatalog.Domain.Entities;
@@ -492,6 +493,14 @@ internal static class SharedGameCatalogEndpoints
             .WithDescription("Aggregates document processing status and agent linkage across bounded contexts to determine if a game is RAG-ready.")
             .Produces<GameRagReadinessDto>()
             .Produces(StatusCodes.Status404NotFound);
+
+        // Issue #119: Per-SharedGame Document Overview (enriched with PDF processing status)
+        group.MapGet("/admin/shared-games/{gameId:guid}/documents/overview", HandleGetSharedGameDocuments)
+            .RequireAuthorization("AdminOrEditorPolicy")
+            .WithName("GetSharedGameDocumentsOverview")
+            .WithSummary("Get document overview for a shared game with PDF status (Admin/Editor)")
+            .WithDescription("Returns all documents associated with a shared game, enriched with PDF processing status from the document processing context.")
+            .Produces<GetSharedGameDocumentsResult>(StatusCodes.Status200OK);
     }
 
     // ========================================
@@ -1482,6 +1491,19 @@ internal static class SharedGameCatalogEndpoints
         CancellationToken ct)
     {
         var query = new GetGameRagReadinessQuery(id);
+        var result = await mediator.Send(query, ct).ConfigureAwait(false);
+        return Results.Ok(result);
+    }
+
+    /// <summary>
+    /// Issue #119: Get all documents for a shared game with PDF processing status.
+    /// </summary>
+    private static async Task<IResult> HandleGetSharedGameDocuments(
+        Guid gameId,
+        IMediator mediator,
+        CancellationToken ct)
+    {
+        var query = new GetSharedGameDocumentsQuery(gameId);
         var result = await mediator.Send(query, ct).ConfigureAwait(false);
         return Results.Ok(result);
     }

--- a/apps/web/src/app/admin/(dashboard)/monitor/mau/MauDashboard.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/mau/MauDashboard.tsx
@@ -152,7 +152,7 @@ export function MauDashboard() {
                           day: 'numeric',
                         })}
                       </td>
-                      <td className="p-2 text-right font-medium">{day.totalUsers}</td>
+                      <td className="p-2 text-right font-medium">{day.activeUsers}</td>
                       <td className="p-2 text-right text-blue-600">{day.aiChatUsers}</td>
                       <td className="p-2 text-right text-green-600">{day.pdfUploadUsers}</td>
                     </tr>

--- a/apps/web/src/app/admin/(dashboard)/monitor/mau/MauDashboard.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/mau/MauDashboard.tsx
@@ -1,0 +1,205 @@
+/**
+ * MAU Monitoring Dashboard
+ *
+ * Issue #113: Monthly Active AI Users monitoring.
+ * Displays KPI cards and feature breakdown for admin monitoring.
+ */
+
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+
+import { Activity, Bot, FileText, MessageSquare, Users } from 'lucide-react';
+
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/data-display/card';
+import { Button } from '@/components/ui/primitives/button';
+import { api } from '@/lib/api';
+import type { ActiveAiUsersResult } from '@/lib/api/clients/adminClient';
+
+// ─── Types ──────────────────────────────────────────────────────────────────
+
+type Period = 7 | 30 | 90;
+
+// ─── Component ──────────────────────────────────────────────────────────────
+
+export function MauDashboard() {
+  const [data, setData] = useState<ActiveAiUsersResult | null>(null);
+  const [period, setPeriod] = useState<Period>(30);
+  const [isLoading, setIsLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const fetchData = useCallback(async (p: Period) => {
+    setIsLoading(true);
+    setError(null);
+    try {
+      const result = await api.admin.getActiveAiUsers(p);
+      setData(result);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load MAU data');
+    } finally {
+      setIsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchData(period);
+  }, [fetchData, period]);
+
+  const handlePeriodChange = useCallback((p: Period) => {
+    setPeriod(p);
+  }, []);
+
+  if (error) {
+    return (
+      <Card className="rounded-xl border bg-white/70 backdrop-blur-md dark:bg-zinc-900/70">
+        <CardContent className="p-6">
+          <p className="text-red-600">{error}</p>
+          <Button className="mt-2" variant="outline" onClick={() => fetchData(period)}>
+            Retry
+          </Button>
+        </CardContent>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Period Selector */}
+      <div className="flex items-center justify-between">
+        <h2 className="text-lg font-semibold">Active AI Users</h2>
+        <div className="flex gap-1 rounded-lg border p-1">
+          {([7, 30, 90] as const).map(p => (
+            <Button
+              key={p}
+              variant={period === p ? 'default' : 'ghost'}
+              size="sm"
+              onClick={() => handlePeriodChange(p)}
+            >
+              {p}d
+            </Button>
+          ))}
+        </div>
+      </div>
+
+      {/* KPI Cards */}
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+        <KpiCard
+          title="Total Active Users"
+          value={data?.totalActiveUsers}
+          icon={<Users className="h-5 w-5 text-orange-500" />}
+          description={`Last ${period} days`}
+          isLoading={isLoading}
+        />
+        <KpiCard
+          title="AI Chat Users"
+          value={data?.aiChatUsers}
+          icon={<MessageSquare className="h-5 w-5 text-blue-500" />}
+          description="Used AI chat"
+          isLoading={isLoading}
+        />
+        <KpiCard
+          title="PDF Upload Users"
+          value={data?.pdfUploadUsers}
+          icon={<FileText className="h-5 w-5 text-green-500" />}
+          description="Uploaded PDFs"
+          isLoading={isLoading}
+        />
+        <KpiCard
+          title="Agent Users"
+          value={data?.agentUsers}
+          icon={<Bot className="h-5 w-5 text-purple-500" />}
+          description="Used AI agents"
+          isLoading={isLoading}
+        />
+      </div>
+
+      {/* Daily Trend */}
+      {data && data.dailyBreakdown.length > 0 && (
+        <Card className="rounded-xl border bg-white/70 backdrop-blur-md dark:bg-zinc-900/70">
+          <CardHeader>
+            <CardTitle className="flex items-center gap-2">
+              <Activity className="h-5 w-5" />
+              Daily Active Users Trend
+            </CardTitle>
+            <CardDescription>
+              {new Date(data.periodStart).toLocaleDateString()} -{' '}
+              {new Date(data.periodEnd).toLocaleDateString()}
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="overflow-x-auto">
+              <table className="w-full text-sm">
+                <thead>
+                  <tr className="border-b text-left">
+                    <th className="p-2">Date</th>
+                    <th className="p-2 text-right">Total</th>
+                    <th className="p-2 text-right">AI Chat</th>
+                    <th className="p-2 text-right">PDF Upload</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {data.dailyBreakdown.slice(-14).map(day => (
+                    <tr key={day.date} className="border-b last:border-0">
+                      <td className="p-2 text-zinc-600 dark:text-zinc-400">
+                        {new Date(day.date).toLocaleDateString(undefined, {
+                          month: 'short',
+                          day: 'numeric',
+                        })}
+                      </td>
+                      <td className="p-2 text-right font-medium">{day.totalUsers}</td>
+                      <td className="p-2 text-right text-blue-600">{day.aiChatUsers}</td>
+                      <td className="p-2 text-right text-green-600">{day.pdfUploadUsers}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}
+
+// ─── KPI Card ───────────────────────────────────────────────────────────────
+
+function KpiCard({
+  title,
+  value,
+  icon,
+  description,
+  isLoading,
+}: {
+  title: string;
+  value: number | undefined;
+  icon: React.ReactNode;
+  description: string;
+  isLoading: boolean;
+}) {
+  return (
+    <Card className="rounded-xl border bg-white/70 backdrop-blur-md dark:bg-zinc-900/70">
+      <CardContent className="p-4">
+        <div className="flex items-center justify-between">
+          <div>
+            <p className="text-xs text-zinc-500">{title}</p>
+            <p className="mt-1 text-2xl font-bold">
+              {isLoading ? (
+                <span className="inline-block h-7 w-12 animate-pulse rounded bg-zinc-200 dark:bg-zinc-700" />
+              ) : (
+                (value ?? 0).toLocaleString()
+              )}
+            </p>
+            <p className="mt-0.5 text-xs text-zinc-400">{description}</p>
+          </div>
+          {icon}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/apps/web/src/app/admin/(dashboard)/monitor/mau/__tests__/MauDashboard.test.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/mau/__tests__/MauDashboard.test.tsx
@@ -1,0 +1,135 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/react';
+
+// ---------------------------------------------------------------------------
+// Mocks
+// ---------------------------------------------------------------------------
+
+const mockGetActiveAiUsers = vi.fn();
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    admin: {
+      getActiveAiUsers: (...args: unknown[]) => mockGetActiveAiUsers(...args),
+    },
+  },
+}));
+
+// ---------------------------------------------------------------------------
+// Component under test
+// ---------------------------------------------------------------------------
+
+import { MauDashboard } from '../MauDashboard';
+
+// ---------------------------------------------------------------------------
+// Test Data
+// ---------------------------------------------------------------------------
+
+const mockMauData = {
+  totalActiveUsers: 150,
+  aiChatUsers: 100,
+  pdfUploadUsers: 60,
+  agentUsers: 30,
+  periodDays: 30,
+  periodStart: '2026-02-13T00:00:00Z',
+  periodEnd: '2026-03-13T00:00:00Z',
+  dailyBreakdown: [
+    { date: '2026-03-12T00:00:00Z', activeUsers: 12, aiChatUsers: 8, pdfUploadUsers: 4 },
+    { date: '2026-03-13T00:00:00Z', activeUsers: 15, aiChatUsers: 10, pdfUploadUsers: 5 },
+  ],
+};
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('MauDashboard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetActiveAiUsers.mockResolvedValue(mockMauData);
+  });
+
+  it('renders KPI cards with data', async () => {
+    render(<MauDashboard />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Total Active Users')).toBeInTheDocument();
+      expect(screen.getByText('150')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('AI Chat Users')).toBeInTheDocument();
+    expect(screen.getByText('100')).toBeInTheDocument();
+    expect(screen.getByText('PDF Upload Users')).toBeInTheDocument();
+    expect(screen.getByText('60')).toBeInTheDocument();
+    expect(screen.getByText('Agent Users')).toBeInTheDocument();
+    expect(screen.getByText('30')).toBeInTheDocument();
+  });
+
+  it('fetches data with default 30-day period', async () => {
+    render(<MauDashboard />);
+
+    await waitFor(() => {
+      expect(mockGetActiveAiUsers).toHaveBeenCalledWith(30);
+    });
+  });
+
+  it('changes period when buttons are clicked', async () => {
+    render(<MauDashboard />);
+
+    await waitFor(() => {
+      expect(mockGetActiveAiUsers).toHaveBeenCalledWith(30);
+    });
+
+    const sevenDayButton = screen.getByText('7d');
+    fireEvent.click(sevenDayButton);
+
+    await waitFor(() => {
+      expect(mockGetActiveAiUsers).toHaveBeenCalledWith(7);
+    });
+  });
+
+  it('displays daily breakdown table', async () => {
+    render(<MauDashboard />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Daily Active Users Trend')).toBeInTheDocument();
+    });
+  });
+
+  it('shows error state and retry button', async () => {
+    mockGetActiveAiUsers.mockRejectedValue(new Error('Network error'));
+
+    render(<MauDashboard />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Network error')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Retry')).toBeInTheDocument();
+  });
+
+  it('retries data fetch on retry button click', async () => {
+    mockGetActiveAiUsers.mockRejectedValueOnce(new Error('Network error'));
+    mockGetActiveAiUsers.mockResolvedValueOnce(mockMauData);
+
+    render(<MauDashboard />);
+
+    await waitFor(() => {
+      expect(screen.getByText('Retry')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText('Retry'));
+
+    await waitFor(() => {
+      expect(mockGetActiveAiUsers).toHaveBeenCalledTimes(2);
+    });
+  });
+
+  it('renders period selector buttons', () => {
+    render(<MauDashboard />);
+
+    expect(screen.getByText('7d')).toBeInTheDocument();
+    expect(screen.getByText('30d')).toBeInTheDocument();
+    expect(screen.getByText('90d')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/admin/(dashboard)/monitor/mau/page.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/mau/page.tsx
@@ -1,0 +1,24 @@
+/**
+ * MAU Monitoring Page - Admin Dashboard
+ *
+ * Route: /admin/monitor/mau
+ * Issue #113: MAU Monitoring Dashboard.
+ */
+
+import { type Metadata } from 'next';
+
+import { MauDashboard } from './MauDashboard';
+
+export const metadata: Metadata = {
+  title: 'MAU Monitoring',
+  description: 'Monthly Active AI Users monitoring dashboard',
+};
+
+export default function MauMonitoringPage() {
+  return (
+    <div className="container py-6">
+      <h1 className="mb-6 text-2xl font-bold">MAU Monitoring Dashboard</h1>
+      <MauDashboard />
+    </div>
+  );
+}

--- a/apps/web/src/app/admin/(dashboard)/shared-games/wizard/CatalogWizard.tsx
+++ b/apps/web/src/app/admin/(dashboard)/shared-games/wizard/CatalogWizard.tsx
@@ -1,0 +1,344 @@
+/**
+ * CatalogWizard - 3-Step Guided Wizard for Shared Game Content
+ *
+ * Issue #118: Guided Wizard for admin content management.
+ * Steps: 1) Select Game  2) Upload PDFs  3) Review & Submit
+ */
+
+'use client';
+
+import { useCallback, useRef, useState } from 'react';
+
+import {
+  ArrowLeft,
+  ArrowRight,
+  CheckCircle2,
+  FileUp,
+  Loader2,
+  Search,
+  XCircle,
+} from 'lucide-react';
+import { useRouter } from 'next/navigation';
+
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/data-display/card';
+import { Alert, AlertDescription } from '@/components/ui/feedback/alert';
+import { Button } from '@/components/ui/primitives/button';
+import { Input } from '@/components/ui/primitives/input';
+import { api } from '@/lib/api';
+import type {
+  BulkUploadPdfsResult,
+  SharedGameDocumentsResult,
+} from '@/lib/api/clients/adminClient';
+
+type WizardStep = 1 | 2 | 3;
+
+interface SelectedGame {
+  id: string;
+  title: string;
+}
+
+export function CatalogWizard() {
+  const router = useRouter();
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const [step, setStep] = useState<WizardStep>(1);
+  const [selectedGame, setSelectedGame] = useState<SelectedGame | null>(null);
+  const [selectedFiles, setSelectedFiles] = useState<File[]>([]);
+  const [uploadResult, setUploadResult] = useState<BulkUploadPdfsResult | null>(null);
+  const [existingDocs, setExistingDocs] = useState<SharedGameDocumentsResult | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [searchQuery, setSearchQuery] = useState('');
+  const [searchResults, setSearchResults] = useState<Array<{ id: string; title: string }>>([]);
+
+  const handleSearch = useCallback(async () => {
+    if (!searchQuery.trim()) return;
+    setIsLoading(true);
+    setError(null);
+    try {
+      const result = await api.sharedGames.search({ searchTerm: searchQuery, pageSize: 10 });
+      setSearchResults(
+        (result.items ?? []).map((g: { id: string; title: string }) => ({
+          id: g.id,
+          title: g.title,
+        }))
+      );
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Search failed');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [searchQuery]);
+
+  const handleSelectGame = useCallback(async (game: SelectedGame) => {
+    setSelectedGame(game);
+    setError(null);
+    try {
+      const docs = await api.admin.getSharedGameDocuments(game.id);
+      setExistingDocs(docs);
+    } catch {
+      // Non-blocking
+    }
+    setStep(2);
+  }, []);
+
+  const handleFileChange = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const files = Array.from(e.target.files ?? []);
+    const pdfFiles = files.filter(
+      f => f.type === 'application/pdf' || f.name.toLowerCase().endsWith('.pdf')
+    );
+    setSelectedFiles(prev => [...prev, ...pdfFiles]);
+    if (e.target) e.target.value = '';
+  }, []);
+
+  const handleRemoveFile = useCallback((index: number) => {
+    setSelectedFiles(prev => prev.filter((_, i) => i !== index));
+  }, []);
+
+  const handleUpload = useCallback(async () => {
+    if (!selectedGame || selectedFiles.length === 0) return;
+    setIsLoading(true);
+    setError(null);
+    try {
+      const result = await api.admin.bulkUploadPdfs(selectedGame.id, selectedFiles);
+      setUploadResult(result);
+      setStep(3);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Upload failed');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [selectedGame, selectedFiles]);
+
+  const handleFinish = useCallback(() => {
+    if (selectedGame) {
+      router.push(`/admin/shared-games/${selectedGame.id}`);
+    } else {
+      router.push('/admin/shared-games/all');
+    }
+  }, [router, selectedGame]);
+
+  const steps = [
+    { number: 1, label: 'Select Game' },
+    { number: 2, label: 'Upload PDFs' },
+    { number: 3, label: 'Review' },
+  ] as const;
+
+  return (
+    <div className="mx-auto max-w-3xl space-y-6">
+      <div className="flex items-center justify-center gap-4">
+        {steps.map((s, i) => (
+          <div key={s.number} className="flex items-center gap-2">
+            <div
+              className={`flex h-8 w-8 items-center justify-center rounded-full text-sm font-medium ${
+                step >= s.number
+                  ? 'bg-orange-500 text-white'
+                  : 'bg-zinc-200 text-zinc-500 dark:bg-zinc-700 dark:text-zinc-400'
+              }`}
+            >
+              {step > s.number ? <CheckCircle2 className="h-4 w-4" /> : s.number}
+            </div>
+            <span
+              className={`text-sm ${
+                step >= s.number
+                  ? 'font-medium text-zinc-900 dark:text-zinc-100'
+                  : 'text-zinc-500 dark:text-zinc-400'
+              }`}
+            >
+              {s.label}
+            </span>
+            {i < steps.length - 1 && (
+              <div
+                className={`h-px w-12 ${
+                  step > s.number ? 'bg-orange-500' : 'bg-zinc-200 dark:bg-zinc-700'
+                }`}
+              />
+            )}
+          </div>
+        ))}
+      </div>
+
+      {error && (
+        <Alert variant="destructive">
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
+
+      {step === 1 && (
+        <Card className="rounded-xl border bg-white/70 backdrop-blur-md dark:bg-zinc-900/70">
+          <CardHeader>
+            <CardTitle>Select a Game</CardTitle>
+            <CardDescription>
+              Search for an existing shared game to add documents to.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="flex gap-2">
+              <Input
+                placeholder="Search games by title..."
+                value={searchQuery}
+                onChange={e => setSearchQuery(e.target.value)}
+                onKeyDown={e => e.key === 'Enter' && handleSearch()}
+              />
+              <Button onClick={handleSearch} disabled={isLoading || !searchQuery.trim()}>
+                {isLoading ? (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                ) : (
+                  <Search className="h-4 w-4" />
+                )}
+              </Button>
+            </div>
+            {searchResults.length > 0 && (
+              <div className="space-y-2">
+                {searchResults.map(game => (
+                  <button
+                    key={game.id}
+                    type="button"
+                    onClick={() => handleSelectGame(game)}
+                    className="w-full rounded-lg border p-3 text-left transition-colors hover:bg-zinc-50 dark:hover:bg-zinc-800"
+                  >
+                    <span className="font-medium">{game.title}</span>
+                  </button>
+                ))}
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      )}
+
+      {step === 2 && selectedGame && (
+        <Card className="rounded-xl border bg-white/70 backdrop-blur-md dark:bg-zinc-900/70">
+          <CardHeader>
+            <CardTitle>Upload PDFs for {selectedGame.title}</CardTitle>
+            <CardDescription>
+              Select one or more PDF files (rulebooks, errata, supplements).
+              {existingDocs && existingDocs.totalCount > 0 && (
+                <span className="ml-1 text-orange-600">
+                  This game already has {existingDocs.totalCount} document(s).
+                </span>
+              )}
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div
+              className="flex cursor-pointer flex-col items-center justify-center rounded-lg border-2 border-dashed border-zinc-300 p-8 transition-colors hover:border-orange-400 dark:border-zinc-600"
+              onClick={() => fileInputRef.current?.click()}
+              role="button"
+              tabIndex={0}
+              onKeyDown={e => e.key === 'Enter' && fileInputRef.current?.click()}
+            >
+              <FileUp className="mb-2 h-8 w-8 text-zinc-400" />
+              <span className="text-sm text-zinc-600 dark:text-zinc-400">
+                Click to select PDF files
+              </span>
+              <input
+                ref={fileInputRef}
+                type="file"
+                accept=".pdf,application/pdf"
+                multiple
+                className="hidden"
+                onChange={handleFileChange}
+              />
+            </div>
+            {selectedFiles.length > 0 && (
+              <div className="space-y-2">
+                <h4 className="text-sm font-medium">Selected Files ({selectedFiles.length})</h4>
+                {selectedFiles.map((file, index) => (
+                  <div
+                    key={`${file.name}-${index}`}
+                    className="flex items-center justify-between rounded-lg border p-2"
+                  >
+                    <div>
+                      <span className="text-sm font-medium">{file.name}</span>
+                      <span className="ml-2 text-xs text-zinc-500">
+                        {(file.size / 1024 / 1024).toFixed(1)} MB
+                      </span>
+                    </div>
+                    <Button variant="ghost" size="sm" onClick={() => handleRemoveFile(index)}>
+                      <XCircle className="h-4 w-4 text-red-500" />
+                    </Button>
+                  </div>
+                ))}
+              </div>
+            )}
+            <div className="flex justify-between pt-4">
+              <Button variant="outline" onClick={() => setStep(1)}>
+                <ArrowLeft className="mr-2 h-4 w-4" /> Back
+              </Button>
+              <Button onClick={handleUpload} disabled={isLoading || selectedFiles.length === 0}>
+                {isLoading ? (
+                  <>
+                    <Loader2 className="mr-2 h-4 w-4 animate-spin" /> Uploading...
+                  </>
+                ) : (
+                  <>
+                    Upload {selectedFiles.length} file(s) <ArrowRight className="ml-2 h-4 w-4" />
+                  </>
+                )}
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+
+      {step === 3 && uploadResult && (
+        <Card className="rounded-xl border bg-white/70 backdrop-blur-md dark:bg-zinc-900/70">
+          <CardHeader>
+            <CardTitle>Upload Complete</CardTitle>
+            <CardDescription>
+              {uploadResult.successCount} of {uploadResult.totalRequested} files uploaded
+              successfully.
+            </CardDescription>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            <div className="grid grid-cols-3 gap-4">
+              <div className="rounded-lg bg-green-50 p-3 text-center dark:bg-green-900/20">
+                <div className="text-2xl font-bold text-green-600">{uploadResult.successCount}</div>
+                <div className="text-xs text-green-700 dark:text-green-400">Succeeded</div>
+              </div>
+              <div className="rounded-lg bg-red-50 p-3 text-center dark:bg-red-900/20">
+                <div className="text-2xl font-bold text-red-600">{uploadResult.failureCount}</div>
+                <div className="text-xs text-red-700 dark:text-red-400">Failed</div>
+              </div>
+              <div className="rounded-lg bg-zinc-50 p-3 text-center dark:bg-zinc-800">
+                <div className="text-2xl font-bold text-zinc-600 dark:text-zinc-300">
+                  {uploadResult.totalRequested}
+                </div>
+                <div className="text-xs text-zinc-500">Total</div>
+              </div>
+            </div>
+            {uploadResult.results.length > 0 && (
+              <div className="space-y-2">
+                <h4 className="text-sm font-medium">File Results</h4>
+                {uploadResult.results.map((item, index) => (
+                  <div
+                    key={`${item.fileName}-${index}`}
+                    className="flex items-center justify-between rounded-lg border p-2"
+                  >
+                    <span className="text-sm">{item.fileName}</span>
+                    {item.success ? (
+                      <CheckCircle2 className="h-4 w-4 text-green-500" />
+                    ) : (
+                      <span className="text-xs text-red-500">{item.errorMessage}</span>
+                    )}
+                  </div>
+                ))}
+              </div>
+            )}
+            <div className="flex justify-end pt-4">
+              <Button onClick={handleFinish}>
+                <CheckCircle2 className="mr-2 h-4 w-4" /> View Game Details
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/admin/(dashboard)/shared-games/wizard/CatalogWizard.tsx
+++ b/apps/web/src/app/admin/(dashboard)/shared-games/wizard/CatalogWizard.tsx
@@ -303,7 +303,7 @@ export function CatalogWizard() {
                 <div className="text-xs text-green-700 dark:text-green-400">Succeeded</div>
               </div>
               <div className="rounded-lg bg-red-50 p-3 text-center dark:bg-red-900/20">
-                <div className="text-2xl font-bold text-red-600">{uploadResult.failureCount}</div>
+                <div className="text-2xl font-bold text-red-600">{uploadResult.failedCount}</div>
                 <div className="text-xs text-red-700 dark:text-red-400">Failed</div>
               </div>
               <div className="rounded-lg bg-zinc-50 p-3 text-center dark:bg-zinc-800">
@@ -313,10 +313,10 @@ export function CatalogWizard() {
                 <div className="text-xs text-zinc-500">Total</div>
               </div>
             </div>
-            {uploadResult.results.length > 0 && (
+            {uploadResult.items.length > 0 && (
               <div className="space-y-2">
                 <h4 className="text-sm font-medium">File Results</h4>
-                {uploadResult.results.map((item, index) => (
+                {uploadResult.items.map((item, index) => (
                   <div
                     key={`${item.fileName}-${index}`}
                     className="flex items-center justify-between rounded-lg border p-2"
@@ -325,7 +325,7 @@ export function CatalogWizard() {
                     {item.success ? (
                       <CheckCircle2 className="h-4 w-4 text-green-500" />
                     ) : (
-                      <span className="text-xs text-red-500">{item.errorMessage}</span>
+                      <span className="text-xs text-red-500">{item.error}</span>
                     )}
                   </div>
                 ))}

--- a/apps/web/src/app/admin/(dashboard)/shared-games/wizard/__tests__/CatalogWizard.test.tsx
+++ b/apps/web/src/app/admin/(dashboard)/shared-games/wizard/__tests__/CatalogWizard.test.tsx
@@ -1,0 +1,101 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+const mockPush = vi.fn();
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+  usePathname: () => '/admin/shared-games/wizard',
+}));
+
+const mockSearch = vi.fn();
+const mockGetSharedGameDocuments = vi.fn();
+const mockBulkUploadPdfs = vi.fn();
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    sharedGames: {
+      search: (...args: unknown[]) => mockSearch(...args),
+    },
+    admin: {
+      getSharedGameDocuments: (...args: unknown[]) => mockGetSharedGameDocuments(...args),
+      bulkUploadPdfs: (...args: unknown[]) => mockBulkUploadPdfs(...args),
+    },
+  },
+}));
+
+import { CatalogWizard } from '../CatalogWizard';
+
+describe('CatalogWizard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders step 1 with search input', () => {
+    render(<CatalogWizard />);
+    expect(screen.getByPlaceholderText('Search games by title...')).toBeInTheDocument();
+    expect(screen.getByText('Select a Game')).toBeInTheDocument();
+  });
+
+  it('displays step indicators', () => {
+    render(<CatalogWizard />);
+    expect(screen.getByText('Select Game')).toBeInTheDocument();
+    expect(screen.getByText('Upload PDFs')).toBeInTheDocument();
+    expect(screen.getByText('Review')).toBeInTheDocument();
+  });
+
+  it('searches for games when search is triggered', async () => {
+    mockSearch.mockResolvedValue({
+      items: [
+        { id: 'game-1', title: 'Catan' },
+        { id: 'game-2', title: 'Carcassonne' },
+      ],
+    });
+
+    render(<CatalogWizard />);
+
+    const input = screen.getByPlaceholderText('Search games by title...');
+    fireEvent.change(input, { target: { value: 'Catan' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    await waitFor(() => {
+      expect(mockSearch).toHaveBeenCalledWith({ searchTerm: 'Catan', pageSize: 10 });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Catan')).toBeInTheDocument();
+      expect(screen.getByText('Carcassonne')).toBeInTheDocument();
+    });
+  });
+
+  it('moves to step 2 when a game is selected', async () => {
+    mockSearch.mockResolvedValue({
+      items: [{ id: 'game-1', title: 'Catan' }],
+    });
+    mockGetSharedGameDocuments.mockResolvedValue({
+      sharedGameId: 'game-1',
+      documents: [],
+      totalCount: 0,
+    });
+
+    render(<CatalogWizard />);
+
+    const input = screen.getByPlaceholderText('Search games by title...');
+    fireEvent.change(input, { target: { value: 'Catan' } });
+    fireEvent.keyDown(input, { key: 'Enter' });
+
+    await waitFor(() => {
+      expect(screen.getByText('Catan')).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByText('Catan'));
+
+    await waitFor(() => {
+      expect(screen.getByText(/Upload PDFs for Catan/)).toBeInTheDocument();
+    });
+  });
+
+  it('renders period selector buttons in step 1', () => {
+    render(<CatalogWizard />);
+    expect(screen.getByText('Select a Game')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/admin/(dashboard)/shared-games/wizard/page.tsx
+++ b/apps/web/src/app/admin/(dashboard)/shared-games/wizard/page.tsx
@@ -1,0 +1,24 @@
+/**
+ * Catalog Wizard Page - Admin Dashboard
+ *
+ * Route: /admin/shared-games/wizard
+ * Issue #118: Guided Wizard for shared game content management.
+ */
+
+import { type Metadata } from 'next';
+
+import { CatalogWizard } from './CatalogWizard';
+
+export const metadata: Metadata = {
+  title: 'Catalog Wizard',
+  description: 'Guided wizard for adding content to shared games',
+};
+
+export default function CatalogWizardPage() {
+  return (
+    <div className="container py-6">
+      <h1 className="mb-6 text-2xl font-bold">Catalog Content Wizard</h1>
+      <CatalogWizard />
+    </div>
+  );
+}

--- a/apps/web/src/lib/api/clients/adminClient.ts
+++ b/apps/web/src/lib/api/clients/adminClient.ts
@@ -3623,8 +3623,8 @@ export type SharedGameDocumentsResult = z.infer<typeof SharedGameDocumentsResult
 export const BulkUploadItemResultSchema = z.object({
   fileName: z.string(),
   success: z.boolean(),
-  pdfDocumentId: z.string().nullable(),
-  errorMessage: z.string().nullable(),
+  documentId: z.string().nullable(),
+  error: z.string().nullable(),
 });
 
 export type BulkUploadItemResult = z.infer<typeof BulkUploadItemResultSchema>;
@@ -3632,8 +3632,8 @@ export type BulkUploadItemResult = z.infer<typeof BulkUploadItemResultSchema>;
 export const BulkUploadPdfsResultSchema = z.object({
   totalRequested: z.number(),
   successCount: z.number(),
-  failureCount: z.number(),
-  results: z.array(BulkUploadItemResultSchema),
+  failedCount: z.number(),
+  items: z.array(BulkUploadItemResultSchema),
 });
 
 export type BulkUploadPdfsResult = z.infer<typeof BulkUploadPdfsResultSchema>;
@@ -3642,7 +3642,7 @@ export type BulkUploadPdfsResult = z.infer<typeof BulkUploadPdfsResultSchema>;
 
 export const DailyActiveUsersSchema = z.object({
   date: z.string(),
-  totalUsers: z.number(),
+  activeUsers: z.number(),
   aiChatUsers: z.number(),
   pdfUploadUsers: z.number(),
 });

--- a/apps/web/src/lib/api/clients/adminClient.ts
+++ b/apps/web/src/lib/api/clients/adminClient.ts
@@ -3224,6 +3224,46 @@ export function createAdminClient({ httpClient }: CreateAdminClientParams) {
     async deactivateEmergencyOverride(action: string): Promise<void> {
       await httpClient.post('/api/v1/admin/llm/emergency/deactivate', { action });
     },
+
+    // ========== Issue #119: Shared Game Documents ==========
+
+    /**
+     * Get all documents for a shared game with PDF processing status.
+     * GET /api/v1/admin/shared-games/:gameId/documents
+     */
+    async getSharedGameDocuments(gameId: string): Promise<SharedGameDocumentsResult> {
+      const response = await httpClient.get(
+        `/api/v1/admin/shared-games/${gameId}/documents/overview`
+      );
+      return response as SharedGameDocumentsResult;
+    },
+
+    // ========== Issue #117: Bulk PDF Upload ==========
+
+    /**
+     * Bulk upload PDFs for a shared game.
+     * POST /api/v1/admin/shared-games/:gameId/documents/bulk-upload
+     */
+    async bulkUploadPdfs(gameId: string, files: File[]): Promise<BulkUploadPdfsResult> {
+      const formData = new FormData();
+      files.forEach(file => formData.append('files', file));
+      const response = await httpClient.post(
+        `/api/v1/admin/shared-games/${gameId}/documents/bulk-upload`,
+        formData
+      );
+      return response as BulkUploadPdfsResult;
+    },
+
+    // ========== Issue #113: MAU Monitoring ==========
+
+    /**
+     * Get Monthly Active AI Users data.
+     * GET /api/v1/admin/monitoring/mau?period={7|30|90}
+     */
+    async getActiveAiUsers(period: number = 30): Promise<ActiveAiUsersResult> {
+      const response = await httpClient.get(`/api/v1/admin/monitoring/mau?period=${period}`);
+      return response as ActiveAiUsersResult;
+    },
   };
 }
 
@@ -3552,3 +3592,72 @@ export type KBClearCacheResponse = {
   message: string;
   clearedAt: string | null;
 };
+
+// ========== Issue #119: Shared Game Documents Schemas ==========
+
+export const SharedGameDocumentDetailSchema = z.object({
+  id: z.string(),
+  sharedGameId: z.string(),
+  fileName: z.string(),
+  documentType: z.string(),
+  approvalStatus: z.string(),
+  description: z.string().nullable(),
+  tags: z.array(z.string()),
+  processingState: z.string().nullable(),
+  fileSizeBytes: z.number().nullable(),
+  uploadedAt: z.string().nullable(),
+});
+
+export type SharedGameDocumentDetail = z.infer<typeof SharedGameDocumentDetailSchema>;
+
+export const SharedGameDocumentsResultSchema = z.object({
+  sharedGameId: z.string(),
+  documents: z.array(SharedGameDocumentDetailSchema),
+  totalCount: z.number(),
+});
+
+export type SharedGameDocumentsResult = z.infer<typeof SharedGameDocumentsResultSchema>;
+
+// ========== Issue #117: Bulk Upload Schemas ==========
+
+export const BulkUploadItemResultSchema = z.object({
+  fileName: z.string(),
+  success: z.boolean(),
+  pdfDocumentId: z.string().nullable(),
+  errorMessage: z.string().nullable(),
+});
+
+export type BulkUploadItemResult = z.infer<typeof BulkUploadItemResultSchema>;
+
+export const BulkUploadPdfsResultSchema = z.object({
+  totalRequested: z.number(),
+  successCount: z.number(),
+  failureCount: z.number(),
+  results: z.array(BulkUploadItemResultSchema),
+});
+
+export type BulkUploadPdfsResult = z.infer<typeof BulkUploadPdfsResultSchema>;
+
+// ========== Issue #113: MAU Monitoring Schemas ==========
+
+export const DailyActiveUsersSchema = z.object({
+  date: z.string(),
+  totalUsers: z.number(),
+  aiChatUsers: z.number(),
+  pdfUploadUsers: z.number(),
+});
+
+export type DailyActiveUsers = z.infer<typeof DailyActiveUsersSchema>;
+
+export const ActiveAiUsersResultSchema = z.object({
+  totalActiveUsers: z.number(),
+  aiChatUsers: z.number(),
+  pdfUploadUsers: z.number(),
+  agentUsers: z.number(),
+  periodDays: z.number(),
+  periodStart: z.string(),
+  periodEnd: z.string(),
+  dailyBreakdown: z.array(DailyActiveUsersSchema),
+});
+
+export type ActiveAiUsersResult = z.infer<typeof ActiveAiUsersResultSchema>;


### PR DESCRIPTION
## Summary
- **#119**: Per-SharedGame Document Overview — query handler joining SharedGameDocuments with PdfDocuments for enriched status view
- **#117**: Bulk PDF Upload — command handler delegating to existing UploadPdfCommand per file with per-file error isolation (500MB limit)
- **#118**: CatalogWizard — 3-step React wizard (select game → upload PDFs → review results) with search and file picker
- **#113**: MAU Monitoring Dashboard — query aggregating AI chat, PDF upload, and agent session activity with daily breakdown and KPI cards

Backend: CQRS handlers in Administration/DocumentProcessing/SharedGameCatalog BCs, AdminSharedGameContentEndpoints routing.
Frontend: adminClient methods + Zod schemas, MauDashboard component, CatalogWizard component, unit tests for both.

## Test plan
- [ ] Verify `dotnet build` passes with 0 errors
- [ ] Verify `pnpm build` passes (new pages: `/admin/monitor/mau`, `/admin/shared-games/wizard`)
- [ ] Verify `pnpm test` passes for MauDashboard and CatalogWizard tests
- [ ] Manual: Navigate to MAU dashboard, verify KPI cards render
- [ ] Manual: Navigate to CatalogWizard, verify 3-step flow works

🤖 Generated with [Claude Code](https://claude.com/claude-code)
