### PR TITLE
feat(admin): per-SharedGame document overview endpoint (#119)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetDocumentOverview/GetDocumentOverviewQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetDocumentOverview/GetDocumentOverviewQuery.cs
@@ -1,0 +1,70 @@
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Queries.GetDocumentOverview;
+
+/// <summary>
+/// Query to get a consolidated document overview for a shared game.
+/// Returns processing status breakdown, per-document details, agent linkage, and RAG readiness.
+/// Issue #119: Per-SharedGame Document Overview.
+/// </summary>
+internal record GetDocumentOverviewQuery(Guid SharedGameId) : IQuery<DocumentOverviewResult>;
+
+/// <summary>
+/// Consolidated document overview for a shared game.
+/// </summary>
+internal record DocumentOverviewResult(
+    Guid SharedGameId,
+    string GameTitle,
+    int TotalDocuments,
+    StatusBreakdownDto StatusBreakdown,
+    IReadOnlyList<DocumentOverviewItemDto> Documents,
+    AgentStatusDto? AgentStatus,
+    RagReadinessDto RagReadiness
+);
+
+/// <summary>
+/// Processing state counts across all documents.
+/// </summary>
+internal record StatusBreakdownDto(
+    int Ready,
+    int Processing,
+    int Failed,
+    int Pending
+);
+
+/// <summary>
+/// Per-document details including processing state and chunk metrics.
+/// </summary>
+internal record DocumentOverviewItemDto(
+    Guid PdfDocumentId,
+    string FileName,
+    string? DocumentCategory,
+    string? DocumentType,
+    string? VersionLabel,
+    string ProcessingState,
+    string? CurrentStep,
+    DateTime UploadedAt,
+    int? ChunkCount,
+    bool IsActiveForRag
+);
+
+/// <summary>
+/// Linked agent status for the shared game.
+/// </summary>
+internal record AgentStatusDto(
+    bool HasLinkedAgent,
+    Guid? AgentId,
+    string? AgentName,
+    bool IsActive,
+    DateTime? LastInvokedAt
+);
+
+/// <summary>
+/// RAG pipeline readiness assessment.
+/// </summary>
+internal record RagReadinessDto(
+    bool IsReady,
+    int ReadyDocumentCount,
+    int TotalChunks,
+    IReadOnlyList<string> Blockers
+);

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetDocumentOverview/GetDocumentOverviewQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetDocumentOverview/GetDocumentOverviewQueryHandler.cs
@@ -1,0 +1,157 @@
+using Api.Infrastructure;
+using Api.SharedKernel.Application.Interfaces;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Queries.GetDocumentOverview;
+
+/// <summary>
+/// Handler for GetDocumentOverviewQuery.
+/// Performs cross-context read-only queries to build a consolidated document overview.
+/// Issue #119: Per-SharedGame Document Overview.
+/// </summary>
+internal sealed class GetDocumentOverviewQueryHandler
+    : IQueryHandler<GetDocumentOverviewQuery, DocumentOverviewResult>
+{
+    private readonly MeepleAiDbContext _db;
+    private readonly ILogger<GetDocumentOverviewQueryHandler> _logger;
+
+    public GetDocumentOverviewQueryHandler(
+        MeepleAiDbContext db,
+        ILogger<GetDocumentOverviewQueryHandler> logger)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<DocumentOverviewResult> Handle(
+        GetDocumentOverviewQuery query,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        // Step 1: Get SharedGame title
+        var game = await _db.SharedGames
+            .AsNoTracking()
+            .Where(g => g.Id == query.SharedGameId && !g.IsDeleted)
+            .Select(g => new { g.Id, g.Title })
+            .FirstOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        if (game is null)
+        {
+            throw new Api.Middleware.Exceptions.NotFoundException("SharedGame", query.SharedGameId.ToString());
+        }
+
+        // Step 2: Get all PDF documents linked to this SharedGame
+        // PDFs link to SharedGame via SharedGameId OR via GameEntity.SharedGameId bridge
+        var pdfs = await _db.PdfDocuments
+            .AsNoTracking()
+            .Where(p => p.SharedGameId == query.SharedGameId
+                || _db.Games.Any(g => g.SharedGameId == query.SharedGameId && g.Id == p.GameId))
+            .Select(p => new
+            {
+                p.Id,
+                p.FileName,
+                p.DocumentCategory,
+                p.DocumentType,
+                p.ProcessingState,
+                p.UploadedAt,
+                p.IsActiveForRag,
+            })
+            .OrderByDescending(p => p.UploadedAt)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        // Step 3: Get chunk counts from VectorDocuments
+        var pdfIds = pdfs.Select(p => p.Id).ToList();
+        var chunkCounts = pdfIds.Count > 0
+            ? await _db.VectorDocuments
+                .AsNoTracking()
+                .Where(v => pdfIds.Contains(v.PdfDocumentId))
+                .Select(v => new { v.PdfDocumentId, v.ChunkCount })
+                .ToListAsync(cancellationToken)
+                .ConfigureAwait(false)
+            : [];
+
+        var chunkMap = chunkCounts.ToDictionary(v => v.PdfDocumentId, v => v.ChunkCount);
+
+        // Step 4: Calculate status breakdown
+        var ready = pdfs.Count(p => string.Equals(p.ProcessingState, "Ready", StringComparison.Ordinal));
+        var failed = pdfs.Count(p => string.Equals(p.ProcessingState, "Failed", StringComparison.Ordinal));
+        var pending = pdfs.Count(p => string.Equals(p.ProcessingState, "Pending", StringComparison.Ordinal));
+        var processing = pdfs.Count - ready - failed - pending;
+
+        // Step 5: Map documents to DTOs
+        var documents = pdfs.Select(p =>
+        {
+            var state = p.ProcessingState ?? "Unknown";
+            string? currentStep = state is not ("Ready" or "Failed" or "Pending")
+                ? state
+                : null;
+
+            return new DocumentOverviewItemDto(
+                PdfDocumentId: p.Id,
+                FileName: p.FileName,
+                DocumentCategory: p.DocumentCategory,
+                DocumentType: p.DocumentType,
+                VersionLabel: null,
+                ProcessingState: state,
+                CurrentStep: currentStep,
+                UploadedAt: p.UploadedAt,
+                ChunkCount: chunkMap.GetValueOrDefault(p.Id),
+                IsActiveForRag: p.IsActiveForRag
+            );
+        }).ToList();
+
+        // Step 6: Get linked agent
+        var agent = await _db.Agents
+            .AsNoTracking()
+            .Where(a => a.SharedGameId == query.SharedGameId
+                || _db.Games.Any(g => g.SharedGameId == query.SharedGameId && g.Id == a.GameId))
+            .Select(a => new { a.Id, a.Name, a.IsActive, a.LastInvokedAt })
+            .FirstOrDefaultAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        var agentStatus = new AgentStatusDto(
+            HasLinkedAgent: agent is not null,
+            AgentId: agent?.Id,
+            AgentName: agent?.Name,
+            IsActive: agent?.IsActive ?? false,
+            LastInvokedAt: agent?.LastInvokedAt
+        );
+
+        // Step 7: Calculate RAG readiness
+        var totalChunks = chunkMap.Values.Sum();
+        var blockers = new List<string>();
+
+        if (pdfs.Count == 0)
+            blockers.Add("No documents uploaded");
+        if (processing > 0)
+            blockers.Add($"{processing} document(s) still processing");
+        if (failed > 0)
+            blockers.Add($"{failed} document(s) failed");
+        if (agent is null)
+            blockers.Add("No AI agent linked");
+
+        var ragReadiness = new RagReadinessDto(
+            IsReady: ready > 0 && failed == 0 && processing == 0 && agent is not null,
+            ReadyDocumentCount: ready,
+            TotalChunks: totalChunks,
+            Blockers: blockers
+        );
+
+        _logger.LogInformation(
+            "DocumentOverview for SharedGame {Id}: {Total} docs ({Ready} ready, {Processing} processing, {Failed} failed)",
+            query.SharedGameId, pdfs.Count, ready, processing, failed);
+
+        return new DocumentOverviewResult(
+            SharedGameId: game.Id,
+            GameTitle: game.Title,
+            TotalDocuments: pdfs.Count,
+            StatusBreakdown: new StatusBreakdownDto(ready, processing, failed, pending),
+            Documents: documents,
+            AgentStatus: agentStatus,
+            RagReadiness: ragReadiness
+        );
+    }
+}

--- a/apps/api/src/Api/Routing/AdminSharedGameContentEndpoints.cs
+++ b/apps/api/src/Api/Routing/AdminSharedGameContentEndpoints.cs
@@ -1,5 +1,6 @@
 using Api.BoundedContexts.Administration.Application.Queries;
 using Api.BoundedContexts.DocumentProcessing.Application.Commands.BulkUploadPdfs;
+using Api.BoundedContexts.SharedGameCatalog.Application.Queries.GetDocumentOverview;
 using Api.Extensions;
 using Api.Filters;
 using MediatR;
@@ -31,6 +32,23 @@ internal static class AdminSharedGameContentEndpoints
             .ProducesProblem(StatusCodes.Status400BadRequest)
             .ProducesProblem(StatusCodes.Status401Unauthorized)
             .ProducesProblem(StatusCodes.Status403Forbidden);
+
+        // GET /api/v1/admin/shared-games/{sharedGameId}/documents/overview
+        // Issue #119: Per-SharedGame Document Overview
+        contentGroup.MapGet("/{sharedGameId:guid}/documents/overview", async (
+                Guid sharedGameId,
+                IMediator mediator,
+                CancellationToken ct) =>
+            {
+                var result = await mediator.Send(new GetDocumentOverviewQuery(sharedGameId), ct)
+                    .ConfigureAwait(false);
+                return Results.Ok(result);
+            })
+            .WithName("GetSharedGameDocumentOverview")
+            .WithSummary("Get consolidated document overview for a shared game (Admin)")
+            .WithDescription("Returns processing status breakdown, per-document details, agent linkage, and RAG readiness assessment.")
+            .Produces<DocumentOverviewResult>(StatusCodes.Status200OK)
+            .ProducesProblem(StatusCodes.Status404NotFound);
 
         // GET /api/v1/admin/shared-games/mau
         // Issue #113: MAU Monitoring Dashboard


### PR DESCRIPTION
## Summary
- Add `GET /api/v1/admin/shared-games/{id}/documents/overview` endpoint
- Returns consolidated view with status breakdown (ready/processing/failed/pending), per-document details with chunk counts, linked agent status, and RAG readiness assessment with blockers
- Cross-context read-only queries joining SharedGames, PdfDocuments, VectorDocuments, and Agents

## Test plan
- [ ] Verify endpoint returns 404 for non-existent SharedGame
- [ ] Verify status breakdown counts match individual document states
- [ ] Verify chunk counts from VectorDocuments are included
- [ ] Verify agent linkage detected via SharedGameId and GameEntity bridge
- [ ] Verify RAG readiness blockers list is accurate
- [ ] Verify admin-only access (RequireAdminSessionFilter)

Closes #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)