### PR TITLE
feat(session-tracking): add turn summary AI data endpoint (#277)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Handlers/GetTurnSummaryDataQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Handlers/GetTurnSummaryDataQueryHandler.cs
@@ -1,0 +1,52 @@
+using MediatR;
+using Api.BoundedContexts.SessionTracking.Application.Queries;
+using Api.BoundedContexts.SessionTracking.Domain.Repositories;
+
+namespace Api.BoundedContexts.SessionTracking.Application.Handlers;
+
+/// <summary>
+/// Issue #277: Handles retrieving session events for AI turn summary generation.
+/// </summary>
+public class GetTurnSummaryDataQueryHandler : IRequestHandler<GetTurnSummaryDataQuery, GetTurnSummaryDataResult>
+{
+    private readonly ISessionEventRepository _eventRepository;
+
+    public GetTurnSummaryDataQueryHandler(ISessionEventRepository eventRepository)
+    {
+        _eventRepository = eventRepository ?? throw new ArgumentNullException(nameof(eventRepository));
+    }
+
+    public async Task<GetTurnSummaryDataResult> Handle(GetTurnSummaryDataQuery request, CancellationToken cancellationToken)
+    {
+        var events = await _eventRepository.GetBySessionIdAsync(
+            request.SessionId,
+            eventType: null,
+            limit: request.LastNEvents ?? 200,
+            offset: 0,
+            cancellationToken).ConfigureAwait(false);
+
+        // Apply time range filter if specified
+        var filtered = events.AsEnumerable();
+
+        if (request.FromTimestamp.HasValue)
+            filtered = filtered.Where(e => e.Timestamp >= request.FromTimestamp.Value);
+
+        if (request.ToTimestamp.HasValue)
+            filtered = filtered.Where(e => e.Timestamp <= request.ToTimestamp.Value);
+
+        var eventList = filtered.ToList();
+
+        var dtos = eventList.Select(e => new TurnEventDto(
+            e.EventType,
+            e.Timestamp,
+            e.Payload,
+            e.Source)).ToList();
+
+        return new GetTurnSummaryDataResult(
+            request.SessionId,
+            dtos,
+            dtos.Count,
+            dtos.Count > 0 ? dtos.Min(e => e.Timestamp) : null,
+            dtos.Count > 0 ? dtos.Max(e => e.Timestamp) : null);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/GetTurnSummaryDataQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/GetTurnSummaryDataQuery.cs
@@ -1,0 +1,35 @@
+using MediatR;
+
+namespace Api.BoundedContexts.SessionTracking.Application.Queries;
+
+/// <summary>
+/// Issue #277: Retrieves session events for AI turn summary generation.
+/// Returns events within a time range or the last N events for summarization.
+/// </summary>
+public record GetTurnSummaryDataQuery(
+    Guid SessionId,
+    DateTime? FromTimestamp = null,
+    DateTime? ToTimestamp = null,
+    int? LastNEvents = null
+) : IRequest<GetTurnSummaryDataResult>;
+
+/// <summary>
+/// Contains event data ready for AI summarization.
+/// </summary>
+public record GetTurnSummaryDataResult(
+    Guid SessionId,
+    IReadOnlyList<TurnEventDto> Events,
+    int TotalEvents,
+    DateTime? EarliestEvent,
+    DateTime? LatestEvent
+);
+
+/// <summary>
+/// Simplified event DTO for turn summary context.
+/// </summary>
+public record TurnEventDto(
+    string EventType,
+    DateTime Timestamp,
+    string? Payload,
+    string? Source
+);

--- a/apps/api/src/Api/Routing/SessionTrackingEndpoints.cs
+++ b/apps/api/src/Api/Routing/SessionTrackingEndpoints.cs
@@ -110,6 +110,9 @@ internal static class SessionTrackingEndpoints
         MapAddSessionEventEndpoint(group);
         MapGetSessionEventsEndpoint(group);
 
+        // Turn summary AI data endpoint (Issue #277)
+        MapGetTurnSummaryDataEndpoint(group);
+
         return group;
     }
 
@@ -1942,6 +1945,31 @@ internal static class SessionTrackingEndpoints
         .Produces<GetSessionEventsResult>(200)
         .Produces(401)
         .Produces(404);
+    }
+
+    // === Issue #277: Turn Summary AI ===
+
+    private static void MapGetTurnSummaryDataEndpoint(RouteGroupBuilder group)
+    {
+        group.MapGet("/game-sessions/{sessionId:guid}/turn-summary", async (
+            Guid sessionId,
+            IMediator mediator,
+            [FromQuery] DateTime? from = null,
+            [FromQuery] DateTime? to = null,
+            [FromQuery] int? lastN = null,
+            CancellationToken ct = default) =>
+        {
+            var query = new GetTurnSummaryDataQuery(sessionId, from, to, lastN);
+            var result = await mediator.Send(query, ct).ConfigureAwait(false);
+            return Results.Ok(result);
+        })
+        .RequireAuthenticatedUser()
+        .WithName("GetTurnSummaryData")
+        .WithTags("SessionTracking", "AI")
+        .WithSummary("Get session events for AI turn summary generation")
+        .WithDescription("Returns session events within a time range or last N events for AI summarization. Issue #277.")
+        .Produces<GetTurnSummaryDataResult>(200)
+        .Produces(401);
     }
 
     internal static RouteGroupBuilder MapSessionStatisticsEndpoints(this RouteGroupBuilder group)


### PR DESCRIPTION
## Summary
- Adds `GET /game-sessions/{id}/turn-summary` endpoint for AI turn summary data retrieval
- Returns session events with optional time range (`from`/`to`) and `lastN` event filtering
- Implements `GetTurnSummaryDataQuery` + handler following CQRS pattern via MediatR

## Related
Closes #277 (Epic #280: Game Host Session Experience)

## Test plan
- [ ] Verify endpoint returns events for valid session ID
- [ ] Test `from`/`to` timestamp filtering
- [ ] Test `lastN` event limit parameter
- [ ] Verify empty result when no events match filters

🤖 Generated with [Claude Code](https://claude.com/claude-code)