### PR TITLE
feat(routing): region-aware routing strategy interface (#28)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Services/LlmManagement/HybridAdaptiveRoutingStrategy.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Services/LlmManagement/HybridAdaptiveRoutingStrategy.cs
@@ -44,7 +44,7 @@ internal class HybridAdaptiveRoutingStrategy : ILlmRoutingStrategy
     }
 
     /// <inheritdoc/>
-    public LlmRoutingDecision SelectProvider(User? user, RagStrategy strategy, string? context = null)
+    public LlmRoutingDecision SelectProvider(User? user, RagStrategy strategy, string? context = null, string? region = null)
     {
         var userId = user?.Id.ToString() ?? "anonymous";
         var tier = MapUserToLlmTier(user);
@@ -58,7 +58,7 @@ internal class HybridAdaptiveRoutingStrategy : ILlmRoutingStrategy
         // Step 1: Check PreferredProvider override (still honored if explicitly set)
         if (TryGetPreferredDecision(settings, userId, out var preferredDecision))
         {
-            return preferredDecision!;
+            return preferredDecision! with { UserRegion = region };
         }
 
         // Step 2: Validate tier has access to the requested strategy
@@ -77,7 +77,10 @@ internal class HybridAdaptiveRoutingStrategy : ILlmRoutingStrategy
         var decision = CreateValidatedDecision(provider, modelId, strategy, tier, userId, settings);
 
         // Step 5: Apply budget mode override if active
-        return ApplyBudgetModeOverride(decision, userId);
+        var finalDecision = ApplyBudgetModeOverride(decision, userId);
+
+        // Step 6: Attach region hint (Issue #28: no-op for now, future multi-region routing)
+        return region is not null ? finalDecision with { UserRegion = region } : finalDecision;
     }
 
     /// <summary>

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Services/LlmManagement/ILlmRoutingStrategy.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Services/LlmManagement/ILlmRoutingStrategy.cs
@@ -13,12 +13,14 @@ internal interface ILlmRoutingStrategy
     /// <summary>
     /// Select the appropriate LLM provider and model based on routing logic.
     /// Issue #3435: Strategy-based routing (strategy determines model, tier validates access).
+    /// Issue #28: Region-aware routing — region parameter accepted but currently ignored (no-op).
     /// </summary>
     /// <param name="user">User making the request (null for anonymous)</param>
     /// <param name="strategy">RAG strategy that determines model selection</param>
     /// <param name="context">Additional context for routing decision</param>
+    /// <param name="region">Geographic region hint for future multi-region routing (currently ignored)</param>
     /// <returns>Routing decision with provider name and model ID</returns>
-    LlmRoutingDecision SelectProvider(User? user, RagStrategy strategy, string? context = null);
+    LlmRoutingDecision SelectProvider(User? user, RagStrategy strategy, string? context = null, string? region = null);
 }
 
 /// <summary>

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Services/HybridLlmServiceFreeTierRoutingTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Services/HybridLlmServiceFreeTierRoutingTests.cs
@@ -138,7 +138,7 @@ public sealed class HybridLlmServiceFreeTierRoutingTests
 
         // Routing strategy must NOT be consulted for AutomatedTest requests
         _routingStrategyMock.Verify(
-            s => s.SelectProvider(It.IsAny<User?>(), It.IsAny<RagStrategy>(), It.IsAny<string?>()),
+            s => s.SelectProvider(It.IsAny<User?>(), It.IsAny<RagStrategy>(), It.IsAny<string?>(), It.IsAny<string?>()),
             Times.Never);
 
         // OpenRouter must never receive a request
