### PR TITLE
feat(admin): cross-link game flows, deprecate RAG wizard (#254, #255, #256)

### DIFF
--- a/apps/web/src/app/admin/(dashboard)/shared-games/[id]/client.tsx
+++ b/apps/web/src/app/admin/(dashboard)/shared-games/[id]/client.tsx
@@ -23,7 +23,6 @@ import {
   Settings2,
   Trash2,
   Unlink,
-  Wand2,
 } from 'lucide-react';
 import Image from 'next/image';
 import Link from 'next/link';
@@ -48,7 +47,6 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@/components/ui/navigation/dropdown-menu';
-import { Sheet, SheetContent, SheetHeader, SheetTitle } from '@/components/ui/navigation/sheet';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/navigation/tabs';
 import { Button } from '@/components/ui/primitives/button';
 import {
@@ -60,8 +58,6 @@ import {
 } from '@/components/ui/select';
 import { api, type SharedGameDocument } from '@/lib/api';
 import { getAgentDefinitions } from '@/lib/api/admin-agent-client';
-
-import { RagWizard } from './rag-wizard/components/rag-wizard';
 
 // ─── Sub-components ──────────────────────────────────────────────────────────
 
@@ -186,15 +182,6 @@ export function GameDetailClient({ params }: GameDetailClientProps) {
       queryClient.invalidateQueries({ queryKey: ['admin', 'shared-games', gameId, 'documents'] });
     },
   });
-
-  // ── RAG Wizard state ────────────────────────────────────────────────────
-  const [showRagWizard, setShowRagWizard] = useState(false);
-
-  const handleRagWizardClose = useCallback(() => {
-    setShowRagWizard(false);
-    queryClient.invalidateQueries({ queryKey: ['admin', 'shared-games', gameId, 'documents'] });
-    queryClient.invalidateQueries({ queryKey: ['admin', 'shared-games', gameId, 'kb-cards'] });
-  }, [queryClient, gameId]);
 
   // ── Agent linking state ──────────────────────────────────────────────────
   const [selectedAgentId, setSelectedAgentId] = useState('');
@@ -643,12 +630,14 @@ export function GameDetailClient({ params }: GameDetailClientProps) {
 
         {/* ── Documents Tab ───────────────────────────────────────────────── */}
         <TabsContent value="documents" className="space-y-6 mt-6">
-          {/* RAG Wizard action */}
+          {/* Link to RAG Setup dashboard (#256: deprecate inline wizard) */}
           <div className="flex justify-end">
-            <Button size="sm" onClick={() => setShowRagWizard(true)}>
-              <Wand2 className="mr-1.5 h-3.5 w-3.5" />
-              Aggiungi RAG
-            </Button>
+            <Link href={`/admin/shared-games/${gameId}/rag-setup`}>
+              <Button size="sm">
+                <Settings2 className="mr-1.5 h-3.5 w-3.5" />
+                RAG Setup Dashboard
+              </Button>
+            </Link>
           </div>
 
           {/* Upload */}
@@ -707,23 +696,6 @@ export function GameDetailClient({ params }: GameDetailClientProps) {
         </TabsContent>
       </Tabs>
 
-      {/* RAG Wizard Sheet */}
-      <Sheet
-        open={showRagWizard}
-        onOpenChange={open => {
-          if (!open) handleRagWizardClose();
-          else setShowRagWizard(true);
-        }}
-      >
-        <SheetContent side="right" className="w-full sm:max-w-xl overflow-y-auto">
-          <SheetHeader>
-            <SheetTitle>Aggiungi RAG — {game.title}</SheetTitle>
-          </SheetHeader>
-          <div className="mt-6">
-            <RagWizard sharedGameId={gameId} onClose={handleRagWizardClose} />
-          </div>
-        </SheetContent>
-      </Sheet>
     </div>
   );
 }

--- a/apps/web/src/app/admin/(dashboard)/shared-games/import/client.tsx
+++ b/apps/web/src/app/admin/(dashboard)/shared-games/import/client.tsx
@@ -177,6 +177,17 @@ export function AdminGameImportWizardClient() {
             Import a game from PDF by uploading, reviewing metadata, matching with BGG, and
             finalizing.
           </p>
+          {/* Cross-link to manual creation (#255) */}
+          <p className="text-sm text-muted-foreground mt-2">
+            Or{' '}
+            <Link
+              href="/admin/shared-games/new"
+              className="text-primary font-medium underline underline-offset-2 hover:text-primary/80"
+            >
+              create a game manually
+            </Link>{' '}
+            without a PDF.
+          </p>
         </div>
 
         {/* Progress Bar */}

--- a/apps/web/src/app/admin/(dashboard)/shared-games/new/client.tsx
+++ b/apps/web/src/app/admin/(dashboard)/shared-games/new/client.tsx
@@ -13,7 +13,8 @@ import { useState } from 'react';
 
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useQuery } from '@tanstack/react-query';
-import { ArrowLeft, Loader2, Plus } from 'lucide-react';
+import { ArrowLeft, FileUp, Loader2, Plus } from 'lucide-react';
+import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 import { useForm, type Resolver } from 'react-hook-form';
 import { z } from 'zod';
@@ -191,6 +192,21 @@ export function NewGameClient() {
             </p>
           </div>
         </div>
+      </div>
+
+      {/* Cross-link to Import flow (#255) */}
+      <div className="rounded-lg border border-dashed border-slate-300 dark:border-zinc-600 bg-slate-50/50 dark:bg-zinc-800/30 px-4 py-3 flex items-center gap-3">
+        <FileUp className="h-4 w-4 text-muted-foreground shrink-0" />
+        <p className="text-sm text-muted-foreground">
+          Have a PDF rulebook?{' '}
+          <Link
+            href="/admin/shared-games/import"
+            className="text-primary font-medium underline underline-offset-2 hover:text-primary/80"
+          >
+            Import from PDF
+          </Link>{' '}
+          to auto-extract game metadata.
+        </p>
       </div>
 
       {/* BGG Search Section */}


### PR DESCRIPTION
## Summary
- **#254**: BGG search autocomplete already implemented in NewGameClient — closing as done
- **#255**: Add cross-links between New Game and Import Game flows (bidirectional navigation)
- **#256**: Deprecate inline RAG Wizard Sheet in game detail Documents tab, replace with link to RAG Setup dashboard page

## Test plan
- [ ] Navigate to /admin/shared-games/new → verify "Import from PDF" link visible, links to /admin/shared-games/import
- [ ] Navigate to /admin/shared-games/import → verify "create a game manually" link visible, links to /admin/shared-games/new
- [ ] Navigate to /admin/shared-games/[id] Documents tab → verify "RAG Setup Dashboard" button links to /admin/shared-games/[id]/rag-setup
- [ ] Verify RAG Wizard Sheet no longer appears on game detail page
- [x] TypeScript compilation passes (no errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)