### PR TITLE
fix(ci): resolve connection pool exhaustion and E2E migration failures

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -178,14 +178,14 @@ jobs:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: testpass
           POSTGRES_DB: meepleai_test
-        # Issue #2693: Increase max_connections from 100 (default) to 500 for parallel tests
-        # --shm-size=512mb provides shared memory for the increased connection pool
+        # Pool fix: MaxPoolSize=5 per test DB → ~100 connections with 4 threads
+        # --shm-size=256mb for shared memory
         options: >-
           --health-cmd "pg_isready -U postgres"
           --health-interval 5s
           --health-timeout 5s
           --health-retries 10
-          --shm-size=512mb
+          --shm-size=256mb
         ports:
           - 5432:5432
 
@@ -278,21 +278,13 @@ jobs:
           printf 'EMBEDDING_SERVICE_URL=http://localhost:8000\n' > infra/secrets/embedding-service.secret
           echo "✅ CI secret files created"
 
-      - name: Configure PostgreSQL for Parallel Tests
+      - name: Verify PostgreSQL Connection Limits
         env:
           PGPASSWORD: testpass
         run: |
-          echo "🔧 Increasing max_connections for parallel test execution..."
-          psql -h localhost -U postgres -d meepleai_test -c "ALTER SYSTEM SET max_connections = 500;"
-          psql -h localhost -U postgres -d meepleai_test -c "ALTER SYSTEM SET shared_buffers = '256MB';"
-          # Restart postgres container to apply changes
-          docker restart $(docker ps -q --filter "ancestor=pgvector/pgvector:pg16") || true
-          echo "⏳ Waiting for PostgreSQL to restart..."
-          sleep 3
-          until pg_isready -h localhost -p 5432 -U postgres; do sleep 1; done
-          # Verify new settings
+          echo "🔧 Verifying PostgreSQL max_connections..."
           psql -h localhost -U postgres -d meepleai_test -c "SHOW max_connections;"
-          echo "✅ PostgreSQL configured with increased max_connections"
+          echo "✅ Pool fix: MaxPoolSize=5 per test DB, 4 threads → fits within default 100 connections"
 
       - name: Build
         run: dotnet build --no-restore --configuration Release
@@ -509,7 +501,7 @@ jobs:
 
       - name: Run Database Migrations
         working-directory: apps/api/src/Api
-        run: dotnet ef database update
+        run: dotnet ef database update --no-build --configuration Release
         env:
           POSTGRES_HOST: localhost
           POSTGRES_PORT: "5432"

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -155,7 +155,7 @@ jobs:
 
       - name: Run Database Migrations
         working-directory: apps/api/src/Api
-        run: dotnet ef database update
+        run: dotnet ef database update --no-build --configuration Release
         env:
           POSTGRES_HOST: localhost
           POSTGRES_PORT: "5432"
@@ -496,7 +496,7 @@ jobs:
 
       - name: Run Database Migrations
         working-directory: apps/api/src/Api
-        run: dotnet ef database update
+        run: dotnet ef database update --no-build --configuration Release
         env:
           POSTGRES_HOST: localhost
           POSTGRES_PORT: "5432"

--- a/apps/api/tests/Api.Tests/Infrastructure/SharedTestcontainersFixture.cs
+++ b/apps/api/tests/Api.Tests/Infrastructure/SharedTestcontainersFixture.cs
@@ -741,8 +741,8 @@ public sealed class SharedTestcontainersFixture : IAsyncLifetime
                 builder.Database = databaseName;
                 builder.Timeout = 60; // Increase timeout to 60s for long-running integration tests
                 builder.CommandTimeout = 60;
-                builder.MaxPoolSize = 50; // Increase pool size to handle concurrent test execution
-                builder.MinPoolSize = 5;
+                builder.MaxPoolSize = 5; // CI: Keep pool small — 4 threads × N test classes × 5 pool ≤ 500 max_connections
+                builder.MinPoolSize = 1;
 
                 // Issue #2577: Log successful database creation with timing
                 var duration = (DateTime.UtcNow - startTime).TotalSeconds;


### PR DESCRIPTION
## Summary
- **Root cause**: `SharedTestcontainersFixture.CreateIsolatedDatabaseAsync` set `MaxPoolSize=50` per test DB — with 4 parallel threads, each test class creates its own pool → hundreds of connections exceed Postgres `max_connections` (100 default)
- **E2E root cause**: `dotnet ef database update` without `--no-build --configuration Release` rebuilt in Debug mode, ignoring the Release build output → migrations silently failed → API startup failed

## Changes
- Reduce `MaxPoolSize` from 50 to 5 in `SharedTestcontainersFixture` (connection budget: 4 threads × N classes × 5 pool ≤ 100)
- Remove fragile `ALTER SYSTEM SET max_connections = 500` + `docker restart` approach
- Fix E2E migration: add `--no-build --configuration Release` to `dotnet ef database update` in `ci.yml` and `test-e2e.yml`

## Test plan
- [ ] CI integration tests pass without "too many clients already" errors
- [ ] E2E critical paths job passes (API starts successfully after migrations)
- [ ] No regression in unit tests


🤖 Generated with [Claude Code](https://claude.com/claude-code)