### PR TITLE
feat(session-tracking): add session diary/timeline events (#276)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/AddSessionEventCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/AddSessionEventCommand.cs
@@ -1,0 +1,60 @@
+using Api.BoundedContexts.SessionTracking.Domain.Enums;
+using Api.BoundedContexts.SessionTracking.Domain.Services;
+using FluentValidation;
+using MediatR;
+
+namespace Api.BoundedContexts.SessionTracking.Application.Commands;
+
+/// <summary>
+/// Command to add a new event to the session timeline (Session Diary).
+/// Requires at least Player role - spectators cannot add events.
+/// Issue #276 - Session Diary / Timeline
+/// </summary>
+public record AddSessionEventCommand(
+    Guid SessionId,
+    Guid RequesterId,
+    string EventType,
+    string? Payload = null,
+    string? Source = null
+) : IRequest<AddSessionEventResult>, IRequireSessionRole
+{
+    /// <summary>Minimum role: Player.</summary>
+    public ParticipantRole MinimumRole => ParticipantRole.Player;
+}
+
+/// <summary>
+/// Result of adding a session event.
+/// </summary>
+public record AddSessionEventResult(
+    Guid EventId,
+    string EventType,
+    DateTime Timestamp
+);
+
+/// <summary>
+/// FluentValidation validator for AddSessionEventCommand.
+/// </summary>
+public class AddSessionEventCommandValidator : AbstractValidator<AddSessionEventCommand>
+{
+    public AddSessionEventCommandValidator()
+    {
+        RuleFor(x => x.SessionId)
+            .NotEmpty()
+            .WithMessage("SessionId is required");
+
+        RuleFor(x => x.RequesterId)
+            .NotEmpty()
+            .WithMessage("RequesterId is required");
+
+        RuleFor(x => x.EventType)
+            .NotEmpty()
+            .WithMessage("EventType is required")
+            .MaximumLength(50)
+            .WithMessage("EventType must be 50 characters or fewer");
+
+        RuleFor(x => x.Source)
+            .MaximumLength(50)
+            .WithMessage("Source must be 50 characters or fewer")
+            .When(x => x.Source != null);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Handlers/AddSessionEventCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Handlers/AddSessionEventCommandHandler.cs
@@ -1,0 +1,54 @@
+using MediatR;
+using Api.BoundedContexts.SessionTracking.Application.Commands;
+using Api.BoundedContexts.SessionTracking.Domain.Entities;
+using Api.BoundedContexts.SessionTracking.Domain.Repositories;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Infrastructure.Persistence;
+
+namespace Api.BoundedContexts.SessionTracking.Application.Handlers;
+
+/// <summary>
+/// Handles adding a new event to the session timeline.
+/// Validates session exists and is active before persisting.
+/// Issue #276 - Session Diary / Timeline
+/// </summary>
+public class AddSessionEventCommandHandler : IRequestHandler<AddSessionEventCommand, AddSessionEventResult>
+{
+    private readonly ISessionRepository _sessionRepository;
+    private readonly ISessionEventRepository _sessionEventRepository;
+    private readonly IUnitOfWork _unitOfWork;
+
+    public AddSessionEventCommandHandler(
+        ISessionRepository sessionRepository,
+        ISessionEventRepository sessionEventRepository,
+        IUnitOfWork unitOfWork)
+    {
+        _sessionRepository = sessionRepository ?? throw new ArgumentNullException(nameof(sessionRepository));
+        _sessionEventRepository = sessionEventRepository ?? throw new ArgumentNullException(nameof(sessionEventRepository));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+    }
+
+    public async Task<AddSessionEventResult> Handle(AddSessionEventCommand request, CancellationToken cancellationToken)
+    {
+        var session = await _sessionRepository.GetByIdAsync(request.SessionId, cancellationToken).ConfigureAwait(false)
+            ?? throw new NotFoundException($"Session {request.SessionId} not found");
+
+        if (session.Status != SessionStatus.Active)
+            throw new ConflictException($"Cannot add events to session with status {session.Status}");
+
+        var sessionEvent = SessionEvent.Create(
+            request.SessionId,
+            request.EventType,
+            request.Payload,
+            request.RequesterId,
+            request.Source);
+
+        await _sessionEventRepository.AddAsync(sessionEvent, cancellationToken).ConfigureAwait(false);
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        return new AddSessionEventResult(
+            sessionEvent.Id,
+            sessionEvent.EventType,
+            sessionEvent.Timestamp);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Handlers/GetSessionEventsQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Handlers/GetSessionEventsQueryHandler.cs
@@ -1,0 +1,58 @@
+using MediatR;
+using Api.BoundedContexts.SessionTracking.Application.Queries;
+using Api.BoundedContexts.SessionTracking.Domain.Repositories;
+using Api.Middleware.Exceptions;
+
+namespace Api.BoundedContexts.SessionTracking.Application.Handlers;
+
+/// <summary>
+/// Handler for GetSessionEventsQuery.
+/// Returns paginated session events for the timeline with optional type filtering.
+/// Issue #276 - Session Diary / Timeline
+/// </summary>
+public class GetSessionEventsQueryHandler : IRequestHandler<GetSessionEventsQuery, GetSessionEventsResult>
+{
+    private readonly ISessionRepository _sessionRepository;
+    private readonly ISessionEventRepository _sessionEventRepository;
+
+    public GetSessionEventsQueryHandler(
+        ISessionRepository sessionRepository,
+        ISessionEventRepository sessionEventRepository)
+    {
+        _sessionRepository = sessionRepository ?? throw new ArgumentNullException(nameof(sessionRepository));
+        _sessionEventRepository = sessionEventRepository ?? throw new ArgumentNullException(nameof(sessionEventRepository));
+    }
+
+    public async Task<GetSessionEventsResult> Handle(GetSessionEventsQuery request, CancellationToken cancellationToken)
+    {
+        // Verify session exists
+        _ = await _sessionRepository.GetByIdAsync(request.SessionId, cancellationToken).ConfigureAwait(false)
+            ?? throw new NotFoundException($"Session {request.SessionId} not found");
+
+        var events = await _sessionEventRepository.GetBySessionIdAsync(
+            request.SessionId,
+            request.EventType,
+            request.Limit,
+            request.Offset,
+            cancellationToken).ConfigureAwait(false);
+
+        var totalCount = await _sessionEventRepository.CountBySessionIdAsync(
+            request.SessionId,
+            request.EventType,
+            cancellationToken).ConfigureAwait(false);
+
+        var eventDtos = events.Select(e => new SessionEventDto(
+            e.Id,
+            e.SessionId,
+            e.EventType,
+            e.Timestamp,
+            e.Payload,
+            e.CreatedBy,
+            e.Source));
+
+        return new GetSessionEventsResult(
+            eventDtos,
+            totalCount,
+            request.Offset + request.Limit < totalCount);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/GetSessionEventsQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/GetSessionEventsQuery.cs
@@ -1,0 +1,36 @@
+using MediatR;
+
+namespace Api.BoundedContexts.SessionTracking.Application.Queries;
+
+/// <summary>
+/// Query to get session events (timeline) for a session with optional filtering and pagination.
+/// Issue #276 - Session Diary / Timeline
+/// </summary>
+public record GetSessionEventsQuery(
+    Guid SessionId,
+    string? EventType = null,
+    int Limit = 50,
+    int Offset = 0
+) : IRequest<GetSessionEventsResult>;
+
+/// <summary>
+/// Result containing paginated session events.
+/// </summary>
+public record GetSessionEventsResult(
+    IEnumerable<SessionEventDto> Events,
+    int TotalCount,
+    bool HasMore
+);
+
+/// <summary>
+/// DTO representing a session event in the timeline.
+/// </summary>
+public record SessionEventDto(
+    Guid Id,
+    Guid SessionId,
+    string EventType,
+    DateTime Timestamp,
+    string? Payload,
+    Guid? CreatedBy,
+    string? Source
+);

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Entities/SessionEvent.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Entities/SessionEvent.cs
@@ -1,0 +1,115 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Api.BoundedContexts.SessionTracking.Domain.Entities;
+
+/// <summary>
+/// Domain entity representing a session timeline event (Session Diary).
+/// Tracks all notable actions in a game session for timeline reconstruction.
+/// Issue #276 - Session Diary / Timeline
+/// </summary>
+public class SessionEvent
+{
+    /// <summary>
+    /// Unique identifier for the session event.
+    /// </summary>
+    public Guid Id { get; private set; }
+
+    /// <summary>
+    /// Session this event belongs to.
+    /// </summary>
+    public Guid SessionId { get; private set; }
+
+    /// <summary>
+    /// Type of event (e.g., "dice_roll", "score_update", "player_joined", "note_added").
+    /// </summary>
+    [MaxLength(50)]
+    public string EventType { get; private set; } = string.Empty;
+
+    /// <summary>
+    /// When the event occurred.
+    /// </summary>
+    public DateTime Timestamp { get; private set; } = DateTime.UtcNow;
+
+    /// <summary>
+    /// JSON payload with event-specific data.
+    /// </summary>
+    public string Payload { get; private set; } = "{}";
+
+    /// <summary>
+    /// User who triggered the event (null for system events).
+    /// </summary>
+    public Guid? CreatedBy { get; private set; }
+
+    /// <summary>
+    /// Source of the event (e.g., "user", "system", "integration").
+    /// </summary>
+    [MaxLength(50)]
+    public string? Source { get; private set; }
+
+    /// <summary>
+    /// Soft delete flag.
+    /// </summary>
+    public bool IsDeleted { get; private set; }
+
+    /// <summary>
+    /// Soft delete timestamp.
+    /// </summary>
+    public DateTime? DeletedAt { get; private set; }
+
+    /// <summary>
+    /// Private constructor for EF Core.
+    /// </summary>
+    private SessionEvent()
+    {
+    }
+
+    /// <summary>
+    /// Factory method to create a new session event.
+    /// </summary>
+    /// <param name="sessionId">Session where the event occurs.</param>
+    /// <param name="eventType">Type of event (max 50 chars).</param>
+    /// <param name="payload">JSON payload with event data (defaults to "{}").</param>
+    /// <param name="createdBy">User who triggered the event (null for system events).</param>
+    /// <param name="source">Source of the event (max 50 chars).</param>
+    /// <returns>New SessionEvent instance.</returns>
+    public static SessionEvent Create(
+        Guid sessionId,
+        string eventType,
+        string? payload = null,
+        Guid? createdBy = null,
+        string? source = null)
+    {
+        if (sessionId == Guid.Empty)
+            throw new ArgumentException("Session ID cannot be empty.", nameof(sessionId));
+
+        if (string.IsNullOrWhiteSpace(eventType))
+            throw new ArgumentException("Event type cannot be empty.", nameof(eventType));
+
+        if (eventType.Length > 50)
+            throw new ArgumentException("Event type must be 50 characters or fewer.", nameof(eventType));
+
+        if (source is { Length: > 50 })
+            throw new ArgumentException("Source must be 50 characters or fewer.", nameof(source));
+
+        return new SessionEvent
+        {
+            Id = Guid.NewGuid(),
+            SessionId = sessionId,
+            EventType = eventType,
+            Timestamp = DateTime.UtcNow,
+            Payload = payload ?? "{}",
+            CreatedBy = createdBy,
+            Source = source,
+            IsDeleted = false
+        };
+    }
+
+    /// <summary>
+    /// Soft deletes the session event.
+    /// </summary>
+    public void SoftDelete()
+    {
+        IsDeleted = true;
+        DeletedAt = DateTime.UtcNow;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Repositories/ISessionEventRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Repositories/ISessionEventRepository.cs
@@ -1,0 +1,40 @@
+using Api.BoundedContexts.SessionTracking.Domain.Entities;
+
+namespace Api.BoundedContexts.SessionTracking.Domain.Repositories;
+
+/// <summary>
+/// Repository interface for SessionEvent aggregate.
+/// Issue #276 - Session Diary / Timeline
+/// </summary>
+public interface ISessionEventRepository
+{
+    /// <summary>
+    /// Gets session events by session ID with optional filtering and pagination.
+    /// </summary>
+    /// <param name="sessionId">Session ID to filter by.</param>
+    /// <param name="eventType">Optional event type filter.</param>
+    /// <param name="limit">Maximum number of events to return.</param>
+    /// <param name="offset">Number of events to skip.</param>
+    /// <param name="ct">Cancellation token.</param>
+    Task<IEnumerable<SessionEvent>> GetBySessionIdAsync(
+        Guid sessionId,
+        string? eventType = null,
+        int limit = 50,
+        int offset = 0,
+        CancellationToken ct = default);
+
+    /// <summary>
+    /// Gets a session event by ID.
+    /// </summary>
+    Task<SessionEvent?> GetByIdAsync(Guid id, CancellationToken ct = default);
+
+    /// <summary>
+    /// Gets the total count of events for a session, optionally filtered by type.
+    /// </summary>
+    Task<int> CountBySessionIdAsync(Guid sessionId, string? eventType = null, CancellationToken ct = default);
+
+    /// <summary>
+    /// Adds a new session event.
+    /// </summary>
+    Task AddAsync(SessionEvent sessionEvent, CancellationToken ct = default);
+}

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/DependencyInjection/SessionTrackingServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/DependencyInjection/SessionTrackingServiceExtensions.cs
@@ -28,6 +28,7 @@ internal static class SessionTrackingServiceExtensions
         services.AddScoped<ISessionMediaRepository, SessionMediaRepository>(); // ISSUE-4760
         services.AddScoped<ISessionChatRepository, SessionChatRepository>(); // ISSUE-4760
         services.AddScoped<IToolkitSessionStateRepository, ToolkitSessionStateRepository>(); // ISSUE-5148: Epic B5
+        services.AddScoped<ISessionEventRepository, SessionEventRepository>(); // ISSUE-276: Session Diary / Timeline
 
         // Register Unit of Work
         services.AddScoped<IUnitOfWork, EfCoreUnitOfWork>();

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/Persistence/SessionEventRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/Persistence/SessionEventRepository.cs
@@ -1,0 +1,83 @@
+using Api.BoundedContexts.SessionTracking.Domain.Entities;
+using Api.BoundedContexts.SessionTracking.Domain.Repositories;
+using Api.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.SessionTracking.Infrastructure.Persistence;
+
+/// <summary>
+/// Repository implementation for SessionEvent aggregate.
+/// Uses MeepleAiDbContext with persistence entities, maps to/from domain entities.
+/// Issue #276 - Session Diary / Timeline
+/// </summary>
+public class SessionEventRepository : ISessionEventRepository
+{
+    private readonly MeepleAiDbContext _context;
+
+    public SessionEventRepository(MeepleAiDbContext context)
+    {
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+    }
+
+    /// <inheritdoc />
+    public async Task<IEnumerable<SessionEvent>> GetBySessionIdAsync(
+        Guid sessionId,
+        string? eventType = null,
+        int limit = 50,
+        int offset = 0,
+        CancellationToken ct = default)
+    {
+        var query = _context.SessionEvents
+            .AsNoTracking()
+            .Where(e => e.SessionId == sessionId && !e.IsDeleted);
+
+        if (!string.IsNullOrWhiteSpace(eventType))
+        {
+            query = query.Where(e => e.EventType == eventType);
+        }
+
+        var entities = await query
+            .OrderByDescending(e => e.Timestamp)
+            .Skip(offset)
+            .Take(limit)
+            .ToListAsync(ct)
+            .ConfigureAwait(false);
+
+        return entities.Select(SessionEventMapper.ToDomain);
+    }
+
+    /// <inheritdoc />
+    public async Task<SessionEvent?> GetByIdAsync(Guid id, CancellationToken ct = default)
+    {
+        var entity = await _context.SessionEvents
+            .AsNoTracking()
+            .FirstOrDefaultAsync(e => e.Id == id && !e.IsDeleted, ct)
+            .ConfigureAwait(false);
+
+        return entity == null ? null : SessionEventMapper.ToDomain(entity);
+    }
+
+    /// <inheritdoc />
+    public async Task<int> CountBySessionIdAsync(Guid sessionId, string? eventType = null, CancellationToken ct = default)
+    {
+        var query = _context.SessionEvents
+            .AsNoTracking()
+            .Where(e => e.SessionId == sessionId && !e.IsDeleted);
+
+        if (!string.IsNullOrWhiteSpace(eventType))
+        {
+            query = query.Where(e => e.EventType == eventType);
+        }
+
+        return await query.CountAsync(ct).ConfigureAwait(false);
+    }
+
+    /// <inheritdoc />
+    public async Task AddAsync(SessionEvent sessionEvent, CancellationToken ct = default)
+    {
+        ArgumentNullException.ThrowIfNull(sessionEvent);
+
+        var entity = SessionEventMapper.ToEntity(sessionEvent);
+        await _context.SessionEvents.AddAsync(entity, ct).ConfigureAwait(false);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/Persistence/SessionMapper.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/Persistence/SessionMapper.cs
@@ -344,3 +344,47 @@ internal static class SessionNoteMapper
             entity.DeletedAt);
     }
 }
+
+/// <summary>
+/// Maps between SessionEvent domain entity and SessionEventEntity persistence entity.
+/// Issue #276 - Session Diary / Timeline
+/// </summary>
+internal static class SessionEventMapper
+{
+    public static SessionEventEntity ToEntity(SessionEvent domain)
+    {
+        ArgumentNullException.ThrowIfNull(domain);
+
+        return new SessionEventEntity
+        {
+            Id = domain.Id,
+            SessionId = domain.SessionId,
+            EventType = domain.EventType,
+            Timestamp = domain.Timestamp,
+            Payload = domain.Payload,
+            CreatedBy = domain.CreatedBy,
+            Source = domain.Source,
+            IsDeleted = domain.IsDeleted,
+            DeletedAt = domain.DeletedAt
+        };
+    }
+
+    public static SessionEvent ToDomain(SessionEventEntity entity)
+    {
+        ArgumentNullException.ThrowIfNull(entity);
+
+        var sessionEvent = (SessionEvent)Activator.CreateInstance(typeof(SessionEvent), true)!;
+
+        typeof(SessionEvent).GetProperty(nameof(SessionEvent.Id))!.SetValue(sessionEvent, entity.Id);
+        typeof(SessionEvent).GetProperty(nameof(SessionEvent.SessionId))!.SetValue(sessionEvent, entity.SessionId);
+        typeof(SessionEvent).GetProperty(nameof(SessionEvent.EventType))!.SetValue(sessionEvent, entity.EventType);
+        typeof(SessionEvent).GetProperty(nameof(SessionEvent.Timestamp))!.SetValue(sessionEvent, entity.Timestamp);
+        typeof(SessionEvent).GetProperty(nameof(SessionEvent.Payload))!.SetValue(sessionEvent, entity.Payload);
+        typeof(SessionEvent).GetProperty(nameof(SessionEvent.CreatedBy))!.SetValue(sessionEvent, entity.CreatedBy);
+        typeof(SessionEvent).GetProperty(nameof(SessionEvent.Source))!.SetValue(sessionEvent, entity.Source);
+        typeof(SessionEvent).GetProperty(nameof(SessionEvent.IsDeleted))!.SetValue(sessionEvent, entity.IsDeleted);
+        typeof(SessionEvent).GetProperty(nameof(SessionEvent.DeletedAt))!.SetValue(sessionEvent, entity.DeletedAt);
+
+        return sessionEvent;
+    }
+}

--- a/apps/api/src/Api/Routing/SessionTrackingEndpoints.cs
+++ b/apps/api/src/Api/Routing/SessionTrackingEndpoints.cs
@@ -106,6 +106,10 @@ internal static class SessionTrackingEndpoints
         MapGetToolkitSessionStateEndpoint(group);
         MapUpdateToolkitWidgetStateEndpoint(group);
 
+        // Session diary / timeline endpoints (Issue #276)
+        MapAddSessionEventEndpoint(group);
+        MapGetSessionEventsEndpoint(group);
+
         return group;
     }
 
@@ -1877,6 +1881,69 @@ internal static class SessionTrackingEndpoints
         .WithOpenApi();
     }
 
+    // ============================================================================
+    // Session diary / timeline endpoints (Issue #276)
+    // ============================================================================
+
+    private static void MapAddSessionEventEndpoint(RouteGroupBuilder group)
+    {
+        group.MapPost("/game-sessions/{sessionId:guid}/events", async (
+            Guid sessionId,
+            AddSessionEventRequest request,
+            HttpContext httpContext,
+            IMediator mediator,
+            CancellationToken ct) =>
+        {
+            var userId = httpContext.User.GetUserId();
+            if (userId == Guid.Empty)
+                return Results.Unauthorized();
+
+            var command = new AddSessionEventCommand(
+                sessionId,
+                userId,
+                request.EventType,
+                request.Payload,
+                request.Source);
+            var result = await mediator.Send(command, ct).ConfigureAwait(false);
+            return Results.Created($"/api/v1/game-sessions/{sessionId}/events/{result.EventId}", result);
+        })
+        .RequireAuthenticatedUser()
+        .WithName("AddSessionEvent")
+        .WithTags("SessionTracking", "SessionDiary")
+        .WithSummary("Add an event to the session timeline")
+        .WithDescription("Records a new event in the session diary. Requires Player role. Issue #276.")
+        .Produces(201)
+        .Produces(400)
+        .Produces(401)
+        .Produces(403)
+        .Produces(404)
+        .Produces(409);
+    }
+
+    private static void MapGetSessionEventsEndpoint(RouteGroupBuilder group)
+    {
+        group.MapGet("/game-sessions/{sessionId:guid}/events", async (
+            Guid sessionId,
+            IMediator mediator,
+            [FromQuery] string? eventType = null,
+            [FromQuery] int limit = 50,
+            [FromQuery] int offset = 0,
+            CancellationToken ct = default) =>
+        {
+            var query = new GetSessionEventsQuery(sessionId, eventType, limit, offset);
+            var result = await mediator.Send(query, ct).ConfigureAwait(false);
+            return Results.Ok(result);
+        })
+        .RequireAuthenticatedUser()
+        .WithName("GetSessionEvents")
+        .WithTags("SessionTracking", "SessionDiary")
+        .WithSummary("Get session timeline events")
+        .WithDescription("Returns paginated session events, optionally filtered by event type. Issue #276.")
+        .Produces<GetSessionEventsResult>(200)
+        .Produces(401)
+        .Produces(404);
+    }
+
     internal static RouteGroupBuilder MapSessionStatisticsEndpoints(this RouteGroupBuilder group)
     {
         group.MapGet("/game-sessions/session-statistics", async (
@@ -1956,3 +2023,6 @@ public sealed record SessionTimerActionRequest(
 
 /// <summary>Request body for sending a chat action. SenderId is derived from the authenticated user.</summary>
 public sealed record SendChatActionRequest(string Content, int? TurnNumber = null, string? MentionsJson = null);
+
+/// <summary>Request body for adding a session event (Issue #276).</summary>
+public sealed record AddSessionEventRequest(string EventType, string? Payload = null, string? Source = null);


### PR DESCRIPTION
## Summary
- Add `SessionEvent` domain entity with factory method, soft delete, and validation
- Implement `ISessionEventRepository` with paginated, filterable queries
- Add `AddSessionEventCommand` (CQRS) with FluentValidation and role-based access (Player minimum)
- Add `GetSessionEventsQuery` with pagination (limit/offset), event type filtering, and HasMore flag
- Register two new endpoints: `POST /game-sessions/{sessionId}/events` and `GET /game-sessions/{sessionId}/events`
- Wire up DI registration for `SessionEventRepository`

## Test plan
- [ ] Verify `POST /game-sessions/{sessionId}/events` creates events for active sessions
- [ ] Verify `GET /game-sessions/{sessionId}/events` returns paginated timeline with correct ordering
- [ ] Verify event type filtering works correctly
- [ ] Verify role-based access control (Player minimum) prevents spectator access
- [ ] Verify validation rejects empty EventType, oversized fields

Closes #276

🤖 Generated with [Claude Code](https://claude.com/claude-code)
