### PR TITLE
feat(speech): Whisper transcription service with tier gating (#327)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/TranscribeAudioCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Commands/TranscribeAudioCommand.cs
@@ -1,0 +1,22 @@
+using MediatR;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Commands;
+
+/// <summary>
+/// Issue #327: Command to transcribe audio to text using Whisper API.
+/// Tier-gated: Free tier is blocked (403).
+/// </summary>
+public record TranscribeAudioCommand(
+    byte[] AudioData,
+    string FileName,
+    string? Language,
+    Guid UserId
+) : IRequest<TranscribeAudioResult>;
+
+/// <summary>
+/// Result of audio transcription.
+/// </summary>
+public record TranscribeAudioResult(
+    string Text,
+    string DetectedLanguage,
+    double DurationSeconds);

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Handlers/TranscribeAudioCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Handlers/TranscribeAudioCommandHandler.cs
@@ -1,0 +1,66 @@
+using Api.BoundedContexts.KnowledgeBase.Application.Commands;
+using Api.BoundedContexts.KnowledgeBase.Domain.Services;
+using Api.SharedKernel.Services;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.Handlers;
+
+/// <summary>
+/// Issue #327: Handles audio transcription with tier gating.
+/// Free tier users receive 403; Normal/Premium users can transcribe.
+/// Rate limited via TierEnforcementService (AgentQuery action).
+/// </summary>
+public class TranscribeAudioCommandHandler : IRequestHandler<TranscribeAudioCommand, TranscribeAudioResult>
+{
+    private readonly ITranscriptionService _transcriptionService;
+    private readonly ITierEnforcementService _tierEnforcement;
+    private readonly ILogger<TranscribeAudioCommandHandler> _logger;
+
+    public TranscribeAudioCommandHandler(
+        ITranscriptionService transcriptionService,
+        ITierEnforcementService tierEnforcement,
+        ILogger<TranscribeAudioCommandHandler> logger)
+    {
+        _transcriptionService = transcriptionService ?? throw new ArgumentNullException(nameof(transcriptionService));
+        _tierEnforcement = tierEnforcement ?? throw new ArgumentNullException(nameof(tierEnforcement));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<TranscribeAudioResult> Handle(
+        TranscribeAudioCommand request,
+        CancellationToken cancellationToken)
+    {
+        // Tier gating: check if user can perform speech transcription
+        var canTranscribe = await _tierEnforcement.CanPerformAsync(
+            request.UserId, TierAction.SpeechTranscription, cancellationToken).ConfigureAwait(false);
+
+        if (!canTranscribe)
+        {
+            _logger.LogWarning(
+                "User {UserId} blocked from speech transcription (tier limit reached)",
+                request.UserId);
+            throw new UnauthorizedAccessException(
+                "Speech transcription is not available for your current tier or rate limit has been reached.");
+        }
+
+        var result = await _transcriptionService.TranscribeAsync(
+            request.AudioData,
+            request.FileName,
+            request.Language,
+            cancellationToken).ConfigureAwait(false);
+
+        // Record usage after successful transcription
+        await _tierEnforcement.RecordUsageAsync(
+            request.UserId, TierAction.SpeechTranscription, cancellationToken).ConfigureAwait(false);
+
+        _logger.LogInformation(
+            "User {UserId} transcribed audio: {Duration}s, language={Language}",
+            request.UserId, result.DurationSeconds, result.Language);
+
+        return new TranscribeAudioResult(
+            result.Text,
+            result.Language,
+            result.DurationSeconds);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Services/ITranscriptionService.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Services/ITranscriptionService.cs
@@ -1,0 +1,29 @@
+namespace Api.BoundedContexts.KnowledgeBase.Domain.Services;
+
+/// <summary>
+/// Issue #327: Service for transcribing audio to text using speech-to-text providers.
+/// </summary>
+public interface ITranscriptionService
+{
+    /// <summary>
+    /// Transcribes audio data to text.
+    /// </summary>
+    /// <param name="audioData">Raw audio bytes</param>
+    /// <param name="fileName">Original filename with extension (used for format detection)</param>
+    /// <param name="language">Optional language hint (e.g., "it", "en")</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>Transcription result with text and metadata</returns>
+    Task<TranscriptionResult> TranscribeAsync(
+        byte[] audioData,
+        string fileName,
+        string? language = null,
+        CancellationToken cancellationToken = default);
+}
+
+/// <summary>
+/// Result of a speech-to-text transcription.
+/// </summary>
+public record TranscriptionResult(
+    string Text,
+    string Language,
+    double DurationSeconds);

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/DependencyInjection/KnowledgeBaseServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/DependencyInjection/KnowledgeBaseServiceExtensions.cs
@@ -115,6 +115,9 @@ internal static class KnowledgeBaseServiceExtensions
         // ISSUE-3491: Context Assembler (orchestrates multi-source context assembly)
         services.AddScoped<ContextAssembler>();
 
+        // Issue #327: Speech-to-text transcription via Whisper API
+        services.AddHttpClient<ITranscriptionService, WhisperTranscriptionService>();
+
         // ISSUE-3760: Arbitro Agent Service (AI-powered move validation)
         services.AddScoped<IArbitroAgentService, ArbitroAgentService>();
 

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/Services/WhisperTranscriptionService.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/Services/WhisperTranscriptionService.cs
@@ -1,0 +1,129 @@
+using System.Net.Http.Headers;
+using System.Text.Json;
+using Api.BoundedContexts.KnowledgeBase.Domain.Services;
+using Api.Infrastructure;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.KnowledgeBase.Infrastructure.Services;
+
+/// <summary>
+/// Issue #327: OpenAI Whisper API proxy for speech-to-text transcription.
+/// </summary>
+internal sealed class WhisperTranscriptionService : ITranscriptionService
+{
+    private static readonly Uri WhisperApiUri = new("https://api.openai.com/v1/audio/transcriptions");
+    private const long MaxFileSizeBytes = 25 * 1024 * 1024; // 25 MB (Whisper limit)
+
+    private static readonly HashSet<string> AllowedExtensions = new(StringComparer.OrdinalIgnoreCase)
+    {
+        ".flac", ".m4a", ".mp3", ".mp4", ".mpeg", ".mpga", ".oga", ".ogg", ".wav", ".webm"
+    };
+
+    private readonly HttpClient _httpClient;
+    private readonly string _apiKey;
+    private readonly string _model;
+    private readonly ILogger<WhisperTranscriptionService> _logger;
+
+    public WhisperTranscriptionService(
+        HttpClient httpClient,
+        IConfiguration configuration,
+        ILogger<WhisperTranscriptionService> logger)
+    {
+        _httpClient = httpClient ?? throw new ArgumentNullException(nameof(httpClient));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+
+        _apiKey = SecretsHelper.GetSecretOrValue(configuration, "WHISPER_API_KEY", logger, required: false)
+            ?? SecretsHelper.GetSecretOrValue(configuration, "OPENROUTER_API_KEY", logger, required: false)
+            ?? throw new InvalidOperationException(
+                "Speech transcription requires WHISPER_API_KEY or OPENROUTER_API_KEY to be configured.");
+
+        _model = configuration["WHISPER_MODEL"] ?? "whisper-1";
+    }
+
+    public async Task<TranscriptionResult> TranscribeAsync(
+        byte[] audioData,
+        string fileName,
+        string? language = null,
+        CancellationToken cancellationToken = default)
+    {
+        if (audioData is null || audioData.Length == 0)
+            throw new ArgumentException("Audio data cannot be empty.", nameof(audioData));
+
+        if (audioData.Length > MaxFileSizeBytes)
+            throw new ArgumentException(
+                $"Audio file exceeds maximum size of {MaxFileSizeBytes / (1024 * 1024)} MB.",
+                nameof(audioData));
+
+        var extension = Path.GetExtension(fileName);
+        if (string.IsNullOrEmpty(extension) || !AllowedExtensions.Contains(extension))
+            throw new ArgumentException(
+                $"Unsupported audio format '{extension}'. Supported: {string.Join(", ", AllowedExtensions)}",
+                nameof(fileName));
+
+        _logger.LogInformation(
+            "Transcribing audio: {FileName} ({Size} bytes, language: {Language})",
+            fileName, audioData.Length, language ?? "auto");
+
+        using var content = new MultipartFormDataContent();
+
+        var fileContent = new ByteArrayContent(audioData);
+        fileContent.Headers.ContentType = new MediaTypeHeaderValue(GetMimeType(extension));
+        content.Add(fileContent, "file", fileName);
+        content.Add(new StringContent(_model), "model");
+        content.Add(new StringContent("verbose_json"), "response_format");
+
+        if (!string.IsNullOrWhiteSpace(language))
+        {
+            content.Add(new StringContent(language), "language");
+        }
+
+        using var request = new HttpRequestMessage(HttpMethod.Post, WhisperApiUri)
+        {
+            Content = content
+        };
+        request.Headers.Authorization = new AuthenticationHeaderValue("Bearer", _apiKey);
+
+        using var response = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
+
+        if (!response.IsSuccessStatusCode)
+        {
+            var errorBody = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+            _logger.LogError(
+                "Whisper API error {StatusCode}: {Body}",
+                (int)response.StatusCode, errorBody);
+            throw new InvalidOperationException(
+                $"Whisper API returned {(int)response.StatusCode}: {response.ReasonPhrase}");
+        }
+
+        var json = await response.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        var text = root.GetProperty("text").GetString() ?? string.Empty;
+        var detectedLanguage = root.TryGetProperty("language", out var langProp)
+            ? langProp.GetString() ?? "unknown"
+            : language ?? "unknown";
+        var duration = root.TryGetProperty("duration", out var durProp)
+            ? durProp.GetDouble()
+            : 0.0;
+
+        _logger.LogInformation(
+            "Transcription complete: {Length} chars, language={Language}, duration={Duration}s",
+            text.Length, detectedLanguage, duration);
+
+        return new TranscriptionResult(text, detectedLanguage, duration);
+    }
+
+    private static string GetMimeType(string extension) => extension.ToLowerInvariant() switch
+    {
+        ".mp3" => "audio/mpeg",
+        ".mp4" or ".m4a" => "audio/mp4",
+        ".wav" => "audio/wav",
+        ".webm" => "audio/webm",
+        ".ogg" or ".oga" => "audio/ogg",
+        ".flac" => "audio/flac",
+        ".mpeg" or ".mpga" => "audio/mpeg",
+        _ => "application/octet-stream"
+    };
+}

--- a/apps/api/src/Api/BoundedContexts/SystemConfiguration/Domain/ValueObjects/TierLimits.cs
+++ b/apps/api/src/Api/BoundedContexts/SystemConfiguration/Domain/ValueObjects/TierLimits.cs
@@ -16,6 +16,8 @@ public record TierLimits
     public int MaxPhotosPerSession { get; init; }
     public bool SessionSaveEnabled { get; init; }
     public int MaxCatalogProposalsPerWeek { get; init; }
+    /// <summary>Issue #327: Maximum speech transcriptions per day (0 = blocked).</summary>
+    public int MaxSpeechTranscriptionsPerDay { get; init; }
 
     private TierLimits() { }
 
@@ -24,7 +26,8 @@ public record TierLimits
         long maxPdfSizeBytes, int maxAgents,
         int maxAgentQueriesPerDay, int maxSessionQueries,
         int maxSessionPlayers, int maxPhotosPerSession,
-        bool sessionSaveEnabled, int maxCatalogProposalsPerWeek)
+        bool sessionSaveEnabled, int maxCatalogProposalsPerWeek,
+        int maxSpeechTranscriptionsPerDay = 0)
     {
         if (maxPrivateGames < 0)
             throw new ArgumentException("Cannot be negative", nameof(maxPrivateGames));
@@ -44,6 +47,8 @@ public record TierLimits
             throw new ArgumentException("Cannot be negative", nameof(maxPhotosPerSession));
         if (maxCatalogProposalsPerWeek < 0)
             throw new ArgumentException("Cannot be negative", nameof(maxCatalogProposalsPerWeek));
+        if (maxSpeechTranscriptionsPerDay < 0)
+            throw new ArgumentException("Cannot be negative", nameof(maxSpeechTranscriptionsPerDay));
 
         return new TierLimits
         {
@@ -56,7 +61,8 @@ public record TierLimits
             MaxSessionPlayers = maxSessionPlayers,
             MaxPhotosPerSession = maxPhotosPerSession,
             SessionSaveEnabled = sessionSaveEnabled,
-            MaxCatalogProposalsPerWeek = maxCatalogProposalsPerWeek
+            MaxCatalogProposalsPerWeek = maxCatalogProposalsPerWeek,
+            MaxSpeechTranscriptionsPerDay = maxSpeechTranscriptionsPerDay
         };
     }
 
@@ -64,13 +70,16 @@ public record TierLimits
     public static TierLimits Unlimited => Create(
         int.MaxValue, int.MaxValue, 500L * 1024 * 1024,
         int.MaxValue, int.MaxValue, int.MaxValue,
-        12, int.MaxValue, true, int.MaxValue);
+        12, int.MaxValue, true, int.MaxValue,
+        maxSpeechTranscriptionsPerDay: int.MaxValue);
 
-    /// <summary>Free tier defaults.</summary>
+    /// <summary>Free tier defaults (speech transcription blocked: 0).</summary>
     public static TierLimits FreeTier => Create(
-        3, 3, 50L * 1024 * 1024, 1, 20, 30, 6, 5, false, 1);
+        3, 3, 50L * 1024 * 1024, 1, 20, 30, 6, 5, false, 1,
+        maxSpeechTranscriptionsPerDay: 0);
 
     /// <summary>Premium tier defaults.</summary>
     public static TierLimits PremiumTier => Create(
-        15, 15, 200L * 1024 * 1024, 10, 200, 150, 12, 20, true, 5);
+        15, 15, 200L * 1024 * 1024, 10, 200, 150, 12, 20, true, 5,
+        maxSpeechTranscriptionsPerDay: 60);
 }

