### PR TITLE
feat(voice): TTS language auto-detection for IT/EN (#330)

### DIFF
--- a/apps/web/src/__tests__/voice/language-detection.test.ts
+++ b/apps/web/src/__tests__/voice/language-detection.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest';
+
+import { detectLanguage } from '@/lib/voice/utils/language-detection';
+
+describe('detectLanguage', () => {
+  // ---------------------------------------------------------------
+  // Italian detection
+  // ---------------------------------------------------------------
+
+  it('detects Italian text with common function words', () => {
+    const text = 'Il gioco è per 2-4 giocatori e il turno dura circa 30 minuti';
+    expect(detectLanguage(text)).toBe('it-IT');
+  });
+
+  it('detects Italian text with diacritical characters', () => {
+    const text = 'È un gioco molto più difficile di quello che sembra perché richiede strategia';
+    expect(detectLanguage(text)).toBe('it-IT');
+  });
+
+  it('detects Italian game rules text', () => {
+    const text =
+      'Le regole del gioco sono semplici: ogni giocatore pesca una carta dal mazzo e la gioca sul tabellone';
+    expect(detectLanguage(text)).toBe('it-IT');
+  });
+
+  // ---------------------------------------------------------------
+  // English detection
+  // ---------------------------------------------------------------
+
+  it('detects English text with common function words', () => {
+    const text = 'The game is designed for 2-4 players and each turn takes about 30 minutes';
+    expect(detectLanguage(text)).toBe('en-US');
+  });
+
+  it('detects English game rules text', () => {
+    const text =
+      'Players take turns rolling the dice and moving their pieces around the board to score points';
+    expect(detectLanguage(text)).toBe('en-US');
+  });
+
+  it('detects English text with technical terms', () => {
+    const text =
+      'This strategy game has been rated as one of the best games of the year by multiple reviewers';
+    expect(detectLanguage(text)).toBe('en-US');
+  });
+
+  // ---------------------------------------------------------------
+  // Edge cases
+  // ---------------------------------------------------------------
+
+  it('returns fallback for empty string', () => {
+    expect(detectLanguage('')).toBe('it-IT');
+  });
+
+  it('returns fallback for whitespace-only string', () => {
+    expect(detectLanguage('   ')).toBe('it-IT');
+  });
+
+  it('returns custom fallback when provided', () => {
+    expect(detectLanguage('', 'en-US')).toBe('en-US');
+  });
+
+  it('returns fallback for very short text with no markers', () => {
+    expect(detectLanguage('OK')).toBe('it-IT');
+  });
+
+  it('handles text with markdown code blocks (strips them)', () => {
+    const text =
+      'The game uses the following rules:\n```\nif (score > 10) win();\n```\nPlayers should follow these instructions carefully.';
+    expect(detectLanguage(text)).toBe('en-US');
+  });
+
+  it('handles text with URLs (strips them)', () => {
+    const text =
+      'Il gioco è disponibile su https://example.com/giochi/strategia per tutti i giocatori';
+    expect(detectLanguage(text)).toBe('it-IT');
+  });
+
+  it('handles mixed language text — returns dominant language', () => {
+    // Predominantly Italian with one English word
+    const text =
+      'Il game design di questo gioco è molto interessante per i giocatori che amano la strategia';
+    expect(detectLanguage(text)).toBe('it-IT');
+  });
+});

--- a/apps/web/src/app/(authenticated)/ask/page.tsx
+++ b/apps/web/src/app/(authenticated)/ask/page.tsx
@@ -407,6 +407,7 @@ export default function QuickAskPage() {
     language: voiceLang,
     preferredVoiceURI: voiceURI ?? undefined,
     rate: rate,
+    autoDetectLanguage: true,
   });
 
   // ------------------------------------------------------------------

