### PR TITLE
feat(epic-379): Game Night Improvvisata — seeding, BGG import, dispute resolution, progress viz

### DIFF
--- a/apps/api/src/Api/BoundedContexts/Administration/Application/Handlers/SeedAdminUserCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/Handlers/SeedAdminUserCommandHandler.cs
@@ -99,6 +99,9 @@ internal sealed class SeedAdminUserCommandHandler : ICommandHandler<SeedAdminUse
             role: role
         );
 
+        // Issue #372: Seeded admin must have verified email to avoid 403 on /auth/me
+        adminUser.VerifyEmail();
+
         // Persist
         await _userRepository.AddAsync(adminUser, cancellationToken).ConfigureAwait(false);
 

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/RagPromptAssemblyService.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/RagPromptAssemblyService.cs
@@ -499,6 +499,17 @@ internal sealed class RagPromptAssemblyService : IRagPromptAssemblyService
             sb.AppendLine();
         }
 
+        // Issue #376: Rule dispute resolution instructions
+        sb.AppendLine("## Rule Dispute Resolution");
+        sb.AppendLine("When players disagree about a rule or ask you to settle a dispute:");
+        sb.AppendLine("1. Search the provided documentation for the exact rule that applies.");
+        sb.AppendLine("2. Quote the relevant rule text directly, including page/section if available.");
+        sb.AppendLine("3. Give a clear verdict: state who is correct and why.");
+        sb.AppendLine("4. If the rule is ambiguous or not explicitly covered, say so and suggest the most reasonable interpretation.");
+        sb.AppendLine("5. Rate your confidence: HIGH (exact rule found), MEDIUM (inferred from related rules), LOW (no direct rule).");
+        sb.AppendLine("Be fair and impartial — base your ruling only on the documented rules.");
+        sb.AppendLine();
+
         // Chain-of-thought reasoning instructions
         sb.AppendLine("## Reasoning Approach");
         sb.AppendLine("Think step-by-step when answering:");

--- a/apps/api/src/Api/Infrastructure/Seeders/Catalog/AgentSeeder.cs
+++ b/apps/api/src/Api/Infrastructure/Seeders/Catalog/AgentSeeder.cs
@@ -89,7 +89,7 @@ internal static class AgentSeeder
 
         // Find admin user for CreatedBy FKs
         var adminUser = await db.Users
-            .FirstOrDefaultAsync(u => u.Role == "admin", cancellationToken)
+            .FirstOrDefaultAsync(u => u.Role == "admin" || u.Role == "superadmin", cancellationToken)
             .ConfigureAwait(false);
 
         if (adminUser is null)

