### PR TITLE
fix(admin): polish Container Dashboard — autoFocus, uptime, tests

### DIFF
--- a/apps/web/src/app/admin/(dashboard)/monitor/containers/ContainerDashboard.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/containers/ContainerDashboard.tsx
@@ -46,8 +46,9 @@ function ContainerStatusBadge({ state }: { state: string }) {
   );
 }
 
-function formatUptime(created: string): string {
-  const diff = Date.now() - new Date(created).getTime();
+function formatUptime(container: ContainerInfo): string {
+  if (container.state !== 'running') return '—';
+  const diff = Date.now() - new Date(container.created).getTime();
   const hours = Math.floor(diff / (1000 * 60 * 60));
   const days = Math.floor(hours / 24);
 
@@ -87,7 +88,7 @@ function ContainerCard({ container }: ContainerCardProps) {
         <div className="rounded-lg bg-muted/50 px-2.5 py-1.5">
           <p className="text-[10px] uppercase tracking-wider text-muted-foreground">Uptime</p>
           <p className="text-xs font-medium" data-testid="container-uptime">
-            {formatUptime(container.created)}
+            {formatUptime(container)}
           </p>
         </div>
       </div>

--- a/apps/web/src/app/admin/(dashboard)/monitor/containers/RestartAllPanel.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/containers/RestartAllPanel.tsx
@@ -227,6 +227,7 @@ export function RestartAllPanel() {
           </p>
 
           <input
+            autoFocus
             data-testid="restart-all-confirm-input"
             type="text"
             value={confirmText}

--- a/apps/web/src/app/admin/(dashboard)/monitor/containers/__tests__/ContainerDashboard.test.tsx
+++ b/apps/web/src/app/admin/(dashboard)/monitor/containers/__tests__/ContainerDashboard.test.tsx
@@ -166,6 +166,19 @@ describe('ContainerDashboard', () => {
     expect(screen.getByText('Resume')).toBeInTheDocument();
   });
 
+  it('shows dash for uptime of stopped containers', async () => {
+    mockGetDockerContainers.mockResolvedValue(mockContainers);
+    render(<ContainerDashboard />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('container-card-ghi789')).toBeInTheDocument();
+    });
+
+    const stoppedCard = screen.getByTestId('container-card-ghi789');
+    const uptimeEl = stoppedCard.querySelector('[data-testid="container-uptime"]');
+    expect(uptimeEl).toHaveTextContent('—');
+  });
+
   it('manual refresh button fetches containers', async () => {
     const user = userEvent.setup();
     mockGetDockerContainers.mockResolvedValue(mockContainers);


### PR DESCRIPTION
## Summary
- Add `autoFocus` to RestartAllPanel confirmation input for UX consistency with peer `RestartServicePanel`
- Fix `formatUptime` to show '—' for non-running containers instead of misleading creation-based uptime
- Add test for stopped-container uptime display (21 tests total, all passing)

## Test plan
- [x] All 21 container dashboard tests pass (ContainerDashboard: 11, RestartAllPanel: 8, page: 2)
- [x] Frontend build verified (Next.js 16.1.6 Turbopack)
- [x] Stopped container card shows '—' for uptime
- [x] Confirmation input auto-focuses when dialog opens

🤖 Generated with [Claude Code](https://claude.com/claude-code)