### PR TITLE
fix(game-night): use agents client for private game agent loading

### DIFF
--- a/apps/web/src/hooks/queries/useGameAgents.ts
+++ b/apps/web/src/hooks/queries/useGameAgents.ts
@@ -46,7 +46,10 @@ export function useGameAgents({ gameId, enabled = true }: UseGameAgentsOptions) 
       if (!gameId) {
         throw new Error('Game ID is required');
       }
-      return api.games.getAgents(gameId);
+      // Use agents client (filters userOwned + activeOnly) — works for both
+      // shared catalog games AND private game UUIDs, unlike api.games.getAgents()
+      // which only handles shared catalog IDs.
+      return api.agents.getUserAgentsForGame(gameId);
     },
     enabled: enabled && gameId !== null,
     staleTime: 30_000, // 30 seconds - agent lists don't change frequently


### PR DESCRIPTION
## Summary

- Fix agent loading for private game sessions: `useGameAgents` was calling `api.games.getAgents()` (endpoint `/api/v1/games/{id}/agents`) which only works for shared catalog IDs, returning 404 for private game UUIDs
- Switch to `api.agents.getUserAgentsForGame()` which queries `/api/v1/agents?gameId=...&userOwned=true&activeOnly=true` and works for both shared catalog and private game IDs

## Test plan

- [ ] Start a live session from a **private game** → agent chat should load (no 404)
- [ ] Start a live session from a **shared catalog game** → agent chat still works (regression check)
- [ ] `pnpm typecheck` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