@@ -181,7 +181,7 @@ public sealed class HybridLlmServiceFreeTierRoutingTests
     public async Task GenerateCompletionAsync_RpdExhausted_ProactivelyRoutesToOllama()
     {
         _routingStrategyMock
-            .Setup(s => s.SelectProvider(It.IsAny<User?>(), It.IsAny<RagStrategy>(), It.IsAny<string?>()))
+            .Setup(s => s.SelectProvider(It.IsAny<User?>(), It.IsAny<RagStrategy>(), It.IsAny<string?>(), It.IsAny<string?>()))
             .Returns(LlmRoutingDecision.OpenRouter(OpenRouterModel, "free tier selected"));
 
         _quotaTrackerMock
@@ -218,7 +218,7 @@ public sealed class HybridLlmServiceFreeTierRoutingTests
     public async Task GenerateCompletionAsync_RpdNotExhausted_UsesOpenRouter()
     {
         _routingStrategyMock
-            .Setup(s => s.SelectProvider(It.IsAny<User?>(), It.IsAny<RagStrategy>(), It.IsAny<string?>()))
+            .Setup(s => s.SelectProvider(It.IsAny<User?>(), It.IsAny<RagStrategy>(), It.IsAny<string?>(), It.IsAny<string?>()))
             .Returns(LlmRoutingDecision.OpenRouter(OpenRouterModel, "free tier selected"));
 
         // IsRpdExhausted returns false (default) — OpenRouter should proceed normally
@@ -252,7 +252,7 @@ public sealed class HybridLlmServiceFreeTierRoutingTests
     public async Task GenerateCompletionAsync_OpenRouterRpdFailure_RecordsRpdToQuotaTracker()
     {
         _routingStrategyMock
-            .Setup(s => s.SelectProvider(It.IsAny<User?>(), It.IsAny<RagStrategy>(), It.IsAny<string?>()))
+            .Setup(s => s.SelectProvider(It.IsAny<User?>(), It.IsAny<RagStrategy>(), It.IsAny<string?>(), It.IsAny<string?>()))
             .Returns(LlmRoutingDecision.OpenRouter(OpenRouterModel, "free tier selected"));
 
         var rateLimitMetadata = new Dictionary<string, string>(StringComparer.Ordinal)
@@ -294,7 +294,7 @@ public sealed class HybridLlmServiceFreeTierRoutingTests
     public async Task GenerateCompletionAsync_OpenRouterRpmFailure_RecordsRpmToQuotaTracker()
     {
         _routingStrategyMock
-            .Setup(s => s.SelectProvider(It.IsAny<User?>(), It.IsAny<RagStrategy>(), It.IsAny<string?>()))
+            .Setup(s => s.SelectProvider(It.IsAny<User?>(), It.IsAny<RagStrategy>(), It.IsAny<string?>(), It.IsAny<string?>()))
             .Returns(LlmRoutingDecision.OpenRouter(OpenRouterModel, "free tier selected"));
 
         var rateLimitMetadata = new Dictionary<string, string>(StringComparer.Ordinal)
@@ -335,7 +335,7 @@ public sealed class HybridLlmServiceFreeTierRoutingTests
     public async Task GenerateCompletionAsync_OpenRouterFailureWithoutRateLimitMetadata_DoesNotRecordToQuotaTracker()
     {
         _routingStrategyMock
-            .Setup(s => s.SelectProvider(It.IsAny<User?>(), It.IsAny<RagStrategy>(), It.IsAny<string?>()))
+            .Setup(s => s.SelectProvider(It.IsAny<User?>(), It.IsAny<RagStrategy>(), It.IsAny<string?>(), It.IsAny<string?>()))
             .Returns(LlmRoutingDecision.OpenRouter(OpenRouterModel, "free tier selected"));
 
         // Plain failure with no rate limit metadata
@@ -366,7 +366,7 @@ public sealed class HybridLlmServiceFreeTierRoutingTests
     public async Task GenerateCompletionAsync_OllamaFailure_DoesNotRecordToQuotaTracker()
     {
         _routingStrategyMock
-            .Setup(s => s.SelectProvider(It.IsAny<User?>(), It.IsAny<RagStrategy>(), It.IsAny<string?>()))
+            .Setup(s => s.SelectProvider(It.IsAny<User?>(), It.IsAny<RagStrategy>(), It.IsAny<string?>(), It.IsAny<string?>()))
             .Returns(LlmRoutingDecision.Ollama(OllamaModel, "local routing"));
 
         _ollamaMock

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Services/LlmResilienceChaosTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Services/LlmResilienceChaosTests.cs
@@ -173,7 +173,7 @@ public sealed class LlmResilienceChaosTests
     public async Task OpenRouter429Burst_FallsBackToOllama()
     {
         _routingStrategyMock
-            .Setup(s => s.SelectProvider(It.IsAny<User?>(), It.IsAny<RagStrategy>(), It.IsAny<string?>()))
+            .Setup(s => s.SelectProvider(It.IsAny<User?>(), It.IsAny<RagStrategy>(), It.IsAny<string?>(), It.IsAny<string?>()))
             .Returns(LlmRoutingDecision.OpenRouter(OpenRouterModel, "default routing"));
 
         // OpenRouter throws (simulating 429)
@@ -207,7 +207,7 @@ public sealed class LlmResilienceChaosTests
     public async Task AllProvidersDown_ReturnsMeaningfulError()
     {
         _routingStrategyMock
-            .Setup(s => s.SelectProvider(It.IsAny<User?>(), It.IsAny<RagStrategy>(), It.IsAny<string?>()))
+            .Setup(s => s.SelectProvider(It.IsAny<User?>(), It.IsAny<RagStrategy>(), It.IsAny<string?>(), It.IsAny<string?>()))
             .Returns(LlmRoutingDecision.OpenRouter(OpenRouterModel, "default routing"));
 
         // Both providers throw
@@ -380,7 +380,7 @@ public sealed class LlmResilienceChaosTests
     {
         // Routing strategy selects OpenRouter by default
         _routingStrategyMock
-            .Setup(s => s.SelectProvider(It.IsAny<User?>(), It.IsAny<RagStrategy>(), It.IsAny<string?>()))
+            .Setup(s => s.SelectProvider(It.IsAny<User?>(), It.IsAny<RagStrategy>(), It.IsAny<string?>(), It.IsAny<string?>()))
             .Returns(LlmRoutingDecision.OpenRouter(OpenRouterModel, "default routing"));
 
         var emergencyMock = new Mock<IEmergencyOverrideService>();
@@ -416,7 +416,7 @@ public sealed class LlmResilienceChaosTests
     public async Task RpdExhausted_OpenRouter_ProactivelyFallsBackToOllama()
     {
         _routingStrategyMock
-            .Setup(s => s.SelectProvider(It.IsAny<User?>(), It.IsAny<RagStrategy>(), It.IsAny<string?>()))
+            .Setup(s => s.SelectProvider(It.IsAny<User?>(), It.IsAny<RagStrategy>(), It.IsAny<string?>(), It.IsAny<string?>()))
             .Returns(LlmRoutingDecision.OpenRouter(OpenRouterModel, "free tier"));
 
         _quotaTrackerMock

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Services/LlmResilienceCombinedFailureTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/Services/LlmResilienceCombinedFailureTests.cs
@@ -125,7 +125,7 @@ public sealed class LlmResilienceCombinedFailureTests
     {
         // Routing strategy nominates OpenRouter
         _routingStrategyMock
-            .Setup(s => s.SelectProvider(It.IsAny<User?>(), It.IsAny<RagStrategy>(), It.IsAny<string?>()))
+            .Setup(s => s.SelectProvider(It.IsAny<User?>(), It.IsAny<RagStrategy>(), It.IsAny<string?>(), It.IsAny<string?>()))
             .Returns(LlmRoutingDecision.OpenRouter(OpenRouterModel, "default routing"));
 
         // RPD quota is exhausted for the OpenRouter model
@@ -174,7 +174,7 @@ public sealed class LlmResilienceCombinedFailureTests
     {
         // Routing strategy selects OpenRouter
         _routingStrategyMock
-            .Setup(s => s.SelectProvider(It.IsAny<User?>(), It.IsAny<RagStrategy>(), It.IsAny<string?>()))
+            .Setup(s => s.SelectProvider(It.IsAny<User?>(), It.IsAny<RagStrategy>(), It.IsAny<string?>(), It.IsAny<string?>()))
             .Returns(LlmRoutingDecision.OpenRouter(OpenRouterModel, "default routing"));
 
         // OpenRouter throws 429
@@ -251,7 +251,7 @@ public sealed class LlmResilienceCombinedFailureTests
     {
         // Routing strategy nominates OpenRouter
         _routingStrategyMock
-            .Setup(s => s.SelectProvider(It.IsAny<User?>(), It.IsAny<RagStrategy>(), It.IsAny<string?>()))
+            .Setup(s => s.SelectProvider(It.IsAny<User?>(), It.IsAny<RagStrategy>(), It.IsAny<string?>(), It.IsAny<string?>()))
             .Returns(LlmRoutingDecision.OpenRouter(OpenRouterModel, "default routing"));
 
         // Circuit breaker is open for OpenRouter — requests not allowed

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Domain/Services/HybridAdaptiveRoutingStrategyTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Domain/Services/HybridAdaptiveRoutingStrategyTests.cs
@@ -506,6 +506,38 @@ public class HybridAdaptiveRoutingStrategyTests
 
     #endregion
 
+    #region Region-aware routing (Issue #28)
+
+    [Fact]
+    public void SelectProvider_WithRegion_PropagatesUserRegionOnDecision()
+    {
+        // Arrange
+        var user = CreateUser(Role.Admin);
+        var sut = CreateStrategy();
+
+        // Act
+        var decision = sut.SelectProvider(user, RagStrategy.Balanced, region: "eu-west-1");
+
+        // Assert
+        Assert.Equal("eu-west-1", decision.UserRegion);
+    }
+
+    [Fact]
+    public void SelectProvider_WithoutRegion_UserRegionIsNull()
+    {
+        // Arrange
+        var user = CreateUser(Role.Admin);
+        var sut = CreateStrategy();
+
+        // Act
+        var decision = sut.SelectProvider(user, RagStrategy.Balanced);
+
+        // Assert
+        Assert.Null(decision.UserRegion);
+    }
+
+    #endregion
+
     private static AuthUser CreateUser(Role role)
     {
         var email = Email.Parse($"test.{role.Value}@meepleai.dev");


### PR DESCRIPTION
## Summary
- Add optional `region` parameter to `ILlmRoutingStrategy.SelectProvider()` for future multi-region routing
- Current implementation propagates region to `UserRegion` on `LlmRoutingDecision` but does not alter routing behavior (no-op)
- Update all Moq test setups to match new 4-parameter signature

## Test plan
- [x] 2 new unit tests: region propagation and null-region default
- [x] All 34 existing routing tests pass (26 strategy + 8 resilience/chaos)
- [x] Build clean (0 errors, 0 new warnings)

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)