### PR TITLE
feat(seeding): layered seeding architecture (Epic #318)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/Administration/Infrastructure/DependencyInjection/AdministrationServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Infrastructure/DependencyInjection/AdministrationServiceExtensions.cs
@@ -9,6 +9,9 @@ using Api.BoundedContexts.Administration.Infrastructure.Repositories;
 using Api.BoundedContexts.Administration.Infrastructure.Scheduling;
 using Api.BoundedContexts.Administration.Infrastructure.Services;
 using Api.Infrastructure.Seeders;
+using Api.Infrastructure.Seeders.Catalog;
+using Api.Infrastructure.Seeders.Core;
+using Api.Infrastructure.Seeders.LivedIn;
 using Api.SharedKernel.Infrastructure.Persistence;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
@@ -89,13 +92,13 @@ internal static class AdministrationServiceExtensions
         services.AddScoped<ILighthouseReportParserService, LighthouseReportParserService>();
         services.AddScoped<IPlaywrightReportParserService, PlaywrightReportParserService>();
 
-        // Seeding orchestrator (replaces legacy AutoConfigurationService)
-        var seedProfile = Enum.TryParse<SeedProfile>(
-            configuration["SEED_PROFILE"] ?? "dev",
-            ignoreCase: true,
-            out var parsed) ? parsed : SeedProfile.Dev;
-        services.AddSingleton(typeof(SeedProfile), seedProfile);
-        services.AddSingleton<SeedOrchestrator>();
+        // ISSUE-2512: AutoConfigurationService removed — replaced by SeedOrchestrator (Epic #318)
+
+        // Epic #318: Layered seeding system
+        services.AddScoped<ISeedLayer, CoreSeedLayer>();
+        services.AddScoped<ISeedLayer, CatalogSeedLayer>();
+        services.AddScoped<ISeedLayer, LivedInSeedLayer>();
+        services.AddScoped<SeedOrchestrator>();
 
         // Issue #3916: AI insights service for personalized dashboard recommendations
         services.AddScoped<IAiInsightsService, AiInsightsService>();

--- a/apps/api/src/Api/Infrastructure/Seeders/AdvisoryLockHelper.cs
+++ b/apps/api/src/Api/Infrastructure/Seeders/AdvisoryLockHelper.cs
@@ -5,27 +5,35 @@ namespace Api.Infrastructure.Seeders;
 
 /// <summary>
 /// PostgreSQL advisory lock wrapper for safe multi-replica seeding.
-/// Uses session-level advisory locks (released on disconnect).
+/// Uses non-blocking try-lock: if another replica holds the lock, this one skips.
 /// </summary>
 internal static class AdvisoryLockHelper
 {
     /// <summary>
-    /// Deterministic lock key derived from "MeepleAI_Seeding" hash.
-    /// All replicas must use the same key.
+    /// Lock key matching the original SeedOrchestrator constant ("MeepleAI" as long).
+    /// Must remain stable across deployments for rolling-update safety.
     /// </summary>
-    public static long SeedingLockKey { get; } = GetDeterministicHashCode("MeepleAI_Seeding");
-
-    public static string AcquireLockSql => $"SELECT pg_advisory_lock({SeedingLockKey})";
-    public static string ReleaseLockSql => $"SELECT pg_advisory_unlock({SeedingLockKey})";
+    public const long SeedingLockKey = 0x4D65_6570_6C65_4149;
 
     /// <summary>
-    /// Acquires the advisory lock. Blocks until the lock is available.
+    /// Attempts to acquire the advisory lock without blocking.
+    /// Returns true if acquired, false if another replica holds it.
     /// </summary>
-    public static async Task AcquireAsync(MeepleAiDbContext db, ILogger logger, CancellationToken ct = default)
+    public static async Task<bool> TryAcquireAsync(MeepleAiDbContext db, ILogger logger, CancellationToken ct = default)
     {
-        logger.LogInformation("Acquiring seeding advisory lock (key={LockKey})...", SeedingLockKey);
-        await db.Database.ExecuteSqlRawAsync(AcquireLockSql, ct).ConfigureAwait(false);
-        logger.LogInformation("Seeding advisory lock acquired");
+        logger.LogInformation("Attempting seeding advisory lock (key={LockKey})...", SeedingLockKey);
+
+        var acquired = await db.Database
+            .SqlQueryRaw<bool>($"SELECT pg_try_advisory_lock({SeedingLockKey}) AS \"Value\"")
+            .FirstOrDefaultAsync(ct)
+            .ConfigureAwait(false);
+
+        if (acquired)
+            logger.LogInformation("Seeding advisory lock acquired");
+        else
+            logger.LogInformation("Another replica holds the seeding lock — skipping");
+
+        return acquired;
     }
 
     /// <summary>
@@ -33,23 +41,9 @@ internal static class AdvisoryLockHelper
     /// </summary>
     public static async Task ReleaseAsync(MeepleAiDbContext db, ILogger logger, CancellationToken ct = default)
     {
-        await db.Database.ExecuteSqlRawAsync(ReleaseLockSql, ct).ConfigureAwait(false);
+        await db.Database
+            .ExecuteSqlRawAsync($"SELECT pg_advisory_unlock({SeedingLockKey})", ct)
+            .ConfigureAwait(false);
         logger.LogInformation("Seeding advisory lock released");
-    }
-
-    /// <summary>
-    /// Deterministic hash code that doesn't change across app restarts (.NET randomizes GetHashCode).
-    /// </summary>
-    private static long GetDeterministicHashCode(string str)
-    {
-        unchecked
-        {
-            long hash = 5381;
-            foreach (var c in str)
-            {
-                hash = ((hash << 5) + hash) ^ c;
-            }
-            return hash;
-        }
     }
 }

--- a/apps/api/src/Api/Infrastructure/Seeders/AdvisoryLockHelper.cs
+++ b/apps/api/src/Api/Infrastructure/Seeders/AdvisoryLockHelper.cs
@@ -1,0 +1,55 @@
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Api.Infrastructure.Seeders;
+
+/// <summary>
+/// PostgreSQL advisory lock wrapper for safe multi-replica seeding.
+/// Uses session-level advisory locks (released on disconnect).
+/// </summary>
+internal static class AdvisoryLockHelper
+{
+    /// <summary>
+    /// Deterministic lock key derived from "MeepleAI_Seeding" hash.
+    /// All replicas must use the same key.
+    /// </summary>
+    public static long SeedingLockKey { get; } = GetDeterministicHashCode("MeepleAI_Seeding");
+
+    public static string AcquireLockSql => $"SELECT pg_advisory_lock({SeedingLockKey})";
+    public static string ReleaseLockSql => $"SELECT pg_advisory_unlock({SeedingLockKey})";
+
+    /// <summary>
+    /// Acquires the advisory lock. Blocks until the lock is available.
+    /// </summary>
+    public static async Task AcquireAsync(MeepleAiDbContext db, ILogger logger, CancellationToken ct = default)
+    {
+        logger.LogInformation("Acquiring seeding advisory lock (key={LockKey})...", SeedingLockKey);
+        await db.Database.ExecuteSqlRawAsync(AcquireLockSql, ct).ConfigureAwait(false);
+        logger.LogInformation("Seeding advisory lock acquired");
+    }
+
+    /// <summary>
+    /// Releases the advisory lock.
+    /// </summary>
+    public static async Task ReleaseAsync(MeepleAiDbContext db, ILogger logger, CancellationToken ct = default)
+    {
+        await db.Database.ExecuteSqlRawAsync(ReleaseLockSql, ct).ConfigureAwait(false);
+        logger.LogInformation("Seeding advisory lock released");
+    }
+
+    /// <summary>
+    /// Deterministic hash code that doesn't change across app restarts (.NET randomizes GetHashCode).
+    /// </summary>
+    private static long GetDeterministicHashCode(string str)
+    {
+        unchecked
+        {
+            long hash = 5381;
+            foreach (var c in str)
+            {
+                hash = ((hash << 5) + hash) ^ c;
+            }
+            return hash;
+        }
+    }
+}

--- a/apps/api/src/Api/Infrastructure/Seeders/Catalog/CatalogSeedLayer.cs
+++ b/apps/api/src/Api/Infrastructure/Seeders/Catalog/CatalogSeedLayer.cs
@@ -1,0 +1,33 @@
+using Api.Services;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Api.Infrastructure.Seeders.Catalog;
+
+/// <summary>
+/// Catalog seed layer: shared games (BGG), PDFs, agents, strategy patterns.
+/// Delegates to CatalogSeeder which orchestrates manifest-driven seeding.
+/// Runs in Staging and Dev profiles.
+/// </summary>
+internal sealed class CatalogSeedLayer : ISeedLayer
+{
+    public string Name => "Catalog";
+    public SeedProfile MinimumProfile => SeedProfile.Staging;
+
+    public async Task SeedAsync(SeedContext context, CancellationToken cancellationToken = default)
+    {
+        var config = context.Services.GetService<IConfiguration>();
+        var bggService = context.Services.GetRequiredService<IBggApiService>();
+        var embeddingService = context.Services.GetService<IEmbeddingService>();
+
+        await CatalogSeeder.SeedAsync(
+            context.Profile,
+            context.DbContext,
+            bggService,
+            context.SystemUserId,
+            context.Logger, cancellationToken,
+            embeddingService,
+            config).ConfigureAwait(false);
+    }
+}

--- a/apps/api/src/Api/Infrastructure/Seeders/Catalog/SeedManifestLoader.cs
+++ b/apps/api/src/Api/Infrastructure/Seeders/Catalog/SeedManifestLoader.cs
@@ -1,0 +1,68 @@
+using Microsoft.Extensions.Logging;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace Api.Infrastructure.Seeders.Catalog;
+
+/// <summary>
+/// Loads and validates YAML seed manifests from data/seed-manifests/.
+/// </summary>
+internal static class SeedManifestLoader
+{
+    private static readonly IDeserializer Deserializer = new DeserializerBuilder()
+        .WithNamingConvention(CamelCaseNamingConvention.Instance)
+        .IgnoreUnmatchedProperties()
+        .Build();
+
+    /// <summary>
+    /// Load manifest from a YAML string.
+    /// </summary>
+    public static SharedGamesManifest LoadFromString(string yaml)
+    {
+        return Deserializer.Deserialize<SharedGamesManifest>(yaml) ?? new SharedGamesManifest();
+    }
+
+    /// <summary>
+    /// Load manifest from a file path.
+    /// </summary>
+    public static SharedGamesManifest LoadFromFile(string filePath, ILogger logger)
+    {
+        if (!File.Exists(filePath))
+        {
+            logger.LogWarning("Seed manifest not found: {Path}", filePath);
+            return new SharedGamesManifest();
+        }
+
+        var yaml = File.ReadAllText(filePath);
+        var manifest = LoadFromString(yaml);
+
+        logger.LogInformation("Loaded seed manifest: {Path} ({Count} games)", filePath, manifest.Games.Count);
+        return manifest;
+    }
+
+    /// <summary>
+    /// Validate manifest entries. Returns list of error messages (empty = valid).
+    /// </summary>
+    public static IReadOnlyList<string> Validate(SharedGamesManifest manifest)
+    {
+        var errors = new List<string>();
+
+        for (var i = 0; i < manifest.Games.Count; i++)
+        {
+            var game = manifest.Games[i];
+            if (string.IsNullOrWhiteSpace(game.Title))
+                errors.Add($"Game at index {i} has empty title");
+        }
+
+        var duplicates = manifest.Games
+            .Where(g => !string.IsNullOrWhiteSpace(g.Title))
+            .GroupBy(g => g.Title, StringComparer.OrdinalIgnoreCase)
+            .Where(g => g.Count() > 1)
+            .Select(g => g.Key);
+
+        foreach (var dup in duplicates)
+            errors.Add($"Duplicate game title: '{dup}'");
+
+        return errors;
+    }
+}

--- a/apps/api/src/Api/Infrastructure/Seeders/Catalog/SeedManifestModels.cs
+++ b/apps/api/src/Api/Infrastructure/Seeders/Catalog/SeedManifestModels.cs
@@ -1,0 +1,22 @@
+namespace Api.Infrastructure.Seeders.Catalog;
+
+/// <summary>
+/// Root model for shared-games.yaml manifest.
+/// </summary>
+public sealed class SharedGamesManifest
+{
+    public List<GameManifestEntry> Games { get; set; } = [];
+}
+
+/// <summary>
+/// A single game entry in the seed manifest.
+/// </summary>
+public sealed class GameManifestEntry
+{
+    public string Title { get; set; } = string.Empty;
+    public int? BggId { get; set; }
+    public string Language { get; set; } = "en";
+    public string? PdfFile { get; set; }
+    public string? ImageUrl { get; set; }
+    public string? ThumbnailUrl { get; set; }
+}

--- a/apps/api/src/Api/Infrastructure/Seeders/Core/CoreSeedLayer.cs
+++ b/apps/api/src/Api/Infrastructure/Seeders/Core/CoreSeedLayer.cs
@@ -1,0 +1,38 @@
+using Api.BoundedContexts.Administration.Application.Commands;
+using Api.BoundedContexts.KnowledgeBase.Application.Commands;
+using Api.BoundedContexts.SystemConfiguration.Application.Commands;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+
+namespace Api.Infrastructure.Seeders.Core;
+
+/// <summary>
+/// Core seed layer: admin user, test user, E2E users, AI models, agent definitions.
+/// Runs in all profiles (Prod, Staging, Dev).
+/// </summary>
+internal sealed class CoreSeedLayer : ISeedLayer
+{
+    public string Name => "Core";
+    public SeedProfile MinimumProfile => SeedProfile.Prod;
+
+    public async Task SeedAsync(SeedContext context, CancellationToken cancellationToken = default)
+    {
+        var mediator = context.Services.GetRequiredService<IMediator>();
+
+        context.Logger.LogInformation("[Core] Seeding admin user...");
+        await mediator.Send(new SeedAdminUserCommand(), cancellationToken).ConfigureAwait(false);
+
+        context.Logger.LogInformation("[Core] Seeding test user...");
+        await mediator.Send(new SeedTestUserCommand(), cancellationToken).ConfigureAwait(false);
+
+        context.Logger.LogInformation("[Core] Seeding E2E test users...");
+        await mediator.Send(new SeedE2ETestUsersCommand(), cancellationToken).ConfigureAwait(false);
+
+        context.Logger.LogInformation("[Core] Seeding AI models...");
+        await mediator.Send(new SeedAiModelsCommand(), cancellationToken).ConfigureAwait(false);
+
+        context.Logger.LogInformation("[Core] Seeding agent definitions...");
+        await mediator.Send(new SeedAgentDefinitionsCommand(), cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/apps/api/src/Api/Infrastructure/Seeders/ISeedLayer.cs
+++ b/apps/api/src/Api/Infrastructure/Seeders/ISeedLayer.cs
@@ -1,0 +1,17 @@
+namespace Api.Infrastructure.Seeders;
+
+/// <summary>
+/// A composable seed layer. Layers run in registration order.
+/// Each layer is idempotent — safe to re-run.
+/// </summary>
+public interface ISeedLayer
+{
+    /// <summary>Display name for logging.</summary>
+    string Name { get; }
+
+    /// <summary>Minimum profile required to run this layer.</summary>
+    SeedProfile MinimumProfile { get; }
+
+    /// <summary>Execute seeding logic.</summary>
+    Task SeedAsync(SeedContext context, CancellationToken cancellationToken = default);
+}

--- a/apps/api/src/Api/Infrastructure/Seeders/LivedIn/LivedInSeedLayer.cs
+++ b/apps/api/src/Api/Infrastructure/Seeders/LivedIn/LivedInSeedLayer.cs
@@ -1,0 +1,20 @@
+using Microsoft.Extensions.Logging;
+
+namespace Api.Infrastructure.Seeders.LivedIn;
+
+/// <summary>
+/// LivedIn seed layer: synthetic game sessions, activity data.
+/// Only runs in Dev profile for realistic development data.
+/// Currently a placeholder — will be expanded with synthetic data generators.
+/// </summary>
+internal sealed class LivedInSeedLayer : ISeedLayer
+{
+    public string Name => "LivedIn";
+    public SeedProfile MinimumProfile => SeedProfile.Dev;
+
+    public Task SeedAsync(SeedContext context, CancellationToken cancellationToken = default)
+    {
+        context.Logger.LogInformation("[LivedIn] Synthetic data seeding (placeholder — no-op)");
+        return Task.CompletedTask;
+    }
+}

--- a/apps/api/src/Api/Infrastructure/Seeders/SeedContext.cs
+++ b/apps/api/src/Api/Infrastructure/Seeders/SeedContext.cs
@@ -1,0 +1,13 @@
+using Microsoft.Extensions.Logging;
+
+namespace Api.Infrastructure.Seeders;
+
+/// <summary>
+/// Shared context passed to all seed layers.
+/// </summary>
+public sealed record SeedContext(
+    SeedProfile Profile,
+    MeepleAiDbContext DbContext,
+    IServiceProvider Services,
+    ILogger Logger,
+    Guid SystemUserId);

--- a/apps/api/src/Api/Infrastructure/Seeders/SeedOrchestrator.cs
+++ b/apps/api/src/Api/Infrastructure/Seeders/SeedOrchestrator.cs
@@ -7,18 +7,22 @@ namespace Api.Infrastructure.Seeders;
 
 /// <summary>
 /// Entry point for all seeding operations. Replaces AutoConfigurationService.
-/// Resolves profile, acquires advisory lock, runs ISeedLayer implementations in order.
+/// Resolves profile, acquires non-blocking advisory lock, runs ISeedLayer implementations in order.
+/// Clears ChangeTracker between layers to prevent entity leaks.
 /// </summary>
 internal sealed class SeedOrchestrator
 {
     private readonly IEnumerable<ISeedLayer> _layers;
+    private readonly IConfiguration _configuration;
     private readonly ILogger<SeedOrchestrator> _logger;
 
     public SeedOrchestrator(
         IEnumerable<ISeedLayer> layers,
+        IConfiguration configuration,
         ILogger<SeedOrchestrator> logger)
     {
         _layers = layers;
+        _configuration = configuration;
         _logger = logger;
     }
 
@@ -28,7 +32,7 @@ internal sealed class SeedOrchestrator
     /// </summary>
     public async Task RunAsync(MeepleAiDbContext db, IServiceProvider services, CancellationToken ct = default)
     {
-        var profile = ResolveProfile(services.GetService(typeof(IConfiguration)) as IConfiguration);
+        var profile = ResolveProfile(_configuration);
 
         if (profile == SeedProfile.None)
         {
@@ -39,21 +43,32 @@ internal sealed class SeedOrchestrator
         _logger.LogInformation("Seeding with profile: {Profile}", profile);
         var sw = Stopwatch.StartNew();
 
-        await AdvisoryLockHelper.AcquireAsync(db, _logger, ct).ConfigureAwait(false);
+        var lockAcquired = await AdvisoryLockHelper.TryAcquireAsync(db, _logger, ct).ConfigureAwait(false);
+        if (!lockAcquired)
+            return;
+
         try
         {
-            var adminUser = await db.Users
-                .FirstOrDefaultAsync(u => u.Role == "admin", ct)
-                .ConfigureAwait(false);
-            var systemUserId = adminUser?.Id ?? Guid.Empty;
+            var layers = FilterLayers(_layers, profile);
+            _logger.LogInformation("Running {Count} seed layer(s)", layers.Count);
 
-            var context = new SeedContext(profile, db, services, _logger, systemUserId);
+            // Resolve systemUserId — may be Guid.Empty on fresh DB before Core seeds admin
+            var systemUserId = await ResolveSystemUserIdAsync(db, ct).ConfigureAwait(false);
 
-            foreach (var layer in FilterLayers(_layers, profile))
+            foreach (var layer in layers)
             {
                 _logger.LogInformation("Running seed layer: {Layer} (min profile: {MinProfile})",
                     layer.Name, layer.MinimumProfile);
+
+                var context = new SeedContext(profile, db, services, _logger, systemUserId);
                 await layer.SeedAsync(context, ct).ConfigureAwait(false);
+
+                // Clear ChangeTracker between layers to prevent entity leaks
+                db.ChangeTracker.Clear();
+
+                // Re-resolve systemUserId after Core layer creates admin user
+                if (layer.MinimumProfile == SeedProfile.Prod)
+                    systemUserId = await ResolveSystemUserIdAsync(db, ct).ConfigureAwait(false);
             }
 
             _logger.LogInformation("Seeding completed in {Elapsed}ms", sw.ElapsedMilliseconds);
@@ -84,8 +99,17 @@ internal sealed class SeedOrchestrator
     }
 
     /// <summary>
-    /// Filter layers by profile ordinal: layer runs if MinimumProfile &lt;= active profile.
+    /// Filter layers by profile ordinal and materialize to list.
+    /// A layer runs if MinimumProfile &lt;= active profile.
     /// </summary>
-    internal static IEnumerable<ISeedLayer> FilterLayers(IEnumerable<ISeedLayer> layers, SeedProfile profile)
-        => layers.Where(l => l.MinimumProfile <= profile).OrderBy(l => l.MinimumProfile);
+    internal static IReadOnlyList<ISeedLayer> FilterLayers(IEnumerable<ISeedLayer> layers, SeedProfile profile)
+        => layers.Where(l => l.MinimumProfile <= profile).OrderBy(l => l.MinimumProfile).ToList();
+
+    private static async Task<Guid> ResolveSystemUserIdAsync(MeepleAiDbContext db, CancellationToken ct)
+    {
+        var adminUser = await db.Users
+            .FirstOrDefaultAsync(u => u.Role == "admin", ct)
+            .ConfigureAwait(false);
+        return adminUser?.Id ?? Guid.Empty;
+    }
 }

--- a/apps/api/src/Api/Infrastructure/Seeders/SeedOrchestrator.cs
+++ b/apps/api/src/Api/Infrastructure/Seeders/SeedOrchestrator.cs
@@ -1,131 +1,91 @@
 using System.Diagnostics;
-using Api.Services;
-using MediatR;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Configuration;
-using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 
 namespace Api.Infrastructure.Seeders;
 
 /// <summary>
 /// Entry point for all seeding operations. Replaces AutoConfigurationService.
-/// Creates isolated DI scopes per layer to prevent ChangeTracker leaks.
-/// Uses PostgreSQL advisory lock for multi-replica safety.
+/// Resolves profile, acquires advisory lock, runs ISeedLayer implementations in order.
 /// </summary>
 internal sealed class SeedOrchestrator
 {
-    private const long SeedingAdvisoryLockId = 0x4D65_6570_6C65_4149; // "MeepleAI" as long
-
-    private readonly SeedProfile _profile;
-    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly IEnumerable<ISeedLayer> _layers;
     private readonly ILogger<SeedOrchestrator> _logger;
 
     public SeedOrchestrator(
-        SeedProfile profile,
-        IServiceScopeFactory scopeFactory,
+        IEnumerable<ISeedLayer> layers,
         ILogger<SeedOrchestrator> logger)
     {
-        _profile = profile;
-        _scopeFactory = scopeFactory;
+        _layers = layers;
         _logger = logger;
     }
 
-    public async Task ExecuteAsync(CancellationToken ct)
+    /// <summary>
+    /// Run all applicable seed layers inside an advisory lock.
+    /// Called from Program.cs startup and the admin endpoint.
+    /// </summary>
+    public async Task RunAsync(MeepleAiDbContext db, IServiceProvider services, CancellationToken ct = default)
     {
-        if (_profile == SeedProfile.None)
+        var profile = ResolveProfile(services.GetService(typeof(IConfiguration)) as IConfiguration);
+
+        if (profile == SeedProfile.None)
         {
-            _logger.LogInformation("Seed profile is None - skipping all seeding");
+            _logger.LogInformation("Seed profile is None — skipping all seeding");
             return;
         }
 
-        _logger.LogInformation("Seeding with profile: {Profile}", _profile);
+        _logger.LogInformation("Seeding with profile: {Profile}", profile);
         var sw = Stopwatch.StartNew();
 
-        // Acquire PostgreSQL advisory lock - only one replica seeds at a time
-        var lockScope = _scopeFactory.CreateAsyncScope();
+        await AdvisoryLockHelper.AcquireAsync(db, _logger, ct).ConfigureAwait(false);
         try
         {
-            var lockDb = lockScope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
-
-            var lockAcquired = await lockDb.Database
-                .SqlQueryRaw<bool>("SELECT pg_try_advisory_lock({0}) AS \"Value\"", SeedingAdvisoryLockId)
-                .FirstOrDefaultAsync(ct)
-                .ConfigureAwait(false);
-
-            if (!lockAcquired)
-            {
-                _logger.LogInformation("Another replica is seeding. Skipping.");
-                return;
-            }
-
-            try
-            {
-                // Layer 1: Core (always) - isolated scope
-                await SeedCoreAsync(ct).ConfigureAwait(false);
-
-                // Layer 2: Catalog (manifest-driven) - isolated scope
-                await SeedCatalogAsync(ct).ConfigureAwait(false);
-
-                _logger.LogInformation("Seeding completed in {Elapsed}ms", sw.ElapsedMilliseconds);
-            }
-            finally
-            {
-                await lockDb.Database
-                    .ExecuteSqlRawAsync("SELECT pg_advisory_unlock({0})", SeedingAdvisoryLockId)
-                    .ConfigureAwait(false);
-            }
-        }
-        finally
-        {
-            await lockScope.DisposeAsync().ConfigureAwait(false);
-        }
-    }
-
-    private async Task SeedCoreAsync(CancellationToken ct)
-    {
-        _logger.LogInformation("Layer 1: Core seeding...");
-        var scope = _scopeFactory.CreateAsyncScope();
-        try
-        {
-            var sp = scope.ServiceProvider;
-            await Core.CoreSeeder.SeedAsync(
-                sp.GetRequiredService<IMediator>(),
-                sp.GetRequiredService<MeepleAiDbContext>(),
-                _logger, ct).ConfigureAwait(false);
-        }
-        finally
-        {
-            await scope.DisposeAsync().ConfigureAwait(false);
-        }
-    }
-
-    private async Task SeedCatalogAsync(CancellationToken ct)
-    {
-        _logger.LogInformation("Layer 2: Catalog seeding (profile: {Profile})...", _profile);
-        var scope = _scopeFactory.CreateAsyncScope();
-        try
-        {
-            var sp = scope.ServiceProvider;
-            var db = sp.GetRequiredService<MeepleAiDbContext>();
             var adminUser = await db.Users
                 .FirstOrDefaultAsync(u => u.Role == "admin", ct)
                 .ConfigureAwait(false);
             var systemUserId = adminUser?.Id ?? Guid.Empty;
 
-            await Catalog.CatalogSeeder.SeedAsync(
-                _profile,
-                db,
-                sp.GetRequiredService<IBggApiService>(),
-                systemUserId,
-                _logger, ct,
-                sp.GetService<IEmbeddingService>(),
-                sp.GetService<IConfiguration>()).ConfigureAwait(false);
+            var context = new SeedContext(profile, db, services, _logger, systemUserId);
+
+            foreach (var layer in FilterLayers(_layers, profile))
+            {
+                _logger.LogInformation("Running seed layer: {Layer} (min profile: {MinProfile})",
+                    layer.Name, layer.MinimumProfile);
+                await layer.SeedAsync(context, ct).ConfigureAwait(false);
+            }
+
+            _logger.LogInformation("Seeding completed in {Elapsed}ms", sw.ElapsedMilliseconds);
         }
         finally
         {
-            await scope.DisposeAsync().ConfigureAwait(false);
+            await AdvisoryLockHelper.ReleaseAsync(db, _logger, ct).ConfigureAwait(false);
         }
     }
 
+    /// <summary>
+    /// Resolve seed profile from SEED_PROFILE env var → Seeding:Profile config → default Dev.
+    /// </summary>
+    internal static SeedProfile ResolveProfile(IConfiguration? configuration)
+    {
+        // 1. Environment variable takes priority
+        var envVar = Environment.GetEnvironmentVariable("SEED_PROFILE");
+        if (!string.IsNullOrWhiteSpace(envVar) && Enum.TryParse<SeedProfile>(envVar, ignoreCase: true, out var envProfile))
+            return envProfile;
+
+        // 2. Configuration section
+        var configValue = configuration?["Seeding:Profile"];
+        if (!string.IsNullOrWhiteSpace(configValue) && Enum.TryParse<SeedProfile>(configValue, ignoreCase: true, out var cfgProfile))
+            return cfgProfile;
+
+        // 3. Default to Dev for local development
+        return SeedProfile.Dev;
+    }
+
+    /// <summary>
+    /// Filter layers by profile ordinal: layer runs if MinimumProfile &lt;= active profile.
+    /// </summary>
+    internal static IEnumerable<ISeedLayer> FilterLayers(IEnumerable<ISeedLayer> layers, SeedProfile profile)
+        => layers.Where(l => l.MinimumProfile <= profile).OrderBy(l => l.MinimumProfile);
 }

--- a/apps/api/src/Api/Infrastructure/Seeders/SeedProfile.cs
+++ b/apps/api/src/Api/Infrastructure/Seeders/SeedProfile.cs
@@ -1,20 +1,18 @@
 namespace Api.Infrastructure.Seeders;
 
 /// <summary>
-/// Controls which seeding layers execute at startup.
-/// Set via SEED_PROFILE environment variable (default: Dev).
+/// Determines which seed layers run and with what data.
+/// Set via SEED_PROFILE env var or Seeding:Profile in appsettings.
+/// Ordinal values control layer filtering: a layer runs if MinimumProfile &lt;= active profile.
 /// </summary>
-internal enum SeedProfile
+public enum SeedProfile
 {
-    /// <summary>Core + Catalog(dev.yml). Auto-runs on startup.</summary>
-    Dev,
-
-    /// <summary>Core + Catalog(staging.yml) + LivedIn. Script-driven via dump/restore.</summary>
-    Staging,
-
-    /// <summary>Core + Catalog(prod.yml). Script-driven via dump/restore.</summary>
-    Prod,
-
-    /// <summary>Skip all seeding (used when restoring from dump).</summary>
-    None
+    /// <summary>No seeding (CI/testing environments).</summary>
+    None = 0,
+    /// <summary>Production: Core layer only (admin + AI models).</summary>
+    Prod = 1,
+    /// <summary>Staging: Core + Catalog (shared games, badges, flags).</summary>
+    Staging = 2,
+    /// <summary>Development: Core + Catalog + LivedIn (synthetic data).</summary>
+    Dev = 3
 }

--- a/apps/api/src/Api/Program.cs
+++ b/apps/api/src/Api/Program.cs
@@ -396,22 +396,9 @@ using (var scope = app.Services.CreateScope())
         app.Logger.LogInformation("✓ Embedding configuration validated: Provider={Provider}, Model={Model}, Dimensions={Dimensions}",
             provider, model, embeddingDimensions);
 
-        // PERF: Skip seeding in Staging/Production — seeding is for dev/test environments only
-        // Use SKIP_SEEDING=true or Staging/Production environment to disable
-        var skipSeeding = app.Configuration.GetValue<bool?>("SkipSeeding").GetValueOrDefault(false)
-            || app.Environment.IsEnvironment("Staging")
-            || app.Environment.IsProduction();
-
-        if (!skipSeeding)
-        {
-            // Layered seeding via SeedOrchestrator (creates its own scopes internally)
-            var seedOrchestrator = app.Services.GetRequiredService<Api.Infrastructure.Seeders.SeedOrchestrator>();
-            await seedOrchestrator.ExecuteAsync(CancellationToken.None).ConfigureAwait(false);
-        }
-        else
-        {
-            app.Logger.LogInformation("Skipping database seeding in {Environment}", app.Environment.EnvironmentName);
-        }
+        // Epic #318: Layered seeding pipeline with advisory lock
+        var seedOrchestrator = scope.ServiceProvider.GetRequiredService<Api.Infrastructure.Seeders.SeedOrchestrator>();
+        await seedOrchestrator.RunAsync(db, scope.ServiceProvider).ConfigureAwait(false);
     }
 }
 

--- a/apps/api/src/Api/Program.cs
+++ b/apps/api/src/Api/Program.cs
@@ -595,6 +595,7 @@ v1Api.MapRagPipelineAdminEndpoints();  // RAG Pipeline builder (Issue #3463)
 v1Api.MapRagExecutionAdminEndpoints(); // RAG Execution replay & compare (Issue #4459)
 v1Api.MapAdminMechanicExtractorEndpoints(); // Mechanic Extractor: Variant C copyright-compliant analysis
 v1Api.MapAdminMiscEndpoints();         // Miscellaneous admin operations
+v1Api.MapAdminSeedingEndpoints();      // Epic #318: Admin seeding re-trigger
 v1Api.MapReportingEndpoints();         // ISSUE-916: Report generation & scheduling
 v1Api.MapTestingMetricsEndpoints();    // Issue #2139: Testing metrics API
 

--- a/apps/api/src/Api/Routing/AdminSeedingEndpoints.cs
+++ b/apps/api/src/Api/Routing/AdminSeedingEndpoints.cs
@@ -1,0 +1,30 @@
+using Api.Filters;
+using Api.Infrastructure;
+using Api.Infrastructure.Seeders;
+
+namespace Api.Routing;
+
+/// <summary>
+/// Admin endpoint for manually triggering the seeding pipeline.
+/// </summary>
+internal static class AdminSeedingEndpoints
+{
+    public static void MapAdminSeedingEndpoints(this IEndpointRouteBuilder routes)
+    {
+        var group = routes.MapGroup("/admin/seeding")
+            .AddEndpointFilter<RequireAdminSessionFilter>()
+            .WithTags("Admin - Seeding");
+
+        group.MapPost("/orchestrate", async (
+            SeedOrchestrator orchestrator,
+            MeepleAiDbContext db,
+            IServiceProvider services,
+            CancellationToken ct) =>
+        {
+            await orchestrator.RunAsync(db, services, ct).ConfigureAwait(false);
+            return Results.Ok(new { message = "Seeding pipeline completed" });
+        })
+        .WithName("OrchestrateSeeding")
+        .WithSummary("Run the seeding pipeline manually");
+    }
+}

--- a/apps/api/tests/Api.Tests/Infrastructure/Seeders/SeedOrchestratorTests.cs
+++ b/apps/api/tests/Api.Tests/Infrastructure/Seeders/SeedOrchestratorTests.cs
@@ -8,7 +8,12 @@ using Xunit;
 
 namespace Api.Tests.Infrastructure.Seeders;
 
+/// <summary>
+/// Tests for SeedOrchestrator static methods: ResolveProfile, FilterLayers.
+/// Env-var tests serialized to avoid parallel interference.
+/// </summary>
 [Trait("Category", TestCategories.Unit)]
+[Collection("EnvironmentVariableTests")]
 public sealed class SeedOrchestratorTests
 {
     [Theory]
@@ -20,14 +25,10 @@ public sealed class SeedOrchestratorTests
     [InlineData("PROD", SeedProfile.Prod)]
     public void ResolveProfile_FromEnvironment_ParsesCorrectly(string envValue, SeedProfile expected)
     {
-        // Arrange
         Environment.SetEnvironmentVariable("SEED_PROFILE", envValue);
         try
         {
-            // Act
             var result = SeedOrchestrator.ResolveProfile(null);
-
-            // Assert
             result.Should().Be(expected);
         }
         finally
@@ -39,57 +40,36 @@ public sealed class SeedOrchestratorTests
     [Fact]
     public void ResolveProfile_FromConfig_WhenNoEnvVar()
     {
-        // Arrange
         Environment.SetEnvironmentVariable("SEED_PROFILE", null);
         var config = new ConfigurationBuilder()
             .AddInMemoryCollection(new Dictionary<string, string?> { ["Seeding:Profile"] = "Staging" })
             .Build();
 
-        // Act
         var result = SeedOrchestrator.ResolveProfile(config);
-
-        // Assert
         result.Should().Be(SeedProfile.Staging);
     }
 
     [Fact]
     public void ResolveProfile_DefaultsToDev_WhenNothingConfigured()
     {
-        // Arrange
         Environment.SetEnvironmentVariable("SEED_PROFILE", null);
-
-        // Act
         var result = SeedOrchestrator.ResolveProfile(null);
-
-        // Assert
         result.Should().Be(SeedProfile.Dev);
     }
 
     [Fact]
     public void FilterLayers_ReturnsOnlyMatchingLayers()
     {
-        // Arrange
-        var core = new Mock<ISeedLayer>();
-        core.Setup(l => l.MinimumProfile).Returns(SeedProfile.Prod);
-        core.Setup(l => l.Name).Returns("Core");
+        var core = MockLayer("Core", SeedProfile.Prod);
+        var catalog = MockLayer("Catalog", SeedProfile.Staging);
+        var livedIn = MockLayer("LivedIn", SeedProfile.Dev);
+        var layers = new[] { core, catalog, livedIn };
 
-        var catalog = new Mock<ISeedLayer>();
-        catalog.Setup(l => l.MinimumProfile).Returns(SeedProfile.Staging);
-        catalog.Setup(l => l.Name).Returns("Catalog");
+        var prodLayers = SeedOrchestrator.FilterLayers(layers, SeedProfile.Prod);
+        var stagingLayers = SeedOrchestrator.FilterLayers(layers, SeedProfile.Staging);
+        var devLayers = SeedOrchestrator.FilterLayers(layers, SeedProfile.Dev);
 
-        var livedIn = new Mock<ISeedLayer>();
-        livedIn.Setup(l => l.MinimumProfile).Returns(SeedProfile.Dev);
-        livedIn.Setup(l => l.Name).Returns("LivedIn");
-
-        var layers = new[] { core.Object, catalog.Object, livedIn.Object };
-
-        // Act - Prod profile should only run Core
-        var prodLayers = SeedOrchestrator.FilterLayers(layers, SeedProfile.Prod).ToList();
-        var stagingLayers = SeedOrchestrator.FilterLayers(layers, SeedProfile.Staging).ToList();
-        var devLayers = SeedOrchestrator.FilterLayers(layers, SeedProfile.Dev).ToList();
-
-        // Assert
-        prodLayers.Should().HaveCount(1).And.Contain(core.Object);
+        prodLayers.Should().HaveCount(1).And.Contain(core);
         stagingLayers.Should().HaveCount(2);
         devLayers.Should().HaveCount(3);
     }
@@ -97,22 +77,39 @@ public sealed class SeedOrchestratorTests
     [Fact]
     public void FilterLayers_OrdersByMinimumProfile()
     {
-        // Arrange - register in reverse order
-        var livedIn = new Mock<ISeedLayer>();
-        livedIn.Setup(l => l.MinimumProfile).Returns(SeedProfile.Dev);
-        livedIn.Setup(l => l.Name).Returns("LivedIn");
+        var livedIn = MockLayer("LivedIn", SeedProfile.Dev);
+        var core = MockLayer("Core", SeedProfile.Prod);
+        var layers = new[] { livedIn, core }; // Reverse order
 
-        var core = new Mock<ISeedLayer>();
-        core.Setup(l => l.MinimumProfile).Returns(SeedProfile.Prod);
-        core.Setup(l => l.Name).Returns("Core");
+        var result = SeedOrchestrator.FilterLayers(layers, SeedProfile.Dev);
 
-        var layers = new[] { livedIn.Object, core.Object };
-
-        // Act
-        var result = SeedOrchestrator.FilterLayers(layers, SeedProfile.Dev).ToList();
-
-        // Assert - should be ordered by MinimumProfile (Prod first, then Dev)
         result[0].Name.Should().Be("Core");
         result[1].Name.Should().Be("LivedIn");
+    }
+
+    [Fact]
+    public void FilterLayers_ReturnsReadOnlyList()
+    {
+        var layers = new[] { MockLayer("Core", SeedProfile.Prod) };
+        var result = SeedOrchestrator.FilterLayers(layers, SeedProfile.Dev);
+
+        result.Should().BeAssignableTo<IReadOnlyList<ISeedLayer>>();
+    }
+
+    [Fact]
+    public void FilterLayers_NoneProfile_ReturnsEmpty()
+    {
+        var layers = new[] { MockLayer("Core", SeedProfile.Prod) };
+        var result = SeedOrchestrator.FilterLayers(layers, SeedProfile.None);
+
+        result.Should().BeEmpty();
+    }
+
+    private static ISeedLayer MockLayer(string name, SeedProfile minProfile)
+    {
+        var mock = new Mock<ISeedLayer>();
+        mock.Setup(l => l.Name).Returns(name);
+        mock.Setup(l => l.MinimumProfile).Returns(minProfile);
+        return mock.Object;
     }
 }

--- a/apps/api/tests/Api.Tests/Infrastructure/Seeders/SeedOrchestratorTests.cs
+++ b/apps/api/tests/Api.Tests/Infrastructure/Seeders/SeedOrchestratorTests.cs
@@ -1,7 +1,7 @@
 using Api.Infrastructure.Seeders;
 using Api.Tests.Constants;
 using FluentAssertions;
-using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
@@ -11,19 +11,108 @@ namespace Api.Tests.Infrastructure.Seeders;
 [Trait("Category", TestCategories.Unit)]
 public sealed class SeedOrchestratorTests
 {
-    [Fact]
-    public async Task ExecuteAsync_ProfileNone_SkipsAllSeeding()
+    [Theory]
+    [InlineData("None", SeedProfile.None)]
+    [InlineData("Prod", SeedProfile.Prod)]
+    [InlineData("Staging", SeedProfile.Staging)]
+    [InlineData("Dev", SeedProfile.Dev)]
+    [InlineData("dev", SeedProfile.Dev)]
+    [InlineData("PROD", SeedProfile.Prod)]
+    public void ResolveProfile_FromEnvironment_ParsesCorrectly(string envValue, SeedProfile expected)
     {
         // Arrange
-        var scopeFactory = new Mock<IServiceScopeFactory>();
-        var logger = new Mock<ILogger<SeedOrchestrator>>();
-        var orchestrator = new SeedOrchestrator(
-            SeedProfile.None, scopeFactory.Object, logger.Object);
+        Environment.SetEnvironmentVariable("SEED_PROFILE", envValue);
+        try
+        {
+            // Act
+            var result = SeedOrchestrator.ResolveProfile(null);
+
+            // Assert
+            result.Should().Be(expected);
+        }
+        finally
+        {
+            Environment.SetEnvironmentVariable("SEED_PROFILE", null);
+        }
+    }
+
+    [Fact]
+    public void ResolveProfile_FromConfig_WhenNoEnvVar()
+    {
+        // Arrange
+        Environment.SetEnvironmentVariable("SEED_PROFILE", null);
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?> { ["Seeding:Profile"] = "Staging" })
+            .Build();
 
         // Act
-        await orchestrator.ExecuteAsync(CancellationToken.None);
+        var result = SeedOrchestrator.ResolveProfile(config);
 
-        // Assert - no scopes created means no seeding happened
-        scopeFactory.Verify(f => f.CreateScope(), Times.Never);
+        // Assert
+        result.Should().Be(SeedProfile.Staging);
+    }
+
+    [Fact]
+    public void ResolveProfile_DefaultsToDev_WhenNothingConfigured()
+    {
+        // Arrange
+        Environment.SetEnvironmentVariable("SEED_PROFILE", null);
+
+        // Act
+        var result = SeedOrchestrator.ResolveProfile(null);
+
+        // Assert
+        result.Should().Be(SeedProfile.Dev);
+    }
+
+    [Fact]
+    public void FilterLayers_ReturnsOnlyMatchingLayers()
+    {
+        // Arrange
+        var core = new Mock<ISeedLayer>();
+        core.Setup(l => l.MinimumProfile).Returns(SeedProfile.Prod);
+        core.Setup(l => l.Name).Returns("Core");
+
+        var catalog = new Mock<ISeedLayer>();
+        catalog.Setup(l => l.MinimumProfile).Returns(SeedProfile.Staging);
+        catalog.Setup(l => l.Name).Returns("Catalog");
+
+        var livedIn = new Mock<ISeedLayer>();
+        livedIn.Setup(l => l.MinimumProfile).Returns(SeedProfile.Dev);
+        livedIn.Setup(l => l.Name).Returns("LivedIn");
+
+        var layers = new[] { core.Object, catalog.Object, livedIn.Object };
+
+        // Act - Prod profile should only run Core
+        var prodLayers = SeedOrchestrator.FilterLayers(layers, SeedProfile.Prod).ToList();
+        var stagingLayers = SeedOrchestrator.FilterLayers(layers, SeedProfile.Staging).ToList();
+        var devLayers = SeedOrchestrator.FilterLayers(layers, SeedProfile.Dev).ToList();
+
+        // Assert
+        prodLayers.Should().HaveCount(1).And.Contain(core.Object);
+        stagingLayers.Should().HaveCount(2);
+        devLayers.Should().HaveCount(3);
+    }
+
+    [Fact]
+    public void FilterLayers_OrdersByMinimumProfile()
+    {
+        // Arrange - register in reverse order
+        var livedIn = new Mock<ISeedLayer>();
+        livedIn.Setup(l => l.MinimumProfile).Returns(SeedProfile.Dev);
+        livedIn.Setup(l => l.Name).Returns("LivedIn");
+
+        var core = new Mock<ISeedLayer>();
+        core.Setup(l => l.MinimumProfile).Returns(SeedProfile.Prod);
+        core.Setup(l => l.Name).Returns("Core");
+
+        var layers = new[] { livedIn.Object, core.Object };
+
+        // Act
+        var result = SeedOrchestrator.FilterLayers(layers, SeedProfile.Dev).ToList();
+
+        // Assert - should be ordered by MinimumProfile (Prod first, then Dev)
+        result[0].Name.Should().Be("Core");
+        result[1].Name.Should().Be("LivedIn");
     }
 }

--- a/apps/web/src/components/game-night/PlayerSetupDialog.tsx
+++ b/apps/web/src/components/game-night/PlayerSetupDialog.tsx
@@ -1,0 +1,174 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+
+import { Gamepad2, Loader2, Plus, Trash2, Users } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogTitle } from '@/components/ui/overlays/dialog';
+import { Input } from '@/components/ui/primitives/input';
+import type { PlayerColor } from '@/lib/api/schemas/live-sessions.schemas';
+
+/**
+ * Color palette for player tokens.
+ * Matches the backend PlayerColor enum + White/Black from PlayerColorSchema.
+ * `label` is the Italian display name; `name` is the API enum value.
+ */
+const PLAYER_COLORS = [
+  { name: 'Red', label: 'Rosso', hex: '#ef4444' },
+  { name: 'Blue', label: 'Blu', hex: '#3b82f6' },
+  { name: 'Green', label: 'Verde', hex: '#22c55e' },
+  { name: 'Yellow', label: 'Giallo', hex: '#eab308' },
+  { name: 'Purple', label: 'Viola', hex: '#a855f7' },
+  { name: 'Orange', label: 'Arancione', hex: '#f97316' },
+  { name: 'Pink', label: 'Rosa', hex: '#ec4899' },
+  { name: 'Teal', label: 'Acquamarina', hex: '#14b8a6' },
+  { name: 'White', label: 'Bianco', hex: '#ffffff' },
+  { name: 'Black', label: 'Nero', hex: '#1f2937' },
+] as const;
+
+export interface PlayerSetup {
+  displayName: string;
+  color: PlayerColor;
+}
+
+/** Internal representation with a stable id for React keys. */
+interface PlayerEntry extends PlayerSetup {
+  id: string;
+}
+
+interface PlayerSetupDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  gameName: string;
+  minPlayers: number;
+  maxPlayers: number;
+  onStart: (players: PlayerSetup[]) => void;
+  isLoading: boolean;
+}
+
+export function PlayerSetupDialog({
+  open,
+  onOpenChange,
+  gameName,
+  minPlayers,
+  maxPlayers,
+  onStart,
+  isLoading,
+}: PlayerSetupDialogProps) {
+  const [players, setPlayers] = useState<PlayerEntry[]>([
+    { id: crypto.randomUUID(), displayName: '', color: PLAYER_COLORS[0].name },
+  ]);
+
+  // Issue 2 fix: guard and color computation inside functional updater
+  // so `players` is not a stale closure dependency.
+  const addPlayer = useCallback(() => {
+    setPlayers(prev => {
+      if (prev.length >= maxPlayers) return prev;
+      const usedColors = new Set(prev.map(p => p.color));
+      const nextColor =
+        PLAYER_COLORS.find(c => !usedColors.has(c.name))?.name ?? PLAYER_COLORS[0].name;
+      return [...prev, { id: crypto.randomUUID(), displayName: '', color: nextColor }];
+    });
+  }, [maxPlayers]);
+
+  const removePlayer = useCallback((id: string) => {
+    setPlayers(prev => prev.filter(p => p.id !== id));
+  }, []);
+
+  const updatePlayer = useCallback((id: string, field: keyof PlayerSetup, value: string) => {
+    setPlayers(prev => prev.map(p => (p.id === id ? { ...p, [field]: value as PlayerColor } : p)));
+  }, []);
+
+  const validPlayers = players.filter(p => p.displayName.trim().length > 0);
+  const canStart = validPlayers.length >= Math.max(1, minPlayers);
+
+  // Issue 1 fix: strip internal `id` before passing to consumer
+  const handleStart = useCallback(() => {
+    onStart(validPlayers.map(({ displayName, color }) => ({ displayName, color })));
+  }, [onStart, validPlayers]);
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md" data-testid="player-setup-dialog">
+        <DialogTitle className="flex items-center gap-2">
+          <Users className="h-5 w-5 text-amber-600" />
+          {gameName} — Giocatori
+        </DialogTitle>
+
+        <div className="space-y-3 pt-2">
+          <p className="text-sm text-muted-foreground">
+            Aggiungi i giocatori ({minPlayers}&ndash;{maxPlayers} giocatori).
+          </p>
+
+          {/* Issue 1 fix: use stable player.id as key instead of array index */}
+          {players.map(player => (
+            <div key={player.id} className="flex items-center gap-2">
+              <div
+                className="h-6 w-6 rounded-full flex-shrink-0 border"
+                style={{
+                  backgroundColor:
+                    PLAYER_COLORS.find(c => c.name === player.color)?.hex ?? '#9ca3af',
+                }}
+              />
+              <Input
+                value={player.displayName}
+                onChange={e => updatePlayer(player.id, 'displayName', e.target.value)}
+                placeholder="Nome giocatore"
+                className="flex-1"
+              />
+              {/* Issue 7 fix: show Italian label, send API enum value */}
+              <select
+                value={player.color}
+                onChange={e => updatePlayer(player.id, 'color', e.target.value)}
+                className="text-xs border rounded px-2 py-1.5 bg-background"
+                aria-label={`Colore giocatore ${players.indexOf(player) + 1}`}
+              >
+                {PLAYER_COLORS.map(c => (
+                  <option key={c.name} value={c.name}>
+                    {c.label}
+                  </option>
+                ))}
+              </select>
+              {players.length > 1 && (
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-8 w-8"
+                  onClick={() => removePlayer(player.id)}
+                >
+                  <Trash2 className="h-4 w-4 text-muted-foreground" />
+                </Button>
+              )}
+            </div>
+          ))}
+
+          {players.length < maxPlayers && (
+            <Button variant="outline" size="sm" onClick={addPlayer} className="w-full">
+              <Plus className="h-4 w-4 mr-1" /> Aggiungi giocatore
+            </Button>
+          )}
+
+          <div className="flex justify-end gap-2 pt-2">
+            <Button variant="outline" size="sm" onClick={() => onOpenChange(false)}>
+              Annulla
+            </Button>
+            <Button
+              size="sm"
+              disabled={!canStart || isLoading}
+              onClick={handleStart}
+              className="bg-amber-600 hover:bg-amber-700 text-white"
+            >
+              {isLoading ? (
+                <Loader2 className="h-4 w-4 mr-2 animate-spin" />
+              ) : (
+                <Gamepad2 className="h-4 w-4 mr-2" />
+              )}
+              Inizia Partita
+            </Button>
+          </div>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/game-night/index.ts
+++ b/apps/web/src/components/game-night/index.ts
@@ -21,3 +21,5 @@ export { ScoreAssistant } from './ScoreAssistant';
 export { SaveCompleteDialog } from './SaveCompleteDialog';
 export { ResumeSessionPanel } from './ResumeSessionPanel';
 export { GameNightWizard } from './GameNightWizard';
+export { PlayerSetupDialog } from './PlayerSetupDialog';
+export type { PlayerSetup as PlayerSetupEntry } from './PlayerSetupDialog';

--- a/apps/web/src/components/library/private-game-detail/PrivateGameHub.tsx
+++ b/apps/web/src/components/library/private-game-detail/PrivateGameHub.tsx
@@ -4,7 +4,9 @@ import { useState, useEffect, useCallback, useRef } from 'react';
 
 import Image from 'next/image';
 import { useRouter } from 'next/navigation';
+import { toast } from 'sonner';
 
+import { PlayerSetupDialog, type PlayerSetup } from '@/components/game-night/PlayerSetupDialog';
 import { CopyrightDisclaimerModal } from '@/components/pdf/CopyrightDisclaimerModal';
 import { PdfProcessingProgressBar } from '@/components/pdf/PdfProcessingProgressBar';
 import { Skeleton } from '@/components/ui/feedback/skeleton';
@@ -28,6 +30,8 @@ export function PrivateGameHub({ privateGameId }: PrivateGameHubProps) {
   const [uploadProgress, setUploadProgress] = useState(0);
   const [agentStatus, setAgentStatus] = useState<AgentStatus>('none');
   const [pausedSessions, setPausedSessions] = useState<PausedSession[]>([]);
+  const [showPlayerSetup, setShowPlayerSetup] = useState(false);
+  const [isStarting, setIsStarting] = useState(false);
 
   // Derive PDF, agent, and session status from API on mount
   useEffect(() => {
@@ -160,16 +164,42 @@ export function PrivateGameHub({ privateGameId }: PrivateGameHubProps) {
     }
   }, [privateGameId]);
 
-  const handleStartGame = useCallback(async () => {
-    try {
-      const sessionId = await api.liveSessions.createSession({
-        gameId: privateGameId,
-      });
-      router.push(`/sessions/${sessionId}/play`);
-    } catch {
-      // Error handling deferred to Task 4+
-    }
-  }, [privateGameId, router]);
+  const handleStartGame = useCallback(() => {
+    setShowPlayerSetup(true);
+  }, []);
+
+  const handlePlayerSetupComplete = useCallback(
+    async (players: PlayerSetup[]) => {
+      setIsStarting(true);
+      try {
+        const sessionId = await api.liveSessions.createSession({
+          gameId: privateGameId,
+          gameName: game?.title,
+        });
+
+        // Add players to session
+        for (const player of players) {
+          await api.liveSessions.addPlayer(sessionId, {
+            displayName: player.displayName,
+            color: player.color,
+          });
+        }
+
+        // Start the session (Created → InProgress)
+        await api.liveSessions.startSession(sessionId);
+
+        setShowPlayerSetup(false);
+        router.push(`/sessions/${sessionId}/play`);
+      } catch {
+        toast.error('Impossibile avviare la partita', {
+          description: 'Riprova tra qualche secondo.',
+        });
+      } finally {
+        setIsStarting(false);
+      }
+    },
+    [privateGameId, game?.title, router]
+  );
 
   const handleResumeSession = useCallback(
     async (sessionId: string) => {
@@ -294,6 +324,19 @@ export function PrivateGameHub({ privateGameId }: PrivateGameHubProps) {
         onAccept={handleDisclaimerAccept}
         onCancel={() => setShowDisclaimer(false)}
       />
+
+      {/* Issue 5 fix: conditional mount resets state on each open */}
+      {showPlayerSetup && (
+        <PlayerSetupDialog
+          open={showPlayerSetup}
+          onOpenChange={setShowPlayerSetup}
+          gameName={game?.title ?? 'Gioco'}
+          minPlayers={game?.minPlayers ?? 1}
+          maxPlayers={game?.maxPlayers ?? 10}
+          onStart={handlePlayerSetupComplete}
+          isLoading={isStarting}
+        />
+      )}
     </div>
   );
 }

--- a/data/seed-manifests/shared-games.yaml
+++ b/data/seed-manifests/shared-games.yaml
@@ -33,7 +33,7 @@ games:
   - title: "Carcassonne"
     bggId: 822
     language: en
-    pdfFile: "carcassone_rulebook.pdf"
+    pdfFile: "carcassonne_rulebook.pdf"
     imageUrl: "https://cf.geekdo-images.com/peUgu3A20LRmAXAMyDQfpQ__original/img/bP18m_PYjyFOv1IBGgMOteQUneA=/0x0/filters:format(jpeg)/pic8621446.jpg"
     thumbnailUrl: "https://cf.geekdo-images.com/peUgu3A20LRmAXAMyDQfpQ__small/img/oEEslN-EGqh82sNI6Aj4_MFXYg0=/fit-in/200x150/filters:strip_icc()/pic8621446.jpg"
 

--- a/data/seed-manifests/shared-games.yaml
+++ b/data/seed-manifests/shared-games.yaml
@@ -1,0 +1,70 @@
+# Shared Game Catalog seed manifest
+# Used by CatalogSeedLayer to create SharedGame entries
+# BGG IDs used to fetch metadata; fallback data used when BGG unavailable
+games:
+  - title: "7 Wonders"
+    bggId: 68448
+    language: en
+    pdfFile: "7-wonders_rulebook.pdf"
+    imageUrl: "https://cf.geekdo-images.com/35h9Za_JvMMMtx_92kT0Jg__original/img/jt70jJDZ1y1FWJs4ZQf5FI8APVY=/0x0/filters:format(jpeg)/pic7149798.jpg"
+    thumbnailUrl: "https://cf.geekdo-images.com/35h9Za_JvMMMtx_92kT0Jg__small/img/BUOso8b0M1aUOkU80FWlhE8uuxc=/fit-in/200x150/filters:strip_icc()/pic7149798.jpg"
+
+  - title: "Agricola"
+    bggId: 31260
+    language: en
+    pdfFile: "agricola_rulebook.pdf"
+    imageUrl: "https://cf.geekdo-images.com/3L6ZtOll9W5O6-3-EwSMyw__original/img/V37KuMJlCzpxAilzN39BzeLvc9Q=/0x0/filters:format(jpeg)/pic1899157.jpg"
+    thumbnailUrl: "https://cf.geekdo-images.com/3L6ZtOll9W5O6-3-EwSMyw__small/img/TpNF65wCIb1n3EGW18eJJ3MlRMo=/fit-in/200x150/filters:strip_icc()/pic1899157.jpg"
+
+  - title: "Azul"
+    bggId: 230802
+    language: en
+    pdfFile: "azul_rulebook.pdf"
+    imageUrl: "https://cf.geekdo-images.com/aPSHJO0d0XOpQR5X-wJonw__original/img/AkbtYVc6xXJF3c9EUrakklcclKw=/0x0/filters:format(png)/pic6973671.png"
+    thumbnailUrl: "https://cf.geekdo-images.com/aPSHJO0d0XOpQR5X-wJonw__small/img/ccsXKrdGJw-YSClWwzVUwk5Nh9Y=/fit-in/200x150/filters:strip_icc()/pic6973671.png"
+
+  - title: "Catan"
+    bggId: 13
+    language: en
+    pdfFile: "catan_rulebook.pdf"
+    imageUrl: "https://cf.geekdo-images.com/W3Bsga_uLP9kO91gZ7H8yw__original/img/IwRwEpu1I6YfkyYjFIekCh80ntc=/0x0/filters:format(jpeg)/pic2419375.jpg"
+    thumbnailUrl: "https://cf.geekdo-images.com/W3Bsga_uLP9kO91gZ7H8yw__small/img/7a0LOL48K-2lC3IG0HyYT3XxJBs=/fit-in/200x150/filters:strip_icc()/pic2419375.jpg"
+
+  - title: "Carcassonne"
+    bggId: 822
+    language: en
+    pdfFile: "carcassone_rulebook.pdf"
+    imageUrl: "https://cf.geekdo-images.com/peUgu3A20LRmAXAMyDQfpQ__original/img/bP18m_PYjyFOv1IBGgMOteQUneA=/0x0/filters:format(jpeg)/pic8621446.jpg"
+    thumbnailUrl: "https://cf.geekdo-images.com/peUgu3A20LRmAXAMyDQfpQ__small/img/oEEslN-EGqh82sNI6Aj4_MFXYg0=/fit-in/200x150/filters:strip_icc()/pic8621446.jpg"
+
+  - title: "Pandemic"
+    bggId: 30549
+    language: en
+    pdfFile: "pandemic_rulebook.pdf"
+    imageUrl: "https://cf.geekdo-images.com/S3ybV1LAp-8SnHIXLLjVqA__original/img/IsrvRLpUV1TEyZsO5rC-btXaPz0=/0x0/filters:format(jpeg)/pic1534148.jpg"
+    thumbnailUrl: "https://cf.geekdo-images.com/S3ybV1LAp-8SnHIXLLjVqA__small/img/oqViRj6nVxK3m36NluTxU1PZkrk=/fit-in/200x150/filters:strip_icc()/pic1534148.jpg"
+
+  - title: "Chess"
+    language: it
+    pdfFile: "scacchi-fide_2017_rulebook.pdf"
+
+  - title: "Splendor"
+    bggId: 148228
+    language: en
+    pdfFile: "splendor_rulebook.pdf"
+    imageUrl: "https://cf.geekdo-images.com/vNFe4JkhKAERzi4T0Ntwpw__original/img/rqcUdtu_N4v-SpI96XVmpYHnJww=/0x0/filters:format(png)/pic8234167.png"
+    thumbnailUrl: "https://cf.geekdo-images.com/vNFe4JkhKAERzi4T0Ntwpw__small/img/KKU_42Uswt4tKCpf1zY5kTzgr-g=/fit-in/200x150/filters:strip_icc()/pic8234167.png"
+
+  - title: "Ticket to Ride"
+    bggId: 9209
+    language: en
+    pdfFile: "ticket-to-ride_rulebook.pdf"
+    imageUrl: "https://cf.geekdo-images.com/kdWYkW-7AqG63HhqPL6ekA__original/img/rWF8r4JXXCQQ7QhiWHhmT-rQ3Pc=/0x0/filters:format(jpeg)/pic8937637.jpg"
+    thumbnailUrl: "https://cf.geekdo-images.com/kdWYkW-7AqG63HhqPL6ekA__small/img/5G46jv8MFh_BfX67iMSouTMhKxc=/fit-in/200x150/filters:strip_icc()/pic8937637.jpg"
+
+  - title: "Wingspan"
+    bggId: 266192
+    language: en
+    pdfFile: "wingspan_en_rulebook.pdf"
+    imageUrl: "https://cf.geekdo-images.com/yLZJCVLlIx4c7eJEWUNJ7w__original/img/cI782Zis9cT66j2MjSHKJGnFPNw=/0x0/filters:format(jpeg)/pic4458123.jpg"
+    thumbnailUrl: "https://cf.geekdo-images.com/yLZJCVLlIx4c7eJEWUNJ7w__small/img/VNToqgS2-pOGU6MuvIkMPKn_y-s=/fit-in/200x150/filters:strip_icc()/pic4458123.jpg"

--- a/docs/superpowers/plans/2026-03-13-seeding-architecture.md
+++ b/docs/superpowers/plans/2026-03-13-seeding-architecture.md
@@ -1,0 +1,1497 @@
+# Epic #318: Hybrid Layered Seeding Architecture — Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the monolithic `AutoConfigurationService` with a layered, profile-driven seed orchestrator that supports YAML manifests, PostgreSQL advisory locks, and composable seed layers (Core, Catalog, LivedIn).
+
+**Architecture:** New `SeedOrchestrator` replaces `AutoConfigurationService.InitializeAsync()` as the single entry point. It reads a `SeedProfile` (Dev/Staging/Prod) and runs composable layers in order: Core (users, AI models, e2e) → Catalog (shared games from YAML + badges + feature flags + rate limits) → LivedIn (synthetic sessions, optional). Each layer implements `ISeedLayer`. YAML manifests in `data/seed-manifests/` drive SharedGame creation instead of hardcoded dictionaries. Advisory lock prevents concurrent seeding across replicas.
+
+**Tech Stack:** .NET 9, EF Core, PostgreSQL advisory locks (`pg_advisory_lock`), YamlDotNet 16.3.0, xUnit, NSubstitute
+
+---
+
+## File Structure
+
+### New Files
+| File | Responsibility |
+|------|----------------|
+| `Infrastructure/Seeders/ISeedLayer.cs` | Interface: `Task SeedAsync(SeedContext ctx, CancellationToken ct)` |
+| `Infrastructure/Seeders/SeedContext.cs` | Record holding `SeedProfile`, `MeepleAiDbContext`, `IServiceProvider`, `ILogger`, `Guid SystemUserId` |
+| `Infrastructure/Seeders/SeedProfile.cs` | Enum: `Dev`, `Staging`, `Prod` |
+| `Infrastructure/Seeders/SeedOrchestrator.cs` | Entry point: advisory lock → resolve layers → run in order |
+| `Infrastructure/Seeders/AdvisoryLockHelper.cs` | `pg_advisory_lock(key)` / `pg_advisory_unlock(key)` wrapper |
+| `Infrastructure/Seeders/Core/CoreSeedLayer.cs` | Layer: admin user, test user, E2E users, AI models |
+| `Infrastructure/Seeders/Catalog/CatalogSeedLayer.cs` | Layer: YAML shared games, badges, rate limits, feature flags, PDF rulebooks, agents |
+| `Infrastructure/Seeders/Catalog/SeedManifestLoader.cs` | Reads + validates YAML from `data/seed-manifests/` |
+| `Infrastructure/Seeders/Catalog/SeedManifestModels.cs` | YAML deserialization models |
+| `Infrastructure/Seeders/LivedIn/LivedInSeedLayer.cs` | Layer: synthetic sessions, placeholder for future |
+| `Routing/AdminSeedingEndpoints.cs` | `POST /admin/seeding/orchestrate` endpoint |
+| `data/seed-manifests/shared-games.yaml` | YAML manifest for shared games (replaces hardcoded dict) |
+| `infra/scripts/db-dump.ps1` | Production data dump script |
+| `infra/scripts/db-restore.ps1` | Staging data restore script |
+
+### Modified Files
+| File | Change |
+|------|--------|
+| `Program.cs:397-401` | Replace `AutoConfigurationService` call with `SeedOrchestrator` |
+| `AdministrationServiceExtensions.cs` | Register `SeedOrchestrator` and seed layers |
+| `AutoConfigurationService.cs` | Mark as `[Obsolete]`, delegate to `SeedOrchestrator` |
+
+### Test Files
+| File | Tests |
+|------|-------|
+| `tests/Api.Tests/Infrastructure/Seeders/SeedOrchestratorTests.cs` | Orchestrator logic, layer ordering, advisory lock |
+| `tests/Api.Tests/Infrastructure/Seeders/SeedManifestLoaderTests.cs` | YAML parsing, validation |
+| `tests/Api.Tests/Infrastructure/Seeders/CoreSeedLayerTests.cs` | Core layer dispatch |
+| `tests/Api.Tests/Infrastructure/Seeders/CatalogSeedLayerTests.cs` | Catalog layer dispatch |
+| `tests/Api.Tests/Infrastructure/Seeders/AdvisoryLockHelperTests.cs` | Lock acquire/release |
+
+---
+
+## Chunk 1: Foundation — ISeedLayer, SeedContext, SeedProfile, AdvisoryLock
+
+### Task 1: Create ISeedLayer interface, SeedContext, and SeedProfile enum (#351)
+
+**Files:**
+- Create: `apps/api/src/Api/Infrastructure/Seeders/ISeedLayer.cs`
+- Create: `apps/api/src/Api/Infrastructure/Seeders/SeedContext.cs`
+- Create: `apps/api/src/Api/Infrastructure/Seeders/SeedProfile.cs`
+- Test: `tests/Api.Tests/Infrastructure/Seeders/SeedContextTests.cs`
+
+- [ ] **Step 1: Create SeedProfile enum**
+
+```csharp
+// apps/api/src/Api/Infrastructure/Seeders/SeedProfile.cs
+namespace Api.Infrastructure.Seeders;
+
+/// <summary>
+/// Determines which seed layers run and with what data.
+/// Set via SEED_PROFILE env var or appsettings.
+/// </summary>
+public enum SeedProfile
+{
+    /// <summary>No seeding (CI/testing environments).</summary>
+    None = 0,
+    /// <summary>Production: Core layer only (admin + AI models).</summary>
+    Prod = 1,
+    /// <summary>Staging: Core + Catalog (shared games, badges, flags).</summary>
+    Staging = 2,
+    /// <summary>Development: Core + Catalog + LivedIn (synthetic data).</summary>
+    Dev = 3
+}
+```
+
+- [ ] **Step 2: Create ISeedLayer interface**
+
+```csharp
+// apps/api/src/Api/Infrastructure/Seeders/ISeedLayer.cs
+namespace Api.Infrastructure.Seeders;
+
+/// <summary>
+/// A composable seed layer. Layers run in registration order.
+/// Each layer is idempotent — safe to re-run.
+/// </summary>
+public interface ISeedLayer
+{
+    /// <summary>Display name for logging.</summary>
+    string Name { get; }
+
+    /// <summary>Minimum profile required to run this layer.</summary>
+    SeedProfile MinimumProfile { get; }
+
+    /// <summary>Execute seeding logic.</summary>
+    Task SeedAsync(SeedContext context, CancellationToken cancellationToken = default);
+}
+```
+
+- [ ] **Step 3: Create SeedContext record**
+
+```csharp
+// apps/api/src/Api/Infrastructure/Seeders/SeedContext.cs
+using Microsoft.Extensions.Logging;
+
+namespace Api.Infrastructure.Seeders;
+
+/// <summary>
+/// Shared context passed to all seed layers.
+/// </summary>
+public sealed record SeedContext(
+    SeedProfile Profile,
+    MeepleAiDbContext DbContext,
+    IServiceProvider Services,
+    ILogger Logger,
+    Guid SystemUserId);
+```
+
+- [ ] **Step 4: Write unit test for SeedContext**
+
+```csharp
+// tests/Api.Tests/Infrastructure/Seeders/SeedContextTests.cs
+using Api.Infrastructure.Seeders;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Xunit;
+
+namespace Api.Tests.Infrastructure.Seeders;
+
+public sealed class SeedContextTests
+{
+    [Fact]
+    public void SeedContext_StoresAllProperties()
+    {
+        var profile = SeedProfile.Dev;
+        var userId = Guid.NewGuid();
+        var services = Substitute.For<IServiceProvider>();
+        var logger = NullLogger.Instance;
+
+        var ctx = new SeedContext(profile, null!, services, logger, userId);
+
+        Assert.Equal(SeedProfile.Dev, ctx.Profile);
+        Assert.Equal(userId, ctx.SystemUserId);
+        Assert.Same(services, ctx.Services);
+    }
+
+    [Theory]
+    [InlineData(SeedProfile.None, 0)]
+    [InlineData(SeedProfile.Prod, 1)]
+    [InlineData(SeedProfile.Staging, 2)]
+    [InlineData(SeedProfile.Dev, 3)]
+    public void SeedProfile_HasCorrectOrdinalValues(SeedProfile profile, int expected)
+    {
+        Assert.Equal(expected, (int)profile);
+    }
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd apps/api/src/Api && dotnet test ../../tests/Api.Tests --filter "FullyQualifiedName~SeedContextTests" -v quiet`
+Expected: 5 tests pass
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/Api/Infrastructure/Seeders/ISeedLayer.cs \
+        apps/api/src/Api/Infrastructure/Seeders/SeedContext.cs \
+        apps/api/src/Api/Infrastructure/Seeders/SeedProfile.cs \
+        tests/Api.Tests/Infrastructure/Seeders/SeedContextTests.cs
+git commit -m "feat(seeding): add ISeedLayer interface, SeedContext, SeedProfile enum (#351)"
+```
+
+---
+
+### Task 2: Create AdvisoryLockHelper (#351)
+
+**Files:**
+- Create: `apps/api/src/Api/Infrastructure/Seeders/AdvisoryLockHelper.cs`
+- Test: `tests/Api.Tests/Infrastructure/Seeders/AdvisoryLockHelperTests.cs`
+
+- [ ] **Step 1: Write failing test for AdvisoryLockHelper**
+
+```csharp
+// tests/Api.Tests/Infrastructure/Seeders/AdvisoryLockHelperTests.cs
+using Api.Infrastructure.Seeders;
+using Microsoft.Extensions.Logging.Abstractions;
+using Xunit;
+
+namespace Api.Tests.Infrastructure.Seeders;
+
+public sealed class AdvisoryLockHelperTests
+{
+    [Fact]
+    public void LockKey_IsConsistentAcrossCalls()
+    {
+        // The lock key must be deterministic so all replicas use the same lock
+        var key1 = AdvisoryLockHelper.SeedingLockKey;
+        var key2 = AdvisoryLockHelper.SeedingLockKey;
+
+        Assert.Equal(key1, key2);
+        Assert.NotEqual(0, key1);
+    }
+
+    [Fact]
+    public void AcquireSql_ContainsPgAdvisoryLock()
+    {
+        var sql = AdvisoryLockHelper.AcquireLockSql;
+        Assert.Contains("pg_advisory_lock", sql);
+        Assert.Contains(AdvisoryLockHelper.SeedingLockKey.ToString(), sql);
+    }
+
+    [Fact]
+    public void ReleaseSql_ContainsPgAdvisoryUnlock()
+    {
+        var sql = AdvisoryLockHelper.ReleaseLockSql;
+        Assert.Contains("pg_advisory_unlock", sql);
+        Assert.Contains(AdvisoryLockHelper.SeedingLockKey.ToString(), sql);
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/api/src/Api && dotnet test ../../tests/Api.Tests --filter "FullyQualifiedName~AdvisoryLockHelperTests" -v quiet`
+Expected: FAIL — `AdvisoryLockHelper` does not exist
+
+- [ ] **Step 3: Implement AdvisoryLockHelper**
+
+```csharp
+// apps/api/src/Api/Infrastructure/Seeders/AdvisoryLockHelper.cs
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace Api.Infrastructure.Seeders;
+
+/// <summary>
+/// PostgreSQL advisory lock wrapper for safe multi-replica seeding.
+/// Uses session-level advisory locks (released on disconnect).
+/// </summary>
+internal static class AdvisoryLockHelper
+{
+    /// <summary>
+    /// Deterministic lock key derived from "MeepleAI_Seeding" hash.
+    /// All replicas must use the same key.
+    /// </summary>
+    public static long SeedingLockKey { get; } = "MeepleAI_Seeding".GetDeterministicHashCode();
+
+    public static string AcquireLockSql => $"SELECT pg_advisory_lock({SeedingLockKey})";
+    public static string ReleaseLockSql => $"SELECT pg_advisory_unlock({SeedingLockKey})";
+
+    /// <summary>
+    /// Acquires the advisory lock. Blocks until the lock is available.
+    /// </summary>
+    public static async Task AcquireAsync(MeepleAiDbContext db, ILogger logger, CancellationToken ct = default)
+    {
+        logger.LogInformation("🔒 Acquiring seeding advisory lock (key={LockKey})...", SeedingLockKey);
+        await db.Database.ExecuteSqlRawAsync(AcquireLockSql, ct).ConfigureAwait(false);
+        logger.LogInformation("🔓 Seeding advisory lock acquired");
+    }
+
+    /// <summary>
+    /// Releases the advisory lock.
+    /// </summary>
+    public static async Task ReleaseAsync(MeepleAiDbContext db, ILogger logger, CancellationToken ct = default)
+    {
+        await db.Database.ExecuteSqlRawAsync(ReleaseLockSql, ct).ConfigureAwait(false);
+        logger.LogInformation("🔒 Seeding advisory lock released");
+    }
+
+    /// <summary>
+    /// Deterministic hash code that doesn't change across app restarts (.NET randomizes GetHashCode).
+    /// </summary>
+    private static long GetDeterministicHashCode(this string str)
+    {
+        unchecked
+        {
+            long hash = 5381;
+            foreach (var c in str)
+            {
+                hash = ((hash << 5) + hash) ^ c;
+            }
+            return hash;
+        }
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd apps/api/src/Api && dotnet test ../../tests/Api.Tests --filter "FullyQualifiedName~AdvisoryLockHelperTests" -v quiet`
+Expected: 3 tests pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/Api/Infrastructure/Seeders/AdvisoryLockHelper.cs \
+        tests/Api.Tests/Infrastructure/Seeders/AdvisoryLockHelperTests.cs
+git commit -m "feat(seeding): add AdvisoryLockHelper with PostgreSQL advisory locks (#351)"
+```
+
+---
+
+### Task 3: Create SeedOrchestrator (#351)
+
+**Files:**
+- Create: `apps/api/src/Api/Infrastructure/Seeders/SeedOrchestrator.cs`
+- Test: `tests/Api.Tests/Infrastructure/Seeders/SeedOrchestratorTests.cs`
+
+- [ ] **Step 1: Write failing test for SeedOrchestrator**
+
+```csharp
+// tests/Api.Tests/Infrastructure/Seeders/SeedOrchestratorTests.cs
+using Api.Infrastructure.Seeders;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
+using NSubstitute;
+using Xunit;
+
+namespace Api.Tests.Infrastructure.Seeders;
+
+public sealed class SeedOrchestratorTests
+{
+    [Fact]
+    public void GetProfile_ReadsFromConfiguration()
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Seeding:Profile"] = "Staging"
+            })
+            .Build();
+
+        var profile = SeedOrchestrator.ResolveProfile(config);
+
+        Assert.Equal(SeedProfile.Staging, profile);
+    }
+
+    [Fact]
+    public void GetProfile_DefaultsToDev_WhenNotSet()
+    {
+        var config = new ConfigurationBuilder().Build();
+
+        var profile = SeedOrchestrator.ResolveProfile(config);
+
+        Assert.Equal(SeedProfile.Dev, profile);
+    }
+
+    [Fact]
+    public void GetProfile_ReadsFromEnvironmentVariable()
+    {
+        var config = new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["SEED_PROFILE"] = "Prod"
+            })
+            .Build();
+
+        var profile = SeedOrchestrator.ResolveProfile(config);
+
+        Assert.Equal(SeedProfile.Prod, profile);
+    }
+
+    [Fact]
+    public void FilterLayers_ExcludesLayersAboveProfile()
+    {
+        var coreMock = CreateMockLayer("Core", SeedProfile.Prod);
+        var catalogMock = CreateMockLayer("Catalog", SeedProfile.Staging);
+        var livedInMock = CreateMockLayer("LivedIn", SeedProfile.Dev);
+
+        var layers = new[] { coreMock, catalogMock, livedInMock };
+
+        var filtered = SeedOrchestrator.FilterLayers(layers, SeedProfile.Staging);
+
+        Assert.Equal(2, filtered.Count);
+        Assert.Equal("Core", filtered[0].Name);
+        Assert.Equal("Catalog", filtered[1].Name);
+    }
+
+    [Fact]
+    public void FilterLayers_NoneProfile_ReturnsEmpty()
+    {
+        var coreMock = CreateMockLayer("Core", SeedProfile.Prod);
+        var layers = new[] { coreMock };
+
+        var filtered = SeedOrchestrator.FilterLayers(layers, SeedProfile.None);
+
+        Assert.Empty(filtered);
+    }
+
+    private static ISeedLayer CreateMockLayer(string name, SeedProfile minProfile)
+    {
+        var layer = Substitute.For<ISeedLayer>();
+        layer.Name.Returns(name);
+        layer.MinimumProfile.Returns(minProfile);
+        return layer;
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/api/src/Api && dotnet test ../../tests/Api.Tests --filter "FullyQualifiedName~SeedOrchestratorTests" -v quiet`
+Expected: FAIL — `SeedOrchestrator` does not exist
+
+- [ ] **Step 3: Implement SeedOrchestrator**
+
+```csharp
+// apps/api/src/Api/Infrastructure/Seeders/SeedOrchestrator.cs
+using Api.BoundedContexts.Authentication.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace Api.Infrastructure.Seeders;
+
+/// <summary>
+/// Entry point for the layered seeding system.
+/// Acquires advisory lock → resolves profile → runs layers in order.
+/// Replaces AutoConfigurationService as the single startup seed orchestrator.
+/// </summary>
+internal sealed class SeedOrchestrator
+{
+    private readonly IEnumerable<ISeedLayer> _layers;
+    private readonly IUserRepository _userRepository;
+    private readonly IConfiguration _configuration;
+    private readonly ILogger<SeedOrchestrator> _logger;
+
+    public SeedOrchestrator(
+        IEnumerable<ISeedLayer> layers,
+        IUserRepository userRepository,
+        IConfiguration configuration,
+        ILogger<SeedOrchestrator> logger)
+    {
+        _layers = layers ?? throw new ArgumentNullException(nameof(layers));
+        _userRepository = userRepository ?? throw new ArgumentNullException(nameof(userRepository));
+        _configuration = configuration ?? throw new ArgumentNullException(nameof(configuration));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <summary>
+    /// Run the seeding pipeline under advisory lock.
+    /// </summary>
+    public async Task RunAsync(MeepleAiDbContext db, IServiceProvider services, CancellationToken ct = default)
+    {
+        var profile = ResolveProfile(_configuration);
+
+        if (profile == SeedProfile.None)
+        {
+            _logger.LogInformation("🌱 Seed profile is None — skipping all seeding");
+            return;
+        }
+
+        _logger.LogInformation("🌱 Starting seeding pipeline (profile={Profile})", profile);
+
+        try
+        {
+            await AdvisoryLockHelper.AcquireAsync(db, _logger, ct).ConfigureAwait(false);
+
+            // Resolve system user (admin) — created by CoreSeedLayer
+            var adminUser = await db.Users
+                .FirstOrDefaultAsync(u => u.Role == "admin", ct)
+                .ConfigureAwait(false);
+            var systemUserId = adminUser?.Id ?? Guid.Empty;
+
+            var context = new SeedContext(profile, db, services, _logger, systemUserId);
+            var activeLayers = FilterLayers(_layers, profile);
+
+            foreach (var layer in activeLayers)
+            {
+                _logger.LogInformation("🌱 Running seed layer: {LayerName}", layer.Name);
+                await layer.SeedAsync(context, ct).ConfigureAwait(false);
+
+                // After Core layer, re-resolve system user ID (admin just created)
+                if (layer.MinimumProfile == SeedProfile.Prod && context.SystemUserId == Guid.Empty)
+                {
+                    adminUser = await db.Users
+                        .FirstOrDefaultAsync(u => u.Role == "admin", ct)
+                        .ConfigureAwait(false);
+                    if (adminUser != null)
+                    {
+                        context = context with { SystemUserId = adminUser.Id };
+                    }
+                }
+            }
+
+            _logger.LogInformation("🌱 Seeding pipeline completed successfully ({LayerCount} layers)", activeLayers.Count);
+        }
+        finally
+        {
+            await AdvisoryLockHelper.ReleaseAsync(db, _logger, ct).ConfigureAwait(false);
+        }
+    }
+
+    /// <summary>
+    /// Resolve seed profile from configuration. Priority: Seeding:Profile > SEED_PROFILE > default Dev.
+    /// </summary>
+    public static SeedProfile ResolveProfile(IConfiguration configuration)
+    {
+        var profileStr = configuration["Seeding:Profile"]
+                      ?? configuration["SEED_PROFILE"];
+
+        if (string.IsNullOrEmpty(profileStr))
+            return SeedProfile.Dev;
+
+        return Enum.TryParse<SeedProfile>(profileStr, ignoreCase: true, out var parsed)
+            ? parsed
+            : SeedProfile.Dev;
+    }
+
+    /// <summary>
+    /// Filter layers to only those matching the active profile.
+    /// A layer runs if its MinimumProfile ordinal ≤ the active profile ordinal.
+    /// </summary>
+    public static IReadOnlyList<ISeedLayer> FilterLayers(IEnumerable<ISeedLayer> layers, SeedProfile profile)
+    {
+        if (profile == SeedProfile.None)
+            return Array.Empty<ISeedLayer>();
+
+        return layers
+            .Where(l => (int)l.MinimumProfile <= (int)profile)
+            .ToList();
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd apps/api/src/Api && dotnet test ../../tests/Api.Tests --filter "FullyQualifiedName~SeedOrchestratorTests" -v quiet`
+Expected: 4 tests pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/Api/Infrastructure/Seeders/SeedOrchestrator.cs \
+        tests/Api.Tests/Infrastructure/Seeders/SeedOrchestratorTests.cs
+git commit -m "feat(seeding): add SeedOrchestrator with profile resolution and layer filtering (#351)"
+```
+
+---
+
+## Chunk 2: Seed Layers — Core, Catalog, LivedIn
+
+### Task 4: Create CoreSeedLayer (#353)
+
+**Files:**
+- Create: `apps/api/src/Api/Infrastructure/Seeders/Core/CoreSeedLayer.cs`
+- Test: `tests/Api.Tests/Infrastructure/Seeders/CoreSeedLayerTests.cs`
+
+- [ ] **Step 1: Write failing test**
+
+```csharp
+// tests/Api.Tests/Infrastructure/Seeders/CoreSeedLayerTests.cs
+using Api.Infrastructure.Seeders;
+using Api.Infrastructure.Seeders.Core;
+using Xunit;
+
+namespace Api.Tests.Infrastructure.Seeders;
+
+public sealed class CoreSeedLayerTests
+{
+    [Fact]
+    public void Name_IsCore()
+    {
+        var layer = new CoreSeedLayer();
+        Assert.Equal("Core", layer.Name);
+    }
+
+    [Fact]
+    public void MinimumProfile_IsProd()
+    {
+        var layer = new CoreSeedLayer();
+        Assert.Equal(SeedProfile.Prod, layer.MinimumProfile);
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/api/src/Api && dotnet test ../../tests/Api.Tests --filter "FullyQualifiedName~CoreSeedLayerTests" -v quiet`
+Expected: FAIL
+
+- [ ] **Step 3: Implement CoreSeedLayer**
+
+This layer wraps existing CQRS seeder commands. It delegates to `IMediator` for admin user, test user, E2E users, AI models — exactly what `AutoConfigurationService.InitializeAsync()` does in its first block.
+
+```csharp
+// apps/api/src/Api/Infrastructure/Seeders/Core/CoreSeedLayer.cs
+using Api.BoundedContexts.Administration.Application.Commands;
+using Api.BoundedContexts.KnowledgeBase.Application.Commands;
+using Api.BoundedContexts.SystemConfiguration.Application.Commands;
+using MediatR;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Api.Infrastructure.Seeders.Core;
+
+/// <summary>
+/// Core seed layer: admin user, test user, E2E users, AI models.
+/// Runs in all profiles (Prod, Staging, Dev).
+/// </summary>
+internal sealed class CoreSeedLayer : ISeedLayer
+{
+    public string Name => "Core";
+    public SeedProfile MinimumProfile => SeedProfile.Prod;
+
+    public async Task SeedAsync(SeedContext context, CancellationToken cancellationToken = default)
+    {
+        var mediator = context.Services.GetRequiredService<IMediator>();
+
+        context.Logger.LogInformation("🌱 [Core] Seeding admin user...");
+        await mediator.Send(new SeedAdminUserCommand(), cancellationToken).ConfigureAwait(false);
+
+        context.Logger.LogInformation("🌱 [Core] Seeding test user...");
+        await mediator.Send(new SeedTestUserCommand(), cancellationToken).ConfigureAwait(false);
+
+        context.Logger.LogInformation("🌱 [Core] Seeding E2E test users...");
+        await mediator.Send(new SeedE2ETestUsersCommand(), cancellationToken).ConfigureAwait(false);
+
+        context.Logger.LogInformation("🌱 [Core] Seeding AI models...");
+        await mediator.Send(new SeedAiModelsCommand(), cancellationToken).ConfigureAwait(false);
+
+        context.Logger.LogInformation("🌱 [Core] Seeding agent definitions...");
+        await mediator.Send(new SeedAgentDefinitionsCommand(), cancellationToken).ConfigureAwait(false);
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd apps/api/src/Api && dotnet test ../../tests/Api.Tests --filter "FullyQualifiedName~CoreSeedLayerTests" -v quiet`
+Expected: 2 tests pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/Api/Infrastructure/Seeders/Core/CoreSeedLayer.cs \
+        tests/Api.Tests/Infrastructure/Seeders/CoreSeedLayerTests.cs
+git commit -m "feat(seeding): add CoreSeedLayer wrapping user/model seeding (#353)"
+```
+
+---
+
+### Task 5: Create YAML SeedManifest models and loader (#352)
+
+**Files:**
+- Create: `apps/api/src/Api/Infrastructure/Seeders/Catalog/SeedManifestModels.cs`
+- Create: `apps/api/src/Api/Infrastructure/Seeders/Catalog/SeedManifestLoader.cs`
+- Create: `data/seed-manifests/shared-games.yaml`
+- Test: `tests/Api.Tests/Infrastructure/Seeders/SeedManifestLoaderTests.cs`
+
+- [ ] **Step 1: Create YAML manifest file**
+
+Extract the hardcoded `SharedGameSeeder.GameMappings` dictionary into YAML. File: `data/seed-manifests/shared-games.yaml`
+
+```yaml
+# Shared Game Catalog seed manifest
+# Used by CatalogSeedLayer to create SharedGame entries
+# BGG IDs used to fetch metadata; fallback data used when BGG unavailable
+games:
+  - title: "7 Wonders"
+    bggId: 68448
+    language: en
+    pdfFile: "7-wonders_rulebook.pdf"
+    imageUrl: "https://cf.geekdo-images.com/35h9Za_JvMMMtx_92kT0Jg__original/img/jt70jJDZ1y1FWJs4ZQf5FI8APVY=/0x0/filters:format(jpeg)/pic7149798.jpg"
+    thumbnailUrl: "https://cf.geekdo-images.com/35h9Za_JvMMMtx_92kT0Jg__small/img/BUOso8b0M1aUOkU80FWlhE8uuxc=/fit-in/200x150/filters:strip_icc()/pic7149798.jpg"
+
+  - title: "Agricola"
+    bggId: 31260
+    language: en
+    pdfFile: "agricola_rulebook.pdf"
+    imageUrl: "https://cf.geekdo-images.com/3L6ZtOll9W5O6-3-EwSMyw__original/img/V37KuMJlCzpxAilzN39BzeLvc9Q=/0x0/filters:format(jpeg)/pic1899157.jpg"
+    thumbnailUrl: "https://cf.geekdo-images.com/3L6ZtOll9W5O6-3-EwSMyw__small/img/TpNF65wCIb1n3EGW18eJJ3MlRMo=/fit-in/200x150/filters:strip_icc()/pic1899157.jpg"
+
+  - title: "Azul"
+    bggId: 230802
+    language: en
+    pdfFile: "azul_rulebook.pdf"
+    imageUrl: "https://cf.geekdo-images.com/aPSHJO0d0XOpQR5X-wJonw__original/img/AkbtYVc6xXJF3c9EUrakklcclKw=/0x0/filters:format(png)/pic6973671.png"
+    thumbnailUrl: "https://cf.geekdo-images.com/aPSHJO0d0XOpQR5X-wJonw__small/img/ccsXKrdGJw-YSClWwzVUwk5Nh9Y=/fit-in/200x150/filters:strip_icc()/pic6973671.png"
+
+  - title: "Catan"
+    bggId: 13
+    language: en
+    pdfFile: "catan_rulebook.pdf"
+    imageUrl: "https://cf.geekdo-images.com/W3Bsga_uLP9kO91gZ7H8yw__original/img/IwRwEpu1I6YfkyYjFIekCh80ntc=/0x0/filters:format(jpeg)/pic2419375.jpg"
+    thumbnailUrl: "https://cf.geekdo-images.com/W3Bsga_uLP9kO91gZ7H8yw__small/img/7a0LOL48K-2lC3IG0HyYT3XxJBs=/fit-in/200x150/filters:strip_icc()/pic2419375.jpg"
+
+  - title: "Carcassonne"
+    bggId: 822
+    language: en
+    pdfFile: "carcassone_rulebook.pdf"
+    imageUrl: "https://cf.geekdo-images.com/peUgu3A20LRmAXAMyDQfpQ__original/img/bP18m_PYjyFOv1IBGgMOteQUneA=/0x0/filters:format(jpeg)/pic8621446.jpg"
+    thumbnailUrl: "https://cf.geekdo-images.com/peUgu3A20LRmAXAMyDQfpQ__small/img/oEEslN-EGqh82sNI6Aj4_MFXYg0=/fit-in/200x150/filters:strip_icc()/pic8621446.jpg"
+
+  - title: "Pandemic"
+    bggId: 30549
+    language: en
+    pdfFile: "pandemic_rulebook.pdf"
+    imageUrl: "https://cf.geekdo-images.com/S3ybV1LAp-8SnHIXLLjVqA__original/img/IsrvRLpUV1TEyZsO5rC-btXaPz0=/0x0/filters:format(jpeg)/pic1534148.jpg"
+    thumbnailUrl: "https://cf.geekdo-images.com/S3ybV1LAp-8SnHIXLLjVqA__small/img/oqViRj6nVxK3m36NluTxU1PZkrk=/fit-in/200x150/filters:strip_icc()/pic1534148.jpg"
+
+  - title: "Chess"
+    bggId: null
+    language: it
+    pdfFile: "scacchi-fide_2017_rulebook.pdf"
+
+  - title: "Splendor"
+    bggId: 148228
+    language: en
+    pdfFile: "splendor_rulebook.pdf"
+    imageUrl: "https://cf.geekdo-images.com/vNFe4JkhKAERzi4T0Ntwpw__original/img/rqcUdtu_N4v-SpI96XVmpYHnJww=/0x0/filters:format(png)/pic8234167.png"
+    thumbnailUrl: "https://cf.geekdo-images.com/vNFe4JkhKAERzi4T0Ntwpw__small/img/KKU_42Uswt4tKCpf1zY5kTzgr-g=/fit-in/200x150/filters:strip_icc()/pic8234167.png"
+
+  - title: "Ticket to Ride"
+    bggId: 9209
+    language: en
+    pdfFile: "ticket-to-ride_rulebook.pdf"
+    imageUrl: "https://cf.geekdo-images.com/kdWYkW-7AqG63HhqPL6ekA__original/img/rWF8r4JXXCQQ7QhiWHhmT-rQ3Pc=/0x0/filters:format(jpeg)/pic8937637.jpg"
+    thumbnailUrl: "https://cf.geekdo-images.com/kdWYkW-7AqG63HhqPL6ekA__small/img/5G46jv8MFh_BfX67iMSouTMhKxc=/fit-in/200x150/filters:strip_icc()/pic8937637.jpg"
+
+  - title: "Wingspan"
+    bggId: 266192
+    language: en
+    pdfFile: "wingspan_en_rulebook.pdf"
+    imageUrl: "https://cf.geekdo-images.com/yLZJCVLlIx4c7eJEWUNJ7w__original/img/cI782Zis9cT66j2MjSHKJGnFPNw=/0x0/filters:format(jpeg)/pic4458123.jpg"
+    thumbnailUrl: "https://cf.geekdo-images.com/yLZJCVLlIx4c7eJEWUNJ7w__small/img/VNToqgS2-pOGU6MuvIkMPKn_y-s=/fit-in/200x150/filters:strip_icc()/pic4458123.jpg"
+```
+
+- [ ] **Step 2: Create SeedManifestModels**
+
+```csharp
+// apps/api/src/Api/Infrastructure/Seeders/Catalog/SeedManifestModels.cs
+namespace Api.Infrastructure.Seeders.Catalog;
+
+/// <summary>
+/// Root model for shared-games.yaml manifest.
+/// </summary>
+public sealed class SharedGamesManifest
+{
+    public List<GameManifestEntry> Games { get; set; } = [];
+}
+
+/// <summary>
+/// A single game entry in the seed manifest.
+/// </summary>
+public sealed class GameManifestEntry
+{
+    public string Title { get; set; } = string.Empty;
+    public int? BggId { get; set; }
+    public string Language { get; set; } = "en";
+    public string? PdfFile { get; set; }
+    public string? ImageUrl { get; set; }
+    public string? ThumbnailUrl { get; set; }
+}
+```
+
+- [ ] **Step 3: Write failing test for SeedManifestLoader**
+
+```csharp
+// tests/Api.Tests/Infrastructure/Seeders/SeedManifestLoaderTests.cs
+using Api.Infrastructure.Seeders.Catalog;
+using Xunit;
+
+namespace Api.Tests.Infrastructure.Seeders;
+
+public sealed class SeedManifestLoaderTests
+{
+    [Fact]
+    public void LoadFromString_ParsesValidYaml()
+    {
+        var yaml = """
+            games:
+              - title: "Catan"
+                bggId: 13
+                language: en
+                pdfFile: "catan_rulebook.pdf"
+                imageUrl: "https://example.com/catan.jpg"
+                thumbnailUrl: "https://example.com/catan_thumb.jpg"
+              - title: "Chess"
+                language: it
+                pdfFile: "chess_rulebook.pdf"
+            """;
+
+        var manifest = SeedManifestLoader.LoadFromString(yaml);
+
+        Assert.Equal(2, manifest.Games.Count);
+        Assert.Equal("Catan", manifest.Games[0].Title);
+        Assert.Equal(13, manifest.Games[0].BggId);
+        Assert.Equal("en", manifest.Games[0].Language);
+        Assert.Equal("Chess", manifest.Games[1].Title);
+        Assert.Null(manifest.Games[1].BggId);
+        Assert.Equal("it", manifest.Games[1].Language);
+    }
+
+    [Fact]
+    public void LoadFromString_EmptyYaml_ReturnsEmptyList()
+    {
+        var yaml = "games: []";
+
+        var manifest = SeedManifestLoader.LoadFromString(yaml);
+
+        Assert.Empty(manifest.Games);
+    }
+
+    [Fact]
+    public void LoadFromString_MissingOptionalFields_UsesDefaults()
+    {
+        var yaml = """
+            games:
+              - title: "Test Game"
+            """;
+
+        var manifest = SeedManifestLoader.LoadFromString(yaml);
+
+        Assert.Single(manifest.Games);
+        Assert.Equal("en", manifest.Games[0].Language);
+        Assert.Null(manifest.Games[0].BggId);
+        Assert.Null(manifest.Games[0].ImageUrl);
+    }
+
+    [Fact]
+    public void Validate_RejectsEmptyTitle()
+    {
+        var manifest = new SharedGamesManifest
+        {
+            Games = [new GameManifestEntry { Title = "" }]
+        };
+
+        var errors = SeedManifestLoader.Validate(manifest);
+
+        Assert.NotEmpty(errors);
+        Assert.Contains(errors, e => e.Contains("title"));
+    }
+
+    [Fact]
+    public void Validate_RejectsDuplicateTitles()
+    {
+        var manifest = new SharedGamesManifest
+        {
+            Games =
+            [
+                new GameManifestEntry { Title = "Catan" },
+                new GameManifestEntry { Title = "Catan" }
+            ]
+        };
+
+        var errors = SeedManifestLoader.Validate(manifest);
+
+        Assert.NotEmpty(errors);
+        Assert.Contains(errors, e => e.Contains("duplicate", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public void Validate_AcceptsValidManifest()
+    {
+        var manifest = new SharedGamesManifest
+        {
+            Games =
+            [
+                new GameManifestEntry { Title = "Catan", BggId = 13 },
+                new GameManifestEntry { Title = "Chess" }
+            ]
+        };
+
+        var errors = SeedManifestLoader.Validate(manifest);
+
+        Assert.Empty(errors);
+    }
+}
+```
+
+- [ ] **Step 4: Run test to verify it fails**
+
+Run: `cd apps/api/src/Api && dotnet test ../../tests/Api.Tests --filter "FullyQualifiedName~SeedManifestLoaderTests" -v quiet`
+Expected: FAIL — `SeedManifestLoader` does not exist
+
+- [ ] **Step 5: Implement SeedManifestLoader**
+
+```csharp
+// apps/api/src/Api/Infrastructure/Seeders/Catalog/SeedManifestLoader.cs
+using Microsoft.Extensions.Logging;
+using YamlDotNet.Serialization;
+using YamlDotNet.Serialization.NamingConventions;
+
+namespace Api.Infrastructure.Seeders.Catalog;
+
+/// <summary>
+/// Loads and validates YAML seed manifests from data/seed-manifests/.
+/// </summary>
+internal static class SeedManifestLoader
+{
+    private static readonly IDeserializer Deserializer = new DeserializerBuilder()
+        .WithNamingConvention(CamelCaseNamingConvention.Instance)
+        .IgnoreUnmatchedProperties()
+        .Build();
+
+    /// <summary>
+    /// Load manifest from a YAML string.
+    /// </summary>
+    public static SharedGamesManifest LoadFromString(string yaml)
+    {
+        return Deserializer.Deserialize<SharedGamesManifest>(yaml) ?? new SharedGamesManifest();
+    }
+
+    /// <summary>
+    /// Load manifest from a file path.
+    /// </summary>
+    public static SharedGamesManifest LoadFromFile(string filePath, ILogger logger)
+    {
+        if (!File.Exists(filePath))
+        {
+            logger.LogWarning("⚠️ Seed manifest not found: {Path}", filePath);
+            return new SharedGamesManifest();
+        }
+
+        var yaml = File.ReadAllText(filePath);
+        var manifest = LoadFromString(yaml);
+
+        logger.LogInformation("📋 Loaded seed manifest: {Path} ({Count} games)", filePath, manifest.Games.Count);
+        return manifest;
+    }
+
+    /// <summary>
+    /// Validate manifest entries. Returns list of error messages (empty = valid).
+    /// </summary>
+    public static IReadOnlyList<string> Validate(SharedGamesManifest manifest)
+    {
+        var errors = new List<string>();
+
+        for (var i = 0; i < manifest.Games.Count; i++)
+        {
+            var game = manifest.Games[i];
+            if (string.IsNullOrWhiteSpace(game.Title))
+                errors.Add($"Game at index {i} has empty title");
+        }
+
+        var duplicates = manifest.Games
+            .Where(g => !string.IsNullOrWhiteSpace(g.Title))
+            .GroupBy(g => g.Title, StringComparer.OrdinalIgnoreCase)
+            .Where(g => g.Count() > 1)
+            .Select(g => g.Key);
+
+        foreach (var dup in duplicates)
+            errors.Add($"Duplicate game title: '{dup}'");
+
+        return errors;
+    }
+}
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `cd apps/api/src/Api && dotnet test ../../tests/Api.Tests --filter "FullyQualifiedName~SeedManifestLoaderTests" -v quiet`
+Expected: 6 tests pass
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/api/src/Api/Infrastructure/Seeders/Catalog/SeedManifestModels.cs \
+        apps/api/src/Api/Infrastructure/Seeders/Catalog/SeedManifestLoader.cs \
+        data/seed-manifests/shared-games.yaml \
+        tests/Api.Tests/Infrastructure/Seeders/SeedManifestLoaderTests.cs
+git commit -m "feat(seeding): add YAML manifest loader and shared-games.yaml (#352)"
+```
+
+---
+
+### Task 6: Create CatalogSeedLayer (#352, #353)
+
+**Files:**
+- Create: `apps/api/src/Api/Infrastructure/Seeders/Catalog/CatalogSeedLayer.cs`
+- Test: `tests/Api.Tests/Infrastructure/Seeders/CatalogSeedLayerTests.cs`
+
+- [ ] **Step 1: Write failing test**
+
+```csharp
+// tests/Api.Tests/Infrastructure/Seeders/CatalogSeedLayerTests.cs
+using Api.Infrastructure.Seeders;
+using Api.Infrastructure.Seeders.Catalog;
+using Xunit;
+
+namespace Api.Tests.Infrastructure.Seeders;
+
+public sealed class CatalogSeedLayerTests
+{
+    [Fact]
+    public void Name_IsCatalog()
+    {
+        var layer = new CatalogSeedLayer();
+        Assert.Equal("Catalog", layer.Name);
+    }
+
+    [Fact]
+    public void MinimumProfile_IsStaging()
+    {
+        var layer = new CatalogSeedLayer();
+        Assert.Equal(SeedProfile.Staging, layer.MinimumProfile);
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/api/src/Api && dotnet test ../../tests/Api.Tests --filter "FullyQualifiedName~CatalogSeedLayerTests" -v quiet`
+Expected: FAIL
+
+- [ ] **Step 3: Implement CatalogSeedLayer**
+
+This layer delegates to existing static seeders (SharedGameSeeder, BadgeSeeder, etc.) and adds YAML-based SharedGame creation. It wraps all the logic from `AutoConfigurationService.SeedSharedGamesAndRelatedDataAsync()`.
+
+```csharp
+// apps/api/src/Api/Infrastructure/Seeders/Catalog/CatalogSeedLayer.cs
+using Api.Services;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+
+namespace Api.Infrastructure.Seeders.Catalog;
+
+/// <summary>
+/// Catalog seed layer: shared games (YAML + BGG), badges, rate limits, feature flags, PDF rulebooks.
+/// Runs in Staging and Dev profiles.
+/// </summary>
+internal sealed class CatalogSeedLayer : ISeedLayer
+{
+    public string Name => "Catalog";
+    public SeedProfile MinimumProfile => SeedProfile.Staging;
+
+    public async Task SeedAsync(SeedContext context, CancellationToken cancellationToken = default)
+    {
+        var db = context.DbContext;
+        var logger = context.Logger;
+        var config = context.Services.GetRequiredService<IConfiguration>();
+        var bggService = context.Services.GetRequiredService<IBggApiService>();
+        var embeddingService = context.Services.GetRequiredService<IEmbeddingService>();
+
+        // 1. Shared games from BGG data (existing seeder — uses hardcoded dict)
+        logger.LogInformation("🌱 [Catalog] Seeding shared games from BGG...");
+        await SharedGameSeeder.SeedSharedGamesAsync(
+            db, bggService, context.SystemUserId, logger, cancellationToken).ConfigureAwait(false);
+
+        // 2. Catan POC Agent (must run before strategy patterns)
+        logger.LogInformation("🌱 [Catalog] Seeding Catan POC Agent...");
+        await CatanPocAgentSeeder.SeedAsync(db, logger, cancellationToken: cancellationToken).ConfigureAwait(false);
+
+        // 3. Strategy patterns (configurable)
+        var strategyEnabled = config.GetValue("Seeding:EnableStrategyPatterns", true);
+        if (strategyEnabled)
+        {
+            logger.LogInformation("🌱 [Catalog] Seeding strategy patterns...");
+            await StrategyPatternSeeder.SeedAsync(db, logger, embeddingService, cancellationToken).ConfigureAwait(false);
+        }
+
+        // 4. Badges
+        logger.LogInformation("🌱 [Catalog] Seeding badges...");
+        await BadgeSeeder.SeedBadgesAsync(db, logger, cancellationToken).ConfigureAwait(false);
+
+        // 5. Rate limit configs
+        logger.LogInformation("🌱 [Catalog] Seeding rate limit configs...");
+        await RateLimitConfigSeeder.SeedRateLimitConfigsAsync(db, logger, cancellationToken).ConfigureAwait(false);
+
+        // 6. Feature flags
+        logger.LogInformation("🌱 [Catalog] Seeding feature flags...");
+        await FeatureFlagSeeder.SeedFeatureFlagsAsync(db, context.SystemUserId, logger, cancellationToken).ConfigureAwait(false);
+
+        // 7. PDF rulebooks
+        logger.LogInformation("🌱 [Catalog] Seeding PDF rulebooks...");
+        await PdfRulebookSeeder.SeedRulebooksAsync(
+            db, context.SystemUserId, logger, config["PDF_STORAGE_PATH"], cancellationToken).ConfigureAwait(false);
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd apps/api/src/Api && dotnet test ../../tests/Api.Tests --filter "FullyQualifiedName~CatalogSeedLayerTests" -v quiet`
+Expected: 2 tests pass
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/Api/Infrastructure/Seeders/Catalog/CatalogSeedLayer.cs \
+        tests/Api.Tests/Infrastructure/Seeders/CatalogSeedLayerTests.cs
+git commit -m "feat(seeding): add CatalogSeedLayer wrapping game/badge/flag seeders (#352, #353)"
+```
+
+---
+
+### Task 7: Create LivedInSeedLayer (#353)
+
+**Files:**
+- Create: `apps/api/src/Api/Infrastructure/Seeders/LivedIn/LivedInSeedLayer.cs`
+
+- [ ] **Step 1: Create LivedInSeedLayer placeholder**
+
+```csharp
+// apps/api/src/Api/Infrastructure/Seeders/LivedIn/LivedInSeedLayer.cs
+namespace Api.Infrastructure.Seeders.LivedIn;
+
+/// <summary>
+/// LivedIn seed layer: synthetic game sessions, activity data.
+/// Only runs in Dev profile for realistic development data.
+/// Currently a placeholder — will be expanded with synthetic data generators.
+/// </summary>
+internal sealed class LivedInSeedLayer : ISeedLayer
+{
+    public string Name => "LivedIn";
+    public SeedProfile MinimumProfile => SeedProfile.Dev;
+
+    public Task SeedAsync(SeedContext context, CancellationToken cancellationToken = default)
+    {
+        context.Logger.LogInformation("🌱 [LivedIn] Synthetic data seeding (placeholder — no-op)");
+        return Task.CompletedTask;
+    }
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add apps/api/src/Api/Infrastructure/Seeders/LivedIn/LivedInSeedLayer.cs
+git commit -m "feat(seeding): add LivedInSeedLayer placeholder for synthetic data (#353)"
+```
+
+---
+
+## Chunk 3: Wiring — DI, Program.cs, Endpoint, Obsolete
+
+### Task 8: Register layers and orchestrator in DI (#351)
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/Administration/Infrastructure/DependencyInjection/AdministrationServiceExtensions.cs`
+
+- [ ] **Step 1: Read current file**
+
+Read `AdministrationServiceExtensions.cs` to find where `IAutoConfigurationService` is registered.
+
+- [ ] **Step 2: Add seed layer registrations**
+
+Add after the existing `IAutoConfigurationService` registration:
+
+```csharp
+// Layered seeding system (Epic #318)
+services.AddScoped<ISeedLayer, CoreSeedLayer>();
+services.AddScoped<ISeedLayer, CatalogSeedLayer>();
+services.AddScoped<ISeedLayer, LivedInSeedLayer>();
+services.AddScoped<SeedOrchestrator>();
+```
+
+Required usings:
+```csharp
+using Api.Infrastructure.Seeders;
+using Api.Infrastructure.Seeders.Core;
+using Api.Infrastructure.Seeders.Catalog;
+using Api.Infrastructure.Seeders.LivedIn;
+```
+
+- [ ] **Step 3: Build to verify compilation**
+
+Run: `cd apps/api/src/Api && dotnet build --no-restore -v quiet`
+Expected: 0 errors
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/Administration/Infrastructure/DependencyInjection/AdministrationServiceExtensions.cs
+git commit -m "feat(seeding): register seed layers and orchestrator in DI (#351)"
+```
+
+---
+
+### Task 9: Update Program.cs to use SeedOrchestrator (#351)
+
+**Files:**
+- Modify: `apps/api/src/Api/Program.cs` (lines 397-401)
+
+- [ ] **Step 1: Read current Program.cs seeding block**
+
+Lines 397-401 currently:
+```csharp
+var autoConfigService = scope.ServiceProvider.GetRequiredService<Api.BoundedContexts.Administration.Application.Services.IAutoConfigurationService>();
+await autoConfigService.InitializeAsync().ConfigureAwait(false);
+```
+
+- [ ] **Step 2: Replace with SeedOrchestrator call**
+
+Replace the above with:
+```csharp
+// Epic #318: Layered seeding pipeline with advisory lock
+var seedOrchestrator = scope.ServiceProvider.GetRequiredService<Api.Infrastructure.Seeders.SeedOrchestrator>();
+await seedOrchestrator.RunAsync(db, scope.ServiceProvider).ConfigureAwait(false);
+```
+
+- [ ] **Step 3: Build to verify compilation**
+
+Run: `cd apps/api/src/Api && dotnet build --no-restore -v quiet`
+Expected: 0 errors
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/api/src/Api/Program.cs
+git commit -m "feat(seeding): switch Program.cs from AutoConfigurationService to SeedOrchestrator (#351)"
+```
+
+---
+
+### Task 10: Mark AutoConfigurationService as obsolete (#353)
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/Administration/Application/Services/AutoConfigurationService.cs`
+
+- [ ] **Step 1: Add [Obsolete] attribute to class**
+
+```csharp
+[Obsolete("Use SeedOrchestrator instead. Will be removed in a future release.")]
+internal sealed class AutoConfigurationService : IAutoConfigurationService
+```
+
+- [ ] **Step 2: Build to verify**
+
+Run: `cd apps/api/src/Api && dotnet build --no-restore -v quiet`
+Expected: 0 errors (warnings OK for obsolete usage)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/Administration/Application/Services/AutoConfigurationService.cs
+git commit -m "refactor(seeding): mark AutoConfigurationService as obsolete (#353)"
+```
+
+---
+
+### Task 11: Create admin seeding endpoint (#351)
+
+**Files:**
+- Create: `apps/api/src/Api/Routing/AdminSeedingEndpoints.cs`
+
+- [ ] **Step 1: Implement admin endpoint**
+
+```csharp
+// apps/api/src/Api/Routing/AdminSeedingEndpoints.cs
+using Api.Filters;
+using Api.Infrastructure.Seeders;
+
+namespace Api.Routing;
+
+/// <summary>
+/// Admin endpoint for manually triggering the seeding pipeline.
+/// </summary>
+internal static class AdminSeedingEndpoints
+{
+    public static void MapAdminSeedingEndpoints(this WebApplication app)
+    {
+        var group = app.MapGroup("/api/v1/admin/seeding")
+            .AddEndpointFilter<RequireAdminSessionFilter>()
+            .WithTags("Admin - Seeding");
+
+        group.MapPost("/orchestrate", async (
+            SeedOrchestrator orchestrator,
+            MeepleAiDbContext db,
+            IServiceProvider services,
+            CancellationToken ct) =>
+        {
+            await orchestrator.RunAsync(db, services, ct).ConfigureAwait(false);
+            return Results.Ok(new { message = "Seeding pipeline completed" });
+        })
+        .WithName("OrchestrateSeeding")
+        .WithSummary("Run the seeding pipeline manually");
+    }
+}
+```
+
+- [ ] **Step 2: Register endpoint in Program.cs**
+
+Find where other admin endpoints are mapped (search for `MapAdmin`) and add:
+```csharp
+app.MapAdminSeedingEndpoints();
+```
+
+- [ ] **Step 3: Build to verify**
+
+Run: `cd apps/api/src/Api && dotnet build --no-restore -v quiet`
+Expected: 0 errors
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/api/src/Api/Routing/AdminSeedingEndpoints.cs apps/api/src/Api/Program.cs
+git commit -m "feat(seeding): add POST /admin/seeding/orchestrate endpoint (#351)"
+```
+
+---
+
+## Chunk 4: Dump/Restore Scripts (#354)
+
+### Task 12: Create database dump script
+
+**Files:**
+- Create: `infra/scripts/db-dump.ps1`
+
+- [ ] **Step 1: Create dump script**
+
+```powershell
+# infra/scripts/db-dump.ps1
+# Exports production database, excluding sensitive tables
+# Usage: pwsh db-dump.ps1 [-OutputFile dump.sql] [-ExcludeSensitive]
+param(
+    [string]$OutputFile = "meepleai-dump-$(Get-Date -Format 'yyyy-MM-dd-HHmmss').sql",
+    [switch]$ExcludeSensitive = $true
+)
+
+$secretFile = Join-Path $PSScriptRoot ".." "secrets" "database.secret"
+if (-not (Test-Path $secretFile)) {
+    Write-Error "database.secret not found at $secretFile"
+    exit 1
+}
+
+# Read connection string from secret
+$envVars = Get-Content $secretFile | Where-Object { $_ -match '=' } | ForEach-Object {
+    $parts = $_ -split '=', 2
+    @{ Name = $parts[0].Trim(); Value = $parts[1].Trim() }
+}
+
+$dbHost = ($envVars | Where-Object { $_.Name -eq 'POSTGRES_HOST' }).Value ?? 'localhost'
+$dbPort = ($envVars | Where-Object { $_.Name -eq 'POSTGRES_PORT' }).Value ?? '5432'
+$dbName = ($envVars | Where-Object { $_.Name -eq 'POSTGRES_DB' }).Value ?? 'meepleai'
+$dbUser = ($envVars | Where-Object { $_.Name -eq 'POSTGRES_USER' }).Value ?? 'meepleai'
+
+# Tables to exclude (contain sensitive data)
+$excludeTables = @(
+    "Users",
+    "Sessions",
+    "RefreshTokens",
+    "ApiKeys",
+    "AuditLogs"
+)
+
+$excludeArgs = if ($ExcludeSensitive) {
+    $excludeTables | ForEach-Object { "--exclude-table-data=$_" }
+} else { @() }
+
+Write-Host "Dumping database $dbName from ${dbHost}:${dbPort}..."
+Write-Host "Output: $OutputFile"
+if ($ExcludeSensitive) { Write-Host "Excluding sensitive data from: $($excludeTables -join ', ')" }
+
+$env:PGPASSWORD = ($envVars | Where-Object { $_.Name -eq 'POSTGRES_PASSWORD' }).Value
+
+& pg_dump -h $dbHost -p $dbPort -U $dbUser -d $dbName `
+    --format=plain --no-owner --no-privileges `
+    @excludeArgs `
+    --file=$OutputFile
+
+if ($LASTEXITCODE -eq 0) {
+    $size = (Get-Item $OutputFile).Length / 1MB
+    Write-Host "Dump completed: $OutputFile ($([math]::Round($size, 2)) MB)"
+} else {
+    Write-Error "pg_dump failed with exit code $LASTEXITCODE"
+    exit 1
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add infra/scripts/db-dump.ps1
+git commit -m "feat(infra): add database dump script with sensitive data exclusion (#354)"
+```
+
+---
+
+### Task 13: Create database restore script
+
+**Files:**
+- Create: `infra/scripts/db-restore.ps1`
+
+- [ ] **Step 1: Create restore script**
+
+```powershell
+# infra/scripts/db-restore.ps1
+# Restores a database dump to a target environment
+# Usage: pwsh db-restore.ps1 -InputFile dump.sql [-TargetDb meepleai_staging]
+param(
+    [Parameter(Mandatory)]
+    [string]$InputFile,
+    [string]$TargetDb = "meepleai_staging",
+    [switch]$DropExisting = $false
+)
+
+if (-not (Test-Path $InputFile)) {
+    Write-Error "Input file not found: $InputFile"
+    exit 1
+}
+
+$secretFile = Join-Path $PSScriptRoot ".." "secrets" "database.secret"
+if (-not (Test-Path $secretFile)) {
+    Write-Error "database.secret not found at $secretFile"
+    exit 1
+}
+
+$envVars = Get-Content $secretFile | Where-Object { $_ -match '=' } | ForEach-Object {
+    $parts = $_ -split '=', 2
+    @{ Name = $parts[0].Trim(); Value = $parts[1].Trim() }
+}
+
+$dbHost = ($envVars | Where-Object { $_.Name -eq 'POSTGRES_HOST' }).Value ?? 'localhost'
+$dbPort = ($envVars | Where-Object { $_.Name -eq 'POSTGRES_PORT' }).Value ?? '5432'
+$dbUser = ($envVars | Where-Object { $_.Name -eq 'POSTGRES_USER' }).Value ?? 'meepleai'
+$env:PGPASSWORD = ($envVars | Where-Object { $_.Name -eq 'POSTGRES_PASSWORD' }).Value
+
+Write-Host "Restoring $InputFile to $TargetDb on ${dbHost}:${dbPort}..."
+
+if ($DropExisting) {
+    Write-Host "WARNING: Dropping existing database $TargetDb in 5 seconds... (Ctrl+C to cancel)"
+    Start-Sleep -Seconds 5
+    & psql -h $dbHost -p $dbPort -U $dbUser -c "DROP DATABASE IF EXISTS $TargetDb;"
+    & psql -h $dbHost -p $dbPort -U $dbUser -c "CREATE DATABASE $TargetDb;"
+}
+
+& psql -h $dbHost -p $dbPort -U $dbUser -d $TargetDb -f $InputFile
+
+if ($LASTEXITCODE -eq 0) {
+    Write-Host "Restore completed successfully to $TargetDb"
+} else {
+    Write-Error "Restore failed with exit code $LASTEXITCODE"
+    exit 1
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add infra/scripts/db-restore.ps1
+git commit -m "feat(infra): add database restore script for staging (#354)"
+```
+
+---
+
+## Chunk 5: Final Verification
+
+### Task 14: Full build + test verification
+
+- [ ] **Step 1: Run full backend build**
+
+Run: `cd apps/api/src/Api && dotnet build --no-restore -v quiet`
+Expected: 0 errors, 0 warnings (obsolete warning OK)
+
+- [ ] **Step 2: Run all new seeder tests**
+
+Run: `cd apps/api/src/Api && dotnet test ../../tests/Api.Tests --filter "FullyQualifiedName~Infrastructure.Seeders" -v normal`
+Expected: All tests pass (≥15 tests)
+
+- [ ] **Step 3: Run full test suite to check no regressions**
+
+Run: `cd apps/api/src/Api && dotnet test ../../tests/Api.Tests --filter "Category=Unit" -v quiet`
+Expected: 0 failures
+
+- [ ] **Step 4: Final commit with all changes verified**
+
+```bash
+git log --oneline -10  # Verify commit history looks clean
+```
+
+---
+
+### Task 15: Close issues on GitHub
+
+- [ ] **Step 1: Update issue #351**
+```bash
+gh issue close 351 --comment "Implemented: SeedOrchestrator, AdvisoryLockHelper, SeedProfile, ISeedLayer interface, admin endpoint, DI wiring, Program.cs integration"
+```
+
+- [ ] **Step 2: Update issue #352**
+```bash
+gh issue close 352 --comment "Implemented: YAML manifest loader (SeedManifestLoader), shared-games.yaml, SeedManifestModels"
+```
+
+- [ ] **Step 3: Update issue #353**
+```bash
+gh issue close 353 --comment "Implemented: CoreSeedLayer, CatalogSeedLayer, LivedInSeedLayer (placeholder), AutoConfigurationService marked obsolete"
+```
+
+- [ ] **Step 4: Update issue #354**
+```bash
+gh issue close 354 --comment "Implemented: db-dump.ps1 and db-restore.ps1 in infra/scripts/"
+```
+
+- [ ] **Step 5: Create PR and request code review**
+
+Use `superpowers:finishing-a-development-branch` to create the PR to `main-dev`.

--- a/infra/scripts/db-dump.ps1
+++ b/infra/scripts/db-dump.ps1
@@ -1,0 +1,56 @@
+# infra/scripts/db-dump.ps1
+# Exports production database, excluding sensitive tables
+# Usage: pwsh db-dump.ps1 [-OutputFile dump.sql] [-ExcludeSensitive]
+param(
+    [string]$OutputFile = "meepleai-dump-$(Get-Date -Format 'yyyy-MM-dd-HHmmss').sql",
+    [switch]$ExcludeSensitive = $true
+)
+
+$secretFile = Join-Path $PSScriptRoot ".." "secrets" "database.secret"
+if (-not (Test-Path $secretFile)) {
+    Write-Error "database.secret not found at $secretFile"
+    exit 1
+}
+
+# Read connection string from secret
+$envVars = Get-Content $secretFile | Where-Object { $_ -match '=' } | ForEach-Object {
+    $parts = $_ -split '=', 2
+    @{ Name = $parts[0].Trim(); Value = $parts[1].Trim() }
+}
+
+$dbHost = ($envVars | Where-Object { $_.Name -eq 'POSTGRES_HOST' }).Value ?? 'localhost'
+$dbPort = ($envVars | Where-Object { $_.Name -eq 'POSTGRES_PORT' }).Value ?? '5432'
+$dbName = ($envVars | Where-Object { $_.Name -eq 'POSTGRES_DB' }).Value ?? 'meepleai'
+$dbUser = ($envVars | Where-Object { $_.Name -eq 'POSTGRES_USER' }).Value ?? 'meepleai'
+
+# Tables to exclude (contain sensitive data)
+$excludeTables = @(
+    "Users",
+    "Sessions",
+    "RefreshTokens",
+    "ApiKeys",
+    "AuditLogs"
+)
+
+$excludeArgs = if ($ExcludeSensitive) {
+    $excludeTables | ForEach-Object { "--exclude-table-data=$_" }
+} else { @() }
+
+Write-Host "Dumping database $dbName from ${dbHost}:${dbPort}..."
+Write-Host "Output: $OutputFile"
+if ($ExcludeSensitive) { Write-Host "Excluding sensitive data from: $($excludeTables -join ', ')" }
+
+$env:PGPASSWORD = ($envVars | Where-Object { $_.Name -eq 'POSTGRES_PASSWORD' }).Value
+
+& pg_dump -h $dbHost -p $dbPort -U $dbUser -d $dbName `
+    --format=plain --no-owner --no-privileges `
+    @excludeArgs `
+    --file=$OutputFile
+
+if ($LASTEXITCODE -eq 0) {
+    $size = (Get-Item $OutputFile).Length / 1MB
+    Write-Host "Dump completed: $OutputFile ($([math]::Round($size, 2)) MB)"
+} else {
+    Write-Error "pg_dump failed with exit code $LASTEXITCODE"
+    exit 1
+}

--- a/infra/scripts/db-restore.ps1
+++ b/infra/scripts/db-restore.ps1
@@ -1,0 +1,48 @@
+# infra/scripts/db-restore.ps1
+# Restores a database dump to a target environment
+# Usage: pwsh db-restore.ps1 -InputFile dump.sql [-TargetDb meepleai_staging]
+param(
+    [Parameter(Mandatory)]
+    [string]$InputFile,
+    [string]$TargetDb = "meepleai_staging",
+    [switch]$DropExisting = $false
+)
+
+if (-not (Test-Path $InputFile)) {
+    Write-Error "Input file not found: $InputFile"
+    exit 1
+}
+
+$secretFile = Join-Path $PSScriptRoot ".." "secrets" "database.secret"
+if (-not (Test-Path $secretFile)) {
+    Write-Error "database.secret not found at $secretFile"
+    exit 1
+}
+
+$envVars = Get-Content $secretFile | Where-Object { $_ -match '=' } | ForEach-Object {
+    $parts = $_ -split '=', 2
+    @{ Name = $parts[0].Trim(); Value = $parts[1].Trim() }
+}
+
+$dbHost = ($envVars | Where-Object { $_.Name -eq 'POSTGRES_HOST' }).Value ?? 'localhost'
+$dbPort = ($envVars | Where-Object { $_.Name -eq 'POSTGRES_PORT' }).Value ?? '5432'
+$dbUser = ($envVars | Where-Object { $_.Name -eq 'POSTGRES_USER' }).Value ?? 'meepleai'
+$env:PGPASSWORD = ($envVars | Where-Object { $_.Name -eq 'POSTGRES_PASSWORD' }).Value
+
+Write-Host "Restoring $InputFile to $TargetDb on ${dbHost}:${dbPort}..."
+
+if ($DropExisting) {
+    Write-Host "WARNING: Dropping existing database $TargetDb in 5 seconds... (Ctrl+C to cancel)"
+    Start-Sleep -Seconds 5
+    & psql -h $dbHost -p $dbPort -U $dbUser -c "DROP DATABASE IF EXISTS $TargetDb;"
+    & psql -h $dbHost -p $dbPort -U $dbUser -c "CREATE DATABASE $TargetDb;"
+}
+
+& psql -h $dbHost -p $dbPort -U $dbUser -d $TargetDb -f $InputFile
+
+if ($LASTEXITCODE -eq 0) {
+    Write-Host "Restore completed successfully to $TargetDb"
+} else {
+    Write-Error "Restore failed with exit code $LASTEXITCODE"
+    exit 1
+}


### PR DESCRIPTION
## Summary

- Replace monolithic `AutoConfigurationService` with composable `ISeedLayer` system (Epic #318)
- `SeedProfile` enum (None/Prod/Staging/Dev) with ordinal-based layer filtering
- `SeedOrchestrator` resolves profile from env/config, acquires PostgreSQL advisory lock, runs matching layers
- Three layers: Core (Prod+), Catalog (Staging+), LivedIn (Dev placeholder)
- YAML manifest (`data/seed-manifests/shared-games.yaml`) for catalog seeding with 10 BGG games
- Admin endpoint `POST /admin/seeding/orchestrate` for manual re-seeding
- `db-dump.ps1` / `db-restore.ps1` scripts for seed data management
- 43 unit tests covering profile resolution, layer filtering, YAML parsing

## Architecture

```
SeedOrchestrator.RunAsync()
  ├── ResolveProfile(env → config → default Dev)
  ├── AdvisoryLockHelper.AcquireAsync()
  ├── FilterLayers(ISeedLayer[], profile)
  │   ├── CoreSeedLayer (Prod+): admin, AI models, flags, badges
  │   ├── CatalogSeedLayer (Staging+): games, PDFs, agents via CatalogSeeder
  │   └── LivedInSeedLayer (Dev): synthetic data (placeholder)
  └── AdvisoryLockHelper.ReleaseAsync()
```

## Test plan

- [x] `dotnet build` — 0 errors, 0 warnings
- [x] 43 unit tests pass (`FullyQualifiedName~Infrastructure.Seeders&Category=Unit`)
- [ ] Integration test: `SEED_PROFILE=Staging dotnet run` seeds shared games from manifest
- [ ] Verify advisory lock prevents concurrent seeding across replicas
- [ ] Manual trigger: `POST /admin/seeding/orchestrate` returns 200

Closes #351, #352, #353, #354

🤖 Generated with [Claude Code](https://claude.com/claude-code)
