### PR TITLE
fix(ci): reduce parallel threads and enable connection pooling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -151,7 +151,7 @@ jobs:
         continue-on-error: true
 
   # Backend Integration Tests (requires service containers, runs in parallel with unit tests)
-  # Phase 2+3: 8 parallel threads per shard, 3-shard matrix for ~8-24x total speedup
+  # Phase 2+3: 4 parallel threads per shard, 3-shard matrix for ~4-12x total speedup
   backend-integration:
     name: Backend - Integration (${{ matrix.shard.name }})
     runs-on: ubuntu-latest
@@ -322,7 +322,7 @@ jobs:
           TEST_POSTGRES_CONNSTRING: Host=localhost;Port=5432;Database=meepleai_test;Username=postgres;Password=testpass
           TEST_REDIS_CONNSTRING: localhost:6379,allowAdmin=true
         run: |
-          echo "🧪 Running integration tests - shard: ${{ matrix.shard.name }} (8 parallel threads)..."
+          echo "🧪 Running integration tests - shard: ${{ matrix.shard.name }} (4 parallel threads)..."
           dotnet test \
             --filter "Category=Integration&FullyQualifiedName!~UploadPdfMidPhaseCancellationTests&FullyQualifiedName!~FrontendSdk&FullyQualifiedName!~ArbitroAgent${{ matrix.shard.filter_extra }}" \
             --settings tests/Api.Tests/integration.runsettings \

--- a/apps/api/tests/Api.Tests/Infrastructure/IntegrationTestBase.cs
+++ b/apps/api/tests/Api.Tests/Infrastructure/IntegrationTestBase.cs
@@ -52,8 +52,14 @@ public abstract class IntegrationTestBase<TRepository> : IAsyncLifetime
             {
                 Database = DatabaseName,
                 SslMode = SslMode.Disable,
-                KeepAlive = 30,
-                Pooling = false
+                KeepAlive = 10,
+                Pooling = true,
+                MinPoolSize = 1,
+                MaxPoolSize = 5,
+                ConnectionIdleLifetime = 30,
+                ConnectionPruningInterval = 5,
+                Timeout = 30,
+                CommandTimeout = 60
             };
             _connectionString = builder.ConnectionString;
         }

--- a/apps/api/tests/Api.Tests/integration.runsettings
+++ b/apps/api/tests/Api.Tests/integration.runsettings
@@ -51,10 +51,10 @@
     </Loggers>
   </LoggerRunSettings>
 
-  <!-- xUnit specific settings -->
+  <!-- xUnit specific settings (note: xUnit reads from xunit.runner.json, not from .runsettings) -->
+  <!-- Kept here for documentation; actual parallelism set in xunit.runner.json -->
   <xUnit>
-    <!-- Phase 2: 8 parallel threads, budget: 8×5 pool = 40 connections (of 500 available) -->
-    <MaxParallelThreads>8</MaxParallelThreads>
+    <MaxParallelThreads>4</MaxParallelThreads>
     <DiagnosticMessages>true</DiagnosticMessages>
     <AppDomain>denied</AppDomain>
   </xUnit>

--- a/apps/api/tests/Api.Tests/xunit.runner.json
+++ b/apps/api/tests/Api.Tests/xunit.runner.json
@@ -2,7 +2,7 @@
   "$schema": "https://xunit.net/schema/current/xunit.runner.schema.json",
   "parallelizeAssembly": false,
   "parallelizeTestCollections": true,
-  "maxParallelThreads": 8,
+  "maxParallelThreads": 4,
   "methodDisplay": "method",
   "diagnosticMessages": false,
   "internalDiagnosticMessages": false,


### PR DESCRIPTION
## Summary
- Reduce `maxParallelThreads` from 8 to 4 in `xunit.runner.json` to prevent PostgreSQL connection exhaustion
- Enable connection pooling (`MaxPoolSize=5`) in `IntegrationTestBase` for CI mode — was `Pooling=false` causing excessive connection churn
- Update `integration.runsettings` with clarifying comments (xUnit reads config from `xunit.runner.json`, not `.runsettings`)

## Root Cause
CI run #23023926363 failed with 909/1984 integration tests failing due to `Npgsql.PostgresException: 53300: sorry, too many clients already`. The combination of 8 parallel threads and `Pooling=false` caused rapid connection creation/teardown that exceeded PostgreSQL's 500 `max_connections` limit.

## Connection Budget
3 shards × 4 threads × 5 pool = **60 max connections** (of 500 available) — safe margin.

## Test plan
- [ ] CI integration tests pass on all 3 shards (KnowledgeBase, Games, Core)
- [ ] No `too many clients already` errors in test logs
- [ ] E2E critical paths pass (health check already uses `/health/live`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
