### PR TITLE
feat(admin): RAG Dashboard Overview (#259)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Handlers/GetEmbeddingServiceStatusQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Handlers/GetEmbeddingServiceStatusQueryHandler.cs
@@ -1,0 +1,69 @@
+using System.Text.Json;
+using Api.BoundedContexts.DocumentProcessing.Application.Queries;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.DocumentProcessing.Application.Handlers;
+
+/// <summary>
+/// Handler for GetEmbeddingServiceStatusQuery.
+/// Calls the embedding service /health endpoint.
+/// Issue #262: Embedding service health check.
+/// </summary>
+internal sealed class GetEmbeddingServiceStatusQueryHandler
+    : IQueryHandler<GetEmbeddingServiceStatusQuery, EmbeddingServiceStatusDto>
+{
+    private readonly IHttpClientFactory _httpClientFactory;
+    private readonly ILogger<GetEmbeddingServiceStatusQueryHandler> _logger;
+
+    public GetEmbeddingServiceStatusQueryHandler(
+        IHttpClientFactory httpClientFactory,
+        ILogger<GetEmbeddingServiceStatusQueryHandler> logger)
+    {
+        _httpClientFactory = httpClientFactory ?? throw new ArgumentNullException(nameof(httpClientFactory));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<EmbeddingServiceStatusDto> Handle(
+        GetEmbeddingServiceStatusQuery request, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var client = _httpClientFactory.CreateClient("EmbeddingService");
+            using var cts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+            cts.CancelAfter(TimeSpan.FromSeconds(5));
+
+            var response = await client.GetAsync("/health", cts.Token).ConfigureAwait(false);
+
+            if (!response.IsSuccessStatusCode)
+            {
+                return new EmbeddingServiceStatusDto(
+                    Status: "unhealthy",
+                    Model: null,
+                    Device: null,
+                    Dimension: 0,
+                    CheckedAt: DateTime.UtcNow);
+            }
+
+            var json = await response.Content.ReadAsStringAsync(cts.Token).ConfigureAwait(false);
+            using var doc = JsonDocument.Parse(json);
+            var root = doc.RootElement;
+
+            return new EmbeddingServiceStatusDto(
+                Status: root.TryGetProperty("status", out var s) ? s.GetString() ?? "unknown" : "unknown",
+                Model: root.TryGetProperty("model", out var m) ? m.GetString() : null,
+                Device: root.TryGetProperty("device", out var d) ? d.GetString() : null,
+                Dimension: 1024,
+                CheckedAt: DateTime.UtcNow);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to check embedding service health");
+            return new EmbeddingServiceStatusDto(
+                Status: "unavailable",
+                Model: null,
+                Device: null,
+                Dimension: 0,
+                CheckedAt: DateTime.UtcNow);
+        }
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Handlers/GetRagPipelineStatsQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Handlers/GetRagPipelineStatsQueryHandler.cs
@@ -1,0 +1,62 @@
+using Api.BoundedContexts.DocumentProcessing.Application.Queries;
+using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
+using Api.Infrastructure;
+using Api.SharedKernel.Application.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.DocumentProcessing.Application.Handlers;
+
+/// <summary>
+/// Handler for GetRagPipelineStatsQuery.
+/// Aggregates PdfDocument counts by ProcessingState.
+/// Issue #260: RAG pipeline stats.
+/// </summary>
+internal sealed class GetRagPipelineStatsQueryHandler
+    : IQueryHandler<GetRagPipelineStatsQuery, RagPipelineStatsDto>
+{
+    private readonly MeepleAiDbContext _dbContext;
+
+    public GetRagPipelineStatsQueryHandler(MeepleAiDbContext dbContext)
+    {
+        _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+    }
+
+    public async Task<RagPipelineStatsDto> Handle(
+        GetRagPipelineStatsQuery request, CancellationToken cancellationToken)
+    {
+        // ProcessingState is already string on the EF entity
+        var countByState = await _dbContext.PdfDocuments
+            .AsNoTracking()
+            .GroupBy(p => p.ProcessingState)
+            .Select(g => new { State = g.Key, Count = g.Count() })
+            .ToDictionaryAsync(x => x.State, x => x.Count, StringComparer.Ordinal, cancellationToken)
+            .ConfigureAwait(false);
+
+        var totalDocuments = countByState.Values.Sum();
+
+        countByState.TryGetValue(PdfProcessingState.Ready.ToString(), out var readyCount);
+        countByState.TryGetValue(PdfProcessingState.Failed.ToString(), out var failedCount);
+
+        // In-progress = everything except Pending, Ready, and Failed
+        var inProgressStates = new HashSet<string>(StringComparer.Ordinal)
+        {
+            PdfProcessingState.Uploading.ToString(),
+            PdfProcessingState.Extracting.ToString(),
+            PdfProcessingState.Chunking.ToString(),
+            PdfProcessingState.Embedding.ToString(),
+            PdfProcessingState.Indexing.ToString()
+        };
+
+        var inProgressCount = countByState
+            .Where(kvp => inProgressStates.Contains(kvp.Key))
+            .Sum(kvp => kvp.Value);
+
+        return new RagPipelineStatsDto(
+            CountByState: countByState,
+            TotalDocuments: totalDocuments,
+            ReadyDocuments: readyCount,
+            FailedDocuments: failedCount,
+            InProgressDocuments: inProgressCount,
+            MeasuredAt: DateTime.UtcNow);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Handlers/GetRecentProcessingActivityQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Handlers/GetRecentProcessingActivityQueryHandler.cs
@@ -1,0 +1,51 @@
+using Api.BoundedContexts.DocumentProcessing.Application.Queries;
+using Api.Infrastructure;
+using Api.SharedKernel.Application.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.DocumentProcessing.Application.Handlers;
+
+/// <summary>
+/// Handler for GetRecentProcessingActivityQuery.
+/// Returns recent PdfDocuments ordered by upload date.
+/// Issue #263: Recent processing activity.
+/// </summary>
+internal sealed class GetRecentProcessingActivityQueryHandler
+    : IQueryHandler<GetRecentProcessingActivityQuery, RecentProcessingActivityDto>
+{
+    private readonly MeepleAiDbContext _dbContext;
+
+    public GetRecentProcessingActivityQueryHandler(MeepleAiDbContext dbContext)
+    {
+        _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+    }
+
+    public async Task<RecentProcessingActivityDto> Handle(
+        GetRecentProcessingActivityQuery request, CancellationToken cancellationToken)
+    {
+        var limit = Math.Clamp(request.Limit, 1, 100);
+
+        var items = await _dbContext.PdfDocuments
+            .AsNoTracking()
+            .OrderByDescending(p => p.UploadedAt)
+            .Take(limit)
+            .Select(p => new ProcessingActivityItem(
+                p.Id,
+                p.FileName,
+                p.ProcessingState,
+                p.UploadedAt,
+                p.ProcessedAt,
+                p.PageCount,
+                p.ProcessingError,
+                p.GameId ?? Guid.Empty))
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        var totalCount = await _dbContext.PdfDocuments
+            .AsNoTracking()
+            .CountAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return new RecentProcessingActivityDto(items, totalCount);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Queries/GetEmbeddingServiceStatusQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Queries/GetEmbeddingServiceStatusQuery.cs
@@ -1,0 +1,16 @@
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.DocumentProcessing.Application.Queries;
+
+/// <summary>
+/// Query to check embedding service health status.
+/// Issue #262: Embedding service health check for RAG dashboard.
+/// </summary>
+internal record GetEmbeddingServiceStatusQuery : IQuery<EmbeddingServiceStatusDto>;
+
+internal record EmbeddingServiceStatusDto(
+    string Status,
+    string? Model,
+    string? Device,
+    int Dimension,
+    DateTime CheckedAt);

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Queries/GetRagPipelineStatsQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Queries/GetRagPipelineStatsQuery.cs
@@ -1,0 +1,17 @@
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.DocumentProcessing.Application.Queries;
+
+/// <summary>
+/// Aggregates PdfDocument counts by ProcessingState for the RAG pipeline dashboard.
+/// Issue #260: RAG pipeline stats query.
+/// </summary>
+internal record GetRagPipelineStatsQuery : IQuery<RagPipelineStatsDto>;
+
+internal record RagPipelineStatsDto(
+    Dictionary<string, int> CountByState,
+    int TotalDocuments,
+    int ReadyDocuments,
+    int FailedDocuments,
+    int InProgressDocuments,
+    DateTime MeasuredAt);

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Queries/GetRecentProcessingActivityQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Queries/GetRecentProcessingActivityQuery.cs
@@ -1,0 +1,23 @@
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.DocumentProcessing.Application.Queries;
+
+/// <summary>
+/// Query to get recent PDF processing activity for the RAG dashboard.
+/// Issue #263: Recent processing activity.
+/// </summary>
+internal record GetRecentProcessingActivityQuery(int Limit = 20) : IQuery<RecentProcessingActivityDto>;
+
+internal record RecentProcessingActivityDto(
+    List<ProcessingActivityItem> Items,
+    int TotalCount);
+
+internal record ProcessingActivityItem(
+    Guid Id,
+    string FileName,
+    string ProcessingState,
+    DateTime UploadedAt,
+    DateTime? ProcessedAt,
+    int? PageCount,
+    string? ProcessingError,
+    Guid GameId);

--- a/apps/api/src/Api/Program.cs
+++ b/apps/api/src/Api/Program.cs
@@ -602,6 +602,7 @@ v1Api.MapAdminResourcesEndpoints();    // Resources monitoring (Issue #3695)
 // Qdrant admin endpoints removed — pgvector is the sole vector store
 v1Api.MapAdminEmbeddingEndpoints();    // Embedding service dashboard (Issue #4878)
 v1Api.MapAdminPipelineEndpoints();     // Pipeline health overview (Issue #4879)
+v1Api.MapAdminRagDashboardEndpoints(); // RAG dashboard overview (Issue #259)
 v1Api.MapAdminKBSettingsEndpoints();   // KB settings read-only (Issue #4881)
 v1Api.MapTierStrategyAdminEndpoints(); // Tier-strategy configuration (Issue #3440)
 v1Api.MapRagPipelineAdminEndpoints();  // RAG Pipeline builder (Issue #3463)

--- a/apps/api/src/Api/Routing/AdminRagDashboardEndpoints.cs
+++ b/apps/api/src/Api/Routing/AdminRagDashboardEndpoints.cs
@@ -1,0 +1,80 @@
+using Api.BoundedContexts.Administration.Application.Queries.Resources;
+using Api.BoundedContexts.DocumentProcessing.Application.Queries;
+using Api.Filters;
+using MediatR;
+
+namespace Api.Routing;
+
+/// <summary>
+/// Admin endpoints for the RAG dashboard overview.
+/// Issue #264: Wire endpoints under /api/v1/admin/rag-dashboard/.
+/// </summary>
+internal static class AdminRagDashboardEndpoints
+{
+    public static RouteGroupBuilder MapAdminRagDashboardEndpoints(this RouteGroupBuilder group)
+    {
+        var ragGroup = group.MapGroup("/admin/rag-dashboard")
+            .WithTags("Admin", "RAG Dashboard")
+            .AddEndpointFilter<RequireAdminSessionFilter>();
+
+        // GET /api/v1/admin/rag-dashboard/pipeline-stats
+        ragGroup.MapGet("/pipeline-stats", GetPipelineStats)
+            .WithName("GetRagPipelineStats")
+            .WithSummary("Get RAG pipeline document counts by processing state");
+
+        // GET /api/v1/admin/rag-dashboard/vector-metrics
+        ragGroup.MapGet("/vector-metrics", GetVectorMetrics)
+            .WithName("GetRagVectorMetrics")
+            .WithSummary("Get vector store collection statistics");
+
+        // GET /api/v1/admin/rag-dashboard/embedding-status
+        ragGroup.MapGet("/embedding-status", GetEmbeddingStatus)
+            .WithName("GetRagEmbeddingStatus")
+            .WithSummary("Get embedding service health status");
+
+        // GET /api/v1/admin/rag-dashboard/recent-activity
+        ragGroup.MapGet("/recent-activity", GetRecentActivity)
+            .WithName("GetRagRecentActivity")
+            .WithSummary("Get recent PDF processing activity");
+
+        return group;
+    }
+
+    private static async Task<IResult> GetPipelineStats(
+        IMediator mediator,
+        CancellationToken cancellationToken)
+    {
+        var result = await mediator.Send(new GetRagPipelineStatsQuery(), cancellationToken)
+            .ConfigureAwait(false);
+        return Results.Ok(result);
+    }
+
+    private static async Task<IResult> GetVectorMetrics(
+        IMediator mediator,
+        CancellationToken cancellationToken)
+    {
+        var result = await mediator.Send(new GetVectorStoreMetricsQuery(), cancellationToken)
+            .ConfigureAwait(false);
+        return Results.Ok(result);
+    }
+
+    private static async Task<IResult> GetEmbeddingStatus(
+        IMediator mediator,
+        CancellationToken cancellationToken)
+    {
+        var result = await mediator.Send(new GetEmbeddingServiceStatusQuery(), cancellationToken)
+            .ConfigureAwait(false);
+        return Results.Ok(result);
+    }
+
+    private static async Task<IResult> GetRecentActivity(
+        IMediator mediator,
+        int? limit,
+        CancellationToken cancellationToken)
+    {
+        var result = await mediator.Send(
+            new GetRecentProcessingActivityQuery(limit ?? 20), cancellationToken)
+            .ConfigureAwait(false);
+        return Results.Ok(result);
+    }
+}

--- a/apps/web/src/app/admin/(dashboard)/knowledge-base/rag-dashboard/NavConfig.tsx
+++ b/apps/web/src/app/admin/(dashboard)/knowledge-base/rag-dashboard/NavConfig.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+/**
+ * RagDashboardNavConfig - Registers ActionBar actions for RAG Dashboard
+ * Issue #259 - Admin RAG Dashboard
+ */
+
+import { useEffect } from 'react';
+
+import { RefreshCw } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+
+import { useSetNavConfig } from '@/hooks/useSetNavConfig';
+
+export function RagDashboardNavConfig() {
+  const setNavConfig = useSetNavConfig();
+  const router = useRouter();
+
+  useEffect(() => {
+    setNavConfig({
+      miniNav: [],
+      actionBar: [
+        {
+          id: 'refresh',
+          label: 'Refresh',
+          icon: RefreshCw,
+          variant: 'primary',
+          onClick: () => router.push('/admin/knowledge-base/rag-dashboard?action=refresh'),
+        },
+      ],
+    });
+  }, [setNavConfig, router]);
+
+  return null;
+}

--- a/apps/web/src/app/admin/(dashboard)/knowledge-base/rag-dashboard/RagDashboard.tsx
+++ b/apps/web/src/app/admin/(dashboard)/knowledge-base/rag-dashboard/RagDashboard.tsx
@@ -1,0 +1,378 @@
+'use client';
+
+/**
+ * RagDashboard - Main RAG Dashboard component
+ *
+ * Issue #259: Admin RAG Dashboard
+ *
+ * Shows pipeline stats, vector metrics, embedding service status,
+ * and recent processing activity in a glassmorphism card layout.
+ */
+
+import { AlertCircle, CheckCircle2, Clock, Database, Cpu, FileText, Loader2 } from 'lucide-react';
+
+import {
+  useRagPipelineStats,
+  useRagVectorMetrics,
+  useRagEmbeddingStatus,
+  useRagRecentActivity,
+} from '@/hooks/queries/useRagDashboard';
+import type { ProcessingActivityItem } from '@/lib/api/schemas/rag-dashboard.schemas';
+
+// ========== Sub-components ==========
+
+function StatCard({
+  title,
+  value,
+  subtitle,
+  icon: Icon,
+  status,
+  testId,
+}: {
+  title: string;
+  value: string | number;
+  subtitle?: string;
+  icon: typeof Database;
+  status?: 'healthy' | 'warning' | 'error' | 'loading';
+  testId?: string;
+}) {
+  const statusColor = {
+    healthy: 'text-emerald-600 dark:text-emerald-400',
+    warning: 'text-amber-600 dark:text-amber-400',
+    error: 'text-red-600 dark:text-red-400',
+    loading: 'text-muted-foreground',
+  }[status ?? 'healthy'];
+
+  return (
+    <div
+      className="rounded-xl border bg-white/70 dark:bg-zinc-900/70 backdrop-blur-md p-4"
+      data-testid={testId}
+    >
+      <div className="flex items-center gap-3">
+        <div className={`rounded-lg p-2 bg-muted/50 ${statusColor}`}>
+          <Icon className="h-5 w-5" />
+        </div>
+        <div className="min-w-0 flex-1">
+          <p className="text-sm text-muted-foreground truncate">{title}</p>
+          <p className="text-xl font-semibold tracking-tight">{value}</p>
+          {subtitle && <p className="text-xs text-muted-foreground mt-0.5">{subtitle}</p>}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function PipelineStatsSection() {
+  const { data, isLoading, error } = useRagPipelineStats();
+
+  if (isLoading) {
+    return (
+      <div
+        className="rounded-xl border bg-white/70 dark:bg-zinc-900/70 backdrop-blur-md p-6"
+        data-testid="pipeline-stats-loading"
+      >
+        <div className="flex items-center gap-2 text-muted-foreground">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          <span className="text-sm">Loading pipeline stats...</span>
+        </div>
+      </div>
+    );
+  }
+
+  if (error || !data) {
+    return (
+      <div
+        className="rounded-xl border bg-white/70 dark:bg-zinc-900/70 backdrop-blur-md p-6"
+        data-testid="pipeline-stats-error"
+      >
+        <div className="flex items-center gap-2 text-red-600 dark:text-red-400">
+          <AlertCircle className="h-4 w-4" />
+          <span className="text-sm">Failed to load pipeline stats</span>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div data-testid="pipeline-stats">
+      <h2 className="text-lg font-semibold mb-3">Pipeline Stats</h2>
+      <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
+        <StatCard
+          title="Total Documents"
+          value={data.totalDocuments}
+          icon={FileText}
+          testId="stat-total-documents"
+        />
+        <StatCard
+          title="Ready"
+          value={data.readyDocuments}
+          icon={CheckCircle2}
+          status="healthy"
+          testId="stat-ready-documents"
+        />
+        <StatCard
+          title="In Progress"
+          value={data.inProgressDocuments}
+          icon={Clock}
+          status={data.inProgressDocuments > 0 ? 'warning' : 'healthy'}
+          testId="stat-in-progress-documents"
+        />
+        <StatCard
+          title="Failed"
+          value={data.failedDocuments}
+          icon={AlertCircle}
+          status={data.failedDocuments > 0 ? 'error' : 'healthy'}
+          testId="stat-failed-documents"
+        />
+      </div>
+
+      {/* State breakdown */}
+      {Object.keys(data.countByState).length > 0 && (
+        <div className="mt-3 rounded-xl border bg-white/70 dark:bg-zinc-900/70 backdrop-blur-md p-4">
+          <h3 className="text-sm font-medium text-muted-foreground mb-2">By State</h3>
+          <div className="flex flex-wrap gap-2">
+            {Object.entries(data.countByState).map(([state, count]) => (
+              <span
+                key={state}
+                className="inline-flex items-center gap-1.5 rounded-full bg-muted/50 px-2.5 py-0.5 text-xs font-medium"
+              >
+                {state}: {count}
+              </span>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function VectorMetricsSection() {
+  const { data, isLoading, error } = useRagVectorMetrics();
+
+  if (isLoading) {
+    return (
+      <div
+        className="rounded-xl border bg-white/70 dark:bg-zinc-900/70 backdrop-blur-md p-6"
+        data-testid="vector-metrics-loading"
+      >
+        <div className="flex items-center gap-2 text-muted-foreground">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          <span className="text-sm">Loading vector metrics...</span>
+        </div>
+      </div>
+    );
+  }
+
+  if (error || !data) {
+    return (
+      <div
+        className="rounded-xl border bg-white/70 dark:bg-zinc-900/70 backdrop-blur-md p-6"
+        data-testid="vector-metrics-error"
+      >
+        <div className="flex items-center gap-2 text-red-600 dark:text-red-400">
+          <AlertCircle className="h-4 w-4" />
+          <span className="text-sm">Failed to load vector metrics</span>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div data-testid="vector-metrics">
+      <h2 className="text-lg font-semibold mb-3">Vector Store</h2>
+      <div className="grid grid-cols-2 sm:grid-cols-3 gap-3">
+        <StatCard
+          title="Collections"
+          value={data.totalCollections}
+          icon={Database}
+          testId="stat-collections"
+        />
+        <StatCard
+          title="Total Vectors"
+          value={data.totalVectors.toLocaleString()}
+          icon={Database}
+          testId="stat-vectors"
+        />
+        <StatCard
+          title="Memory"
+          value={data.memoryFormatted}
+          icon={Database}
+          testId="stat-memory"
+        />
+      </div>
+    </div>
+  );
+}
+
+function EmbeddingStatusSection() {
+  const { data, isLoading, error } = useRagEmbeddingStatus();
+
+  if (isLoading) {
+    return (
+      <div
+        className="rounded-xl border bg-white/70 dark:bg-zinc-900/70 backdrop-blur-md p-6"
+        data-testid="embedding-status-loading"
+      >
+        <div className="flex items-center gap-2 text-muted-foreground">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          <span className="text-sm">Checking embedding service...</span>
+        </div>
+      </div>
+    );
+  }
+
+  if (error || !data) {
+    return (
+      <div
+        className="rounded-xl border bg-white/70 dark:bg-zinc-900/70 backdrop-blur-md p-6"
+        data-testid="embedding-status-error"
+      >
+        <div className="flex items-center gap-2 text-red-600 dark:text-red-400">
+          <AlertCircle className="h-4 w-4" />
+          <span className="text-sm">Failed to check embedding service</span>
+        </div>
+      </div>
+    );
+  }
+
+  const isHealthy = data.status === 'healthy' || data.status === 'ok';
+
+  return (
+    <div data-testid="embedding-status">
+      <h2 className="text-lg font-semibold mb-3">Embedding Service</h2>
+      <div className="rounded-xl border bg-white/70 dark:bg-zinc-900/70 backdrop-blur-md p-4">
+        <div className="flex items-center gap-3">
+          <div
+            className={`rounded-lg p-2 ${isHealthy ? 'bg-emerald-100 dark:bg-emerald-900/30 text-emerald-600 dark:text-emerald-400' : 'bg-red-100 dark:bg-red-900/30 text-red-600 dark:text-red-400'}`}
+          >
+            <Cpu className="h-5 w-5" />
+          </div>
+          <div>
+            <p className="font-medium" data-testid="embedding-service-status">
+              {isHealthy ? 'Healthy' : data.status}
+            </p>
+            {data.model && <p className="text-sm text-muted-foreground">Model: {data.model}</p>}
+            {data.device && (
+              <p className="text-xs text-muted-foreground">
+                Device: {data.device} | Dimensions: {data.dimension}
+              </p>
+            )}
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function formatTimeAgo(dateStr: string): string {
+  const now = new Date();
+  const date = new Date(dateStr);
+  const diffMs = now.getTime() - date.getTime();
+  const diffMin = Math.floor(diffMs / 60_000);
+  const diffHour = Math.floor(diffMs / 3_600_000);
+  const diffDay = Math.floor(diffMs / 86_400_000);
+
+  if (diffMin < 1) return 'just now';
+  if (diffMin < 60) return `${diffMin}m ago`;
+  if (diffHour < 24) return `${diffHour}h ago`;
+  return `${diffDay}d ago`;
+}
+
+function stateColor(state: string): string {
+  switch (state) {
+    case 'Ready':
+      return 'bg-emerald-100 text-emerald-700 dark:bg-emerald-900/30 dark:text-emerald-400';
+    case 'Failed':
+      return 'bg-red-100 text-red-700 dark:bg-red-900/30 dark:text-red-400';
+    case 'Pending':
+      return 'bg-zinc-100 text-zinc-700 dark:bg-zinc-800 dark:text-zinc-400';
+    default:
+      return 'bg-amber-100 text-amber-700 dark:bg-amber-900/30 dark:text-amber-400';
+  }
+}
+
+function RecentActivitySection() {
+  const { data, isLoading, error } = useRagRecentActivity(15);
+
+  if (isLoading) {
+    return (
+      <div
+        className="rounded-xl border bg-white/70 dark:bg-zinc-900/70 backdrop-blur-md p-6"
+        data-testid="recent-activity-loading"
+      >
+        <div className="flex items-center gap-2 text-muted-foreground">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          <span className="text-sm">Loading recent activity...</span>
+        </div>
+      </div>
+    );
+  }
+
+  if (error || !data) {
+    return (
+      <div
+        className="rounded-xl border bg-white/70 dark:bg-zinc-900/70 backdrop-blur-md p-6"
+        data-testid="recent-activity-error"
+      >
+        <div className="flex items-center gap-2 text-red-600 dark:text-red-400">
+          <AlertCircle className="h-4 w-4" />
+          <span className="text-sm">Failed to load recent activity</span>
+        </div>
+      </div>
+    );
+  }
+
+  return (
+    <div data-testid="recent-activity">
+      <h2 className="text-lg font-semibold mb-3">
+        Recent Activity
+        <span className="ml-2 text-sm font-normal text-muted-foreground">
+          ({data.totalCount} total)
+        </span>
+      </h2>
+      <div className="rounded-xl border bg-white/70 dark:bg-zinc-900/70 backdrop-blur-md overflow-hidden">
+        {data.items.length === 0 ? (
+          <div className="p-6 text-center text-muted-foreground text-sm">
+            No processing activity yet
+          </div>
+        ) : (
+          <div className="divide-y divide-border">
+            {data.items.map((item: ProcessingActivityItem) => (
+              <div key={item.id} className="flex items-center gap-3 px-4 py-3">
+                <span
+                  className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${stateColor(item.processingState)}`}
+                >
+                  {item.processingState}
+                </span>
+                <span className="text-sm font-medium truncate flex-1 min-w-0">{item.fileName}</span>
+                {item.pageCount && (
+                  <span className="text-xs text-muted-foreground whitespace-nowrap">
+                    {item.pageCount}p
+                  </span>
+                )}
+                <span className="text-xs text-muted-foreground whitespace-nowrap">
+                  {formatTimeAgo(item.uploadedAt)}
+                </span>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+// ========== Main Dashboard ==========
+
+export function RagDashboard() {
+  return (
+    <div className="space-y-6" data-testid="rag-dashboard">
+      <PipelineStatsSection />
+      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <VectorMetricsSection />
+        <EmbeddingStatusSection />
+      </div>
+      <RecentActivitySection />
+    </div>
+  );
+}

--- a/apps/web/src/app/admin/(dashboard)/knowledge-base/rag-dashboard/__tests__/RagDashboard.test.tsx
+++ b/apps/web/src/app/admin/(dashboard)/knowledge-base/rag-dashboard/__tests__/RagDashboard.test.tsx
@@ -1,0 +1,227 @@
+/**
+ * RagDashboard Component Tests
+ * Issue #259 - Admin RAG Dashboard
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import type {
+  RagPipelineStats,
+  VectorStoreMetricsResponse,
+  EmbeddingServiceStatus,
+  RecentProcessingActivity,
+} from '@/lib/api/schemas/rag-dashboard.schemas';
+
+// ========== Mock API ==========
+
+const mockGetRagPipelineStats = vi.hoisted(() => vi.fn());
+const mockGetRagVectorMetrics = vi.hoisted(() => vi.fn());
+const mockGetRagEmbeddingStatus = vi.hoisted(() => vi.fn());
+const mockGetRagRecentActivity = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    admin: {
+      getRagPipelineStats: mockGetRagPipelineStats,
+      getRagVectorMetrics: mockGetRagVectorMetrics,
+      getRagEmbeddingStatus: mockGetRagEmbeddingStatus,
+      getRagRecentActivity: mockGetRagRecentActivity,
+    },
+  },
+}));
+
+import { RagDashboard } from '../RagDashboard';
+
+// ========== Test Fixtures ==========
+
+const mockPipelineStats: RagPipelineStats = {
+  countByState: {
+    Pending: 2,
+    Extracting: 1,
+    Ready: 15,
+    Failed: 3,
+  },
+  totalDocuments: 21,
+  readyDocuments: 15,
+  failedDocuments: 3,
+  inProgressDocuments: 3,
+  measuredAt: new Date().toISOString(),
+};
+
+const mockVectorMetrics: VectorStoreMetricsResponse = {
+  totalCollections: 3,
+  totalVectors: 12500,
+  indexedVectors: 12400,
+  memoryBytes: 52_428_800,
+  memoryFormatted: '50 MB',
+  collections: [
+    {
+      collectionName: 'game_docs',
+      vectorCount: 10000,
+      indexedCount: 9900,
+      vectorDimensions: 1024,
+      distanceMetric: 'Cosine',
+      memoryBytes: 40_000_000,
+      memoryFormatted: '38.15 MB',
+    },
+  ],
+  measuredAt: new Date().toISOString(),
+};
+
+const mockEmbeddingStatus: EmbeddingServiceStatus = {
+  status: 'healthy',
+  model: 'multilingual-e5-large-instruct',
+  device: 'cuda',
+  dimension: 1024,
+  checkedAt: new Date().toISOString(),
+};
+
+const mockRecentActivity: RecentProcessingActivity = {
+  items: [
+    {
+      id: '00000000-0000-0000-0000-000000000001',
+      fileName: 'catan-rules.pdf',
+      processingState: 'Ready',
+      uploadedAt: new Date(Date.now() - 3_600_000).toISOString(),
+      processedAt: new Date(Date.now() - 3_000_000).toISOString(),
+      pageCount: 24,
+      processingError: null,
+      gameId: '00000000-0000-0000-0000-000000000010',
+    },
+    {
+      id: '00000000-0000-0000-0000-000000000002',
+      fileName: 'ticket-to-ride.pdf',
+      processingState: 'Failed',
+      uploadedAt: new Date(Date.now() - 7_200_000).toISOString(),
+      processedAt: null,
+      pageCount: null,
+      processingError: 'Extraction timeout',
+      gameId: '00000000-0000-0000-0000-000000000020',
+    },
+  ],
+  totalCount: 42,
+};
+
+// ========== Test Helpers ==========
+
+function createQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        gcTime: 0,
+      },
+    },
+  });
+}
+
+function renderWithProviders(ui: React.ReactElement) {
+  const queryClient = createQueryClient();
+  return render(<QueryClientProvider client={queryClient}>{ui}</QueryClientProvider>);
+}
+
+// ========== Tests ==========
+
+describe('RagDashboard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetRagPipelineStats.mockResolvedValue(mockPipelineStats);
+    mockGetRagVectorMetrics.mockResolvedValue(mockVectorMetrics);
+    mockGetRagEmbeddingStatus.mockResolvedValue(mockEmbeddingStatus);
+    mockGetRagRecentActivity.mockResolvedValue(mockRecentActivity);
+  });
+
+  it('renders the dashboard container', async () => {
+    renderWithProviders(<RagDashboard />);
+    await waitFor(() => {
+      expect(screen.getByTestId('rag-dashboard')).toBeInTheDocument();
+    });
+  });
+
+  it('renders pipeline stats with document counts', async () => {
+    renderWithProviders(<RagDashboard />);
+    await waitFor(() => {
+      expect(screen.getByTestId('pipeline-stats')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('stat-total-documents')).toHaveTextContent('21');
+    expect(screen.getByTestId('stat-ready-documents')).toHaveTextContent('15');
+    expect(screen.getByTestId('stat-failed-documents')).toHaveTextContent('3');
+    expect(screen.getByTestId('stat-in-progress-documents')).toHaveTextContent('3');
+  });
+
+  it('renders vector store metrics', async () => {
+    renderWithProviders(<RagDashboard />);
+    await waitFor(() => {
+      expect(screen.getByTestId('vector-metrics')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('stat-collections')).toHaveTextContent('3');
+    // toLocaleString output is locale-dependent; check for the raw number
+    expect(screen.getByTestId('stat-vectors')).toHaveTextContent(/12[.,]?500/);
+    expect(screen.getByTestId('stat-memory')).toHaveTextContent('50 MB');
+  });
+
+  it('renders embedding service status', async () => {
+    renderWithProviders(<RagDashboard />);
+    await waitFor(() => {
+      expect(screen.getByTestId('embedding-status')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('embedding-service-status')).toHaveTextContent('Healthy');
+    expect(
+      screen.getByText('multilingual-e5-large-instruct', { exact: false })
+    ).toBeInTheDocument();
+  });
+
+  it('renders recent activity list', async () => {
+    renderWithProviders(<RagDashboard />);
+    await waitFor(() => {
+      expect(screen.getByTestId('recent-activity')).toBeInTheDocument();
+    });
+    expect(screen.getByText('catan-rules.pdf')).toBeInTheDocument();
+    expect(screen.getByText('ticket-to-ride.pdf')).toBeInTheDocument();
+    expect(screen.getByText('42 total', { exact: false })).toBeInTheDocument();
+  });
+
+  it('shows loading states initially', () => {
+    mockGetRagPipelineStats.mockReturnValue(new Promise(() => {}));
+    mockGetRagVectorMetrics.mockReturnValue(new Promise(() => {}));
+    mockGetRagEmbeddingStatus.mockReturnValue(new Promise(() => {}));
+    mockGetRagRecentActivity.mockReturnValue(new Promise(() => {}));
+
+    renderWithProviders(<RagDashboard />);
+    expect(screen.getByTestId('pipeline-stats-loading')).toBeInTheDocument();
+    expect(screen.getByTestId('vector-metrics-loading')).toBeInTheDocument();
+    expect(screen.getByTestId('embedding-status-loading')).toBeInTheDocument();
+    expect(screen.getByTestId('recent-activity-loading')).toBeInTheDocument();
+  });
+
+  it('shows error states when API fails', async () => {
+    mockGetRagPipelineStats.mockRejectedValue(new Error('Network error'));
+    mockGetRagVectorMetrics.mockRejectedValue(new Error('Network error'));
+    mockGetRagEmbeddingStatus.mockRejectedValue(new Error('Network error'));
+    mockGetRagRecentActivity.mockRejectedValue(new Error('Network error'));
+
+    renderWithProviders(<RagDashboard />);
+    await waitFor(() => {
+      expect(screen.getByTestId('pipeline-stats-error')).toBeInTheDocument();
+    });
+    expect(screen.getByTestId('vector-metrics-error')).toBeInTheDocument();
+    expect(screen.getByTestId('embedding-status-error')).toBeInTheDocument();
+    expect(screen.getByTestId('recent-activity-error')).toBeInTheDocument();
+  });
+
+  it('shows unhealthy embedding status correctly', async () => {
+    mockGetRagEmbeddingStatus.mockResolvedValue({
+      ...mockEmbeddingStatus,
+      status: 'unavailable',
+      model: null,
+      device: null,
+    });
+
+    renderWithProviders(<RagDashboard />);
+    await waitFor(() => {
+      expect(screen.getByTestId('embedding-service-status')).toHaveTextContent('unavailable');
+    });
+  });
+});

--- a/apps/web/src/app/admin/(dashboard)/knowledge-base/rag-dashboard/page.tsx
+++ b/apps/web/src/app/admin/(dashboard)/knowledge-base/rag-dashboard/page.tsx
@@ -1,0 +1,27 @@
+/**
+ * Admin RAG Dashboard Page
+ * Issue #259 - Admin RAG Dashboard
+ *
+ * Route: /admin/knowledge-base/rag-dashboard
+ * Shows pipeline stats, vector metrics, embedding status, and recent activity.
+ */
+
+import { RagDashboardNavConfig } from './NavConfig';
+import { RagDashboard } from './RagDashboard';
+
+export default function RagDashboardPage() {
+  return (
+    <div className="space-y-5" data-testid="rag-dashboard-page">
+      <RagDashboardNavConfig />
+      <div>
+        <h1 className="font-quicksand text-xl sm:text-2xl font-bold tracking-tight text-foreground">
+          RAG Dashboard
+        </h1>
+        <p className="mt-0.5 text-sm text-muted-foreground">
+          Monitor RAG pipeline health, vector store metrics, and embedding service status.
+        </p>
+      </div>
+      <RagDashboard />
+    </div>
+  );
+}

--- a/apps/web/src/hooks/queries/useRagDashboard.ts
+++ b/apps/web/src/hooks/queries/useRagDashboard.ts
@@ -1,0 +1,70 @@
+/**
+ * useRagDashboard - TanStack Query hooks for Admin RAG Dashboard
+ *
+ * Issue #259: Admin RAG Dashboard
+ *
+ * Provides query hooks for RAG pipeline stats, vector metrics,
+ * embedding service status, and recent processing activity.
+ */
+
+import { useQuery } from '@tanstack/react-query';
+
+import { api } from '@/lib/api';
+
+/**
+ * Query key factory for RAG dashboard queries
+ */
+export const ragDashboardKeys = {
+  all: ['rag-dashboard'] as const,
+  pipelineStats: () => [...ragDashboardKeys.all, 'pipeline-stats'] as const,
+  vectorMetrics: () => [...ragDashboardKeys.all, 'vector-metrics'] as const,
+  embeddingStatus: () => [...ragDashboardKeys.all, 'embedding-status'] as const,
+  recentActivity: (limit?: number) => [...ragDashboardKeys.all, 'recent-activity', limit] as const,
+};
+
+/**
+ * Hook to fetch RAG pipeline document counts by processing state
+ */
+export function useRagPipelineStats() {
+  return useQuery({
+    queryKey: ragDashboardKeys.pipelineStats(),
+    queryFn: () => api.admin.getRagPipelineStats(),
+    staleTime: 30_000,
+    refetchInterval: 30_000,
+  });
+}
+
+/**
+ * Hook to fetch vector store collection metrics
+ */
+export function useRagVectorMetrics() {
+  return useQuery({
+    queryKey: ragDashboardKeys.vectorMetrics(),
+    queryFn: () => api.admin.getRagVectorMetrics(),
+    staleTime: 60_000,
+  });
+}
+
+/**
+ * Hook to fetch embedding service health status
+ */
+export function useRagEmbeddingStatus() {
+  return useQuery({
+    queryKey: ragDashboardKeys.embeddingStatus(),
+    queryFn: () => api.admin.getRagEmbeddingStatus(),
+    staleTime: 30_000,
+    refetchInterval: 30_000,
+  });
+}
+
+/**
+ * Hook to fetch recent PDF processing activity
+ */
+export function useRagRecentActivity(limit?: number) {
+  return useQuery({
+    queryKey: ragDashboardKeys.recentActivity(limit),
+    queryFn: () => api.admin.getRagRecentActivity(limit),
+    staleTime: 15_000,
+    refetchInterval: 15_000,
+  });
+}

--- a/apps/web/src/lib/api/clients/adminClient.ts
+++ b/apps/web/src/lib/api/clients/adminClient.ts
@@ -220,6 +220,16 @@ import {
 } from '../schemas/financial-ledger.schemas';
 import * as MechanicExtractorSchemas from '../schemas/mechanic-extractor.schemas';
 import {
+  RagPipelineStatsSchema,
+  VectorStoreMetricsResponseSchema,
+  EmbeddingServiceStatusSchema,
+  RecentProcessingActivitySchema,
+  type RagPipelineStats,
+  type VectorStoreMetricsResponse,
+  type EmbeddingServiceStatus,
+  type RecentProcessingActivity,
+} from '../schemas/rag-dashboard.schemas';
+import {
   ResourceForecastEstimationResultSchema,
   ResourceForecastsResponseSchema,
   SaveForecastResponseSchema,
@@ -258,6 +268,13 @@ export const ADMIN_PDF_ROUTES = {
 export const ADMIN_KB_ROUTES = {
   vectorCollections: '/api/v1/admin/kb/vector-collections',
   processingQueue: '/api/v1/admin/kb/processing-queue',
+} as const;
+
+export const ADMIN_RAG_DASHBOARD_ROUTES = {
+  pipelineStats: '/api/v1/admin/rag-dashboard/pipeline-stats',
+  vectorMetrics: '/api/v1/admin/rag-dashboard/vector-metrics',
+  embeddingStatus: '/api/v1/admin/rag-dashboard/embedding-status',
+  recentActivity: '/api/v1/admin/rag-dashboard/recent-activity',
 } as const;
 
 // ============================================================================
@@ -2537,6 +2554,56 @@ export function createAdminClient({ httpClient }: CreateAdminClientParams) {
         {}
       );
       return result ?? { success: false, message: 'No response', clearedAt: null };
+    },
+
+    // ========== RAG Dashboard (Issue #259) ==========
+
+    /**
+     * Get RAG pipeline stats (document counts by processing state)
+     * GET /api/v1/admin/rag-dashboard/pipeline-stats
+     * Issue #260
+     */
+    async getRagPipelineStats(): Promise<RagPipelineStats | null> {
+      return httpClient.get(ADMIN_RAG_DASHBOARD_ROUTES.pipelineStats, RagPipelineStatsSchema);
+    },
+
+    /**
+     * Get vector store metrics (collection statistics)
+     * GET /api/v1/admin/rag-dashboard/vector-metrics
+     * Issue #261
+     */
+    async getRagVectorMetrics(): Promise<VectorStoreMetricsResponse | null> {
+      return httpClient.get(
+        ADMIN_RAG_DASHBOARD_ROUTES.vectorMetrics,
+        VectorStoreMetricsResponseSchema
+      );
+    },
+
+    /**
+     * Get embedding service health status
+     * GET /api/v1/admin/rag-dashboard/embedding-status
+     * Issue #262
+     */
+    async getRagEmbeddingStatus(): Promise<EmbeddingServiceStatus | null> {
+      return httpClient.get(
+        ADMIN_RAG_DASHBOARD_ROUTES.embeddingStatus,
+        EmbeddingServiceStatusSchema
+      );
+    },
+
+    /**
+     * Get recent PDF processing activity
+     * GET /api/v1/admin/rag-dashboard/recent-activity
+     * Issue #263
+     */
+    async getRagRecentActivity(limit?: number): Promise<RecentProcessingActivity | null> {
+      const params = new URLSearchParams();
+      if (limit) params.set('limit', String(limit));
+      const qs = params.toString();
+      return httpClient.get(
+        `${ADMIN_RAG_DASHBOARD_ROUTES.recentActivity}${qs ? `?${qs}` : ''}`,
+        RecentProcessingActivitySchema
+      );
     },
 
     // ========== OpenRouter Usage Dashboard (Issues #5078-#5083) ==========

--- a/apps/web/src/lib/api/schemas/rag-dashboard.schemas.ts
+++ b/apps/web/src/lib/api/schemas/rag-dashboard.schemas.ts
@@ -1,0 +1,78 @@
+/**
+ * RAG Dashboard Schemas (Issue #259)
+ *
+ * Zod schemas for admin RAG dashboard endpoints:
+ * pipeline stats, vector metrics, embedding status, recent activity.
+ */
+
+import { z } from 'zod';
+
+// ========== Pipeline Stats (Issue #260) ==========
+
+export const RagPipelineStatsSchema = z.object({
+  countByState: z.record(z.string(), z.number()),
+  totalDocuments: z.number(),
+  readyDocuments: z.number(),
+  failedDocuments: z.number(),
+  inProgressDocuments: z.number(),
+  measuredAt: z.string(),
+});
+
+export type RagPipelineStats = z.infer<typeof RagPipelineStatsSchema>;
+
+// ========== Vector Store Metrics (Issue #261) ==========
+
+export const CollectionStatsSchema = z.object({
+  collectionName: z.string(),
+  vectorCount: z.number(),
+  indexedCount: z.number(),
+  vectorDimensions: z.number(),
+  distanceMetric: z.string(),
+  memoryBytes: z.number(),
+  memoryFormatted: z.string(),
+});
+
+export const VectorStoreMetricsResponseSchema = z.object({
+  totalCollections: z.number(),
+  totalVectors: z.number(),
+  indexedVectors: z.number(),
+  memoryBytes: z.number(),
+  memoryFormatted: z.string(),
+  collections: z.array(CollectionStatsSchema),
+  measuredAt: z.string(),
+});
+
+export type VectorStoreMetricsResponse = z.infer<typeof VectorStoreMetricsResponseSchema>;
+
+// ========== Embedding Service Status (Issue #262) ==========
+
+export const EmbeddingServiceStatusSchema = z.object({
+  status: z.string(),
+  model: z.string().nullable(),
+  device: z.string().nullable(),
+  dimension: z.number(),
+  checkedAt: z.string(),
+});
+
+export type EmbeddingServiceStatus = z.infer<typeof EmbeddingServiceStatusSchema>;
+
+// ========== Recent Processing Activity (Issue #263) ==========
+
+export const ProcessingActivityItemSchema = z.object({
+  id: z.string(),
+  fileName: z.string(),
+  processingState: z.string(),
+  uploadedAt: z.string(),
+  processedAt: z.string().nullable(),
+  pageCount: z.number().nullable(),
+  processingError: z.string().nullable(),
+  gameId: z.string(),
+});
+
+export const RecentProcessingActivitySchema = z.object({
+  items: z.array(ProcessingActivityItemSchema),
+  totalCount: z.number(),
+});
+
+export type ProcessingActivityItem = z.infer<typeof ProcessingActivityItemSchema>;
+export type RecentProcessingActivity = z.infer<typeof RecentProcessingActivitySchema>;


### PR DESCRIPTION
## Summary
Full-stack implementation of the Admin RAG Dashboard (#259) covering 9 sub-issues (#260-#268):

**Backend (CQRS queries + handlers):**
- `GetRagPipelineStatsQuery` — Aggregates PdfDocument counts by ProcessingState
- `GetEmbeddingServiceStatusQuery` — Health check for embedding service via HTTP
- `GetRecentProcessingActivityQuery` — Recent PdfDocuments with processing details
- Reuses existing `GetVectorStoreMetricsQuery` for Qdrant stats
- All wired under `/api/v1/admin/rag-dashboard/` with `RequireAdminSessionFilter`

**Frontend:**
- Zod schemas + adminClient methods for all endpoints
- React Query hooks (`useRagDashboard.ts`) for data fetching
- Glassmorphism dashboard with pipeline stats, vector metrics, embedding status, recent activity
- Loading/error states with auto-refresh
- 8 unit tests

## Test plan
- [ ] Verify `dotnet build` passes with 0 errors
- [ ] Verify `pnpm build` passes (new page: `/admin/knowledge-base/rag-dashboard`)
- [ ] Run `pnpm test` — verify 8 RagDashboard tests pass
- [ ] Manual: Navigate to RAG dashboard, verify stats cards render
- [ ] Manual: Verify auto-refresh and error handling

🤖 Generated with [Claude Code](https://claude.com/claude-code)
