### PR TITLE
feat(admin): Container Dashboard - Infrastructure Panel Phase 4 (#143, #144, #145)

### DIFF
--- a/apps/web/src/app/admin/(dashboard)/monitor/containers/ContainerDashboard.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/containers/ContainerDashboard.tsx
@@ -1,0 +1,281 @@
+'use client';
+
+/**
+ * ContainerDashboard — Container status grid with auto-refresh, metrics, and action buttons.
+ * Issue #143 — Admin Infrastructure Panel Phase 4
+ */
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+import { Box, Clock, Loader2, Pause, Play, RefreshCw, ScrollText } from 'lucide-react';
+import Link from 'next/link';
+
+import { Badge } from '@/components/ui/data-display/badge';
+import { Button } from '@/components/ui/primitives/button';
+import { useToast } from '@/hooks/use-toast';
+import { api } from '@/lib/api';
+import type { ContainerInfo } from '@/lib/api/schemas';
+import { cn } from '@/lib/utils';
+
+/* ------------------------------------------------------------------ */
+/*  Constants                                                          */
+/* ------------------------------------------------------------------ */
+
+const REFRESH_OPTIONS = [
+  { value: 15, label: '15s' },
+  { value: 30, label: '30s' },
+  { value: 60, label: '60s' },
+] as const;
+
+/* ------------------------------------------------------------------ */
+/*  Sub-components                                                     */
+/* ------------------------------------------------------------------ */
+
+function ContainerStatusBadge({ state }: { state: string }) {
+  const variant =
+    state === 'running' ? 'secondary' : state === 'exited' ? 'destructive' : 'outline';
+
+  const dotColor =
+    state === 'running' ? 'bg-green-500' : state === 'exited' ? 'bg-red-500' : 'bg-yellow-500';
+
+  return (
+    <Badge variant={variant} className="gap-1.5 text-xs" data-testid="container-status-badge">
+      <span className={cn('inline-block h-2 w-2 rounded-full', dotColor)} />
+      {state}
+    </Badge>
+  );
+}
+
+function formatUptime(created: string): string {
+  const diff = Date.now() - new Date(created).getTime();
+  const hours = Math.floor(diff / (1000 * 60 * 60));
+  const days = Math.floor(hours / 24);
+
+  if (days > 0) return `${days}d ${hours % 24}h`;
+  if (hours > 0) return `${hours}h`;
+  const minutes = Math.floor(diff / (1000 * 60));
+  return `${minutes}m`;
+}
+
+interface ContainerCardProps {
+  container: ContainerInfo;
+}
+
+function ContainerCard({ container }: ContainerCardProps) {
+  return (
+    <div
+      data-testid={`container-card-${container.id}`}
+      className="rounded-xl border bg-white/70 p-4 backdrop-blur-md transition-shadow hover:shadow-md dark:bg-zinc-900/70"
+    >
+      {/* Header */}
+      <div className="mb-3 flex items-start justify-between">
+        <div className="min-w-0 flex-1">
+          <h3 className="truncate text-sm font-semibold text-foreground">{container.name}</h3>
+          <p className="mt-0.5 truncate text-xs text-muted-foreground">{container.image}</p>
+        </div>
+        <ContainerStatusBadge state={container.state} />
+      </div>
+
+      {/* Metrics row */}
+      <div className="mb-3 grid grid-cols-2 gap-2">
+        <div className="rounded-lg bg-muted/50 px-2.5 py-1.5">
+          <p className="text-[10px] uppercase tracking-wider text-muted-foreground">Status</p>
+          <p className="text-xs font-medium" data-testid="container-status-text">
+            {container.status}
+          </p>
+        </div>
+        <div className="rounded-lg bg-muted/50 px-2.5 py-1.5">
+          <p className="text-[10px] uppercase tracking-wider text-muted-foreground">Uptime</p>
+          <p className="text-xs font-medium" data-testid="container-uptime">
+            {formatUptime(container.created)}
+          </p>
+        </div>
+      </div>
+
+      {/* Actions */}
+      <div className="flex items-center gap-2">
+        <Link
+          href={`/admin/monitor/logs`}
+          className="inline-flex items-center gap-1 rounded-md px-2.5 py-1.5 text-xs font-medium text-primary hover:bg-primary/10 transition-colors"
+          data-testid={`view-logs-${container.id}`}
+        >
+          <ScrollText className="h-3 w-3" />
+          View Logs
+        </Link>
+      </div>
+    </div>
+  );
+}
+
+function StatusSummary({ containers }: { containers: ContainerInfo[] }) {
+  const running = containers.filter(c => c.state === 'running').length;
+  const stopped = containers.filter(c => c.state !== 'running').length;
+  const total = containers.length;
+
+  return (
+    <div className="grid grid-cols-3 gap-3" data-testid="status-summary">
+      <div className="rounded-xl border bg-white/70 p-3 backdrop-blur-md dark:bg-zinc-900/70">
+        <p className="text-xs text-muted-foreground">Total</p>
+        <p className="text-lg font-semibold font-mono">{total}</p>
+      </div>
+      <div className="rounded-xl border bg-white/70 p-3 backdrop-blur-md dark:bg-zinc-900/70">
+        <p className="text-xs text-green-600">Running</p>
+        <p className="text-lg font-semibold font-mono text-green-600">{running}</p>
+      </div>
+      <div className="rounded-xl border bg-white/70 p-3 backdrop-blur-md dark:bg-zinc-900/70">
+        <p className="text-xs text-red-600">Stopped</p>
+        <p className="text-lg font-semibold font-mono text-red-600">{stopped}</p>
+      </div>
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Main Component                                                     */
+/* ------------------------------------------------------------------ */
+
+export function ContainerDashboard() {
+  const [containers, setContainers] = useState<ContainerInfo[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [autoRefresh, setAutoRefresh] = useState(true);
+  const [refreshInterval, setRefreshInterval] = useState(30);
+  const [countdown, setCountdown] = useState(30);
+
+  const intervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const countdownRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const hasLoadedRef = useRef(false);
+  const { toast } = useToast();
+
+  const fetchContainers = useCallback(async () => {
+    try {
+      const data = await api.admin.getDockerContainers();
+      setContainers(data);
+      hasLoadedRef.current = true;
+    } catch {
+      if (!hasLoadedRef.current) {
+        toast({ title: 'Failed to load container data', variant: 'destructive' });
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, [toast]);
+
+  // Initial fetch
+  useEffect(() => {
+    fetchContainers();
+  }, [fetchContainers]);
+
+  // Auto-refresh interval
+  useEffect(() => {
+    if (intervalRef.current) clearInterval(intervalRef.current);
+    if (countdownRef.current) clearInterval(countdownRef.current);
+
+    if (autoRefresh) {
+      setCountdown(refreshInterval);
+
+      countdownRef.current = setInterval(() => {
+        setCountdown(prev => {
+          if (prev <= 1) return refreshInterval;
+          return prev - 1;
+        });
+      }, 1000);
+
+      intervalRef.current = setInterval(() => {
+        fetchContainers();
+        setCountdown(refreshInterval);
+      }, refreshInterval * 1000);
+    }
+
+    return () => {
+      if (intervalRef.current) clearInterval(intervalRef.current);
+      if (countdownRef.current) clearInterval(countdownRef.current);
+    };
+  }, [autoRefresh, refreshInterval, fetchContainers]);
+
+  return (
+    <div className="space-y-6" data-testid="container-dashboard">
+      {/* Header Controls */}
+      <div className="flex flex-wrap items-center gap-3">
+        {/* Auto-refresh toggle */}
+        <div className="flex items-center gap-2" data-testid="auto-refresh-controls">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => setAutoRefresh(!autoRefresh)}
+            className="gap-1.5"
+            data-testid="auto-refresh-toggle"
+          >
+            {autoRefresh ? <Pause className="h-3.5 w-3.5" /> : <Play className="h-3.5 w-3.5" />}
+            {autoRefresh ? 'Pause' : 'Resume'}
+          </Button>
+
+          {autoRefresh && (
+            <div className="flex items-center gap-1.5 text-xs text-muted-foreground">
+              <Clock className="h-3 w-3" />
+              <span data-testid="countdown">{countdown}s</span>
+            </div>
+          )}
+
+          <select
+            value={refreshInterval}
+            onChange={e => {
+              setRefreshInterval(Number(e.target.value));
+              setCountdown(Number(e.target.value));
+            }}
+            className="rounded-md border bg-background px-2 py-1 text-xs"
+            data-testid="refresh-interval-select"
+          >
+            {REFRESH_OPTIONS.map(opt => (
+              <option key={opt.value} value={opt.value}>
+                {opt.label}
+              </option>
+            ))}
+          </select>
+        </div>
+
+        {/* Manual refresh */}
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => fetchContainers()}
+          className="gap-1.5 ml-auto"
+          data-testid="manual-refresh"
+        >
+          <RefreshCw className="h-3.5 w-3.5" />
+          Refresh
+        </Button>
+      </div>
+
+      {loading ? (
+        <div className="flex items-center justify-center py-10" data-testid="container-loading">
+          <Loader2 className="h-6 w-6 animate-spin text-muted-foreground" />
+        </div>
+      ) : containers.length === 0 ? (
+        <div
+          data-testid="container-empty"
+          className="rounded-xl border bg-white/70 p-8 text-center backdrop-blur-md dark:bg-zinc-900/70"
+        >
+          <Box className="mx-auto mb-3 h-8 w-8 text-muted-foreground" />
+          <p className="text-muted-foreground">
+            No containers found. Make sure Docker Socket Proxy is running.
+          </p>
+        </div>
+      ) : (
+        <>
+          {/* Status Summary */}
+          <StatusSummary containers={containers} />
+
+          {/* Container Grid */}
+          <div
+            className="grid grid-cols-1 gap-4 md:grid-cols-2 lg:grid-cols-3"
+            data-testid="container-grid"
+          >
+            {containers.map(container => (
+              <ContainerCard key={container.id} container={container} />
+            ))}
+          </div>
+        </>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/admin/(dashboard)/monitor/containers/NavConfig.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/containers/NavConfig.tsx
@@ -1,0 +1,35 @@
+'use client';
+
+/**
+ * ContainersNavConfig — Registers ActionBar actions for /admin/monitor/containers
+ * Issue #143
+ */
+
+import { useEffect } from 'react';
+
+import { RefreshCw } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+
+import { useSetNavConfig } from '@/hooks/useSetNavConfig';
+
+export function ContainersNavConfig() {
+  const setNavConfig = useSetNavConfig();
+  const router = useRouter();
+
+  useEffect(() => {
+    setNavConfig({
+      miniNav: [],
+      actionBar: [
+        {
+          id: 'refresh',
+          label: 'Refresh',
+          icon: RefreshCw,
+          variant: 'primary',
+          onClick: () => router.refresh(),
+        },
+      ],
+    });
+  }, [setNavConfig, router]);
+
+  return null;
+}

--- a/apps/web/src/app/admin/(dashboard)/monitor/containers/RestartAllPanel.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/containers/RestartAllPanel.tsx
@@ -8,7 +8,7 @@
  * unstructured, smoldocling) → application (api).
  */
 
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { AlertTriangle, Check, Loader2, RefreshCw, Shield, X } from 'lucide-react';
 
@@ -29,19 +29,21 @@ interface ServiceDef {
 }
 
 /**
- * Dependency-ordered service tiers:
- * Tier 1: Infrastructure (databases, caches)
- * Tier 2: AI/processing services
- * Tier 3: Application layer
+ * Dependency-ordered service tiers (restartable services only).
+ * Infrastructure containers (postgres, redis, qdrant) are excluded — they are
+ * managed by docker compose and the Docker API is read-only.
+ *
+ * Tier 1: AI/processing services (independent, restart first)
+ * Tier 2: Application layer (depends on AI services)
  */
 const SERVICE_TIERS: ServiceDef[] = [
-  // Tier 1 — Infrastructure (no internal deps)
-  { id: 'embedding-service', label: 'Embedding Service', tier: 2 },
-  { id: 'reranker-service', label: 'Reranker Service', tier: 2 },
-  { id: 'unstructured-service', label: 'Unstructured Service', tier: 2 },
-  { id: 'smoldocling-service', label: 'SmolDocling Service', tier: 2 },
-  // Tier 3 — Application (depends on all above)
-  { id: 'api', label: 'API Service', tier: 3 },
+  // Tier 1 — AI/processing services (no internal deps)
+  { id: 'embedding-service', label: 'Embedding Service', tier: 1 },
+  { id: 'reranker-service', label: 'Reranker Service', tier: 1 },
+  { id: 'unstructured-service', label: 'Unstructured Service', tier: 1 },
+  { id: 'smoldocling-service', label: 'SmolDocling Service', tier: 1 },
+  // Tier 2 — Application (depends on all above)
+  { id: 'api', label: 'API Service', tier: 2 },
 ];
 
 type RestartStatus = 'pending' | 'restarting' | 'done' | 'failed';
@@ -94,6 +96,13 @@ export function RestartAllPanel() {
   const [confirmText, setConfirmText] = useState('');
   const [isRestarting, setIsRestarting] = useState(false);
   const [progress, setProgress] = useState<ServiceProgress[]>([]);
+  const mountedRef = useRef(true);
+
+  useEffect(() => {
+    return () => {
+      mountedRef.current = false;
+    };
+  }, []);
 
   const isConfirmMatch = confirmText === 'RESTART ALL';
 
@@ -120,18 +129,22 @@ export function RestartAllPanel() {
 
       // Restart all services in same tier sequentially
       for (const service of tierServices) {
+        if (!mountedRef.current) return;
+
         setProgress(prev =>
           prev.map(p => (p.id === service.id ? { ...p, status: 'restarting' } : p))
         );
 
         try {
           const result = await api.admin.restartService(service.id);
+          if (!mountedRef.current) return;
           setProgress(prev =>
             prev.map(p =>
               p.id === service.id ? { ...p, status: 'done', message: result.message } : p
             )
           );
         } catch (err) {
+          if (!mountedRef.current) return;
           const message = err instanceof Error ? err.message : 'Unknown error';
           setProgress(prev =>
             prev.map(p => (p.id === service.id ? { ...p, status: 'failed', message } : p))
@@ -144,6 +157,8 @@ export function RestartAllPanel() {
         await new Promise(resolve => setTimeout(resolve, 1000));
       }
     }
+
+    if (!mountedRef.current) return;
 
     setIsRestarting(false);
 

--- a/apps/web/src/app/admin/(dashboard)/monitor/containers/RestartAllPanel.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/containers/RestartAllPanel.tsx
@@ -1,0 +1,286 @@
+'use client';
+
+/**
+ * RestartAllPanel — Dependency-ordered sequential restart of all services.
+ * Issue #145 — Restart All with dependency order.
+ *
+ * Restart order: infrastructure first (postgres, redis, qdrant) → services (embedding, reranker,
+ * unstructured, smoldocling) → application (api).
+ */
+
+import { useCallback, useState } from 'react';
+
+import { AlertTriangle, Check, Loader2, RefreshCw, Shield, X } from 'lucide-react';
+
+import { Badge } from '@/components/ui/data-display/badge';
+import { Button } from '@/components/ui/primitives/button';
+import { useToast } from '@/hooks/use-toast';
+import { api } from '@/lib/api';
+import { cn } from '@/lib/utils';
+
+/* ------------------------------------------------------------------ */
+/*  Types & Constants                                                  */
+/* ------------------------------------------------------------------ */
+
+interface ServiceDef {
+  id: string;
+  label: string;
+  tier: number; // lower = restart first
+}
+
+/**
+ * Dependency-ordered service tiers:
+ * Tier 1: Infrastructure (databases, caches)
+ * Tier 2: AI/processing services
+ * Tier 3: Application layer
+ */
+const SERVICE_TIERS: ServiceDef[] = [
+  // Tier 1 — Infrastructure (no internal deps)
+  { id: 'embedding-service', label: 'Embedding Service', tier: 2 },
+  { id: 'reranker-service', label: 'Reranker Service', tier: 2 },
+  { id: 'unstructured-service', label: 'Unstructured Service', tier: 2 },
+  { id: 'smoldocling-service', label: 'SmolDocling Service', tier: 2 },
+  // Tier 3 — Application (depends on all above)
+  { id: 'api', label: 'API Service', tier: 3 },
+];
+
+type RestartStatus = 'pending' | 'restarting' | 'done' | 'failed';
+
+interface ServiceProgress {
+  id: string;
+  label: string;
+  status: RestartStatus;
+  message?: string;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Sub-components                                                     */
+/* ------------------------------------------------------------------ */
+
+function ServiceProgressRow({ service }: { service: ServiceProgress }) {
+  return (
+    <div
+      data-testid={`restart-progress-${service.id}`}
+      className="flex items-center justify-between rounded-lg border px-3 py-2"
+    >
+      <div className="flex items-center gap-2">
+        {service.status === 'restarting' && (
+          <Loader2 className="h-3.5 w-3.5 animate-spin text-primary" />
+        )}
+        {service.status === 'done' && <Check className="h-3.5 w-3.5 text-green-600" />}
+        {service.status === 'failed' && <X className="h-3.5 w-3.5 text-red-600" />}
+        {service.status === 'pending' && (
+          <span className="h-3.5 w-3.5 rounded-full border-2 border-muted-foreground/30" />
+        )}
+        <span className="text-sm font-medium">{service.label}</span>
+      </div>
+      <div className="text-xs text-muted-foreground">
+        {service.status === 'restarting' && 'Restarting...'}
+        {service.status === 'done' && (service.message ?? 'Done')}
+        {service.status === 'failed' && (service.message ?? 'Failed')}
+        {service.status === 'pending' && 'Waiting'}
+      </div>
+    </div>
+  );
+}
+
+/* ------------------------------------------------------------------ */
+/*  Main Component                                                     */
+/* ------------------------------------------------------------------ */
+
+export function RestartAllPanel() {
+  const { toast } = useToast();
+  const [showConfirm, setShowConfirm] = useState(false);
+  const [confirmText, setConfirmText] = useState('');
+  const [isRestarting, setIsRestarting] = useState(false);
+  const [progress, setProgress] = useState<ServiceProgress[]>([]);
+
+  const isConfirmMatch = confirmText === 'RESTART ALL';
+
+  const executeRestartAll = useCallback(async () => {
+    setIsRestarting(true);
+    setShowConfirm(false);
+    setConfirmText('');
+
+    // Initialize progress
+    const initial: ServiceProgress[] = SERVICE_TIERS.map(s => ({
+      id: s.id,
+      label: s.label,
+      status: 'pending',
+    }));
+    setProgress(initial);
+
+    // Group by tier for sequential execution
+    const tiers = [...new Set(SERVICE_TIERS.map(s => s.tier))].sort((a, b) => a - b);
+
+    let allSucceeded = true;
+
+    for (const tier of tiers) {
+      const tierServices = SERVICE_TIERS.filter(s => s.tier === tier);
+
+      // Restart all services in same tier sequentially
+      for (const service of tierServices) {
+        setProgress(prev =>
+          prev.map(p => (p.id === service.id ? { ...p, status: 'restarting' } : p))
+        );
+
+        try {
+          const result = await api.admin.restartService(service.id);
+          setProgress(prev =>
+            prev.map(p =>
+              p.id === service.id ? { ...p, status: 'done', message: result.message } : p
+            )
+          );
+        } catch (err) {
+          const message = err instanceof Error ? err.message : 'Unknown error';
+          setProgress(prev =>
+            prev.map(p => (p.id === service.id ? { ...p, status: 'failed', message } : p))
+          );
+          allSucceeded = false;
+          // Continue with remaining services even if one fails
+        }
+
+        // Brief delay between services in same tier
+        await new Promise(resolve => setTimeout(resolve, 1000));
+      }
+    }
+
+    setIsRestarting(false);
+
+    toast({
+      title: allSucceeded ? 'All services restarted' : 'Restart completed with errors',
+      description: allSucceeded
+        ? 'All services have been restarted in dependency order.'
+        : 'Some services failed to restart. Check the progress panel.',
+      variant: allSucceeded ? 'default' : 'destructive',
+    });
+  }, [toast]);
+
+  return (
+    <section
+      data-testid="restart-all-panel"
+      className="rounded-xl border bg-white/70 p-6 backdrop-blur-md dark:bg-zinc-900/70"
+    >
+      {/* Header */}
+      <div className="mb-5 flex items-center gap-3">
+        <div className="flex h-9 w-9 items-center justify-center rounded-lg bg-destructive/10 dark:bg-destructive/20">
+          <Shield className="h-5 w-5 text-destructive" />
+        </div>
+        <div className="flex items-center gap-2">
+          <h2 className="text-lg font-semibold text-foreground">Restart All Services</h2>
+          <Badge
+            data-testid="superadmin-badge"
+            variant="destructive"
+            className="text-[10px] uppercase tracking-wider"
+          >
+            SuperAdmin
+          </Badge>
+        </div>
+      </div>
+
+      <p className="mb-4 text-sm text-muted-foreground">
+        Restarts all services in dependency order: AI services first, then the API. Each tier waits
+        for the previous to complete.
+      </p>
+
+      {/* Progress */}
+      {progress.length > 0 && (
+        <div className="mb-4 space-y-2" data-testid="restart-progress">
+          {progress.map(service => (
+            <ServiceProgressRow key={service.id} service={service} />
+          ))}
+        </div>
+      )}
+
+      {/* Confirmation */}
+      {showConfirm && !isRestarting && (
+        <div
+          data-testid="restart-all-confirm"
+          className="mb-4 rounded-lg border border-destructive/30 bg-destructive/5 p-4 dark:border-destructive/40 dark:bg-destructive/10"
+        >
+          <div className="mb-3 flex items-center gap-2 text-sm font-semibold text-destructive">
+            <AlertTriangle className="h-4 w-4" />
+            <span>Level 2 Confirmation Required</span>
+          </div>
+
+          <p className="mb-3 text-sm text-muted-foreground">
+            Type{' '}
+            <code className="rounded bg-muted px-1.5 py-0.5 font-mono text-xs font-bold text-foreground">
+              RESTART ALL
+            </code>{' '}
+            to confirm restarting all services.
+          </p>
+
+          <input
+            data-testid="restart-all-confirm-input"
+            type="text"
+            value={confirmText}
+            onChange={e => setConfirmText(e.target.value)}
+            placeholder='Type "RESTART ALL" to confirm'
+            className={cn(
+              'mb-3 w-full rounded-md border bg-background px-3 py-2 text-sm outline-none transition-colors',
+              'placeholder:text-muted-foreground/60',
+              'focus:border-destructive/50 focus:ring-1 focus:ring-destructive/30',
+              isConfirmMatch &&
+                'border-green-500/50 focus:border-green-500/50 focus:ring-green-500/30'
+            )}
+            onKeyDown={e => {
+              if (e.key === 'Enter' && isConfirmMatch) {
+                executeRestartAll();
+              }
+              if (e.key === 'Escape') {
+                setShowConfirm(false);
+                setConfirmText('');
+              }
+            }}
+          />
+
+          <div className="flex items-center gap-2">
+            <Button
+              data-testid="restart-all-cancel"
+              variant="ghost"
+              size="sm"
+              onClick={() => {
+                setShowConfirm(false);
+                setConfirmText('');
+              }}
+            >
+              <X className="mr-1 h-3 w-3" />
+              Cancel
+            </Button>
+            <Button
+              data-testid="restart-all-execute"
+              variant="destructive"
+              size="sm"
+              disabled={!isConfirmMatch}
+              onClick={executeRestartAll}
+            >
+              <RefreshCw className="mr-1 h-3 w-3" />
+              Confirm Restart All
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {/* Action button */}
+      {!showConfirm && !isRestarting && (
+        <Button
+          data-testid="restart-all-btn"
+          variant="destructive"
+          onClick={() => setShowConfirm(true)}
+          className="gap-1.5"
+        >
+          <RefreshCw className="h-4 w-4" />
+          Restart All Services
+        </Button>
+      )}
+
+      {isRestarting && (
+        <div className="flex items-center gap-2 text-sm text-muted-foreground">
+          <Loader2 className="h-4 w-4 animate-spin" />
+          <span>Restarting services in dependency order...</span>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/apps/web/src/app/admin/(dashboard)/monitor/containers/__tests__/ContainerDashboard.test.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/containers/__tests__/ContainerDashboard.test.tsx
@@ -1,0 +1,185 @@
+/**
+ * ContainerDashboard Component Tests
+ * Issue #144 — Container Management tests
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+const mockGetDockerContainers = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    admin: {
+      getDockerContainers: mockGetDockerContainers,
+    },
+  },
+}));
+
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
+import { ContainerDashboard } from '../ContainerDashboard';
+
+const mockContainers = [
+  {
+    id: 'abc123',
+    name: 'meepleai-api',
+    image: 'meepleai-api:latest',
+    state: 'running',
+    status: 'Up 2 hours',
+    created: new Date(Date.now() - 2 * 60 * 60 * 1000).toISOString(),
+    labels: {},
+  },
+  {
+    id: 'def456',
+    name: 'meepleai-postgres',
+    image: 'pgvector/pgvector:pg16',
+    state: 'running',
+    status: 'Up 5 hours',
+    created: new Date(Date.now() - 5 * 60 * 60 * 1000).toISOString(),
+    labels: {},
+  },
+  {
+    id: 'ghi789',
+    name: 'meepleai-redis',
+    image: 'redis:7-alpine',
+    state: 'exited',
+    status: 'Exited (0) 1 hour ago',
+    created: new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString(),
+    labels: {},
+  },
+];
+
+describe('ContainerDashboard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('shows loading state initially', () => {
+    mockGetDockerContainers.mockReturnValue(new Promise(() => {}));
+    render(<ContainerDashboard />);
+
+    expect(screen.getByTestId('container-loading')).toBeInTheDocument();
+  });
+
+  it('shows empty state when no containers', async () => {
+    mockGetDockerContainers.mockResolvedValue([]);
+    render(<ContainerDashboard />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('container-empty')).toBeInTheDocument();
+    });
+  });
+
+  it('renders container grid with cards', async () => {
+    mockGetDockerContainers.mockResolvedValue(mockContainers);
+    render(<ContainerDashboard />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('container-grid')).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId('container-card-abc123')).toBeInTheDocument();
+    expect(screen.getByTestId('container-card-def456')).toBeInTheDocument();
+    expect(screen.getByTestId('container-card-ghi789')).toBeInTheDocument();
+  });
+
+  it('displays status summary with correct counts', async () => {
+    mockGetDockerContainers.mockResolvedValue(mockContainers);
+    render(<ContainerDashboard />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('status-summary')).toBeInTheDocument();
+    });
+
+    // 3 total, 2 running, 1 stopped
+    expect(screen.getByText('3')).toBeInTheDocument();
+    expect(screen.getByText('2')).toBeInTheDocument();
+    expect(screen.getByText('1')).toBeInTheDocument();
+  });
+
+  it('shows container name and image in cards', async () => {
+    mockGetDockerContainers.mockResolvedValue(mockContainers);
+    render(<ContainerDashboard />);
+
+    await waitFor(() => {
+      expect(screen.getByText('meepleai-api')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('meepleai-api:latest')).toBeInTheDocument();
+    expect(screen.getByText('meepleai-postgres')).toBeInTheDocument();
+  });
+
+  it('shows status badges for each container', async () => {
+    mockGetDockerContainers.mockResolvedValue(mockContainers);
+    render(<ContainerDashboard />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('container-grid')).toBeInTheDocument();
+    });
+
+    const badges = screen.getAllByTestId('container-status-badge');
+    expect(badges.length).toBe(3);
+  });
+
+  it('has View Logs link for each container', async () => {
+    mockGetDockerContainers.mockResolvedValue(mockContainers);
+    render(<ContainerDashboard />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('view-logs-abc123')).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId('view-logs-abc123')).toHaveAttribute('href', '/admin/monitor/logs');
+  });
+
+  it('auto-refresh controls are visible', async () => {
+    mockGetDockerContainers.mockResolvedValue(mockContainers);
+    render(<ContainerDashboard />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('auto-refresh-controls')).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId('auto-refresh-toggle')).toBeInTheDocument();
+    expect(screen.getByTestId('refresh-interval-select')).toBeInTheDocument();
+    expect(screen.getByTestId('countdown')).toBeInTheDocument();
+  });
+
+  it('toggles auto-refresh on button click', async () => {
+    const user = userEvent.setup();
+    mockGetDockerContainers.mockResolvedValue(mockContainers);
+    render(<ContainerDashboard />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('auto-refresh-toggle')).toBeInTheDocument();
+    });
+
+    // Initially auto-refresh is on, shows "Pause"
+    expect(screen.getByText('Pause')).toBeInTheDocument();
+
+    await user.click(screen.getByTestId('auto-refresh-toggle'));
+
+    expect(screen.getByText('Resume')).toBeInTheDocument();
+  });
+
+  it('manual refresh button fetches containers', async () => {
+    const user = userEvent.setup();
+    mockGetDockerContainers.mockResolvedValue(mockContainers);
+    render(<ContainerDashboard />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('manual-refresh')).toBeInTheDocument();
+    });
+
+    const callsBefore = mockGetDockerContainers.mock.calls.length;
+    await user.click(screen.getByTestId('manual-refresh'));
+
+    await waitFor(() => {
+      expect(mockGetDockerContainers.mock.calls.length).toBeGreaterThan(callsBefore);
+    });
+  });
+});

--- a/apps/web/src/app/admin/(dashboard)/monitor/containers/__tests__/RestartAllPanel.test.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/containers/__tests__/RestartAllPanel.test.tsx
@@ -1,0 +1,152 @@
+/**
+ * RestartAllPanel Component Tests
+ * Issue #144 — Container Management tests (Restart All #145)
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+const mockRestartService = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    admin: {
+      restartService: mockRestartService,
+    },
+  },
+}));
+
+const mockToast = vi.hoisted(() => vi.fn());
+
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast: mockToast }),
+}));
+
+import { RestartAllPanel } from '../RestartAllPanel';
+
+describe('RestartAllPanel', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders panel with restart button', () => {
+    render(<RestartAllPanel />);
+
+    expect(screen.getByTestId('restart-all-panel')).toBeInTheDocument();
+    expect(screen.getByTestId('restart-all-btn')).toBeInTheDocument();
+    expect(screen.getByText('Restart All Services', { selector: 'h2' })).toBeInTheDocument();
+  });
+
+  it('shows SuperAdmin badge', () => {
+    render(<RestartAllPanel />);
+
+    expect(screen.getByTestId('superadmin-badge')).toBeInTheDocument();
+  });
+
+  it('shows confirmation dialog on button click', async () => {
+    const user = userEvent.setup();
+    render(<RestartAllPanel />);
+
+    await user.click(screen.getByTestId('restart-all-btn'));
+
+    expect(screen.getByTestId('restart-all-confirm')).toBeInTheDocument();
+    expect(screen.getByTestId('restart-all-confirm-input')).toBeInTheDocument();
+  });
+
+  it('confirm button is disabled until correct text entered', async () => {
+    const user = userEvent.setup();
+    render(<RestartAllPanel />);
+
+    await user.click(screen.getByTestId('restart-all-btn'));
+
+    const executeBtn = screen.getByTestId('restart-all-execute');
+    expect(executeBtn).toBeDisabled();
+
+    await user.type(screen.getByTestId('restart-all-confirm-input'), 'RESTART ALL');
+
+    expect(executeBtn).not.toBeDisabled();
+  });
+
+  it('cancel button hides confirmation dialog', async () => {
+    const user = userEvent.setup();
+    render(<RestartAllPanel />);
+
+    await user.click(screen.getByTestId('restart-all-btn'));
+    expect(screen.getByTestId('restart-all-confirm')).toBeInTheDocument();
+
+    await user.click(screen.getByTestId('restart-all-cancel'));
+    expect(screen.queryByTestId('restart-all-confirm')).not.toBeInTheDocument();
+  });
+
+  it('executes restart all in dependency order', async () => {
+    const user = userEvent.setup();
+    mockRestartService.mockResolvedValue({ message: 'Restarted', estimatedDowntime: '10s' });
+    render(<RestartAllPanel />);
+
+    await user.click(screen.getByTestId('restart-all-btn'));
+    await user.type(screen.getByTestId('restart-all-confirm-input'), 'RESTART ALL');
+    await user.click(screen.getByTestId('restart-all-execute'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('restart-progress')).toBeInTheDocument();
+    });
+
+    // Should call restartService for each service
+    await waitFor(
+      () => {
+        expect(mockRestartService).toHaveBeenCalledTimes(5);
+      },
+      { timeout: 10000 }
+    );
+
+    // Verify services were called
+    expect(mockRestartService).toHaveBeenCalledWith('embedding-service');
+    expect(mockRestartService).toHaveBeenCalledWith('reranker-service');
+    expect(mockRestartService).toHaveBeenCalledWith('api');
+  });
+
+  it('shows toast on successful restart', async () => {
+    const user = userEvent.setup();
+    mockRestartService.mockResolvedValue({ message: 'Restarted', estimatedDowntime: '10s' });
+    render(<RestartAllPanel />);
+
+    await user.click(screen.getByTestId('restart-all-btn'));
+    await user.type(screen.getByTestId('restart-all-confirm-input'), 'RESTART ALL');
+    await user.click(screen.getByTestId('restart-all-execute'));
+
+    await waitFor(
+      () => {
+        expect(mockToast).toHaveBeenCalledWith(
+          expect.objectContaining({ title: 'All services restarted' })
+        );
+      },
+      { timeout: 10000 }
+    );
+  });
+
+  it('handles partial failure gracefully', async () => {
+    const user = userEvent.setup();
+    mockRestartService
+      .mockResolvedValueOnce({ message: 'OK', estimatedDowntime: '5s' })
+      .mockRejectedValueOnce(new Error('Connection refused'))
+      .mockResolvedValueOnce({ message: 'OK', estimatedDowntime: '5s' })
+      .mockResolvedValueOnce({ message: 'OK', estimatedDowntime: '5s' })
+      .mockResolvedValueOnce({ message: 'OK', estimatedDowntime: '5s' });
+
+    render(<RestartAllPanel />);
+
+    await user.click(screen.getByTestId('restart-all-btn'));
+    await user.type(screen.getByTestId('restart-all-confirm-input'), 'RESTART ALL');
+    await user.click(screen.getByTestId('restart-all-execute'));
+
+    await waitFor(
+      () => {
+        expect(mockToast).toHaveBeenCalledWith(
+          expect.objectContaining({ title: 'Restart completed with errors' })
+        );
+      },
+      { timeout: 10000 }
+    );
+  });
+});

--- a/apps/web/src/app/admin/(dashboard)/monitor/containers/__tests__/page.test.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/containers/__tests__/page.test.tsx
@@ -1,0 +1,51 @@
+/**
+ * Container Dashboard Page Tests
+ * Issue #144 — Container Management tests
+ */
+
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+vi.mock('@/hooks/useSetNavConfig', () => ({
+  useSetNavConfig: () => vi.fn(),
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ refresh: vi.fn() }),
+}));
+
+const mockGetDockerContainers = vi.hoisted(() => vi.fn());
+const mockRestartService = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    admin: {
+      getDockerContainers: mockGetDockerContainers,
+      restartService: mockRestartService,
+    },
+  },
+}));
+
+vi.mock('@/hooks/use-toast', () => ({
+  useToast: () => ({ toast: vi.fn() }),
+}));
+
+import ContainerDashboardPage from '../page';
+
+describe('ContainerDashboardPage', () => {
+  it('renders page with title', () => {
+    mockGetDockerContainers.mockReturnValue(new Promise(() => {}));
+    render(<ContainerDashboardPage />);
+
+    expect(screen.getByTestId('containers-page')).toBeInTheDocument();
+    expect(screen.getByText('Container Dashboard')).toBeInTheDocument();
+  });
+
+  it('renders container dashboard and restart panel', () => {
+    mockGetDockerContainers.mockReturnValue(new Promise(() => {}));
+    render(<ContainerDashboardPage />);
+
+    expect(screen.getByTestId('container-dashboard')).toBeInTheDocument();
+    expect(screen.getByTestId('restart-all-panel')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/app/admin/(dashboard)/monitor/containers/page.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/containers/page.tsx
@@ -1,0 +1,31 @@
+'use client';
+
+/**
+ * Container Dashboard Page — Admin Infrastructure Panel Phase 4
+ * Issue #143
+ */
+
+import { ContainerDashboard } from './ContainerDashboard';
+import { ContainersNavConfig } from './NavConfig';
+import { RestartAllPanel } from './RestartAllPanel';
+
+export default function ContainerDashboardPage() {
+  return (
+    <div data-testid="containers-page" className="space-y-6">
+      <ContainersNavConfig />
+      <div>
+        <h1 className="font-quicksand text-xl sm:text-2xl font-bold tracking-tight text-foreground">
+          Container Dashboard
+        </h1>
+        <p className="mt-0.5 text-sm text-muted-foreground">
+          Docker container status, metrics, and management controls.
+        </p>
+      </div>
+
+      <ContainerDashboard />
+
+      {/* Issue #145: Restart All with dependency-ordered restart */}
+      <RestartAllPanel />
+    </div>
+  );
+}

--- a/apps/web/src/config/admin-dashboard-navigation.ts
+++ b/apps/web/src/config/admin-dashboard-navigation.ts
@@ -48,6 +48,7 @@ import {
   ScrollTextIcon,
   HeartPulseIcon,
   BarChart3Icon,
+  BoxIcon,
 } from 'lucide-react';
 
 // ─── Types ───────────────────────────────────────────────────────────────────
@@ -363,6 +364,20 @@ export const DASHBOARD_SECTIONS: DashboardSection[] = [
         label: 'Grafana',
         icon: BarChart3Icon,
         activePattern: /^\/admin\/monitor\/grafana/,
+      },
+      // Log Viewer (Issue #140)
+      {
+        href: '/admin/monitor/logs',
+        label: 'Logs',
+        icon: ScrollTextIcon,
+        activePattern: /^\/admin\/monitor\/logs/,
+      },
+      // Container Dashboard (Issue #143)
+      {
+        href: '/admin/monitor/containers',
+        label: 'Containers',
+        icon: BoxIcon,
+        activePattern: /^\/admin\/monitor\/containers/,
       },
       // Config items
       {


### PR DESCRIPTION
## Summary
- **Container Dashboard page** (`/admin/monitor/containers`) with responsive grid layout, status summary (total/running/stopped), auto-refresh (15/30/60s), container cards with status badges and uptime
- **Restart All panel** with dependency-ordered sequential restart (AI services → API), Level 2 confirmation, per-service progress tracking
- **Navigation entries** for Logs and Containers in admin sidebar
- **20 tests** covering dashboard rendering, auto-refresh, restart flow, confirmation dialog, and error handling

## Issues
Closes #143 (Container Dashboard), #144 (Container Management tests), #145 (Restart All)

## Test plan
- [ ] Verify container dashboard loads and shows container cards
- [ ] Verify auto-refresh toggles and countdown works
- [ ] Verify Restart All requires typing "RESTART ALL" to proceed
- [ ] Verify partial restart failure shows error toast
- [ ] Run `pnpm test` — 20/20 pass
- [ ] Run `pnpm build` — compiles clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
