### PR TITLE
feat(voice): VoiceChatButton with provider quality badge (#329)

### DIFF
--- a/apps/web/src/components/chat-unified/ChatThreadView.tsx
+++ b/apps/web/src/components/chat-unified/ChatThreadView.tsx
@@ -23,6 +23,7 @@ import { useAuth } from '@/components/auth/AuthProvider';
 import { buildWelcomeMessage, getWelcomeFollowUpQuestions } from '@/config/agent-welcome';
 import { useAgentChatStream, type ProxyGameContext } from '@/hooks/useAgentChatStream';
 import { useVoiceInput } from '@/hooks/useVoiceInput';
+import type { UserTier } from '@/hooks/useVoiceInput';
 import { useVoiceOutput } from '@/hooks/useVoiceOutput';
 import { api } from '@/lib/api';
 import { cn } from '@/lib/utils';
@@ -38,9 +39,9 @@ import { ResponseMetaBadge } from './ResponseMetaBadge';
 import { RuleSourceCard } from './RuleSourceCard';
 import { TechnicalDetailsPanel } from './TechnicalDetailsPanel';
 import { TtsSpeakerButton } from './TtsSpeakerButton';
-import { VoiceMicButton } from './VoiceMicButton';
 import { VoiceSettingsPopover } from './VoiceSettingsPopover';
 import { VoiceTranscriptOverlay } from './VoiceTranscriptOverlay';
+import { VoiceChatButton } from '../chat/VoiceChatButton';
 
 // ============================================================================
 // Types
@@ -102,6 +103,9 @@ export function ChatThreadView({ threadId }: ChatThreadViewProps) {
   const lastMessageWasVoiceRef = useRef(false);
   const handleSendRef = useRef<((content?: string) => void) | undefined>(undefined);
 
+  // Derive tier from user role for voice provider selection
+  const voiceTier: UserTier = isAdmin ? 'admin' : isEditor ? 'premium' : 'free';
+
   const {
     state: voiceState,
     interimText,
@@ -110,9 +114,11 @@ export function ChatThreadView({ threadId }: ChatThreadViewProps) {
     stopListening,
     cancelListening,
     isSupported: isVoiceSupported,
+    providerName: voiceProviderName,
   } = useVoiceInput({
     language: voicePrefs.language,
     autoSend: voicePrefs.autoSend,
+    tier: voiceTier,
     onTranscript: text => {
       if (voicePrefs.autoSend && text.trim()) {
         lastMessageWasVoiceRef.current = true;
@@ -738,10 +744,11 @@ export function ChatThreadView({ threadId }: ChatThreadViewProps) {
                 disabled={isSending || streamState.isStreaming}
                 data-testid="message-input"
               />
-              <VoiceMicButton
+              <VoiceChatButton
                 state={voiceState}
                 onTap={handleVoiceTap}
                 disabled={!isVoiceSupported || isSending || streamState.isStreaming}
+                providerName={voiceProviderName}
                 size="md"
               />
               {isVoiceSupported && (

--- a/apps/web/src/components/chat/VoiceChatButton.tsx
+++ b/apps/web/src/components/chat/VoiceChatButton.tsx
@@ -1,0 +1,80 @@
+'use client';
+
+/**
+ * VoiceChatButton - Composite voice input button with quality badge (#329)
+ *
+ * Wraps VoiceMicButton with a provider quality badge showing whether
+ * the user is using Whisper (cloud) or WebSpeech (browser) STT.
+ * Integrates into the chat input area.
+ */
+
+import { cn } from '@/lib/utils';
+import type { VoiceRecognitionState } from '@/lib/voice/types';
+
+import { VoiceMicButton } from '../chat-unified/VoiceMicButton';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+interface VoiceChatButtonProps {
+  state: VoiceRecognitionState;
+  onTap: () => void;
+  disabled?: boolean;
+  /** Which STT provider is active */
+  providerName: 'whisper' | 'web-speech';
+  /** sm = 32px, md = 40px */
+  size?: 'sm' | 'md';
+  className?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+const PROVIDER_LABELS: Record<'whisper' | 'web-speech', string> = {
+  whisper: 'AI',
+  'web-speech': 'STT',
+};
+
+const PROVIDER_COLORS: Record<'whisper' | 'web-speech', string> = {
+  whisper: 'bg-amber-500/90 text-white',
+  'web-speech': 'bg-muted text-muted-foreground',
+};
+
+// ---------------------------------------------------------------------------
+// Component
+// ---------------------------------------------------------------------------
+
+export function VoiceChatButton({
+  state,
+  onTap,
+  disabled = false,
+  providerName,
+  size = 'md',
+  className,
+}: VoiceChatButtonProps) {
+  const showBadge = state !== 'idle' || !disabled;
+
+  return (
+    <div className={cn('relative inline-flex', className)} data-testid="voice-chat-button">
+      <VoiceMicButton state={state} onTap={onTap} disabled={disabled} size={size} />
+
+      {/* Quality badge */}
+      {showBadge && (
+        <span
+          className={cn(
+            'absolute -top-1 -right-1 px-1 rounded text-[9px] font-bold leading-tight pointer-events-none select-none',
+            PROVIDER_COLORS[providerName]
+          )}
+          data-testid="voice-quality-badge"
+          aria-label={
+            providerName === 'whisper' ? 'Cloud AI transcription' : 'Browser speech recognition'
+          }
+        >
+          {PROVIDER_LABELS[providerName]}
+        </span>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/chat/__tests__/VoiceChatButton.test.tsx
+++ b/apps/web/src/components/chat/__tests__/VoiceChatButton.test.tsx
@@ -1,0 +1,50 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { VoiceChatButton } from '../VoiceChatButton';
+
+describe('VoiceChatButton', () => {
+  it('renders mic button and quality badge', () => {
+    render(<VoiceChatButton state="idle" onTap={vi.fn()} providerName="whisper" />);
+
+    expect(screen.getByTestId('voice-chat-button')).toBeInTheDocument();
+    expect(screen.getByTestId('voice-quality-badge')).toBeInTheDocument();
+  });
+
+  it('shows AI badge for whisper provider', () => {
+    render(<VoiceChatButton state="idle" onTap={vi.fn()} providerName="whisper" />);
+
+    const badge = screen.getByTestId('voice-quality-badge');
+    expect(badge).toHaveTextContent('AI');
+  });
+
+  it('shows STT badge for web-speech provider', () => {
+    render(<VoiceChatButton state="idle" onTap={vi.fn()} providerName="web-speech" />);
+
+    const badge = screen.getByTestId('voice-quality-badge');
+    expect(badge).toHaveTextContent('STT');
+  });
+
+  it('forwards onTap to underlying VoiceMicButton', () => {
+    const onTap = vi.fn();
+    render(<VoiceChatButton state="idle" onTap={onTap} providerName="whisper" />);
+
+    const button = screen.getByRole('button');
+    fireEvent.click(button);
+    expect(onTap).toHaveBeenCalledOnce();
+  });
+
+  it('disables button when disabled prop is true', () => {
+    render(<VoiceChatButton state="idle" onTap={vi.fn()} disabled providerName="whisper" />);
+
+    const button = screen.getByRole('button');
+    expect(button).toBeDisabled();
+  });
+
+  it('renders with listening state', () => {
+    render(<VoiceChatButton state="listening" onTap={vi.fn()} providerName="whisper" />);
+
+    const button = screen.getByRole('button');
+    expect(button).toHaveAttribute('aria-pressed', 'true');
+  });
+});

--- a/apps/web/src/hooks/useVoiceInput.ts
+++ b/apps/web/src/hooks/useVoiceInput.ts
@@ -19,7 +19,7 @@
  * ```
  */
 
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
 import { createSpeechRecognitionProvider } from '@/lib/voice/providers/provider-factory';
 import type {
@@ -36,6 +36,8 @@ import { isSpeechRecognitionSupported } from '@/lib/voice/utils/voice-detection'
 // Types
 // ============================================================================
 
+export type UserTier = 'free' | 'premium' | 'admin';
+
 export interface UseVoiceInputOptions {
   /** BCP 47 language tag (default: from DEFAULT_VOICE_CONFIG) */
   language?: string;
@@ -43,6 +45,8 @@ export interface UseVoiceInputOptions {
   autoSend?: boolean;
   /** Silence timeout in ms before auto-stopping (default: from DEFAULT_VOICE_CONFIG) */
   silenceTimeoutMs?: number;
+  /** User subscription tier for provider selection (default: 'free') */
+  tier?: UserTier;
   /** Called when a final transcript is produced */
   onTranscript?: (text: string, confidence: number) => void;
   /** Called when an error occurs */
@@ -68,6 +72,8 @@ export interface UseVoiceInputReturn {
   error: VoiceError | null;
   /** Clear the current error */
   clearError: () => void;
+  /** Name of the active STT provider ('whisper' | 'web-speech') */
+  providerName: 'whisper' | 'web-speech';
 }
 
 // ============================================================================
@@ -84,6 +90,7 @@ export function useVoiceInput(options: UseVoiceInputOptions = {}): UseVoiceInput
   const {
     language = DEFAULT_VOICE_CONFIG.language,
     silenceTimeoutMs = DEFAULT_VOICE_CONFIG.silenceTimeoutMs,
+    tier = 'free',
     onTranscript,
     onError,
   } = options;
@@ -107,6 +114,17 @@ export function useVoiceInput(options: UseVoiceInputOptions = {}): UseVoiceInput
 
   // Browser support check (SSR-safe, computed once)
   const [isSupported] = useState(() => isSpeechRecognitionSupported());
+
+  // Determine provider name based on tier + support
+  const providerName: 'whisper' | 'web-speech' = useMemo(() => {
+    if (tier === 'premium' || tier === 'admin') {
+      // Check if MediaRecorder is available for WhisperProvider
+      if (typeof window !== 'undefined' && typeof MediaRecorder !== 'undefined') {
+        return 'whisper';
+      }
+    }
+    return 'web-speech';
+  }, [tier]);
 
   // ------------------------------------------------------------------
   // Error helpers
@@ -143,6 +161,7 @@ export function useVoiceInput(options: UseVoiceInputOptions = {}): UseVoiceInput
 
   const getOrCreateProvider = useCallback((): ISpeechRecognitionProvider => {
     if (providerRef.current === null) {
+      // TODO: Pass tier to createSpeechRecognitionProvider once #328 merges
       providerRef.current = createSpeechRecognitionProvider();
     }
     return providerRef.current;
@@ -243,5 +262,6 @@ export function useVoiceInput(options: UseVoiceInputOptions = {}): UseVoiceInput
     isSupported,
     error,
     clearError,
+    providerName,
   };
 }


### PR DESCRIPTION
## Summary
- Create `VoiceChatButton` component wrapping `VoiceMicButton` with quality badge (AI/STT)
- Update `useVoiceInput` hook to accept `tier` parameter and expose `providerName`
- Wire into `ChatThreadView` with role-based tier derivation (admin→admin, editor→premium, user→free)

## Files
- **New**: `apps/web/src/components/chat/VoiceChatButton.tsx`
- **New**: `apps/web/src/components/chat/__tests__/VoiceChatButton.test.tsx` — 6 tests
- **Modified**: `apps/web/src/hooks/useVoiceInput.ts` — added `tier`, `providerName`
- **Modified**: `apps/web/src/components/chat-unified/ChatThreadView.tsx` — use VoiceChatButton

## Test plan
- [x] 6 VoiceChatButton tests pass
- [x] All 140 voice tests pass (7 files)
- [x] Frontend build passes
- [x] TypeScript type check passes
- [ ] Visual check: badge shows "AI" for admin, "STT" for free users

**Note**: Full Whisper integration activates when PR #406 (#328) merges.

Closes #329

🤖 Generated with [Claude Code](https://claude.com/claude-code)