### PR TITLE
feat(game-management): phase tracker default template and jump-to-phase (#273)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/LiveSessions/ApplyDefaultPhasesCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/LiveSessions/ApplyDefaultPhasesCommand.cs
@@ -1,0 +1,9 @@
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.GameManagement.Application.Commands.LiveSessions;
+
+/// <summary>
+/// Applies the default phase template (Setup → Play → Scoring → End) to a live session.
+/// Issue #273: Phase/Round Tracker Tool.
+/// </summary>
+internal sealed record ApplyDefaultPhasesCommand(Guid SessionId) : ICommand;

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/LiveSessions/SetPhaseIndexCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/LiveSessions/SetPhaseIndexCommand.cs
@@ -1,0 +1,9 @@
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.GameManagement.Application.Commands.LiveSessions;
+
+/// <summary>
+/// Jumps to a specific phase by index in a live session.
+/// Issue #273: Phase/Round Tracker Tool — supports non-sequential phase navigation.
+/// </summary>
+internal sealed record SetPhaseIndexCommand(Guid SessionId, int PhaseIndex) : ICommand;

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Handlers/LiveSessions/PhaseAndSnapshotCommandHandlers.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Handlers/LiveSessions/PhaseAndSnapshotCommandHandlers.cs
@@ -1,6 +1,7 @@
 using Api.BoundedContexts.GameManagement.Application.Commands.LiveSessions;
 using Api.BoundedContexts.GameManagement.Application.Commands.SessionSnapshot;
 using Api.BoundedContexts.GameManagement.Application.DTOs.SessionSnapshot;
+using Api.BoundedContexts.GameManagement.Domain.Entities;
 using Api.BoundedContexts.GameManagement.Domain.Repositories;
 using Api.Middleware.Exceptions;
 using Api.SharedKernel.Application.Interfaces;
@@ -137,5 +138,80 @@ internal class TriggerEventSnapshotCommandHandler
         await _sessionRepository.UpdateAsync(session, cancellationToken).ConfigureAwait(false);
 
         return result;
+    }
+}
+
+/// <summary>
+/// Applies the default phase template (Setup → Play → Scoring → End) to a live session.
+/// Issue #273: Phase/Round Tracker Tool.
+/// </summary>
+internal class ApplyDefaultPhasesCommandHandler : ICommandHandler<ApplyDefaultPhasesCommand>
+{
+    private readonly ILiveSessionRepository _sessionRepository;
+    private readonly TimeProvider _timeProvider;
+
+    public ApplyDefaultPhasesCommandHandler(
+        ILiveSessionRepository sessionRepository,
+        TimeProvider timeProvider)
+    {
+        _sessionRepository = sessionRepository ?? throw new ArgumentNullException(nameof(sessionRepository));
+        _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
+    }
+
+    public async Task Handle(ApplyDefaultPhasesCommand command, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        var session = await _sessionRepository.GetByIdAsync(command.SessionId, cancellationToken)
+            .ConfigureAwait(false)
+            ?? throw new NotFoundException("LiveGameSession", command.SessionId.ToString());
+
+        session.ConfigurePhases(LiveGameSession.DefaultPhaseNames, _timeProvider);
+        await _sessionRepository.UpdateAsync(session, cancellationToken).ConfigureAwait(false);
+    }
+}
+
+/// <summary>
+/// Handles jumping to a specific phase by index in a live session.
+/// Issue #273: Phase/Round Tracker Tool — non-sequential phase navigation.
+/// </summary>
+internal class SetPhaseIndexCommandHandler : ICommandHandler<SetPhaseIndexCommand>
+{
+    private readonly ILiveSessionRepository _sessionRepository;
+    private readonly TimeProvider _timeProvider;
+    private readonly IMediator _mediator;
+
+    public SetPhaseIndexCommandHandler(
+        ILiveSessionRepository sessionRepository,
+        TimeProvider timeProvider,
+        IMediator mediator)
+    {
+        _sessionRepository = sessionRepository ?? throw new ArgumentNullException(nameof(sessionRepository));
+        _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
+        _mediator = mediator ?? throw new ArgumentNullException(nameof(mediator));
+    }
+
+    public async Task Handle(SetPhaseIndexCommand command, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        var session = await _sessionRepository.GetByIdAsync(command.SessionId, cancellationToken)
+            .ConfigureAwait(false)
+            ?? throw new NotFoundException("LiveGameSession", command.SessionId.ToString());
+
+        session.SetPhaseIndex(command.PhaseIndex, _timeProvider);
+        await _sessionRepository.UpdateAsync(session, cancellationToken).ConfigureAwait(false);
+
+        // Auto-trigger snapshot on phase change if configured
+        var triggerConfig = session.SnapshotTriggerConfig;
+        if (triggerConfig != null && triggerConfig.IsTriggerEnabled(
+                Domain.Entities.SessionSnapshot.SnapshotTrigger.PhaseAdvanced))
+        {
+            await _mediator.Send(new TriggerEventSnapshotCommand(
+                command.SessionId,
+                Domain.Entities.SessionSnapshot.SnapshotTrigger.PhaseAdvanced,
+                $"Phase set to {session.GetCurrentPhaseName() ?? $"phase {session.CurrentPhaseIndex}"}",
+                null), cancellationToken).ConfigureAwait(false);
+        }
     }
 }

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/LiveGameSession.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/LiveGameSession.cs
@@ -22,6 +22,12 @@ internal sealed class LiveGameSession : AggregateRoot<Guid>
     private const int MaxTeams = 10;
     private const int MaxTurns = 9999;
 