--- a/apps/api/src/Api/Program.cs
+++ b/apps/api/src/Api/Program.cs
@@ -524,6 +524,7 @@ v1Api.MapBggEndpoints(); // ISSUE-3120: BoardGameGeek integration
 v1Api.MapRulebookAnalysisEndpoints(); // ISSUE-2402: Rulebook analysis service
 v1Api.MapLlmEndpoints(); // ISSUE-2391: Sprint 2 - LLM provider management
 v1Api.MapAiEndpoints();
+v1Api.MapSpeechEndpoints(); // Issue #327: Speech-to-text transcription
 v1Api.MapPdfEndpoints();
 v1Api.MapDocumentCollectionEndpoints();
 v1Api.MapRuleSpecEndpoints();

--- a/apps/api/src/Api/Routing/SpeechEndpoints.cs
+++ b/apps/api/src/Api/Routing/SpeechEndpoints.cs
@@ -1,0 +1,101 @@
+using Api.BoundedContexts.KnowledgeBase.Application.Commands;
+using Api.Extensions;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Api.Routing;
+
+/// <summary>
+/// Issue #327: Speech-to-text transcription endpoints.
+/// POST /api/v1/speech/transcribe — multipart audio upload → text
+/// </summary>
+internal static class SpeechEndpoints
+{
+    public static RouteGroupBuilder MapSpeechEndpoints(this RouteGroupBuilder group)
+    {
+        group.MapPost("/speech/transcribe", HandleTranscribe)
+            .DisableAntiforgery()
+            .RequireSession()
+            .WithMetadata(new RequestSizeLimitAttribute(26_214_400)) // 25 MB
+            .WithTags("Speech")
+            .WithName("TranscribeAudio")
+            .WithOpenApi(operation =>
+            {
+                operation.Summary = "Transcribe audio to text";
+                operation.Description = "Uploads an audio file and returns transcribed text using Whisper API. " +
+                    "Free tier is blocked (403). Supported formats: flac, m4a, mp3, mp4, mpeg, mpga, oga, ogg, wav, webm.";
+                return operation;
+            });
+
+        return group;
+    }
+
+    private static async Task<IResult> HandleTranscribe(
+        HttpContext context,
+        IMediator mediator,
+        ILogger<Program> logger,
+        CancellationToken ct)
+    {
+        var (authenticated, session, error) = context.TryGetActiveSession();
+        if (!authenticated) return error!;
+
+        var userId = session!.User!.Id;
+
+        var form = await context.Request.ReadFormAsync(ct).ConfigureAwait(false);
+        var file = form.Files.GetFile("file");
+
+        if (file is null || file.Length == 0)
+        {
+            return Results.BadRequest(new
+            {
+                error = "validation_failed",
+                message = "No audio file provided. Send a 'file' field with multipart/form-data."
+            });
+        }
+
+        var language = form.TryGetValue("language", out var langValues)
+            ? langValues.FirstOrDefault()
+            : null;
+
+        byte[] audioData;
+        using (var ms = new MemoryStream())
+        {
+            await file.CopyToAsync(ms, ct).ConfigureAwait(false);
+            audioData = ms.ToArray();
+        }
+
+        try
+        {
+            var result = await mediator.Send(new TranscribeAudioCommand(
+                audioData,
+                file.FileName,
+                language,
+                userId), ct).ConfigureAwait(false);
+
+            return Results.Ok(new
+            {
+                text = result.Text,
+                language = result.DetectedLanguage,
+                duration = result.DurationSeconds
+            });
+        }
+        catch (UnauthorizedAccessException ex)
+        {
+            logger.LogWarning(ex, "User {UserId} blocked from transcription", userId);
+            return Results.Json(
+                new { error = "tier_blocked", message = ex.Message },
+                statusCode: 403);
+        }
+        catch (ArgumentException ex)
+        {
+            return Results.BadRequest(new { error = "validation_failed", message = ex.Message });
+        }
+        catch (InvalidOperationException ex) when (ex.Message.Contains("Whisper API"))
+        {
+            logger.LogError(ex, "Whisper API error for user {UserId}", userId);
+            return Results.Json(
+                new { error = "transcription_failed", message = "Speech transcription service temporarily unavailable." },
+                statusCode: 502);
+        }
+    }
+}

