### PR TITLE
fix(auth): add missing EmailVerified and Onboarding mappings to UserDto handlers

### DIFF
--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/Login/LoginCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/Login/LoginCommandHandler.cs
@@ -185,8 +185,11 @@ internal class LoginCommandHandler : ICommandHandler<LoginCommand, LoginResponse
             TwoFactorEnabledAt: user.TwoFactorEnabledAt,
             Level: user.Level,
             ExperiencePoints: user.ExperiencePoints,
-            OnboardingCompleted: user.OnboardingCompleted,              // Issue #323
-            OnboardingSkipped: user.OnboardingSkipped                   // Issue #323
+            EmailVerified: user.EmailVerified,
+            EmailVerifiedAt: user.EmailVerifiedAt,
+            VerificationGracePeriodEndsAt: user.VerificationGracePeriodEndsAt,
+            OnboardingCompleted: user.OnboardingCompleted,
+            OnboardingSkipped: user.OnboardingSkipped
         );
     }
 }

--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/Sessions/CreateSessionCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/Sessions/CreateSessionCommandHandler.cs
@@ -74,7 +74,12 @@ internal class CreateSessionCommandHandler : ICommandHandler<CreateSessionComman
             IsTwoFactorEnabled: user.IsTwoFactorEnabled,
             TwoFactorEnabledAt: user.TwoFactorEnabledAt,
             Level: user.Level,
-            ExperiencePoints: user.ExperiencePoints
+            ExperiencePoints: user.ExperiencePoints,
+            EmailVerified: user.EmailVerified,
+            EmailVerifiedAt: user.EmailVerifiedAt,
+            VerificationGracePeriodEndsAt: user.VerificationGracePeriodEndsAt,
+            OnboardingCompleted: user.OnboardingCompleted,
+            OnboardingSkipped: user.OnboardingSkipped
         );
     }
 }

--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/Queries/GetUserByIdQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/Queries/GetUserByIdQueryHandler.cs
@@ -37,7 +37,12 @@ internal class GetUserByIdQueryHandler : IQueryHandler<GetUserByIdQuery, UserDto
             IsTwoFactorEnabled: user.IsTwoFactorEnabled,
             TwoFactorEnabledAt: user.TwoFactorEnabledAt,
             Level: user.Level,
-            ExperiencePoints: user.ExperiencePoints
+            ExperiencePoints: user.ExperiencePoints,
+            EmailVerified: user.EmailVerified,
+            EmailVerifiedAt: user.EmailVerifiedAt,
+            VerificationGracePeriodEndsAt: user.VerificationGracePeriodEndsAt,
+            OnboardingCompleted: user.OnboardingCompleted,
+            OnboardingSkipped: user.OnboardingSkipped
         );
     }
 }

--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/Queries/ValidateApiKeyQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/Queries/ValidateApiKeyQueryHandler.cs
@@ -69,7 +69,12 @@ internal class ValidateApiKeyQueryHandler : IQueryHandler<ValidateApiKeyQuery, U
             IsTwoFactorEnabled: user.IsTwoFactorEnabled,
             TwoFactorEnabledAt: user.TwoFactorEnabledAt,
             Level: user.Level,
-            ExperiencePoints: user.ExperiencePoints
+            ExperiencePoints: user.ExperiencePoints,
+            EmailVerified: user.EmailVerified,
+            EmailVerifiedAt: user.EmailVerifiedAt,
+            VerificationGracePeriodEndsAt: user.VerificationGracePeriodEndsAt,
+            OnboardingCompleted: user.OnboardingCompleted,
+            OnboardingSkipped: user.OnboardingSkipped
         );
     }
 }

--- a/apps/api/src/Api/Middleware/EmailVerificationMiddleware.cs
+++ b/apps/api/src/Api/Middleware/EmailVerificationMiddleware.cs
@@ -73,8 +73,9 @@ internal class EmailVerificationMiddleware
 
             var user = session.User;
 
-            // Admin and Editor roles are always exempt from email verification
-            if (user.Role.Equals("admin", StringComparison.OrdinalIgnoreCase) ||
+            // Admin, SuperAdmin, and Editor roles are always exempt from email verification
+            if (user.Role.Equals("superadmin", StringComparison.OrdinalIgnoreCase) ||
+                user.Role.Equals("admin", StringComparison.OrdinalIgnoreCase) ||
                 user.Role.Equals("editor", StringComparison.OrdinalIgnoreCase))
             {
                 await _next(context).ConfigureAwait(false);


### PR DESCRIPTION
## Summary
- Fix 4 `MapToUserDto` implementations missing `EmailVerified`, `EmailVerifiedAt`, `VerificationGracePeriodEndsAt`, `OnboardingCompleted`, and `OnboardingSkipped` fields — these returned default `false`/`null` regardless of DB state
- Add `superadmin` role exemption to `EmailVerificationMiddleware` (previously only exempted `admin` and `editor`)

## Affected handlers
- `LoginCommandHandler` — login response
- `CreateSessionCommandHandler` — OAuth/2FA session creation
- `ValidateApiKeyQueryHandler` — API key auth
- `GetUserByIdQueryHandler` — user lookup
- `EmailVerificationMiddleware` — role exemption

## Test plan
- [ ] Verify login response includes correct `emailVerified` value
- [ ] Verify superadmin users are not blocked by email verification middleware
- [ ] Verify API key auth returns correct user DTO fields

🤖 Generated with [Claude Code](https://claude.com/claude-code)