### PR TITLE
feat(voice): add WhisperProvider for cloud-based STT (#328)

### DIFF
--- a/apps/web/src/__tests__/voice/whisper-provider.test.ts
+++ b/apps/web/src/__tests__/voice/whisper-provider.test.ts
@@ -1,0 +1,484 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import type { SpeechRecognitionConfig, SpeechRecognitionEvents } from '@/lib/voice/types';
+import { WhisperProvider } from '@/lib/voice/providers/whisper-provider';
+import { WebSpeechProvider } from '@/lib/voice/providers/web-speech-provider';
+
+// ---------------------------------------------------------------------------
+// Mock MediaRecorder
+// ---------------------------------------------------------------------------
+
+let lastMockRecorder: MockMediaRecorder | null = null;
+
+class MockMediaRecorder {
+  state: 'inactive' | 'recording' | 'paused' = 'inactive';
+  ondataavailable: ((event: { data: Blob }) => void) | null = null;
+  onstart: (() => void) | null = null;
+  onstop: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+
+  start = vi.fn(() => {
+    this.state = 'recording';
+    // Trigger onstart asynchronously like real MediaRecorder
+    setTimeout(() => this.onstart?.(), 0);
+  });
+
+  stop = vi.fn(() => {
+    this.state = 'inactive';
+    setTimeout(() => this.onstop?.(), 0);
+  });
+
+  static isTypeSupported = vi.fn(() => true);
+
+  constructor() {
+    lastMockRecorder = this;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Mock getUserMedia
+// ---------------------------------------------------------------------------
+
+function createMockStream(): MediaStream {
+  const track = { stop: vi.fn(), kind: 'audio' } as unknown as MediaStreamTrack;
+  return {
+    getTracks: () => [track],
+    getAudioTracks: () => [track],
+  } as unknown as MediaStream;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeConfig(overrides?: Partial<SpeechRecognitionConfig>): SpeechRecognitionConfig {
+  return {
+    language: 'it-IT',
+    interimResults: true,
+    silenceTimeoutMs: 2000,
+    maxDurationMs: 30000,
+    noSpeechTimeoutMs: 5000,
+    ...overrides,
+  };
+}
+
+function makeEvents(overrides?: Partial<SpeechRecognitionEvents>): SpeechRecognitionEvents {
+  return {
+    onInterimResult: vi.fn(),
+    onFinalResult: vi.fn(),
+    onSpeechStart: vi.fn(),
+    onSpeechEnd: vi.fn(),
+    onError: vi.fn(),
+    onStateChange: vi.fn(),
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Setup and teardown
+// ---------------------------------------------------------------------------
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  lastMockRecorder = null;
+
+  // Provide MediaRecorder global
+  vi.stubGlobal('MediaRecorder', MockMediaRecorder);
+
+  // Provide navigator.mediaDevices.getUserMedia
+  const mockStream = createMockStream();
+  vi.stubGlobal('navigator', {
+    mediaDevices: {
+      getUserMedia: vi.fn().mockResolvedValue(mockStream),
+    },
+  });
+
+  // Stub AudioContext to avoid errors in setupAudioAnalyser
+  vi.stubGlobal(
+    'AudioContext',
+    vi.fn(() => ({
+      createMediaStreamSource: vi.fn(() => ({
+        connect: vi.fn(),
+      })),
+      createAnalyser: vi.fn(() => ({
+        fftSize: 256,
+        getFloatTimeDomainData: vi.fn(),
+      })),
+      close: vi.fn().mockResolvedValue(undefined),
+    }))
+  );
+
+  // Default fetch mock
+  vi.stubGlobal('fetch', vi.fn());
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+  vi.restoreAllMocks();
+  vi.unstubAllGlobals();
+});
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('WhisperProvider', () => {
+  describe('isSupported', () => {
+    it('returns true when MediaRecorder and getUserMedia are available', () => {
+      const provider = new WhisperProvider();
+      expect(provider.isSupported).toBe(true);
+    });
+
+    it('returns false when MediaRecorder is not available', () => {
+      vi.stubGlobal('MediaRecorder', undefined);
+      const provider = new WhisperProvider();
+      expect(provider.isSupported).toBe(false);
+    });
+  });
+
+  describe('start()', () => {
+    it('transitions through requesting → listening states', async () => {
+      const events = makeEvents();
+      const provider = new WhisperProvider();
+
+      provider.start(makeConfig(), events);
+
+      expect(provider.state).toBe('requesting');
+      expect(events.onStateChange).toHaveBeenCalledWith('requesting');
+
+      // Let getUserMedia resolve and MediaRecorder.onstart fire
+      await vi.advanceTimersByTimeAsync(10);
+
+      expect(provider.state).toBe('listening');
+      expect(events.onStateChange).toHaveBeenCalledWith('listening');
+    });
+
+    it('emits permission_denied error when getUserMedia rejects with NotAllowedError', async () => {
+      const events = makeEvents();
+      const provider = new WhisperProvider();
+
+      const notAllowedError = new DOMException('Permission denied', 'NotAllowedError');
+      vi.mocked(navigator.mediaDevices.getUserMedia).mockRejectedValueOnce(notAllowedError);
+
+      provider.start(makeConfig(), events);
+      await vi.advanceTimersByTimeAsync(10);
+
+      expect(provider.state).toBe('error');
+      expect(events.onError).toHaveBeenCalledWith(
+        expect.objectContaining({
+          code: 'permission_denied',
+          recoverable: false,
+        })
+      );
+    });
+
+    it('emits audio_capture_error for generic getUserMedia failures', async () => {
+      const events = makeEvents();
+      const provider = new WhisperProvider();
+
+      vi.mocked(navigator.mediaDevices.getUserMedia).mockRejectedValueOnce(new Error('No mic'));
+
+      provider.start(makeConfig(), events);
+      await vi.advanceTimersByTimeAsync(10);
+
+      expect(provider.state).toBe('error');
+      expect(events.onError).toHaveBeenCalledWith(
+        expect.objectContaining({
+          code: 'audio_capture_error',
+          recoverable: true,
+        })
+      );
+    });
+
+    it('emits not_supported error when MediaRecorder unavailable', () => {
+      vi.stubGlobal('MediaRecorder', undefined);
+      const events = makeEvents();
+      const provider = new WhisperProvider();
+
+      provider.start(makeConfig(), events);
+
+      expect(provider.state).toBe('error');
+      expect(events.onError).toHaveBeenCalledWith(
+        expect.objectContaining({
+          code: 'not_supported',
+          recoverable: false,
+        })
+      );
+    });
+
+    it('does nothing if already listening', async () => {
+      const events = makeEvents();
+      const provider = new WhisperProvider();
+
+      provider.start(makeConfig(), events);
+      await vi.advanceTimersByTimeAsync(10);
+
+      expect(provider.state).toBe('listening');
+      const callCount = vi.mocked(events.onStateChange).mock.calls.length;
+
+      provider.start(makeConfig(), events);
+      expect(vi.mocked(events.onStateChange).mock.calls.length).toBe(callCount);
+    });
+  });
+
+  describe('stop()', () => {
+    it('transitions to processing and triggers transcription', async () => {
+      const events = makeEvents();
+      const provider = new WhisperProvider();
+
+      vi.mocked(fetch).mockResolvedValueOnce(
+        new Response(JSON.stringify({ text: 'Hello world', language: 'en', duration: 1.5 }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      );
+
+      provider.start(makeConfig(), events);
+      await vi.advanceTimersByTimeAsync(10);
+
+      // Simulate data available
+      lastMockRecorder?.ondataavailable?.({ data: new Blob(['audio'], { type: 'audio/webm' }) });
+
+      provider.stop();
+      expect(provider.state).toBe('processing');
+
+      // Let onstop fire and transcription complete
+      await vi.advanceTimersByTimeAsync(10);
+      await vi.runAllTimersAsync();
+
+      expect(fetch).toHaveBeenCalledWith(
+        expect.stringContaining('/api/v1/speech/transcribe'),
+        expect.objectContaining({ method: 'POST' })
+      );
+      expect(events.onFinalResult).toHaveBeenCalledWith('Hello world', 1.0);
+    });
+  });
+
+  describe('transcription responses', () => {
+    it('handles 403 tier-blocked response', async () => {
+      const events = makeEvents();
+      const provider = new WhisperProvider();
+
+      vi.mocked(fetch).mockResolvedValueOnce(new Response('Forbidden', { status: 403 }));
+
+      provider.start(makeConfig(), events);
+      await vi.advanceTimersByTimeAsync(10);
+
+      lastMockRecorder?.ondataavailable?.({ data: new Blob(['audio'], { type: 'audio/webm' }) });
+      provider.stop();
+      await vi.advanceTimersByTimeAsync(10);
+      await vi.runAllTimersAsync();
+
+      expect(events.onError).toHaveBeenCalledWith(
+        expect.objectContaining({
+          code: 'permission_denied',
+          recoverable: false,
+        })
+      );
+    });
+
+    it('handles server error response', async () => {
+      const events = makeEvents();
+      const provider = new WhisperProvider();
+
+      vi.mocked(fetch).mockResolvedValueOnce(new Response('Internal error', { status: 500 }));
+
+      provider.start(makeConfig(), events);
+      await vi.advanceTimersByTimeAsync(10);
+
+      lastMockRecorder?.ondataavailable?.({ data: new Blob(['audio'], { type: 'audio/webm' }) });
+      provider.stop();
+      await vi.advanceTimersByTimeAsync(10);
+      await vi.runAllTimersAsync();
+
+      expect(events.onError).toHaveBeenCalledWith(
+        expect.objectContaining({
+          code: 'server_error',
+          recoverable: true,
+        })
+      );
+    });
+
+    it('handles empty transcription result', async () => {
+      const events = makeEvents();
+      const provider = new WhisperProvider();
+
+      vi.mocked(fetch).mockResolvedValueOnce(
+        new Response(JSON.stringify({ text: '', language: 'en', duration: 0.5 }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      );
+
+      provider.start(makeConfig(), events);
+      await vi.advanceTimersByTimeAsync(10);
+
+      lastMockRecorder?.ondataavailable?.({ data: new Blob(['audio'], { type: 'audio/webm' }) });
+      provider.stop();
+      await vi.advanceTimersByTimeAsync(10);
+      await vi.runAllTimersAsync();
+
+      expect(events.onError).toHaveBeenCalledWith(expect.objectContaining({ code: 'no_speech' }));
+    });
+
+    it('handles network failure', async () => {
+      const events = makeEvents();
+      const provider = new WhisperProvider();
+
+      vi.mocked(fetch).mockRejectedValueOnce(new TypeError('Failed to fetch'));
+
+      provider.start(makeConfig(), events);
+      await vi.advanceTimersByTimeAsync(10);
+
+      lastMockRecorder?.ondataavailable?.({ data: new Blob(['audio'], { type: 'audio/webm' }) });
+      provider.stop();
+      await vi.advanceTimersByTimeAsync(10);
+      await vi.runAllTimersAsync();
+
+      expect(events.onError).toHaveBeenCalledWith(
+        expect.objectContaining({
+          code: 'network_error',
+          recoverable: true,
+        })
+      );
+    });
+  });
+
+  describe('abort()', () => {
+    it('stops recording and transitions to idle', async () => {
+      const events = makeEvents();
+      const provider = new WhisperProvider();
+
+      provider.start(makeConfig(), events);
+      await vi.advanceTimersByTimeAsync(10);
+
+      provider.abort();
+      await vi.advanceTimersByTimeAsync(10);
+
+      expect(provider.state).toBe('idle');
+    });
+  });
+
+  describe('dispose()', () => {
+    it('aborts and cleans up', async () => {
+      const events = makeEvents();
+      const provider = new WhisperProvider();
+
+      provider.start(makeConfig(), events);
+      await vi.advanceTimersByTimeAsync(10);
+
+      provider.dispose();
+      await vi.advanceTimersByTimeAsync(10);
+
+      expect(provider.state).toBe('idle');
+    });
+  });
+
+  describe('no-speech timeout', () => {
+    it('fires error after noSpeechTimeoutMs with no audio', async () => {
+      const events = makeEvents();
+      const provider = new WhisperProvider();
+
+      provider.start(makeConfig({ noSpeechTimeoutMs: 3000 }), events);
+      await vi.advanceTimersByTimeAsync(10);
+
+      // Advance past the no-speech timeout
+      await vi.advanceTimersByTimeAsync(3100);
+
+      expect(events.onError).toHaveBeenCalledWith(
+        expect.objectContaining({
+          code: 'no_speech',
+          recoverable: true,
+        })
+      );
+    });
+  });
+
+  describe('max duration timeout', () => {
+    it('stops recording after maxDurationMs', async () => {
+      const events = makeEvents();
+      const provider = new WhisperProvider();
+
+      vi.mocked(fetch).mockResolvedValueOnce(
+        new Response(JSON.stringify({ text: 'result', language: 'en', duration: 30.0 }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      );
+
+      provider.start(makeConfig({ maxDurationMs: 5000, noSpeechTimeoutMs: 60000 }), events);
+      await vi.advanceTimersByTimeAsync(10);
+
+      // Simulate some data
+      lastMockRecorder?.ondataavailable?.({ data: new Blob(['audio'], { type: 'audio/webm' }) });
+
+      // Advance past max duration
+      await vi.advanceTimersByTimeAsync(5100);
+
+      // Should have called stop() internally
+      expect(lastMockRecorder?.stop).toHaveBeenCalled();
+    });
+  });
+
+  describe('language handling', () => {
+    it('sends language prefix to backend', async () => {
+      const events = makeEvents();
+      const provider = new WhisperProvider();
+
+      vi.mocked(fetch).mockResolvedValueOnce(
+        new Response(JSON.stringify({ text: 'Ciao mondo', language: 'it', duration: 1.0 }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        })
+      );
+
+      provider.start(makeConfig({ language: 'it-IT' }), events);
+      await vi.advanceTimersByTimeAsync(10);
+
+      lastMockRecorder?.ondataavailable?.({ data: new Blob(['audio'], { type: 'audio/webm' }) });
+      provider.stop();
+      await vi.advanceTimersByTimeAsync(10);
+      await vi.runAllTimersAsync();
+
+      const fetchCall = vi.mocked(fetch).mock.calls[0];
+      const formData = fetchCall[1]?.body as FormData;
+      expect(formData.get('language')).toBe('it');
+    });
+  });
+});
+
+describe('createSpeechRecognitionProvider', () => {
+  // Import after globals are set up
+  let createSpeechRecognitionProvider: typeof import('@/lib/voice/providers/provider-factory').createSpeechRecognitionProvider;
+
+  beforeEach(async () => {
+    const mod = await import('@/lib/voice/providers/provider-factory');
+    createSpeechRecognitionProvider = mod.createSpeechRecognitionProvider;
+  });
+
+  it('returns WebSpeechProvider for free tier', () => {
+    const provider = createSpeechRecognitionProvider('free');
+    expect(provider).toBeInstanceOf(WebSpeechProvider);
+  });
+
+  it('returns WebSpeechProvider when no tier specified (default)', () => {
+    const provider = createSpeechRecognitionProvider();
+    expect(provider).toBeInstanceOf(WebSpeechProvider);
+  });
+
+  it('returns WhisperProvider for premium tier', () => {
+    const provider = createSpeechRecognitionProvider('premium');
+    expect(provider).toBeInstanceOf(WhisperProvider);
+  });
+
+  it('returns WhisperProvider for admin tier', () => {
+    const provider = createSpeechRecognitionProvider('admin');
+    expect(provider).toBeInstanceOf(WhisperProvider);
+  });
+
+  it('falls back to WebSpeechProvider for premium if MediaRecorder unavailable', () => {
+    vi.stubGlobal('MediaRecorder', undefined);
+    const provider = createSpeechRecognitionProvider('premium');
+    expect(provider).toBeInstanceOf(WebSpeechProvider);
+  });
+});

--- a/apps/web/src/lib/voice/providers/provider-factory.ts
+++ b/apps/web/src/lib/voice/providers/provider-factory.ts
@@ -2,18 +2,35 @@
  * Speech Recognition Provider Factory
  *
  * Creates the appropriate ISpeechRecognitionProvider based on
- * environment configuration.
+ * user tier and environment configuration.
  *
- * Phase 1: Always returns WebSpeechProvider (browser native API)
- * Phase 2: Will check NEXT_PUBLIC_VOICE_SERVER_STT for server-side STT
+ * - Paid tiers (premium/admin): WhisperProvider (cloud STT via backend proxy)
+ * - Free tier / fallback: WebSpeechProvider (browser native API)
  */
 
 import { WebSpeechProvider } from './web-speech-provider';
+import { WhisperProvider } from './whisper-provider';
 
 import type { ISpeechRecognitionProvider } from '../types';
 
-export function createSpeechRecognitionProvider(): ISpeechRecognitionProvider {
-  // Phase 1: always use WebSpeechProvider (browser native API)
-  // Phase 2: check NEXT_PUBLIC_VOICE_SERVER_STT env var for server-side STT
+export type UserTier = 'free' | 'premium' | 'admin';
+
+/**
+ * Creates a speech recognition provider based on user tier.
+ *
+ * @param tier - User's subscription tier. Defaults to 'free'.
+ * @returns The appropriate ISpeechRecognitionProvider for the tier.
+ */
+export function createSpeechRecognitionProvider(
+  tier: UserTier = 'free'
+): ISpeechRecognitionProvider {
+  if (tier === 'premium' || tier === 'admin') {
+    const whisper = new WhisperProvider();
+    if (whisper.isSupported) {
+      return whisper;
+    }
+    // Fall back to WebSpeech if MediaRecorder not available
+  }
+
   return new WebSpeechProvider();
 }

--- a/apps/web/src/lib/voice/providers/whisper-provider.ts
+++ b/apps/web/src/lib/voice/providers/whisper-provider.ts
@@ -1,0 +1,446 @@
+'use client';
+
+/**
+ * Whisper API Provider
+ *
+ * Cloud-based implementation of ISpeechRecognitionProvider using
+ * MediaRecorder to capture audio and proxying to the backend
+ * POST /api/v1/speech/transcribe endpoint (OpenAI Whisper API).
+ *
+ * Handles:
+ * - MediaRecorder audio capture with webm/opus codec
+ * - Silence timeout (auto-stop after speech ends with no audio activity)
+ * - Max duration timeout (hard limit on recording session)
+ * - No-speech timeout (no audio level detected after start)
+ * - Backend proxy with multipart form upload
+ * - Clean state machine transitions matching ISpeechRecognitionProvider
+ */
+
+import type {
+  ISpeechRecognitionProvider,
+  SpeechRecognitionConfig,
+  SpeechRecognitionEvents,
+  VoiceRecognitionState,
+} from '../types';
+
+const API_BASE_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8080';
+
+interface TranscriptionResponse {
+  text: string;
+  language: string;
+  duration: number;
+}
+
+export class WhisperProvider implements ISpeechRecognitionProvider {
+  private _state: VoiceRecognitionState = 'idle';
+  private mediaRecorder: MediaRecorder | null = null;
+  private mediaStream: MediaStream | null = null;
+  private audioChunks: Blob[] = [];
+  private events: SpeechRecognitionEvents | null = null;
+  private config: SpeechRecognitionConfig | null = null;
+  private abortController: AbortController | null = null;
+
+  private maxDurationTimer: ReturnType<typeof setTimeout> | null = null;
+  private noSpeechTimer: ReturnType<typeof setTimeout> | null = null;
+  private silenceTimer: ReturnType<typeof setTimeout> | null = null;
+
+  private analyserNode: AnalyserNode | null = null;
+  private audioContext: AudioContext | null = null;
+  private silenceCheckInterval: ReturnType<typeof setInterval> | null = null;
+  private hasSpeechDetected = false;
+
+  /** Minimum RMS amplitude to consider as speech (0-1 scale). */
+  private static readonly SPEECH_THRESHOLD = 0.01;
+  /** How often to check audio levels in ms. */
+  private static readonly LEVEL_CHECK_INTERVAL_MS = 100;
+
+  get isSupported(): boolean {
+    if (typeof window === 'undefined') return false;
+    return (
+      typeof MediaRecorder !== 'undefined' &&
+      typeof navigator?.mediaDevices?.getUserMedia === 'function'
+    );
+  }
+
+  get state(): VoiceRecognitionState {
+    return this._state;
+  }
+
+  start(config: SpeechRecognitionConfig, events: SpeechRecognitionEvents): void {
+    if (this._state !== 'idle' && this._state !== 'error') {
+      return;
+    }
+
+    if (!this.isSupported) {
+      this.setState('error', events);
+      events.onError({
+        code: 'not_supported',
+        message: 'MediaRecorder is not supported in this browser.',
+        recoverable: false,
+      });
+      return;
+    }
+
+    this.config = config;
+    this.events = events;
+    this.audioChunks = [];
+    this.hasSpeechDetected = false;
+
+    this.setState('requesting', events);
+    this.requestMicrophone();
+  }
+
+  stop(): void {
+    if (!this.mediaRecorder) return;
+
+    if (this._state === 'listening') {
+      this.setState('processing', this.events);
+    }
+
+    this.clearAllTimers();
+    this.stopSilenceDetection();
+
+    if (this.mediaRecorder.state === 'recording') {
+      // onstop handler will trigger transcription
+      this.mediaRecorder.stop();
+    }
+  }
+
+  abort(): void {
+    this.clearAllTimers();
+    this.stopSilenceDetection();
+    this.abortController?.abort();
+
+    if (this.mediaRecorder?.state === 'recording') {
+      this.mediaRecorder.stop();
+    }
+
+    this.releaseMediaStream();
+    this.cleanup();
+  }
+
+  dispose(): void {
+    this.abort();
+    this.events = null;
+    this.config = null;
+  }
+
+  // ---------------------------------------------------------------
+  // Private helpers
+  // ---------------------------------------------------------------
+
+  private async requestMicrophone(): Promise<void> {
+    try {
+      const stream = await navigator.mediaDevices.getUserMedia({
+        audio: {
+          echoCancellation: true,
+          noiseSuppression: true,
+          sampleRate: 16000,
+        },
+      });
+
+      this.mediaStream = stream;
+      this.setupMediaRecorder(stream);
+      this.setupAudioAnalyser(stream);
+    } catch (err) {
+      this.setState('error', this.events);
+      const isDenied =
+        err instanceof DOMException &&
+        (err.name === 'NotAllowedError' || err.name === 'PermissionDeniedError');
+
+      this.events?.onError({
+        code: isDenied ? 'permission_denied' : 'audio_capture_error',
+        message: isDenied
+          ? 'Microphone permission was denied. Please allow microphone access and try again.'
+          : 'Could not capture audio. Please check your microphone.',
+        recoverable: !isDenied,
+      });
+    }
+  }
+
+  private setupMediaRecorder(stream: MediaStream): void {
+    const mimeType = this.getPreferredMimeType();
+    const recorder = new MediaRecorder(stream, mimeType ? { mimeType } : undefined);
+
+    recorder.ondataavailable = (event: BlobEvent) => {
+      if (event.data.size > 0) {
+        this.audioChunks.push(event.data);
+      }
+    };
+
+    recorder.onstart = () => {
+      this.setState('listening', this.events);
+      this.startNoSpeechTimer();
+      this.startMaxDurationTimer();
+      this.startSilenceDetection();
+      this.events?.onSpeechStart();
+    };
+
+    recorder.onstop = () => {
+      this.releaseMediaStream();
+
+      if (this._state === 'processing' && this.audioChunks.length > 0) {
+        this.transcribeAudio();
+      } else {
+        this.cleanup();
+      }
+    };
+
+    recorder.onerror = () => {
+      this.clearAllTimers();
+      this.stopSilenceDetection();
+      this.releaseMediaStream();
+      this.setState('error', this.events);
+      this.events?.onError({
+        code: 'audio_capture_error',
+        message: 'An error occurred during audio recording.',
+        recoverable: true,
+      });
+    };
+
+    this.mediaRecorder = recorder;
+    // Collect data every 250ms for interim feedback
+    recorder.start(250);
+  }
+
+  private setupAudioAnalyser(stream: MediaStream): void {
+    try {
+      const ctx = new AudioContext();
+      const source = ctx.createMediaStreamSource(stream);
+      const analyser = ctx.createAnalyser();
+      analyser.fftSize = 256;
+      source.connect(analyser);
+
+      this.audioContext = ctx;
+      this.analyserNode = analyser;
+    } catch {
+      // Audio analysis is best-effort; recording still works without it
+    }
+  }
+
+  private startSilenceDetection(): void {
+    if (!this.analyserNode) return;
+
+    const bufferLength = this.analyserNode.fftSize;
+    const dataArray = new Float32Array(bufferLength);
+
+    this.silenceCheckInterval = setInterval(() => {
+      if (!this.analyserNode) return;
+      this.analyserNode.getFloatTimeDomainData(dataArray);
+
+      // Calculate RMS amplitude
+      let sum = 0;
+      for (let i = 0; i < bufferLength; i++) {
+        sum += dataArray[i] * dataArray[i];
+      }
+      const rms = Math.sqrt(sum / bufferLength);
+
+      if (rms > WhisperProvider.SPEECH_THRESHOLD) {
+        this.hasSpeechDetected = true;
+        this.clearTimer('noSpeech');
+        this.clearTimer('silence');
+        // Provide interim feedback based on audio activity
+        this.events?.onInterimResult('...');
+      } else if (this.hasSpeechDetected) {
+        // Speech was detected before but now it's silent — start silence timer
+        this.startSilenceTimer();
+      }
+    }, WhisperProvider.LEVEL_CHECK_INTERVAL_MS);
+  }
+
+  private stopSilenceDetection(): void {
+    if (this.silenceCheckInterval !== null) {
+      clearInterval(this.silenceCheckInterval);
+      this.silenceCheckInterval = null;
+    }
+    if (this.audioContext) {
+      this.audioContext.close().catch(() => {});
+      this.audioContext = null;
+    }
+    this.analyserNode = null;
+  }
+
+  private async transcribeAudio(): Promise<void> {
+    const mimeType = this.audioChunks[0]?.type || 'audio/webm';
+    const audioBlob = new Blob(this.audioChunks, { type: mimeType });
+    this.audioChunks = [];
+
+    // Determine file extension from mime type
+    const ext = mimeType.includes('ogg') ? 'ogg' : mimeType.includes('mp4') ? 'mp4' : 'webm';
+    const fileName = `recording.${ext}`;
+
+    const formData = new FormData();
+    formData.append('file', audioBlob, fileName);
+    if (this.config?.language) {
+      // Send only the language prefix (e.g., 'it' from 'it-IT')
+      formData.append('language', this.config.language.substring(0, 2));
+    }
+
+    this.abortController = new AbortController();
+
+    try {
+      const response = await fetch(`${API_BASE_URL}/api/v1/speech/transcribe`, {
+        method: 'POST',
+        body: formData,
+        credentials: 'include',
+        signal: this.abortController.signal,
+      });
+
+      if (!response.ok) {
+        const errorCode = response.status === 403 ? 'permission_denied' : 'server_error';
+        const errorMsg =
+          response.status === 403
+            ? 'Speech transcription is not available on your current plan.'
+            : `Transcription failed (${response.status}).`;
+
+        this.setState('error', this.events);
+        this.events?.onError({
+          code: errorCode,
+          message: errorMsg,
+          recoverable: response.status !== 403,
+        });
+        return;
+      }
+
+      const result = (await response.json()) as TranscriptionResponse;
+
+      if (result.text && result.text.trim().length > 0) {
+        this.events?.onFinalResult(result.text.trim(), 1.0);
+        this.events?.onSpeechEnd();
+      } else {
+        this.events?.onSpeechEnd();
+        this.setState('error', this.events);
+        this.events?.onError({
+          code: 'no_speech',
+          message: 'No speech was detected in the audio.',
+          recoverable: true,
+        });
+        return;
+      }
+
+      this.setState('idle', this.events);
+    } catch (err) {
+      if (err instanceof Error && err.name === 'AbortError') {
+        this.setState('idle', this.events);
+        return;
+      }
+
+      this.setState('error', this.events);
+      this.events?.onError({
+        code: 'network_error',
+        message: 'Failed to connect to the transcription service.',
+        recoverable: true,
+      });
+    } finally {
+      this.abortController = null;
+    }
+  }
+
+  private getPreferredMimeType(): string | null {
+    const candidates = [
+      'audio/webm;codecs=opus',
+      'audio/webm',
+      'audio/ogg;codecs=opus',
+      'audio/mp4',
+    ];
+    for (const candidate of candidates) {
+      if (MediaRecorder.isTypeSupported(candidate)) {
+        return candidate;
+      }
+    }
+    return null;
+  }
+
+  private releaseMediaStream(): void {
+    if (this.mediaStream) {
+      for (const track of this.mediaStream.getTracks()) {
+        track.stop();
+      }
+      this.mediaStream = null;
+    }
+  }
+
+  // ---------------------------------------------------------------
+  // Timer management
+  // ---------------------------------------------------------------
+
+  private startSilenceTimer(): void {
+    if (this.silenceTimer !== null) return; // Already running
+    if (!this.config) return;
+
+    this.silenceTimer = setTimeout(() => {
+      this.silenceTimer = null;
+      this.stop();
+    }, this.config.silenceTimeoutMs);
+  }
+
+  private startMaxDurationTimer(): void {
+    this.clearTimer('maxDuration');
+    if (!this.config) return;
+
+    this.maxDurationTimer = setTimeout(() => {
+      this.stop();
+    }, this.config.maxDurationMs);
+  }
+
+  private startNoSpeechTimer(): void {
+    this.clearTimer('noSpeech');
+    if (!this.config) return;
+
+    this.noSpeechTimer = setTimeout(() => {
+      if (!this.hasSpeechDetected) {
+        this.abort();
+        this.setState('error', this.events);
+        this.events?.onError({
+          code: 'no_speech',
+          message: 'No speech was detected. Please try again.',
+          recoverable: true,
+        });
+      }
+    }, this.config.noSpeechTimeoutMs);
+  }
+
+  private clearTimer(which: 'silence' | 'maxDuration' | 'noSpeech'): void {
+    switch (which) {
+      case 'silence':
+        if (this.silenceTimer !== null) {
+          clearTimeout(this.silenceTimer);
+          this.silenceTimer = null;
+        }
+        break;
+      case 'maxDuration':
+        if (this.maxDurationTimer !== null) {
+          clearTimeout(this.maxDurationTimer);
+          this.maxDurationTimer = null;
+        }
+        break;
+      case 'noSpeech':
+        if (this.noSpeechTimer !== null) {
+          clearTimeout(this.noSpeechTimer);
+          this.noSpeechTimer = null;
+        }
+        break;
+    }
+  }
+
+  private clearAllTimers(): void {
+    this.clearTimer('silence');
+    this.clearTimer('maxDuration');
+    this.clearTimer('noSpeech');
+  }
+
+  private setState(newState: VoiceRecognitionState, events: SpeechRecognitionEvents | null): void {
+    if (this._state === newState) return;
+    this._state = newState;
+    events?.onStateChange(newState);
+  }
+
+  private cleanup(): void {
+    this.clearAllTimers();
+    this.stopSilenceDetection();
+    if (this._state !== 'error') {
+      this.setState('idle', this.events);
+    }
+    this.mediaRecorder = null;
+  }
+}


### PR DESCRIPTION
## Summary
- Create `WhisperProvider` implementing `ISpeechRecognitionProvider` using MediaRecorder + backend proxy (`POST /api/v1/speech/transcribe`)
- Update `provider-factory.ts` with tier-based selection: Whisper for paid tiers, WebSpeech fallback for free tier
- Audio level analysis via `AudioContext`/`AnalyserNode` for silence detection and no-speech timeout

## Files
- **New**: `apps/web/src/lib/voice/providers/whisper-provider.ts` — WhisperProvider class
- **Modified**: `apps/web/src/lib/voice/providers/provider-factory.ts` — tier-based factory
- **New**: `apps/web/src/__tests__/voice/whisper-provider.test.ts` — 22 tests

## Test plan
- [x] All 22 new WhisperProvider tests pass
- [x] All 156 existing voice tests pass (7 files, 0 failures)
- [x] `createSpeechRecognitionProvider()` without args still returns WebSpeechProvider (backward compatible)
- [x] Frontend build passes
- [ ] Manual test with paid-tier user connecting to live Whisper backend

Closes #328

🤖 Generated with [Claude Code](https://claude.com/claude-code)