--- a/apps/api/src/Api/SharedKernel/Services/ITierEnforcementService.cs
+++ b/apps/api/src/Api/SharedKernel/Services/ITierEnforcementService.cs
@@ -33,7 +33,8 @@ public enum TierAction
     SessionAgentQuery,
     UploadSessionPhoto,
     SaveSession,
-    ProposeToSharedCatalog
+    ProposeToSharedCatalog,
+    SpeechTranscription
 }
 
 /// <summary>

--- a/apps/api/src/Api/SharedKernel/Services/TierEnforcementService.cs
+++ b/apps/api/src/Api/SharedKernel/Services/TierEnforcementService.cs
@@ -188,7 +188,7 @@ internal sealed class TierEnforcementService : ITierEnforcementService
 
     private static string GetDateBucket(TierAction action) => action switch
     {
-        TierAction.AgentQuery or TierAction.SessionAgentQuery
+        TierAction.AgentQuery or TierAction.SessionAgentQuery or TierAction.SpeechTranscription
             => DateTime.UtcNow.ToString("yyyy-MM-dd", CultureInfo.InvariantCulture),
 
         TierAction.UploadPdf
@@ -214,7 +214,7 @@ internal sealed class TierEnforcementService : ITierEnforcementService
 
     private static TimeSpan GetTtlForAction(TierAction action) => action switch
     {
-        TierAction.AgentQuery or TierAction.SessionAgentQuery or TierAction.UploadSessionPhoto
+        TierAction.AgentQuery or TierAction.SessionAgentQuery or TierAction.UploadSessionPhoto or TierAction.SpeechTranscription
             => DailyTtl,
 
         TierAction.UploadPdf
@@ -235,6 +235,7 @@ internal sealed class TierEnforcementService : ITierEnforcementService
         TierAction.SessionAgentQuery => limits.MaxSessionQueries,
         TierAction.UploadSessionPhoto => limits.MaxPhotosPerSession,
         TierAction.ProposeToSharedCatalog => limits.MaxCatalogProposalsPerWeek,
+        TierAction.SpeechTranscription => limits.MaxSpeechTranscriptionsPerDay,
         _ => int.MaxValue
     };
 }


### PR DESCRIPTION
## Summary
- Adds `POST /api/v1/speech/transcribe` multipart endpoint proxying to OpenAI Whisper API
- `ITranscriptionService` + `WhisperTranscriptionService` with 25MB file limit, format validation
- Tier-gated via `TierAction.SpeechTranscription`: Free=blocked (0), Premium=60/day, Admin=unlimited
- Falls back to `OPENROUTER_API_KEY` if `WHISPER_API_KEY` not set
- Supports: flac, m4a, mp3, mp4, mpeg, mpga, oga, ogg, wav, webm

## Related
Closes #327 (Epic #312: Voice-to-Text & Text-to-Speech in Chat)

## Test plan
- [ ] Verify Free tier returns 403
- [ ] Verify Premium/Admin tier can transcribe audio
- [ ] Test rate limiting (60 req/day for Premium)
- [ ] Test invalid file format returns 400
- [ ] Test oversized file returns 400

🤖 Generated with [Claude Code](https://claude.com/claude-code)