--- a/apps/web/src/components/chat-unified/ChatThreadView.tsx
+++ b/apps/web/src/components/chat-unified/ChatThreadView.tsx
@@ -131,6 +131,7 @@ export function ChatThreadView({ threadId }: ChatThreadViewProps) {
     language: voicePrefs.language,
     preferredVoiceURI: voicePrefs.voiceURI ?? undefined,
     rate: voicePrefs.rate,
+    autoDetectLanguage: true,
   });
 
   const handleVoiceTap = useCallback(() => {

--- a/apps/web/src/hooks/useVoiceOutput.ts
+++ b/apps/web/src/hooks/useVoiceOutput.ts
@@ -17,6 +17,7 @@
 
 import { useCallback, useEffect, useRef, useState } from 'react';
 
+import { detectLanguage } from '@/lib/voice/utils/language-detection';
 import { sanitizeForTts } from '@/lib/voice/utils/text-sanitizer';
 import { findBestVoice, isSpeechSynthesisSupported } from '@/lib/voice/utils/voice-detection';
 
@@ -33,10 +34,13 @@ export interface UseVoiceOutputOptions {
   maxTextLength?: number;
   /** Speech rate 0.5-2.0 (default: 1.0) */
   rate?: number;
+  /** Auto-detect response language for TTS (#330). Default: false */
+  autoDetectLanguage?: boolean;
 }
 
 export interface UseVoiceOutputReturn {
-  /** Speak the given text (sanitized and truncated automatically) */
+  /** Speak the given text (sanitized and truncated automatically).
+   *  If autoDetectLanguage is enabled, the language is detected from text content. */
   speak: (text: string) => void;
   /** Stop current speech immediately */
   stop: () => void;
@@ -59,7 +63,8 @@ export interface UseVoiceOutputReturn {
 const DEFAULT_LANGUAGE = 'it-IT';
 const DEFAULT_MAX_TEXT_LENGTH = 500;
 const DEFAULT_RATE = 1.0;
-const TRUNCATION_SUFFIX = '... leggi la risposta completa sullo schermo';
+const TRUNCATION_SUFFIX_IT = '... leggi la risposta completa sullo schermo';
+const TRUNCATION_SUFFIX_EN = '... read the full response on screen';
 
 /**
  * Firefox workaround: calling speechSynthesis.speak() too quickly after
@@ -78,6 +83,7 @@ export function useVoiceOutput(options: UseVoiceOutputOptions = {}): UseVoiceOut
     preferredVoiceURI,
     maxTextLength = DEFAULT_MAX_TEXT_LENGTH,
     rate = DEFAULT_RATE,
+    autoDetectLanguage = false,
   } = options;
 
   const [isSpeaking, setIsSpeaking] = useState(false);
@@ -88,6 +94,7 @@ export function useVoiceOutput(options: UseVoiceOutputOptions = {}): UseVoiceOut
   // Mutable refs for timers and cooldown tracking
   const lastCancelTimeRef = useRef<number>(0);
   const pendingSpeakRef = useRef<string | null>(null);
+  const pendingLangRef = useRef<string | null>(null);
   const cooldownTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const utteranceRef = useRef<SpeechSynthesisUtterance | null>(null);
 
@@ -151,11 +158,12 @@ export function useVoiceOutput(options: UseVoiceOutputOptions = {}): UseVoiceOut
   // ------------------------------------------------------------------
 
   const processText = useCallback(
-    (text: string): string => {
+    (text: string, lang?: string): string => {
       let processed = sanitizeForTts(text);
 
       if (processed.length > maxTextLength) {
-        processed = processed.substring(0, maxTextLength) + TRUNCATION_SUFFIX;
+        const suffix = lang?.startsWith('en') ? TRUNCATION_SUFFIX_EN : TRUNCATION_SUFFIX_IT;
+        processed = processed.substring(0, maxTextLength) + suffix;
       }
 
       return processed;
@@ -168,22 +176,28 @@ export function useVoiceOutput(options: UseVoiceOutputOptions = {}): UseVoiceOut
   // ------------------------------------------------------------------
 
   const speakNow = useCallback(
-    (text: string) => {
+    (text: string, langOverride?: string) => {
       if (!isSupported) return;
 
-      const processed = processText(text);
+      const effectiveLang = langOverride ?? language;
+      const processed = processText(text, effectiveLang);
       if (!processed) return;
 
       // Cancel any current speech first
       if (speechSynthesis.speaking) {
         speechSynthesis.cancel();
       }
-
       const utterance = new SpeechSynthesisUtterance(processed);
-      utterance.lang = language;
+      utterance.lang = effectiveLang;
       utterance.rate = Math.max(0.5, Math.min(2.0, rate));
 
-      if (selectedVoice) {
+      // When language differs from default, pick the best voice for that language
+      if (langOverride && langOverride !== language) {
+        const langVoice = findBestVoice(langOverride);
+        if (langVoice) {
+          utterance.voice = langVoice;
+        }
+      } else if (selectedVoice) {
         utterance.voice = selectedVoice;
       }
 
@@ -214,11 +228,17 @@ export function useVoiceOutput(options: UseVoiceOutputOptions = {}): UseVoiceOut
     (text: string) => {
       if (!isSupported) return;
 
+      // Auto-detect language when enabled (#330)
+      const langOverride = autoDetectLanguage
+        ? detectLanguage(text, language as 'it-IT' | 'en-US')
+        : undefined;
+
       const elapsed = Date.now() - lastCancelTimeRef.current;
 
       if (elapsed < CANCEL_COOLDOWN_MS) {
         // Firefox workaround: defer speaking until cooldown passes
         pendingSpeakRef.current = text;
+        pendingLangRef.current = langOverride ?? null;
 
         // Clear any existing cooldown timer
         if (cooldownTimerRef.current !== null) {
@@ -228,17 +248,20 @@ export function useVoiceOutput(options: UseVoiceOutputOptions = {}): UseVoiceOut
         cooldownTimerRef.current = setTimeout(() => {
           cooldownTimerRef.current = null;
           const pending = pendingSpeakRef.current;
+          const pendingLang = pendingLangRef.current;
           pendingSpeakRef.current = null;
+          pendingLangRef.current = null;
           if (pending) {
-            speakNow(pending);
+            speakNow(pending, pendingLang ?? undefined);
           }
         }, CANCEL_COOLDOWN_MS - elapsed);
       } else {
         pendingSpeakRef.current = null;
-        speakNow(text);
+        pendingLangRef.current = null;
+        speakNow(text, langOverride);
       }
     },
-    [isSupported, speakNow]
+    [isSupported, autoDetectLanguage, language, speakNow]
   );
 
   const stop = useCallback(() => {
@@ -250,6 +273,7 @@ export function useVoiceOutput(options: UseVoiceOutputOptions = {}): UseVoiceOut
       cooldownTimerRef.current = null;
     }
     pendingSpeakRef.current = null;
+    pendingLangRef.current = null;
 
     if (speechSynthesis.speaking || speechSynthesis.pending) {
       speechSynthesis.cancel();

--- a/apps/web/src/lib/voice/index.ts
+++ b/apps/web/src/lib/voice/index.ts
@@ -29,6 +29,8 @@ export { createSpeechRecognitionProvider } from './providers/provider-factory';
 export { WebSpeechProvider } from './providers/web-speech-provider';
 
 // Utilities
+export { detectLanguage } from './utils/language-detection';
+export type { DetectedLanguage } from './utils/language-detection';
 export { sanitizeForTts } from './utils/text-sanitizer';
 export {
   findBestVoice,

--- a/apps/web/src/lib/voice/utils/language-detection.ts
+++ b/apps/web/src/lib/voice/utils/language-detection.ts
@@ -1,0 +1,183 @@
+/**
+ * Language Detection for TTS Output (#330)
+ *
+ * Simple heuristic-based language detection for Italian vs English.
+ * Uses character frequency, common word matching, and diacritical markers
+ * to determine the most likely language of a text snippet.
+ *
+ * Designed for MeepleAI where responses are either Italian or English.
+ */
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export type DetectedLanguage = 'it-IT' | 'en-US';
+
+// ============================================================================
+// Constants
+// ============================================================================
+
+/**
+ * High-frequency Italian function words unlikely to appear in English text.
+ * Weighted toward short, unambiguous markers.
+ */
+const ITALIAN_MARKERS: ReadonlySet<string> = new Set([
+  'il',
+  'lo',
+  'la',
+  'le',
+  'gli',
+  'un',
+  'una',
+  'uno',
+  'di',
+  'del',
+  'della',
+  'dei',
+  'delle',
+  'dello',
+  'degli',
+  'che',
+  'è',
+  'sono',
+  'hai',
+  'ha',
+  'hanno',
+  'sei',
+  'siamo',
+  'non',
+  'per',
+  'con',
+  'nel',
+  'nella',
+  'questo',
+  'questa',
+  'come',
+  'anche',
+  'più',
+  'perché',
+  'quando',
+  'dove',
+  'gioco',
+  'giocatori',
+  'turno',
+  'regole',
+  'carta',
+  'carte',
+  'pedina',
+  'pedine',
+  'dado',
+  'dadi',
+  'tabellone',
+  'punteggio',
+]);
+
+/**
+ * High-frequency English function words unlikely to appear in Italian text.
+ */
+const ENGLISH_MARKERS: ReadonlySet<string> = new Set([
+  'the',
+  'is',
+  'are',
+  'was',
+  'were',
+  'been',
+  'being',
+  'have',
+  'has',
+  'had',
+  'do',
+  'does',
+  'did',
+  'will',
+  'would',
+  'could',
+  'should',
+  'might',
+  'this',
+  'that',
+  'these',
+  'those',
+  'which',
+  'what',
+  'from',
+  'with',
+  'about',
+  'into',
+  'through',
+  'game',
+  'player',
+  'players',
+  'turn',
+  'rules',
+  'card',
+  'cards',
+  'board',
+  'dice',
+  'score',
+  'piece',
+  'pieces',
+]);
+
+/**
+ * Italian diacritical characters — strong signal for Italian.
+ */
+const ITALIAN_DIACRITICS = /[àèéìòù]/;
+
+// ============================================================================
+// Detection
+// ============================================================================
+
+/**
+ * Detect whether text is Italian or English.
+ *
+ * @param text - Text to analyze (typically an AI response)
+ * @param fallback - Language to return when detection is inconclusive (default: 'it-IT')
+ * @returns BCP 47 language tag
+ */
+export function detectLanguage(
+  text: string,
+  fallback: DetectedLanguage = 'it-IT'
+): DetectedLanguage {
+  if (!text || text.trim().length === 0) return fallback;
+
+  // Normalize: lowercase, extract words (strip markdown/punctuation)
+  const cleaned = text
+    .replace(/```[\s\S]*?```/g, '') // strip code blocks
+    .replace(/`[^`]+`/g, '') // strip inline code
+    .replace(/https?:\/\/[^\s]+/g, '') // strip URLs
+    .toLowerCase();
+
+  const words = cleaned.match(/[a-zàèéìòùa-z]+/g);
+  if (!words || words.length < 3) return fallback;
+
+  // Check for Italian diacritics — strong signal
+  const hasDiacritics = ITALIAN_DIACRITICS.test(cleaned);
+
+  // Count marker word hits
+  let italianHits = 0;
+  let englishHits = 0;
+
+  for (const word of words) {
+    if (ITALIAN_MARKERS.has(word)) italianHits++;
+    if (ENGLISH_MARKERS.has(word)) englishHits++;
+  }
+
+  // Diacritics bonus for Italian
+  if (hasDiacritics) {
+    italianHits += 3;
+  }
+
+  // Calculate ratios
+  const totalHits = italianHits + englishHits;
+  if (totalHits === 0) return fallback;
+
+  const italianRatio = italianHits / totalHits;
+
+  // Threshold: >55% Italian markers → Italian, otherwise English
+  if (italianRatio > 0.55) return 'it-IT';
+  if (italianRatio < 0.45) return 'en-US';
+
+  return fallback;
+}


### PR DESCRIPTION
## Summary
- Add heuristic-based language detection utility (`language-detection.ts`) that identifies Italian vs English text using word frequency markers, diacritical characters, and board game domain terms
- Extend `useVoiceOutput` hook with `autoDetectLanguage` option — when enabled, detects response language per utterance and selects the appropriate voice automatically
- Language-aware truncation suffix (Italian/English)
- Enabled in both `ChatThreadView` and `/ask` page

## Changes
- **New**: `lib/voice/utils/language-detection.ts` — `detectLanguage()` with IT/EN heuristics
- **New**: `__tests__/voice/language-detection.test.ts` — 13 tests (Italian, English, edge cases)
- **Modified**: `hooks/useVoiceOutput.ts` — `autoDetectLanguage` option, per-utterance voice selection
- **Modified**: `lib/voice/index.ts` — export `detectLanguage` and `DetectedLanguage`
- **Modified**: `ChatThreadView.tsx` — `autoDetectLanguage: true`
- **Modified**: `ask/page.tsx` — `autoDetectLanguage: true`

## Test plan
- [x] 13 language detection unit tests pass
- [x] All 147 existing voice tests pass
- [x] TypeScript type check clean
- [x] Frontend build passes
- [ ] Manual: Speak Italian response → Italian voice
- [ ] Manual: Speak English response → English voice
- [ ] Manual: TTS fallback when synthesis unsupported

Closes #330

🤖 Generated with [Claude Code](https://claude.com/claude-code)