--- a/apps/api/src/Api/Infrastructure/Seeders/Core/CoreSeeder.cs
+++ b/apps/api/src/Api/Infrastructure/Seeders/Core/CoreSeeder.cs
@@ -44,7 +44,7 @@ internal static class CoreSeeder
     private static async Task<Guid> GetAdminUserIdAsync(MeepleAiDbContext db, CancellationToken ct)
     {
         var adminUser = await db.Users
-            .FirstOrDefaultAsync(u => u.Role == "admin", ct)
+            .FirstOrDefaultAsync(u => u.Role == "admin" || u.Role == "superadmin", ct)
             .ConfigureAwait(false);
 
         return adminUser?.Id ?? Guid.Empty;

--- a/apps/api/src/Api/Infrastructure/Seeders/SeedOrchestrator.cs
+++ b/apps/api/src/Api/Infrastructure/Seeders/SeedOrchestrator.cs
@@ -107,8 +107,9 @@ internal sealed class SeedOrchestrator
 
     private static async Task<Guid> ResolveSystemUserIdAsync(MeepleAiDbContext db, CancellationToken ct)
     {
+        // Issue #372: Query must match both admin and superadmin roles
         var adminUser = await db.Users
-            .FirstOrDefaultAsync(u => u.Role == "admin", ct)
+            .FirstOrDefaultAsync(u => u.Role == "admin" || u.Role == "superadmin", ct)
             .ConfigureAwait(false);
         return adminUser?.Id ?? Guid.Empty;
     }

--- a/apps/web/src/app/(authenticated)/library/AddGameDrawer.tsx
+++ b/apps/web/src/app/(authenticated)/library/AddGameDrawer.tsx
@@ -12,22 +12,24 @@
  *   Step 2  (Catalog PDF): UserWizardClient starting at PDF upload (gameId pre-set)
  *
  * URL integration:
- *   ?action=add     → drawer opens
- *   close / ESC     → removes ?action=add from URL
+ *   ?action=add         → drawer opens (choice step)
+ *   ?action=import-bgg  → drawer opens (BGG search step) — Issue #373
+ *   close / ESC         → removes ?action from URL
  */
 
-import { useCallback, useState } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 
-import { BookOpen, PenLine } from 'lucide-react';
+import { BookOpen, Globe, PenLine } from 'lucide-react';
 import { useRouter, useSearchParams } from 'next/navigation';
 
 import { CatalogSearchStep } from '@/app/(authenticated)/library/CatalogSearchStep';
 import { UserWizardClient } from '@/app/(authenticated)/library/private/add/client';
+import { BggSearchPanel } from '@/components/games/BggSearchPanel';
 import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/navigation/sheet';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
-type DrawerStep = 'choice' | 'manual' | 'catalog' | 'catalog-pdf';
+type DrawerStep = 'choice' | 'manual' | 'catalog' | 'catalog-pdf' | 'bgg';
 
 interface CatalogSelection {
   gameId: string;
@@ -73,12 +75,21 @@ function ChoiceCard({ icon, title, description, onClick, 'data-testid': testId }
 interface AddGameDrawerProps {
   open: boolean;
   onClose: () => void;
+  /** Issue #373: Allow opening directly to a specific step (e.g., 'bgg' from URL) */
+  initialStep?: DrawerStep;
 }
 
-export function AddGameDrawer({ open, onClose }: AddGameDrawerProps) {
+export function AddGameDrawer({ open, onClose, initialStep }: AddGameDrawerProps) {
   const router = useRouter();
-  const [step, setStep] = useState<DrawerStep>('choice');
+  const [step, setStep] = useState<DrawerStep>(initialStep ?? 'choice');
   const [catalogSelection, setCatalogSelection] = useState<CatalogSelection | null>(null);
+
+  // Sync step when initialStep prop changes (e.g., URL switches from ?action=add to ?action=import-bgg)
+  useEffect(() => {
+    if (open && initialStep) {
+      setStep(initialStep);
+    }
+  }, [open, initialStep]);
 
   // Reset to choice step after close animation finishes
   const handleOpenChange = useCallback(
@@ -105,7 +116,9 @@ export function AddGameDrawer({ open, onClose }: AddGameDrawerProps) {
       ? 'Add game manually'
       : step === 'catalog' || step === 'catalog-pdf'
         ? 'Add from catalog'
-        : 'Add a game';
+        : step === 'bgg'
+          ? 'Import from BoardGameGeek'
+          : 'Add a game';
 
   return (
     <Sheet open={open} onOpenChange={handleOpenChange}>
@@ -139,6 +152,14 @@ export function AddGameDrawer({ open, onClose }: AddGameDrawerProps) {
                 description="Search the community catalog and add a game to your personal library."
                 onClick={() => setStep('catalog')}
               />
+
+              <ChoiceCard
+                data-testid="add-game-choice-bgg"
+                icon={<Globe className="h-6 w-6" />}
+                title="Import from BoardGameGeek"
+                description="Search BGG and import a game as a private game in your library."
+                onClick={() => setStep('bgg')}
+              />
             </div>
           )}
 
@@ -153,6 +174,19 @@ export function AddGameDrawer({ open, onClose }: AddGameDrawerProps) {
           {step === 'catalog' && (
             <div data-testid="add-game-step-catalog">
               <CatalogSearchStep onSelect={handleCatalogSelect} onBack={() => setStep('choice')} />
+            </div>
+          )}
+
+          {/* Step: BGG search & import (Issue #373) */}
+          {step === 'bgg' && (
+            <div className="px-6 py-6" data-testid="add-game-step-bgg">
+              <BggSearchPanel
+                onImportSuccess={result => {
+                  // After import, navigate to the new private game
+                  onClose();
+                  router.push(`/library/private/${result.privateGameId}`);
+                }}
+              />
             </div>
           )}
 
@@ -180,13 +214,16 @@ export function AddGameDrawer({ open, onClose }: AddGameDrawerProps) {
 // ─── URL-aware wrapper ────────────────────────────────────────────────────────
 
 /**
- * AddGameDrawerController — reads ?action=add from URL and drives open state.
+ * AddGameDrawerController — reads ?action=add|import-bgg from URL and drives open state.
  * Mount once in _content.tsx; it manages its own open/close via router.
+ * Issue #373: Also handles ?action=import-bgg to open directly to BGG search step.
  */
 export function AddGameDrawerController() {
   const router = useRouter();
   const searchParams = useSearchParams();
-  const isOpen = searchParams.get('action') === 'add';
+  const action = searchParams.get('action');
+  const isOpen = action === 'add' || action === 'import-bgg';
+  const initialStep: DrawerStep | undefined = action === 'import-bgg' ? 'bgg' : undefined;
 
   const handleClose = useCallback(() => {
     const params = new URLSearchParams(searchParams.toString());
@@ -195,5 +232,5 @@ export function AddGameDrawerController() {
     router.replace(newUrl);
   }, [router, searchParams]);
 
-  return <AddGameDrawer open={isOpen} onClose={handleClose} />;
+  return <AddGameDrawer open={isOpen} onClose={handleClose} initialStep={initialStep} />;
 }

--- a/apps/web/src/components/auth/RequireRole.tsx
+++ b/apps/web/src/components/auth/RequireRole.tsx
@@ -99,9 +99,12 @@ export function RequireRole({
           return;
         }
 
-        // Check authorization (role-based)
+        // Check authorization (role-based with hierarchy)
+        // Issue #372: SuperAdmin has all permissions — inherits every role
         const userRole = result.user.role.toLowerCase();
-        const hasRequiredRole = allowedRoles.some(role => role.toLowerCase() === userRole);
+        const isSuperAdmin = userRole === 'superadmin';
+        const hasRequiredRole =
+          isSuperAdmin || allowedRoles.some(role => role.toLowerCase() === userRole);
 
         if (!hasRequiredRole) {
           // Authenticated but not authorized

--- a/apps/web/src/components/library/private-game-detail/PrivateGameHub.tsx
+++ b/apps/web/src/components/library/private-game-detail/PrivateGameHub.tsx
@@ -9,6 +9,7 @@ import { toast } from 'sonner';
 import { PlayerSetupDialog, type PlayerSetup } from '@/components/game-night/PlayerSetupDialog';
 import { CopyrightDisclaimerModal } from '@/components/pdf/CopyrightDisclaimerModal';
 import { PdfProcessingProgressBar } from '@/components/pdf/PdfProcessingProgressBar';
+import { ProgressCard } from '@/components/pdf/progress-card';
 import { Skeleton } from '@/components/ui/feedback/skeleton';
 import { usePrivateGame } from '@/hooks/queries/useLibrary';
 import { api } from '@/lib/api';
@@ -27,6 +28,7 @@ export function PrivateGameHub({ privateGameId }: PrivateGameHubProps) {
   const [showDisclaimer, setShowDisclaimer] = useState(false);
   const [pdfStatus, setPdfStatus] = useState<PdfStatus>('none');
   const [activePdfId, setActivePdfId] = useState<string | null>(null);
+  const [activePdfName, setActivePdfName] = useState<string>('');
   const [uploadProgress, setUploadProgress] = useState(0);
   const [agentStatus, setAgentStatus] = useState<AgentStatus>('none');
   const [pausedSessions, setPausedSessions] = useState<PausedSession[]>([]);
@@ -143,6 +145,7 @@ export function PrivateGameHub({ privateGameId }: PrivateGameHubProps) {
         });
 
         setActivePdfId(result.documentId);
+        setActivePdfName(file.name);
         setPdfStatus('processing');
       } catch {
         setPdfStatus('failed');
@@ -300,12 +303,20 @@ export function PrivateGameHub({ privateGameId }: PrivateGameHubProps) {
           </div>
         )}
         {pdfStatus === 'processing' && activePdfId && (
-          <PdfProcessingProgressBar
-            pdfId={activePdfId}
-            onComplete={() => setPdfStatus('ready')}
-            onError={() => setPdfStatus('failed')}
-            onCancel={() => setPdfStatus('none')}
-          />
+          <>
+            <ProgressCard
+              documentId={activePdfId}
+              title={activePdfName || 'PDF'}
+              subtitle="Elaborazione in corso..."
+              defaultExpanded
+            />
+            <PdfProcessingProgressBar
+              pdfId={activePdfId}
+              onComplete={() => setPdfStatus('ready')}
+              onError={() => setPdfStatus('failed')}
+              onCancel={() => setPdfStatus('none')}
+            />
+          </>
         )}
       </ActivationChecklist>
 

--- a/apps/web/src/components/pdf/progress-badge.tsx
+++ b/apps/web/src/components/pdf/progress-badge.tsx
@@ -58,20 +58,21 @@ export interface ProgressBadgeProps {
 
 function getStateColor(state: string): string {
   const colors: Record<string, string> = {
-    'pending': 'text-muted-foreground bg-muted',
-    'uploading': 'text-amber-600 bg-amber-100 dark:text-amber-400 dark:bg-amber-900/30',
-    'extracting': 'text-blue-600 bg-blue-100 dark:text-blue-400 dark:bg-blue-900/30',
-    'chunking': 'text-blue-600 bg-blue-100 dark:text-blue-400 dark:bg-blue-900/30',
-    'embedding': 'text-blue-600 bg-blue-100 dark:text-blue-400 dark:bg-blue-900/30',
-    'indexing': 'text-blue-600 bg-blue-100 dark:text-blue-400 dark:bg-blue-900/30',
-    'ready': 'text-green-600 bg-green-100 dark:text-green-400 dark:bg-green-900/30',
-    'failed': 'text-destructive bg-destructive/10',
+    pending: 'text-muted-foreground bg-muted',
+    uploading: 'text-amber-600 bg-amber-100 dark:text-amber-400 dark:bg-amber-900/30',
+    extracting: 'text-blue-600 bg-blue-100 dark:text-blue-400 dark:bg-blue-900/30',
+    chunking: 'text-blue-600 bg-blue-100 dark:text-blue-400 dark:bg-blue-900/30',
+    embedding: 'text-blue-600 bg-blue-100 dark:text-blue-400 dark:bg-blue-900/30',
+    indexing: 'text-blue-600 bg-blue-100 dark:text-blue-400 dark:bg-blue-900/30',
+    ready: 'text-green-600 bg-green-100 dark:text-green-400 dark:bg-green-900/30',
+    indexed: 'text-green-600 bg-green-100 dark:text-green-400 dark:bg-green-900/30',
+    failed: 'text-destructive bg-destructive/10',
   };
-  return colors[state] || colors['pending'];
+  return colors[state.toLowerCase()] || colors['pending'];
 }
 
 function getStateIcon(state: string): React.ReactNode {
-  const iconClass = "h-3.5 w-3.5";
+  const iconClass = 'h-3.5 w-3.5';
 
   switch (state) {
     case 'pending':
@@ -79,6 +80,7 @@ function getStateIcon(state: string): React.ReactNode {
     case 'uploading':
       return <Upload className={iconClass} />;
     case 'ready':
+    case 'indexed':
       return <Check className={iconClass} />;
     case 'failed':
       return <X className={iconClass} />;
@@ -90,14 +92,15 @@ function getStateIcon(state: string): React.ReactNode {
 
 function getStateLabel(state: string): string {
   const labels: Record<string, string> = {
-    'pending': 'Pending',
-    'uploading': 'Uploading',
-    'extracting': 'Extracting',
-    'chunking': 'Chunking',
-    'embedding': 'Embedding',
-    'indexing': 'Indexing',
-    'ready': 'Ready',
-    'failed': 'Failed',
+    pending: 'Pending',
+    uploading: 'Uploading',
+    extracting: 'Extracting',
+    chunking: 'Chunking',
+    embedding: 'Embedding',
+    indexing: 'Indexing',
+    ready: 'Ready',
+    indexed: 'Ready',
+    failed: 'Failed',
   };
   return labels[state] || state;
 }
@@ -128,7 +131,8 @@ export function ProgressBadge({
   // ============================================================================
 
   const state = hookData.status?.state ?? staticState ?? 'pending';
-  const progress = hookData.metrics?.progressPercentage ?? hookData.status?.progress ?? staticProgress ?? 0;
+  const progress =
+    hookData.metrics?.progressPercentage ?? hookData.status?.progress ?? staticProgress ?? 0;
   const eta = hookData.metrics?.estimatedTimeRemaining ?? hookData.status?.eta ?? staticEta;
 
   // Format ETA
@@ -180,7 +184,8 @@ export function ProgressBadge({
                 </p>
                 {eta && (
                   <p className="text-muted-foreground">
-                    ETA: <span className="text-amber-600 dark:text-amber-400">{formatEta(eta)}</span>
+                    ETA:{' '}
+                    <span className="text-amber-600 dark:text-amber-400">{formatEta(eta)}</span>
                   </p>
                 )}
               </>

--- a/apps/web/src/components/ui/data-display/meeple-info-card.tsx
+++ b/apps/web/src/components/ui/data-display/meeple-info-card.tsx
@@ -40,6 +40,7 @@ import {
 } from '@/components/library/kb-utils';
 import { PdfUploadModal } from '@/components/library/PdfUploadModal';
 import { PdfViewerModal } from '@/components/pdf/PdfViewerModal';
+import { ProgressBadge } from '@/components/pdf/progress-badge';
 import { Button } from '@/components/ui/primitives/button';
 import { api } from '@/lib/api';
 import type { PdfDocumentDto } from '@/lib/api';
@@ -317,9 +318,10 @@ export function MeepleInfoCard({
                               {formatFileSize(doc.fileSizeBytes)}
                             </span>
                             {!ready && (
-                              <span className={cn('text-xs font-medium', status.color)}>
-                                {status.label}
-                              </span>
+                              <ProgressBadge
+                                documentId={doc.id}
+                                state={doc.processingState || doc.processingStatus || 'pending'}
+                              />
                             )}
                           </div>
                         </div>


### PR DESCRIPTION
## Summary

Epic #379: Game Night Improvvisata — implements the core user story for impromptu game nights.

- **#372** fix(seeding): Admin EmailVerified=true + SuperAdmin role hierarchy (3 files: SeedAdminUserCommandHandler, SeedOrchestrator, RequireRole)
- **#373** feat(frontend): BGG Import dialog wired from library page (AddGameDrawer + URL ?action=import-bgg)
- **#375** closed as already implemented — score tracking components already wired into session pages
- **#376** feat(ai): Rule dispute resolution instructions added to RAG system prompt (5-step process with confidence rating)
- **#377** feat(pdf): ProgressBadge in MeepleInfoCard + ProgressCard in PrivateGameHub for real-time PDF processing visualization

## Changes

**Backend** (2 files):
- `SeedAdminUserCommandHandler.cs`: Call `VerifyEmail()` on seeded admin
- `SeedOrchestrator.cs`: Query both admin/superadmin roles in `ResolveSystemUserIdAsync`
- `RagPromptAssemblyService.cs`: Rule Dispute Resolution section in system prompt

**Frontend** (3 files):
- `RequireRole.tsx`: SuperAdmin inherits all role permissions
- `AddGameDrawer.tsx`: BGG step + URL controller for `?action=import-bgg`
- `meeple-info-card.tsx`: ProgressBadge replaces inline status text
- `PrivateGameHub.tsx`: ProgressCard with circular progress ring during PDF processing

## Test plan

- [ ] Verify seeded admin can access /admin pages (EmailVerified=true)
- [ ] SuperAdmin role passes RequireRole checks for all allowedRoles
- [ ] Navigate to /library?action=import-bgg → BGG search panel opens
- [ ] Import BGG game → redirects to /library/private/{id}
- [ ] Upload PDF on private game → ProgressCard shows with real-time updates
- [ ] MeepleInfoCard KB tab shows ProgressBadge for processing documents
- [ ] Ask agent to settle a rule dispute → structured verdict with confidence

🤖 Generated with [Claude Code](https://claude.com/claude-code)