+    /// <summary>
+    /// Default phase template for games without custom phase definitions.
+    /// Issue #273: Phase/Round Tracker Tool.
+    /// </summary>
+    public static readonly string[] DefaultPhaseNames = ["Setup", "Play", "Scoring", "End"];
+
     private readonly List<LiveSessionPlayer> _players = new();
     private readonly List<LiveSessionTeam> _teams = new();
     private readonly List<Guid> _turnOrder = new();
@@ -552,6 +558,31 @@ internal sealed class LiveGameSession : AggregateRoot<Guid>
 
         var now = (timeProvider ?? TimeProvider.System).GetUtcNow().UtcDateTime;
         UpdatedAt = now;
+    }
+
+    /// <summary>
+    /// Jumps to a specific phase by index. Fires a phase advanced event.
+    /// Issue #273: Phase/Round Tracker Tool — supports non-sequential phase navigation.
+    /// </summary>
+    public void SetPhaseIndex(int phaseIndex, TimeProvider? timeProvider = null)
+    {
+        if (Status != LiveSessionStatus.InProgress)
+            throw new ConflictException($"Cannot set phase in {Status} status. Must be InProgress.");
+
+        if (PhaseNames.Length == 0)
+            throw new DomainException("No phases configured for this session.");
+
+        if (phaseIndex < 0 || phaseIndex >= PhaseNames.Length)
+            throw new ValidationException($"Phase index must be between 0 and {PhaseNames.Length - 1}.");
+
+        var now = (timeProvider ?? TimeProvider.System).GetUtcNow().UtcDateTime;
+        CurrentPhaseIndex = phaseIndex;
+        UpdatedAt = now;
+
+        AddDomainEvent(new LiveSessionPhaseAdvancedEvent(
+            Id, CurrentTurnIndex, CurrentPhaseIndex,
+            PhaseNames[CurrentPhaseIndex],
+            PhaseNames.Length));
     }
 
     /// <summary>

--- a/apps/api/src/Api/Routing/LiveSessionEndpoints.cs
+++ b/apps/api/src/Api/Routing/LiveSessionEndpoints.cs
@@ -160,6 +160,25 @@ internal static class LiveSessionEndpoints
             .WithSummary("Configure turn phases")
             .WithDescription("Sets the phase names for the session's turn structure. Issue #4761.");
 
+        group.MapPost("/live-sessions/{sessionId}/phases/default", HandleApplyDefaultPhases)
+            .RequireAuthenticatedUser()
+            .Produces(204)
+            .Produces(404)
+            .Produces(409)
+            .WithTags("LiveSessions")
+            .WithSummary("Apply default phase template")
+            .WithDescription("Applies the default phase template (Setup → Play → Scoring → End). Issue #273.");
+
+        group.MapPut("/live-sessions/{sessionId}/phases/{phaseIndex:int}", HandleSetPhaseIndex)
+            .RequireAuthenticatedUser()
+            .Produces(204)
+            .Produces(400)
+            .Produces(404)
+            .Produces(409)
+            .WithTags("LiveSessions")
+            .WithSummary("Jump to a specific phase")
+            .WithDescription("Sets the current phase to the specified index. Issue #273.");
+
         group.MapPost("/live-sessions/{sessionId}/trigger-snapshot", HandleTriggerSnapshot)
             .RequireAuthenticatedUser()
             .Produces<SessionSnapshotDto>(201)
@@ -464,6 +483,25 @@ internal static class LiveSessionEndpoints
         CancellationToken cancellationToken)
     {
         await mediator.Send(new ConfigureLiveSessionPhasesCommand(sessionId, request.PhaseNames), cancellationToken).ConfigureAwait(false);
+        return Results.NoContent();
+    }
+
+    private static async Task<IResult> HandleApplyDefaultPhases(
+        Guid sessionId,
+        [FromServices] IMediator mediator,
+        CancellationToken cancellationToken)
+    {
+        await mediator.Send(new ApplyDefaultPhasesCommand(sessionId), cancellationToken).ConfigureAwait(false);
+        return Results.NoContent();
+    }
+
+    private static async Task<IResult> HandleSetPhaseIndex(
+        Guid sessionId,
+        int phaseIndex,
+        [FromServices] IMediator mediator,
+        CancellationToken cancellationToken)
+    {
+        await mediator.Send(new SetPhaseIndexCommand(sessionId, phaseIndex), cancellationToken).ConfigureAwait(false);
         return Results.NoContent();
     }
 


### PR DESCRIPTION
## Summary
- Add `DefaultPhaseNames` constant (`Setup → Play → Scoring → End`) to `LiveGameSession` domain
- Add `SetPhaseIndex()` method for non-sequential phase navigation (jump to any phase)
- Add `ApplyDefaultPhasesCommand` + handler to apply default template when no game-specific phases exist
- Add `SetPhaseIndexCommand` + handler with auto-snapshot trigger support
- Add two new endpoints:
  - `POST /live-sessions/{sessionId}/phases/default` — Apply default phase template
  - `PUT /live-sessions/{sessionId}/phases/{phaseIndex}` — Jump to specific phase

## Notes
- Session diary integration (phase changes → SessionEvent) depends on #276 being merged first
- Frontend components (`PhaseTrackerPanel`, `usePhaseTrackerTool`) are separate frontend work
- Existing endpoints already cover: configure phases, advance phase, get phases

## Test plan
- [ ] Verify `POST /phases/default` applies Setup/Play/Scoring/End to a session
- [ ] Verify `PUT /phases/{index}` jumps to correct phase and fires domain event
- [ ] Verify `SetPhaseIndex` validates bounds (rejects negative and out-of-range)
- [ ] Verify phase operations respect session status (only InProgress allowed)
- [ ] Verify auto-snapshot triggers on phase jump when configured

Closes #273

🤖 Generated with [Claude Code](https://claude.com/claude-code)
