### PR TITLE
fix(agents): Sprint 1 — expose SharedGameId/DocumentIds in agent setup endpoint

### DIFF
--- a/apps/api/src/Api/Routing/AgentEndpoints.cs
+++ b/apps/api/src/Api/Routing/AgentEndpoints.cs
@@ -808,7 +808,11 @@ internal static class AgentEndpoints
                 AgentName: req.AgentName,
                 StrategyName: req.StrategyName,
                 StrategyParameters: req.StrategyParameters
-            );
+            )
+            {
+                SharedGameId = req.SharedGameId,
+                DocumentIds = req.DocumentIds
+            };
 
             var result = await mediator.Send(command, ct).ConfigureAwait(false);
 
@@ -1087,7 +1091,9 @@ internal record CreateAgentWithSetupRequest(
     string AgentType,
     string? AgentName = null,
     string? StrategyName = null,
-    IDictionary<string, object>? StrategyParameters = null
+    IDictionary<string, object>? StrategyParameters = null,
+    Guid? SharedGameId = null,
+    List<Guid>? DocumentIds = null
 );
 
 /// <summary>


### PR DESCRIPTION
## Summary
- Exposes `SharedGameId` and `DocumentIds` fields in the `CreateAgentWithSetup` HTTP request DTO, closing the gap between the endpoint and the underlying command (Issue #262)
- All other Sprint 1 RAG Pipeline E2E issues (#260, #261, #263-#269) verified as already implemented and closed

## Test plan
- [ ] Verify `POST /api/v1/agents/with-setup` accepts `sharedGameId` and `documentIds` in request body
- [ ] Confirm agent creation with shared game linkage works end-to-end
- [ ] Validate existing agent creation flows (without new fields) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)