### PR TITLE
feat(session-tracking): session checkpoint / deep save (#278)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/CreateCheckpointCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/CreateCheckpointCommand.cs
@@ -1,0 +1,19 @@
+using MediatR;
+
+namespace Api.BoundedContexts.SessionTracking.Application.Commands;
+
+/// <summary>
+/// Issue #278: Creates a session checkpoint (deep save).
+/// </summary>
+public record CreateCheckpointCommand(
+    Guid SessionId,
+    string Name,
+    string SnapshotData,
+    int DiaryEventCount,
+    Guid? CreatedBy = null
+) : IRequest<CreateCheckpointResult>;
+
+public record CreateCheckpointResult(
+    Guid CheckpointId,
+    DateTime Timestamp
+);

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/DeleteCheckpointCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/DeleteCheckpointCommand.cs
@@ -1,0 +1,8 @@
+using MediatR;
+
+namespace Api.BoundedContexts.SessionTracking.Application.Commands;
+
+/// <summary>
+/// Issue #278: Deletes a session checkpoint.
+/// </summary>
+public record DeleteCheckpointCommand(Guid CheckpointId) : IRequest;

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Handlers/CheckpointCommandHandlers.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Handlers/CheckpointCommandHandlers.cs
@@ -1,0 +1,63 @@
+using MediatR;
+using Api.BoundedContexts.SessionTracking.Application.Commands;
+using Api.BoundedContexts.SessionTracking.Domain.Entities;
+using Api.BoundedContexts.SessionTracking.Domain.Repositories;
+using Api.Middleware.Exceptions;
+
+namespace Api.BoundedContexts.SessionTracking.Application.Handlers;
+
+/// <summary>
+/// Issue #278: Handles creating a session checkpoint.
+/// </summary>
+public class CreateCheckpointCommandHandler : IRequestHandler<CreateCheckpointCommand, CreateCheckpointResult>
+{
+    private readonly ISessionCheckpointRepository _checkpointRepository;
+    private readonly ISessionRepository _sessionRepository;
+
+    public CreateCheckpointCommandHandler(
+        ISessionCheckpointRepository checkpointRepository,
+        ISessionRepository sessionRepository)
+    {
+        _checkpointRepository = checkpointRepository ?? throw new ArgumentNullException(nameof(checkpointRepository));
+        _sessionRepository = sessionRepository ?? throw new ArgumentNullException(nameof(sessionRepository));
+    }
+
+    public async Task<CreateCheckpointResult> Handle(CreateCheckpointCommand request, CancellationToken cancellationToken)
+    {
+        // Verify session exists
+        _ = await _sessionRepository.GetByIdAsync(request.SessionId, cancellationToken).ConfigureAwait(false)
+            ?? throw new NotFoundException($"Session {request.SessionId} not found");
+
+        var checkpoint = SessionCheckpoint.Create(
+            request.SessionId,
+            request.Name,
+            request.SnapshotData,
+            request.DiaryEventCount,
+            request.CreatedBy);
+
+        await _checkpointRepository.AddAsync(checkpoint, cancellationToken).ConfigureAwait(false);
+
+        return new CreateCheckpointResult(checkpoint.Id, checkpoint.Timestamp);
+    }
+}
+
+/// <summary>
+/// Issue #278: Handles deleting a session checkpoint.
+/// </summary>
+public class DeleteCheckpointCommandHandler : IRequestHandler<DeleteCheckpointCommand>
+{
+    private readonly ISessionCheckpointRepository _checkpointRepository;
+
+    public DeleteCheckpointCommandHandler(ISessionCheckpointRepository checkpointRepository)
+    {
+        _checkpointRepository = checkpointRepository ?? throw new ArgumentNullException(nameof(checkpointRepository));
+    }
+
+    public async Task Handle(DeleteCheckpointCommand request, CancellationToken cancellationToken)
+    {
+        _ = await _checkpointRepository.GetByIdAsync(request.CheckpointId, cancellationToken).ConfigureAwait(false)
+            ?? throw new NotFoundException($"Checkpoint {request.CheckpointId} not found");
+
+        await _checkpointRepository.DeleteAsync(request.CheckpointId, cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Handlers/CheckpointQueryHandlers.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Handlers/CheckpointQueryHandlers.cs
@@ -1,0 +1,62 @@
+using MediatR;
+using Api.BoundedContexts.SessionTracking.Application.Queries;
+using Api.BoundedContexts.SessionTracking.Domain.Repositories;
+using Api.Middleware.Exceptions;
+
+namespace Api.BoundedContexts.SessionTracking.Application.Handlers;
+
+/// <summary>
+/// Issue #278: Handles listing checkpoints for a session.
+/// </summary>
+public class GetCheckpointsQueryHandler : IRequestHandler<GetCheckpointsQuery, GetCheckpointsResult>
+{
+    private readonly ISessionCheckpointRepository _checkpointRepository;
+
+    public GetCheckpointsQueryHandler(ISessionCheckpointRepository checkpointRepository)
+    {
+        _checkpointRepository = checkpointRepository ?? throw new ArgumentNullException(nameof(checkpointRepository));
+    }
+
+    public async Task<GetCheckpointsResult> Handle(GetCheckpointsQuery request, CancellationToken cancellationToken)
+    {
+        var checkpoints = await _checkpointRepository.GetBySessionIdAsync(request.SessionId, cancellationToken).ConfigureAwait(false);
+
+        var dtos = checkpoints.Select(c => new CheckpointDto(
+            c.Id,
+            c.SessionId,
+            c.Name,
+            c.Timestamp,
+            c.DiaryEventCount,
+            c.CreatedBy)).ToList();
+
+        return new GetCheckpointsResult(dtos);
+    }
+}
+
+/// <summary>
+/// Issue #278: Handles retrieving a specific checkpoint's snapshot data.
+/// </summary>
+public class GetCheckpointSnapshotQueryHandler : IRequestHandler<GetCheckpointSnapshotQuery, GetCheckpointSnapshotResult>
+{
+    private readonly ISessionCheckpointRepository _checkpointRepository;
+
+    public GetCheckpointSnapshotQueryHandler(ISessionCheckpointRepository checkpointRepository)
+    {
+        _checkpointRepository = checkpointRepository ?? throw new ArgumentNullException(nameof(checkpointRepository));
+    }
+
+    public async Task<GetCheckpointSnapshotResult> Handle(GetCheckpointSnapshotQuery request, CancellationToken cancellationToken)
+    {
+        var checkpoint = await _checkpointRepository.GetByIdAsync(request.CheckpointId, cancellationToken).ConfigureAwait(false)
+            ?? throw new NotFoundException($"Checkpoint {request.CheckpointId} not found");
+
+        return new GetCheckpointSnapshotResult(
+            checkpoint.Id,
+            checkpoint.SessionId,
+            checkpoint.Name,
+            checkpoint.Timestamp,
+            checkpoint.SnapshotData,
+            checkpoint.DiaryEventCount,
+            checkpoint.CreatedBy);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/GetCheckpointSnapshotQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/GetCheckpointSnapshotQuery.cs
@@ -1,0 +1,18 @@
+using MediatR;
+
+namespace Api.BoundedContexts.SessionTracking.Application.Queries;
+
+/// <summary>
+/// Issue #278: Retrieves a specific checkpoint's snapshot data for restore.
+/// </summary>
+public record GetCheckpointSnapshotQuery(Guid CheckpointId) : IRequest<GetCheckpointSnapshotResult>;
+
+public record GetCheckpointSnapshotResult(
+    Guid Id,
+    Guid SessionId,
+    string Name,
+    DateTime Timestamp,
+    string SnapshotData,
+    int DiaryEventCount,
+    Guid? CreatedBy
+);

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/GetCheckpointsQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/GetCheckpointsQuery.cs
@@ -1,0 +1,19 @@
+using MediatR;
+
+namespace Api.BoundedContexts.SessionTracking.Application.Queries;
+
+/// <summary>
+/// Issue #278: Retrieves all checkpoints for a session.
+/// </summary>
+public record GetCheckpointsQuery(Guid SessionId) : IRequest<GetCheckpointsResult>;
+
+public record CheckpointDto(
+    Guid Id,
+    Guid SessionId,
+    string Name,
+    DateTime Timestamp,
+    int DiaryEventCount,
+    Guid? CreatedBy
+);
+
+public record GetCheckpointsResult(IReadOnlyList<CheckpointDto> Checkpoints);

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Entities/SessionCheckpoint.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Entities/SessionCheckpoint.cs
@@ -1,0 +1,54 @@
+namespace Api.BoundedContexts.SessionTracking.Domain.Entities;
+
+/// <summary>
+/// Issue #278: Session checkpoint for deep save/restore of full session state.
+/// Captures a snapshot of all toolkit states, phase/round/turn, and diary event count.
+/// </summary>
+public class SessionCheckpoint
+{
+    public Guid Id { get; private set; }
+    public Guid SessionId { get; private set; }
+    public string Name { get; private set; } = string.Empty;
+    public DateTime Timestamp { get; private set; }
+    public string SnapshotData { get; private set; } = "{}";
+    public int DiaryEventCount { get; private set; }
+    public Guid? CreatedBy { get; private set; }
+
+    private SessionCheckpoint() { }
+
+    /// <summary>
+    /// Creates a new session checkpoint.
+    /// </summary>
+    /// <param name="sessionId">The session to checkpoint.</param>
+    /// <param name="name">User-given name for the checkpoint.</param>
+    /// <param name="snapshotData">JSON snapshot of full session state.</param>
+    /// <param name="diaryEventCount">Number of diary events at checkpoint time.</param>
+    /// <param name="createdBy">User who created the checkpoint.</param>
+    public static SessionCheckpoint Create(
+        Guid sessionId,
+        string name,
+        string snapshotData,
+        int diaryEventCount,
+        Guid? createdBy = null)
+    {
+        if (sessionId == Guid.Empty)
+            throw new ArgumentException("Session ID cannot be empty.", nameof(sessionId));
+
+        if (string.IsNullOrWhiteSpace(name))
+            throw new ArgumentException("Checkpoint name cannot be empty.", nameof(name));
+
+        if (name.Length > 200)
+            throw new ArgumentException("Checkpoint name cannot exceed 200 characters.", nameof(name));
+
+        return new SessionCheckpoint
+        {
+            Id = Guid.NewGuid(),
+            SessionId = sessionId,
+            Name = name.Trim(),
+            Timestamp = DateTime.UtcNow,
+            SnapshotData = snapshotData,
+            DiaryEventCount = diaryEventCount,
+            CreatedBy = createdBy
+        };
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Repositories/ISessionCheckpointRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Repositories/ISessionCheckpointRepository.cs
@@ -1,0 +1,14 @@
+using Api.BoundedContexts.SessionTracking.Domain.Entities;
+
+namespace Api.BoundedContexts.SessionTracking.Domain.Repositories;
+
+/// <summary>
+/// Issue #278: Repository interface for session checkpoints.
+/// </summary>
+public interface ISessionCheckpointRepository
+{
+    Task<SessionCheckpoint?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<SessionCheckpoint>> GetBySessionIdAsync(Guid sessionId, CancellationToken cancellationToken = default);
+    Task AddAsync(SessionCheckpoint checkpoint, CancellationToken cancellationToken = default);
+    Task DeleteAsync(Guid id, CancellationToken cancellationToken = default);
+}

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/DependencyInjection/SessionTrackingServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/DependencyInjection/SessionTrackingServiceExtensions.cs
@@ -29,6 +29,7 @@ internal static class SessionTrackingServiceExtensions
         services.AddScoped<ISessionChatRepository, SessionChatRepository>(); // ISSUE-4760
         services.AddScoped<IToolkitSessionStateRepository, ToolkitSessionStateRepository>(); // ISSUE-5148: Epic B5
         services.AddScoped<ISessionEventRepository, SessionEventRepository>(); // ISSUE-276: Session Diary / Timeline
+        services.AddScoped<ISessionCheckpointRepository, SessionCheckpointRepository>(); // ISSUE-278: Session Checkpoint / Deep Save
 
         // Register Unit of Work
         services.AddScoped<IUnitOfWork, EfCoreUnitOfWork>();

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/Persistence/SessionCheckpointRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/Persistence/SessionCheckpointRepository.cs
@@ -1,0 +1,101 @@
+using Api.BoundedContexts.SessionTracking.Domain.Entities;
+using Api.BoundedContexts.SessionTracking.Domain.Repositories;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.SessionTracking;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.SessionTracking.Infrastructure.Persistence;
+
+/// <summary>
+/// Issue #278: EF Core repository for session checkpoints.
+/// </summary>
+internal sealed class SessionCheckpointRepository : ISessionCheckpointRepository
+{
+    private readonly MeepleAiDbContext _context;
+
+    public SessionCheckpointRepository(MeepleAiDbContext context)
+    {
+        _context = context ?? throw new ArgumentNullException(nameof(context));
+    }
+
+    public async Task<SessionCheckpoint?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        var entity = await _context.SessionCheckpoints
+            .AsNoTracking()
+            .FirstOrDefaultAsync(e => e.Id == id, cancellationToken)
+            .ConfigureAwait(false);
+
+        return entity is null ? null : SessionCheckpointMapper.ToDomain(entity);
+    }
+
+    public async Task<IReadOnlyList<SessionCheckpoint>> GetBySessionIdAsync(Guid sessionId, CancellationToken cancellationToken = default)
+    {
+        var entities = await _context.SessionCheckpoints
+            .AsNoTracking()
+            .Where(e => e.SessionId == sessionId)
+            .OrderByDescending(e => e.Timestamp)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return entities.Select(SessionCheckpointMapper.ToDomain).ToList();
+    }
+
+    public async Task AddAsync(SessionCheckpoint checkpoint, CancellationToken cancellationToken = default)
+    {
+        var entity = SessionCheckpointMapper.ToEntity(checkpoint);
+        _context.SessionCheckpoints.Add(entity);
+        await _context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task DeleteAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        var entity = await _context.SessionCheckpoints
+            .FirstOrDefaultAsync(e => e.Id == id, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (entity is not null)
+        {
+            _context.SessionCheckpoints.Remove(entity);
+            await _context.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        }
+    }
+}
+
+/// <summary>
+/// Maps between SessionCheckpoint domain entity and SessionCheckpointEntity persistence entity.
+/// </summary>
+internal static class SessionCheckpointMapper
+{
+    public static SessionCheckpointEntity ToEntity(SessionCheckpoint domain)
+    {
+        ArgumentNullException.ThrowIfNull(domain);
+
+        return new SessionCheckpointEntity
+        {
+            Id = domain.Id,
+            SessionId = domain.SessionId,
+            Name = domain.Name,
+            Timestamp = domain.Timestamp,
+            SnapshotData = domain.SnapshotData,
+            DiaryEventCount = domain.DiaryEventCount,
+            CreatedBy = domain.CreatedBy
+        };
+    }
+
+    public static SessionCheckpoint ToDomain(SessionCheckpointEntity entity)
+    {
+        ArgumentNullException.ThrowIfNull(entity);
+
+        var checkpoint = (SessionCheckpoint)Activator.CreateInstance(typeof(SessionCheckpoint), true)!;
+
+        typeof(SessionCheckpoint).GetProperty(nameof(SessionCheckpoint.Id))!.SetValue(checkpoint, entity.Id);
+        typeof(SessionCheckpoint).GetProperty(nameof(SessionCheckpoint.SessionId))!.SetValue(checkpoint, entity.SessionId);
+        typeof(SessionCheckpoint).GetProperty(nameof(SessionCheckpoint.Name))!.SetValue(checkpoint, entity.Name);
+        typeof(SessionCheckpoint).GetProperty(nameof(SessionCheckpoint.Timestamp))!.SetValue(checkpoint, entity.Timestamp);
+        typeof(SessionCheckpoint).GetProperty(nameof(SessionCheckpoint.SnapshotData))!.SetValue(checkpoint, entity.SnapshotData);
+        typeof(SessionCheckpoint).GetProperty(nameof(SessionCheckpoint.DiaryEventCount))!.SetValue(checkpoint, entity.DiaryEventCount);
+        typeof(SessionCheckpoint).GetProperty(nameof(SessionCheckpoint.CreatedBy))!.SetValue(checkpoint, entity.CreatedBy);
+
+        return checkpoint;
+    }
+}

--- a/apps/api/src/Api/Routing/SessionTrackingEndpoints.cs
+++ b/apps/api/src/Api/Routing/SessionTrackingEndpoints.cs
@@ -110,6 +110,12 @@ internal static class SessionTrackingEndpoints
         MapAddSessionEventEndpoint(group);
         MapGetSessionEventsEndpoint(group);
 
+        // Session checkpoint / deep save endpoints (Issue #278)
+        MapCreateCheckpointEndpoint(group);
+        MapGetCheckpointsEndpoint(group);
+        MapGetCheckpointSnapshotEndpoint(group);
+        MapDeleteCheckpointEndpoint(group);
+
         return group;
     }
 
@@ -1944,6 +1950,102 @@ internal static class SessionTrackingEndpoints
         .Produces(404);
     }
 
+    // === Issue #278: Session Checkpoint / Deep Save ===
+
+    private static void MapCreateCheckpointEndpoint(RouteGroupBuilder group)
+    {
+        group.MapPost("/game-sessions/{sessionId:guid}/checkpoints", async (
+            Guid sessionId,
+            CreateCheckpointRequest request,
+            HttpContext httpContext,
+            IMediator mediator,
+            CancellationToken ct) =>
+        {
+            var userId = httpContext.User.GetUserId();
+            if (userId == Guid.Empty)
+                return Results.Unauthorized();
+
+            var command = new CreateCheckpointCommand(
+                sessionId,
+                request.Name,
+                request.SnapshotData,
+                request.DiaryEventCount,
+                userId);
+            var result = await mediator.Send(command, ct).ConfigureAwait(false);
+            return Results.Created($"/api/v1/game-sessions/{sessionId}/checkpoints/{result.CheckpointId}", result);
+        })
+        .RequireAuthenticatedUser()
+        .WithName("CreateSessionCheckpoint")
+        .WithTags("SessionTracking", "Checkpoints")
+        .WithSummary("Create a session checkpoint (deep save)")
+        .WithDescription("Saves full session state as a named checkpoint for later restore. Issue #278.")
+        .Produces(201)
+        .Produces(400)
+        .Produces(401)
+        .Produces(404);
+    }
+
+    private static void MapGetCheckpointsEndpoint(RouteGroupBuilder group)
+    {
+        group.MapGet("/game-sessions/{sessionId:guid}/checkpoints", async (
+            Guid sessionId,
+            IMediator mediator,
+            CancellationToken ct) =>
+        {
+            var query = new GetCheckpointsQuery(sessionId);
+            var result = await mediator.Send(query, ct).ConfigureAwait(false);
+            return Results.Ok(result);
+        })
+        .RequireAuthenticatedUser()
+        .WithName("GetSessionCheckpoints")
+        .WithTags("SessionTracking", "Checkpoints")
+        .WithSummary("List all checkpoints for a session")
+        .WithDescription("Returns all saved checkpoints ordered by most recent first. Issue #278.")
+        .Produces<GetCheckpointsResult>(200)
+        .Produces(401);
+    }
+
+    private static void MapGetCheckpointSnapshotEndpoint(RouteGroupBuilder group)
+    {
+        group.MapGet("/game-sessions/checkpoints/{checkpointId:guid}", async (
+            Guid checkpointId,
+            IMediator mediator,
+            CancellationToken ct) =>
+        {
+            var query = new GetCheckpointSnapshotQuery(checkpointId);
+            var result = await mediator.Send(query, ct).ConfigureAwait(false);
+            return Results.Ok(result);
+        })
+        .RequireAuthenticatedUser()
+        .WithName("GetCheckpointSnapshot")
+        .WithTags("SessionTracking", "Checkpoints")
+        .WithSummary("Get checkpoint snapshot data for restore")
+        .WithDescription("Returns the full snapshot data of a checkpoint for client-side restore. Issue #278.")
+        .Produces<GetCheckpointSnapshotResult>(200)
+        .Produces(401)
+        .Produces(404);
+    }
+
+    private static void MapDeleteCheckpointEndpoint(RouteGroupBuilder group)
+    {
+        group.MapDelete("/game-sessions/checkpoints/{checkpointId:guid}", async (
+            Guid checkpointId,
+            IMediator mediator,
+            CancellationToken ct) =>
+        {
+            await mediator.Send(new DeleteCheckpointCommand(checkpointId), ct).ConfigureAwait(false);
+            return Results.NoContent();
+        })
+        .RequireAuthenticatedUser()
+        .WithName("DeleteSessionCheckpoint")
+        .WithTags("SessionTracking", "Checkpoints")
+        .WithSummary("Delete a session checkpoint")
+        .WithDescription("Permanently removes a session checkpoint. Issue #278.")
+        .Produces(204)
+        .Produces(401)
+        .Produces(404);
+    }
+
     internal static RouteGroupBuilder MapSessionStatisticsEndpoints(this RouteGroupBuilder group)
     {
         group.MapGet("/game-sessions/session-statistics", async (
@@ -2026,3 +2128,6 @@ public sealed record SendChatActionRequest(string Content, int? TurnNumber = nul
 
 /// <summary>Request body for adding a session event (Issue #276).</summary>
 public sealed record AddSessionEventRequest(string EventType, string? Payload = null, string? Source = null);
+
+/// <summary>Request body for creating a session checkpoint (Issue #278).</summary>
+public sealed record CreateCheckpointRequest(string Name, string SnapshotData, int DiaryEventCount);


### PR DESCRIPTION
## Summary
- Add `SessionCheckpoint` domain entity with `Create()` factory method
- Add `ISessionCheckpointRepository` interface and EF Core implementation with mapper
- CQRS: `CreateCheckpointCommand`, `DeleteCheckpointCommand`, `GetCheckpointsQuery`, `GetCheckpointSnapshotQuery` with handlers
- REST endpoints: `POST/GET /game-sessions/{id}/checkpoints`, `GET/DELETE /game-sessions/checkpoints/{id}`
- Register repository in DI container
- DB table (`session_checkpoints`) already exists from prior migration

## Test plan
- [x] Backend build passes (0 errors)
- [ ] Manual test: create checkpoint with JSON snapshot, list checkpoints, get snapshot, delete
- [ ] Verify checkpoint persists across browser sessions
- [ ] Frontend checkpoint UI (separate issue/PR)

Closes #278

🤖 Generated with [Claude Code](https://claude.com/claude-code)
