### PR TITLE
feat(session-tracking): session checkpoint (#278) + turn summary AI (#277)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/CreateSessionCheckpointCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/CreateSessionCheckpointCommand.cs
@@ -1,0 +1,27 @@
+using Api.BoundedContexts.SessionTracking.Domain.Enums;
+using Api.BoundedContexts.SessionTracking.Domain.Services;
+using FluentValidation;
+using MediatR;
+
+namespace Api.BoundedContexts.SessionTracking.Application.Commands;
+
+public record CreateSessionCheckpointCommand(
+    Guid SessionId, Guid RequesterId, string Name
+) : IRequest<CreateSessionCheckpointResult>, IRequireSessionRole
+{
+    public ParticipantRole MinimumRole => ParticipantRole.Player;
+}
+
+public record CreateSessionCheckpointResult(
+    Guid CheckpointId, string Name, DateTime CreatedAt, int DiaryEventCount);
+
+public class CreateSessionCheckpointCommandValidator : AbstractValidator<CreateSessionCheckpointCommand>
+{
+    public CreateSessionCheckpointCommandValidator()
+    {
+        RuleFor(x => x.SessionId).NotEmpty().WithMessage("SessionId is required");
+        RuleFor(x => x.RequesterId).NotEmpty().WithMessage("RequesterId is required");
+        RuleFor(x => x.Name).NotEmpty().WithMessage("Checkpoint name is required")
+            .MaximumLength(200).WithMessage("Checkpoint name must be 200 characters or fewer");
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/GetTurnSummaryCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/GetTurnSummaryCommand.cs
@@ -1,0 +1,30 @@
+using Api.BoundedContexts.SessionTracking.Domain.Enums;
+using Api.BoundedContexts.SessionTracking.Domain.Services;
+using MediatR;
+
+namespace Api.BoundedContexts.SessionTracking.Application.Commands;
+
+/// <summary>
+/// Command to generate an AI-powered summary of session events.
+/// Issue #277 - Turn Summary AI Feature
+/// </summary>
+public record GetTurnSummaryCommand(
+    Guid SessionId,
+    Guid RequesterId,
+    int? FromPhase = null,
+    int? ToPhase = null,
+    int? LastNEvents = null
+) : IRequest<TurnSummaryResult>, IRequireSessionRole
+{
+    public ParticipantRole MinimumRole => ParticipantRole.Player;
+}
+
+/// <summary>
+/// Result of a turn summary generation.
+/// </summary>
+public record TurnSummaryResult(
+    Guid SummaryEventId,
+    string Summary,
+    int EventsAnalyzed,
+    DateTime GeneratedAt
+);

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/GetTurnSummaryCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/GetTurnSummaryCommandValidator.cs
@@ -1,0 +1,40 @@
+using FluentValidation;
+
+namespace Api.BoundedContexts.SessionTracking.Application.Commands;
+
+/// <summary>
+/// Validates GetTurnSummaryCommand.
+/// Issue #277 - Turn Summary AI Feature
+/// </summary>
+public class GetTurnSummaryCommandValidator : AbstractValidator<GetTurnSummaryCommand>
+{
+    public GetTurnSummaryCommandValidator()
+    {
+        RuleFor(x => x.SessionId)
+            .NotEmpty();
+
+        RuleFor(x => x.RequesterId)
+            .NotEmpty();
+
+        RuleFor(x => x.LastNEvents)
+            .InclusiveBetween(1, 100)
+            .When(x => x.LastNEvents.HasValue);
+
+        RuleFor(x => x.FromPhase)
+            .GreaterThanOrEqualTo(0)
+            .When(x => x.FromPhase.HasValue);
+
+        RuleFor(x => x.ToPhase)
+            .GreaterThanOrEqualTo(0)
+            .When(x => x.ToPhase.HasValue);
+
+        RuleFor(x => x)
+            .Must(x => x.LastNEvents.HasValue || x.FromPhase.HasValue || x.ToPhase.HasValue)
+            .WithMessage("At least one of LastNEvents, FromPhase, or ToPhase must be provided.");
+
+        RuleFor(x => x)
+            .Must(x => !x.FromPhase.HasValue || !x.ToPhase.HasValue || x.ToPhase.Value >= x.FromPhase.Value)
+            .When(x => x.FromPhase.HasValue && x.ToPhase.HasValue)
+            .WithMessage("ToPhase must be greater than or equal to FromPhase.");
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/RestoreSessionCheckpointCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Commands/RestoreSessionCheckpointCommand.cs
@@ -1,0 +1,26 @@
+using Api.BoundedContexts.SessionTracking.Domain.Enums;
+using Api.BoundedContexts.SessionTracking.Domain.Services;
+using FluentValidation;
+using MediatR;
+
+namespace Api.BoundedContexts.SessionTracking.Application.Commands;
+
+public record RestoreSessionCheckpointCommand(
+    Guid SessionId, Guid RequesterId, Guid CheckpointId
+) : IRequest<RestoreSessionCheckpointResult>, IRequireSessionRole
+{
+    public ParticipantRole MinimumRole => ParticipantRole.Player;
+}
+
+public record RestoreSessionCheckpointResult(
+    Guid CheckpointId, string Name, DateTime RestoredAt, int WidgetsRestored);
+
+public class RestoreSessionCheckpointCommandValidator : AbstractValidator<RestoreSessionCheckpointCommand>
+{
+    public RestoreSessionCheckpointCommandValidator()
+    {
+        RuleFor(x => x.SessionId).NotEmpty().WithMessage("SessionId is required");
+        RuleFor(x => x.RequesterId).NotEmpty().WithMessage("RequesterId is required");
+        RuleFor(x => x.CheckpointId).NotEmpty().WithMessage("CheckpointId is required");
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Handlers/CreateSessionCheckpointCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Handlers/CreateSessionCheckpointCommandHandler.cs
@@ -1,0 +1,79 @@
+using System.Text.Json;
+using MediatR;
+using Api.BoundedContexts.SessionTracking.Application.Commands;
+using Api.BoundedContexts.SessionTracking.Domain.Entities;
+using Api.BoundedContexts.SessionTracking.Domain.Repositories;
+using Api.Infrastructure;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.SessionTracking.Application.Handlers;
+
+public class CreateSessionCheckpointCommandHandler
+    : IRequestHandler<CreateSessionCheckpointCommand, CreateSessionCheckpointResult>
+{
+    private static readonly JsonSerializerOptions SnapshotJsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = false
+    };
+
+    private readonly ISessionRepository _sessionRepository;
+    private readonly ISessionCheckpointRepository _checkpointRepository;
+    private readonly ISessionEventRepository _sessionEventRepository;
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly MeepleAiDbContext _db;
+
+    public CreateSessionCheckpointCommandHandler(
+        ISessionRepository sessionRepository,
+        ISessionCheckpointRepository checkpointRepository,
+        ISessionEventRepository sessionEventRepository,
+        IUnitOfWork unitOfWork,
+        MeepleAiDbContext db)
+    {
+        _sessionRepository = sessionRepository ?? throw new ArgumentNullException(nameof(sessionRepository));
+        _checkpointRepository = checkpointRepository ?? throw new ArgumentNullException(nameof(checkpointRepository));
+        _sessionEventRepository = sessionEventRepository ?? throw new ArgumentNullException(nameof(sessionEventRepository));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+    }
+
+    public async Task<CreateSessionCheckpointResult> Handle(
+        CreateSessionCheckpointCommand request, CancellationToken cancellationToken)
+    {
+        var session = await _sessionRepository
+            .GetByIdAsync(request.SessionId, cancellationToken).ConfigureAwait(false)
+            ?? throw new NotFoundException($"Session {request.SessionId} not found");
+
+        if (session.Status != SessionStatus.Active)
+            throw new ConflictException($"Cannot create checkpoint for session with status {session.Status}");
+
+        var toolkitStates = await _db.ToolkitSessionStates
+            .AsNoTracking()
+            .Where(t => t.SessionId == request.SessionId)
+            .ToListAsync(cancellationToken).ConfigureAwait(false);
+
+        var snapshots = toolkitStates.Select(t => new
+        {
+            t.ToolkitId,
+            WidgetStatesJson = t.GetWidgetStatesJson(),
+            t.UpdatedAt
+        });
+
+        var snapshotData = JsonSerializer.Serialize(snapshots, SnapshotJsonOptions);
+
+        var diaryEventCount = await _sessionEventRepository
+            .CountBySessionIdAsync(request.SessionId, ct: cancellationToken).ConfigureAwait(false);
+
+        var checkpoint = SessionCheckpoint.Create(
+            request.SessionId, request.Name, request.RequesterId,
+            snapshotData, diaryEventCount);
+
+        await _checkpointRepository.AddAsync(checkpoint, cancellationToken).ConfigureAwait(false);
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        return new CreateSessionCheckpointResult(
+            checkpoint.Id, checkpoint.Name, checkpoint.CreatedAt, checkpoint.DiaryEventCount);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Handlers/GetTurnSummaryCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Handlers/GetTurnSummaryCommandHandler.cs
@@ -1,0 +1,185 @@
+using System.Globalization;
+using System.Text;
+using System.Text.Json;
+using MediatR;
+using Api.BoundedContexts.SessionTracking.Application.Commands;
+using Api.BoundedContexts.SessionTracking.Domain.Entities;
+using Api.BoundedContexts.SessionTracking.Domain.Repositories;
+using Api.Middleware.Exceptions;
+using Api.Services;
+using Api.SharedKernel.Infrastructure.Persistence;
+
+namespace Api.BoundedContexts.SessionTracking.Application.Handlers;
+
+internal class GetTurnSummaryCommandHandler : IRequestHandler<GetTurnSummaryCommand, TurnSummaryResult>
+{
+    private readonly ISessionRepository _sessionRepository;
+    private readonly ISessionEventRepository _sessionEventRepository;
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly ILlmService _llmService;
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase,
+        WriteIndented = false
+    };
+
+    private const string SystemPrompt =
+        "You are a board game session assistant. Your job is to summarize what happened " +
+        "during a game session based on the timeline of events.\n\n" +
+        "Guidelines:\n" +
+        "- Write a concise, engaging summary in 2-4 paragraphs.\n" +
+        "- Highlight key moments: notable dice rolls, score changes, card draws, and player notes.\n" +
+        "- Use natural language, not bullet points.\n" +
+        "- Mention participants by name when relevant.\n" +
+        "- Keep the tone friendly and informative.\n" +
+        "- If phase/turn information is available, organize the summary chronologically.\n" +
+        "- Do not make up events that are not in the data.";
+
+    public GetTurnSummaryCommandHandler(
+        ISessionRepository sessionRepository,
+        ISessionEventRepository sessionEventRepository,
+        IUnitOfWork unitOfWork,
+        ILlmService llmService)
+    {
+        _sessionRepository = sessionRepository ?? throw new ArgumentNullException(nameof(sessionRepository));
+        _sessionEventRepository = sessionEventRepository ?? throw new ArgumentNullException(nameof(sessionEventRepository));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+        _llmService = llmService ?? throw new ArgumentNullException(nameof(llmService));
+    }
+
+    public async Task<TurnSummaryResult> Handle(GetTurnSummaryCommand request, CancellationToken cancellationToken)
+    {
+        _ = await _sessionRepository.GetByIdAsync(request.SessionId, cancellationToken).ConfigureAwait(false)
+            ?? throw new NotFoundException(string.Format(CultureInfo.InvariantCulture, "Session {0} not found", request.SessionId));
+
+        var events = await FetchEventsAsync(request, cancellationToken).ConfigureAwait(false);
+
+        var eventList = events.ToList();
+        if (eventList.Count == 0)
+        {
+            throw new ConflictException("No events found for the specified range. Cannot generate a summary.");
+        }
+
+        var groupedEvents = GroupEventsByType(eventList);
+        var userPrompt = BuildUserPrompt(groupedEvents, eventList.Count);
+
+        var llmResult = await _llmService.GenerateCompletionAsync(
+            SystemPrompt,
+            userPrompt,
+            RequestSource.AgentTask,
+            cancellationToken).ConfigureAwait(false);
+
+        if (!llmResult.Success)
+        {
+            throw new ConflictException(string.Format(CultureInfo.InvariantCulture, "AI summary generation failed: {0}", llmResult.ErrorMessage));
+        }
+
+        var summaryText = llmResult.Response;
+
+        var summaryPayload = JsonSerializer.Serialize(new
+        {
+            summary = summaryText,
+            eventsAnalyzed = eventList.Count,
+            fromTimestamp = eventList.Min(e => e.Timestamp),
+            toTimestamp = eventList.Max(e => e.Timestamp),
+            eventTypeBreakdown = groupedEvents.ToDictionary(
+                g => g.Key, g => g.Count(), StringComparer.Ordinal)
+        }, JsonOptions);
+
+        var summaryEvent = SessionEvent.Create(
+            request.SessionId,
+            "turn_summary",
+            summaryPayload,
+            request.RequesterId,
+            "ai");
+
+        await _sessionEventRepository.AddAsync(summaryEvent, cancellationToken).ConfigureAwait(false);
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        return new TurnSummaryResult(
+            summaryEvent.Id,
+            summaryText,
+            eventList.Count,
+            summaryEvent.Timestamp);
+    }
+
+    private async Task<IEnumerable<SessionEvent>> FetchEventsAsync(
+        GetTurnSummaryCommand request, CancellationToken cancellationToken)
+    {
+        if (request.LastNEvents.HasValue)
+        {
+            return await _sessionEventRepository.GetBySessionIdAsync(
+                request.SessionId, eventType: null, limit: request.LastNEvents.Value,
+                offset: 0, ct: cancellationToken).ConfigureAwait(false);
+        }
+
+        var allEvents = await _sessionEventRepository.GetBySessionIdAsync(
+            request.SessionId, eventType: null, limit: 500,
+            offset: 0, ct: cancellationToken).ConfigureAwait(false);
+
+        var eventList = allEvents.ToList();
+
+        if (!request.FromPhase.HasValue && !request.ToPhase.HasValue)
+            return eventList;
+
+        return eventList.Where(e => IsEventInPhaseRange(e, request.FromPhase, request.ToPhase));
+    }
+
+    private static bool IsEventInPhaseRange(SessionEvent evt, int? fromPhase, int? toPhase)
+    {
+        try
+        {
+            if (string.IsNullOrWhiteSpace(evt.Payload) || string.Equals(evt.Payload, "{}", StringComparison.Ordinal))
+                return true;
+
+            using var doc = JsonDocument.Parse(evt.Payload);
+            if (doc.RootElement.TryGetProperty("phase", out var phaseElement) &&
+                phaseElement.TryGetInt32(out var phase))
+            {
+                if (fromPhase.HasValue && phase < fromPhase.Value) return false;
+                if (toPhase.HasValue && phase > toPhase.Value) return false;
+            }
+            return true;
+        }
+        catch (JsonException) { return true; }
+    }
+
+    private static ILookup<string, SessionEvent> GroupEventsByType(List<SessionEvent> events)
+        => events.ToLookup(e => e.EventType, StringComparer.Ordinal);
+
+    private static string BuildUserPrompt(ILookup<string, SessionEvent> groupedEvents, int totalCount)
+    {
+        var sb = new StringBuilder();
+        sb.Append(CultureInfo.InvariantCulture, $"Please summarize the following {totalCount} session events:");
+        sb.AppendLine();
+        sb.AppendLine();
+
+        foreach (var group in groupedEvents.OrderBy(g => g.Key, StringComparer.Ordinal))
+        {
+            sb.Append(CultureInfo.InvariantCulture, $"## {FormatEventType(group.Key)} ({group.Count()} events)");
+            sb.AppendLine();
+            foreach (var evt in group.OrderBy(e => e.Timestamp))
+            {
+                sb.Append(CultureInfo.InvariantCulture, $"- [{evt.Timestamp:HH:mm:ss}] {evt.Payload}");
+                sb.AppendLine();
+            }
+            sb.AppendLine();
+        }
+        return sb.ToString();
+    }
+
+    private static string FormatEventType(string eventType) => eventType switch
+    {
+        "dice_roll" => "Dice Rolls",
+        "card_draw" => "Card Draws",
+        "note_added" => "Notes",
+        "score_update" => "Score Updates",
+        "phase_change" => "Phase Changes",
+        "player_joined" => "Player Joins",
+        "player_left" => "Player Departures",
+        "timer_action" => "Timer Actions",
+        "turn_summary" => "Previous Summaries",
+        _ => eventType.Replace('_', ' ').ToUpperInvariant()
+    };
+}

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Handlers/ListSessionCheckpointsQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Handlers/ListSessionCheckpointsQueryHandler.cs
@@ -1,0 +1,37 @@
+using MediatR;
+using Api.BoundedContexts.SessionTracking.Application.Queries;
+using Api.BoundedContexts.SessionTracking.Domain.Repositories;
+using Api.Middleware.Exceptions;
+
+namespace Api.BoundedContexts.SessionTracking.Application.Handlers;
+
+public class ListSessionCheckpointsQueryHandler
+    : IRequestHandler<ListSessionCheckpointsQuery, ListSessionCheckpointsResult>
+{
+    private readonly ISessionRepository _sessionRepository;
+    private readonly ISessionCheckpointRepository _checkpointRepository;
+
+    public ListSessionCheckpointsQueryHandler(
+        ISessionRepository sessionRepository,
+        ISessionCheckpointRepository checkpointRepository)
+    {
+        _sessionRepository = sessionRepository ?? throw new ArgumentNullException(nameof(sessionRepository));
+        _checkpointRepository = checkpointRepository ?? throw new ArgumentNullException(nameof(checkpointRepository));
+    }
+
+    public async Task<ListSessionCheckpointsResult> Handle(
+        ListSessionCheckpointsQuery request, CancellationToken cancellationToken)
+    {
+        _ = await _sessionRepository
+            .GetByIdAsync(request.SessionId, cancellationToken).ConfigureAwait(false)
+            ?? throw new NotFoundException($"Session {request.SessionId} not found");
+
+        var checkpoints = await _checkpointRepository
+            .GetBySessionIdAsync(request.SessionId, cancellationToken).ConfigureAwait(false);
+
+        var dtos = checkpoints.Select(c => new SessionCheckpointDto(
+            c.Id, c.Name, c.CreatedAt, c.CreatedBy, c.DiaryEventCount)).ToList();
+
+        return new ListSessionCheckpointsResult(dtos);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Handlers/RestoreSessionCheckpointCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Handlers/RestoreSessionCheckpointCommandHandler.cs
@@ -1,0 +1,88 @@
+using System.Text.Json;
+using MediatR;
+using Api.BoundedContexts.SessionTracking.Application.Commands;
+using Api.BoundedContexts.SessionTracking.Domain.Entities;
+using Api.BoundedContexts.SessionTracking.Domain.Repositories;
+using Api.Infrastructure;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.SessionTracking.Application.Handlers;
+
+public class RestoreSessionCheckpointCommandHandler
+    : IRequestHandler<RestoreSessionCheckpointCommand, RestoreSessionCheckpointResult>
+{
+    private static readonly JsonSerializerOptions SnapshotJsonOptions = new()
+    {
+        PropertyNamingPolicy = JsonNamingPolicy.CamelCase
+    };
+
+    private readonly ISessionRepository _sessionRepository;
+    private readonly ISessionCheckpointRepository _checkpointRepository;
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly MeepleAiDbContext _db;
+
+    public RestoreSessionCheckpointCommandHandler(
+        ISessionRepository sessionRepository,
+        ISessionCheckpointRepository checkpointRepository,
+        IUnitOfWork unitOfWork,
+        MeepleAiDbContext db)
+    {
+        _sessionRepository = sessionRepository ?? throw new ArgumentNullException(nameof(sessionRepository));
+        _checkpointRepository = checkpointRepository ?? throw new ArgumentNullException(nameof(checkpointRepository));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+    }
+
+    public async Task<RestoreSessionCheckpointResult> Handle(
+        RestoreSessionCheckpointCommand request, CancellationToken cancellationToken)
+    {
+        var session = await _sessionRepository
+            .GetByIdAsync(request.SessionId, cancellationToken).ConfigureAwait(false)
+            ?? throw new NotFoundException($"Session {request.SessionId} not found");
+
+        if (session.Status != SessionStatus.Active)
+            throw new ConflictException($"Cannot restore checkpoint for session with status {session.Status}");
+
+        var checkpoint = await _checkpointRepository
+            .GetByIdAsync(request.CheckpointId, cancellationToken).ConfigureAwait(false)
+            ?? throw new NotFoundException($"Checkpoint {request.CheckpointId} not found");
+
+        if (checkpoint.SessionId != request.SessionId)
+            throw new ConflictException("Checkpoint does not belong to the specified session");
+
+        var snapshots = JsonSerializer.Deserialize<List<CheckpointSnapshot>>(
+            checkpoint.SnapshotData, SnapshotJsonOptions) ?? [];
+
+        var widgetsRestored = 0;
+        foreach (var snapshot in snapshots)
+        {
+            var existingState = await _db.ToolkitSessionStates
+                .FirstOrDefaultAsync(
+                    t => t.SessionId == request.SessionId && t.ToolkitId == snapshot.ToolkitId,
+                    cancellationToken).ConfigureAwait(false);
+
+            if (existingState != null)
+            {
+                existingState.RestoreWidgetStates(snapshot.WidgetStatesJson);
+                widgetsRestored++;
+            }
+            else
+            {
+                var newState = ToolkitSessionState.Create(request.SessionId, snapshot.ToolkitId);
+                newState.RestoreWidgetStates(snapshot.WidgetStatesJson);
+                _db.ToolkitSessionStates.Add(newState);
+                widgetsRestored++;
+            }
+        }
+
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        return new RestoreSessionCheckpointResult(
+            checkpoint.Id, checkpoint.Name, DateTime.UtcNow, widgetsRestored);
+    }
+
+    private sealed record CheckpointSnapshot(
+        Guid ToolkitId, string WidgetStatesJson, DateTime UpdatedAt);
+}

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/ListSessionCheckpointsQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Application/Queries/ListSessionCheckpointsQuery.cs
@@ -1,0 +1,22 @@
+using FluentValidation;
+using MediatR;
+
+namespace Api.BoundedContexts.SessionTracking.Application.Queries;
+
+public record ListSessionCheckpointsQuery(
+    Guid SessionId, Guid RequesterId
+) : IRequest<ListSessionCheckpointsResult>;
+
+public record ListSessionCheckpointsResult(IReadOnlyList<SessionCheckpointDto> Checkpoints);
+
+public record SessionCheckpointDto(
+    Guid Id, string Name, DateTime CreatedAt, Guid CreatedBy, int DiaryEventCount);
+
+public class ListSessionCheckpointsQueryValidator : AbstractValidator<ListSessionCheckpointsQuery>
+{
+    public ListSessionCheckpointsQueryValidator()
+    {
+        RuleFor(x => x.SessionId).NotEmpty().WithMessage("SessionId is required");
+        RuleFor(x => x.RequesterId).NotEmpty().WithMessage("RequesterId is required");
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Entities/SessionCheckpoint.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Entities/SessionCheckpoint.cs
@@ -1,0 +1,61 @@
+using System.ComponentModel.DataAnnotations;
+
+namespace Api.BoundedContexts.SessionTracking.Domain.Entities;
+
+/// <summary>
+/// Domain entity representing a deep save/checkpoint of session state.
+/// Issue #278 - Session Checkpoint / Deep Save
+/// </summary>
+public class SessionCheckpoint
+{
+    public Guid Id { get; private set; }
+    public Guid SessionId { get; private set; }
+
+    [MaxLength(200)]
+    public string Name { get; private set; } = string.Empty;
+
+    public DateTime CreatedAt { get; private set; } = DateTime.UtcNow;
+    public Guid CreatedBy { get; private set; }
+    public string SnapshotData { get; private set; } = "{}";
+    public int DiaryEventCount { get; private set; }
+    public bool IsDeleted { get; private set; }
+    public DateTime? DeletedAt { get; private set; }
+
+    private SessionCheckpoint() { }
+
+    public static SessionCheckpoint Create(
+        Guid sessionId, string name, Guid createdBy,
+        string snapshotData, int diaryEventCount)
+    {
+        if (sessionId == Guid.Empty)
+            throw new ArgumentException("Session ID cannot be empty.", nameof(sessionId));
+        if (string.IsNullOrWhiteSpace(name))
+            throw new ArgumentException("Name cannot be empty.", nameof(name));
+        if (name.Length > 200)
+            throw new ArgumentException("Name must be 200 characters or fewer.", nameof(name));
+        if (createdBy == Guid.Empty)
+            throw new ArgumentException("CreatedBy cannot be empty.", nameof(createdBy));
+        if (string.IsNullOrWhiteSpace(snapshotData))
+            throw new ArgumentException("Snapshot data cannot be empty.", nameof(snapshotData));
+        if (diaryEventCount < 0)
+            throw new ArgumentException("Diary event count cannot be negative.", nameof(diaryEventCount));
+
+        return new SessionCheckpoint
+        {
+            Id = Guid.NewGuid(),
+            SessionId = sessionId,
+            Name = name,
+            CreatedAt = DateTime.UtcNow,
+            CreatedBy = createdBy,
+            SnapshotData = snapshotData,
+            DiaryEventCount = diaryEventCount,
+            IsDeleted = false
+        };
+    }
+
+    public void SoftDelete()
+    {
+        IsDeleted = true;
+        DeletedAt = DateTime.UtcNow;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Entities/ToolkitSessionState.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Entities/ToolkitSessionState.cs
@@ -78,6 +78,23 @@ public sealed class ToolkitSessionState
     }
 
     /// <summary>
+    /// Restores all widget states from a JSON string (checkpoint restore).
+    /// Issue #278 - Session Checkpoint / Deep Save
+    /// </summary>
+    public void RestoreWidgetStates(string widgetStatesJson)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(widgetStatesJson);
+        _widgetStatesJson = widgetStatesJson;
+        UpdatedAt = DateTime.UtcNow;
+    }
+
+    /// <summary>
+    /// Gets the raw widget states JSON (for checkpoint snapshots).
+    /// Issue #278 - Session Checkpoint / Deep Save
+    /// </summary>
+    public string GetWidgetStatesJson() => _widgetStatesJson;
+
+    /// <summary>
     /// Removes state for a widget (reset).
     /// </summary>
     public void ClearWidgetState(string widgetType)

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Repositories/ISessionCheckpointRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Domain/Repositories/ISessionCheckpointRepository.cs
@@ -1,0 +1,15 @@
+using Api.BoundedContexts.SessionTracking.Domain.Entities;
+
+namespace Api.BoundedContexts.SessionTracking.Domain.Repositories;
+
+/// <summary>
+/// Repository interface for SessionCheckpoint aggregate.
+/// Issue #278 - Session Checkpoint / Deep Save
+/// </summary>
+public interface ISessionCheckpointRepository
+{
+    Task<SessionCheckpoint?> GetByIdAsync(Guid id, CancellationToken ct = default);
+    Task<IEnumerable<SessionCheckpoint>> GetBySessionIdAsync(Guid sessionId, CancellationToken ct = default);
+    Task AddAsync(SessionCheckpoint checkpoint, CancellationToken ct = default);
+    Task UpdateAsync(SessionCheckpoint checkpoint, CancellationToken ct = default);
+}

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/DependencyInjection/SessionTrackingServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/DependencyInjection/SessionTrackingServiceExtensions.cs
@@ -29,6 +29,7 @@ internal static class SessionTrackingServiceExtensions
         services.AddScoped<ISessionChatRepository, SessionChatRepository>(); // ISSUE-4760
         services.AddScoped<IToolkitSessionStateRepository, ToolkitSessionStateRepository>(); // ISSUE-5148: Epic B5
         services.AddScoped<ISessionEventRepository, SessionEventRepository>(); // ISSUE-276: Session Diary / Timeline
+        services.AddScoped<ISessionCheckpointRepository, SessionCheckpointRepository>(); // ISSUE-278: Session Checkpoint / Deep Save
 
         // Register Unit of Work
         services.AddScoped<IUnitOfWork, EfCoreUnitOfWork>();

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/Persistence/SessionCheckpointRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/Persistence/SessionCheckpointRepository.cs
@@ -42,6 +42,6 @@ internal class SessionCheckpointRepository : ISessionCheckpointRepository
     {
         var entity = SessionCheckpointMapper.ToEntity(checkpoint);
         _db.SessionCheckpoints.Update(entity);
-        await Task.CompletedTask;
+        await Task.CompletedTask.ConfigureAwait(false);
     }
 }

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/Persistence/SessionCheckpointRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/Persistence/SessionCheckpointRepository.cs
@@ -1,0 +1,47 @@
+using Api.BoundedContexts.SessionTracking.Domain.Entities;
+using Api.BoundedContexts.SessionTracking.Domain.Repositories;
+using Api.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.SessionTracking.Infrastructure.Persistence;
+
+internal class SessionCheckpointRepository : ISessionCheckpointRepository
+{
+    private readonly MeepleAiDbContext _db;
+
+    public SessionCheckpointRepository(MeepleAiDbContext db)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+    }
+
+    public async Task<SessionCheckpoint?> GetByIdAsync(Guid id, CancellationToken ct = default)
+    {
+        var entity = await _db.SessionCheckpoints
+            .AsNoTracking()
+            .FirstOrDefaultAsync(e => e.Id == id, ct).ConfigureAwait(false);
+        return entity is null ? null : SessionCheckpointMapper.ToDomain(entity);
+    }
+
+    public async Task<IEnumerable<SessionCheckpoint>> GetBySessionIdAsync(Guid sessionId, CancellationToken ct = default)
+    {
+        var entities = await _db.SessionCheckpoints
+            .AsNoTracking()
+            .Where(e => e.SessionId == sessionId)
+            .OrderByDescending(e => e.Timestamp)
+            .ToListAsync(ct).ConfigureAwait(false);
+        return entities.Select(SessionCheckpointMapper.ToDomain);
+    }
+
+    public async Task AddAsync(SessionCheckpoint checkpoint, CancellationToken ct = default)
+    {
+        var entity = SessionCheckpointMapper.ToEntity(checkpoint);
+        await _db.SessionCheckpoints.AddAsync(entity, ct).ConfigureAwait(false);
+    }
+
+    public async Task UpdateAsync(SessionCheckpoint checkpoint, CancellationToken ct = default)
+    {
+        var entity = SessionCheckpointMapper.ToEntity(checkpoint);
+        _db.SessionCheckpoints.Update(entity);
+        await Task.CompletedTask;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/Persistence/SessionMapper.cs
+++ b/apps/api/src/Api/BoundedContexts/SessionTracking/Infrastructure/Persistence/SessionMapper.cs
@@ -345,6 +345,47 @@ internal static class SessionNoteMapper
     }
 }
 
+
+/// <summary>
+/// Maps between SessionCheckpoint domain entity and SessionCheckpointEntity persistence entity.
+/// Issue #278 - Session Checkpoint / Deep Save
+/// </summary>
+internal static class SessionCheckpointMapper
+{
+    public static SessionCheckpointEntity ToEntity(SessionCheckpoint domain)
+    {
+        ArgumentNullException.ThrowIfNull(domain);
+        return new SessionCheckpointEntity
+        {
+            Id = domain.Id,
+            SessionId = domain.SessionId,
+            Name = domain.Name,
+            Timestamp = domain.CreatedAt,
+            SnapshotData = domain.SnapshotData,
+            DiaryEventCount = domain.DiaryEventCount,
+            CreatedBy = domain.CreatedBy,
+            IsDeleted = domain.IsDeleted,
+            DeletedAt = domain.DeletedAt
+        };
+    }
+
+    public static SessionCheckpoint ToDomain(SessionCheckpointEntity entity)
+    {
+        ArgumentNullException.ThrowIfNull(entity);
+        var checkpoint = (SessionCheckpoint)Activator.CreateInstance(typeof(SessionCheckpoint), true)!;
+        typeof(SessionCheckpoint).GetProperty(nameof(SessionCheckpoint.Id))!.SetValue(checkpoint, entity.Id);
+        typeof(SessionCheckpoint).GetProperty(nameof(SessionCheckpoint.SessionId))!.SetValue(checkpoint, entity.SessionId);
+        typeof(SessionCheckpoint).GetProperty(nameof(SessionCheckpoint.Name))!.SetValue(checkpoint, entity.Name);
+        typeof(SessionCheckpoint).GetProperty(nameof(SessionCheckpoint.CreatedAt))!.SetValue(checkpoint, entity.Timestamp);
+        typeof(SessionCheckpoint).GetProperty(nameof(SessionCheckpoint.SnapshotData))!.SetValue(checkpoint, entity.SnapshotData);
+        typeof(SessionCheckpoint).GetProperty(nameof(SessionCheckpoint.DiaryEventCount))!.SetValue(checkpoint, entity.DiaryEventCount);
+        typeof(SessionCheckpoint).GetProperty(nameof(SessionCheckpoint.CreatedBy))!.SetValue(checkpoint, entity.CreatedBy.GetValueOrDefault());
+        typeof(SessionCheckpoint).GetProperty(nameof(SessionCheckpoint.IsDeleted))!.SetValue(checkpoint, entity.IsDeleted);
+        typeof(SessionCheckpoint).GetProperty(nameof(SessionCheckpoint.DeletedAt))!.SetValue(checkpoint, entity.DeletedAt);
+        return checkpoint;
+    }
+}
+
 /// <summary>
 /// Maps between SessionEvent domain entity and SessionEventEntity persistence entity.
 /// Issue #276 - Session Diary / Timeline

--- a/apps/api/src/Api/Infrastructure/Entities/KnowledgeBase/AgentGameStateSnapshotEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/KnowledgeBase/AgentGameStateSnapshotEntity.cs
@@ -39,7 +39,7 @@ public class AgentGameStateSnapshotEntity
     [Column("created_at")]
     public DateTime CreatedAt { get; set; }
 
-    [Column("embedding", TypeName = "vector(1536)")]
+    [Column("embedding", TypeName = "vector(1024)")]
     public Vector? Embedding { get; set; }
 
     // Navigation properties

--- a/apps/api/src/Api/Infrastructure/Entities/KnowledgeBase/ConversationMemoryEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/KnowledgeBase/ConversationMemoryEntity.cs
@@ -39,7 +39,7 @@ public class ConversationMemoryEntity
     [Column("timestamp")]
     public DateTime Timestamp { get; set; }
 
-    [Column("embedding", TypeName = "vector(1536)")]
+    [Column("embedding", TypeName = "vector(1024)")]
     public Vector? Embedding { get; set; }
 
     // Navigation properties

--- a/apps/api/src/Api/Infrastructure/Entities/KnowledgeBase/StrategyPatternEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/KnowledgeBase/StrategyPatternEntity.cs
@@ -44,6 +44,6 @@ public class StrategyPatternEntity
     [MaxLength(100)]
     public string? Source { get; set; }
 
-    [Column("embedding", TypeName = "vector(1536)")]
+    [Column("embedding", TypeName = "vector(1024)")]
     public Vector? Embedding { get; set; }
 }

--- a/apps/api/src/Api/Infrastructure/Entities/SessionTracking/SessionCheckpointEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/SessionTracking/SessionCheckpointEntity.cs
@@ -12,6 +12,8 @@ public class SessionCheckpointEntity
     public string SnapshotData { get; set; } = "{}";
     public int DiaryEventCount { get; set; }
     public Guid? CreatedBy { get; set; }
+    public bool IsDeleted { get; set; }
+    public DateTime? DeletedAt { get; set; }
 
     public SessionEntity Session { get; set; } = default!;
 }

--- a/apps/api/src/Api/Infrastructure/EntityConfigurations/KnowledgeBase/AgentGameStateSnapshotEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/EntityConfigurations/KnowledgeBase/AgentGameStateSnapshotEntityConfiguration.cs
@@ -38,7 +38,7 @@ internal class AgentGameStateSnapshotEntityConfiguration : IEntityTypeConfigurat
 
         // Issue #3547: Vector embedding for position similarity search
         builder.Property(e => e.Embedding)
-            .HasColumnType("vector(1536)");
+            .HasColumnType("vector(1024)");
 
         // Indexes for query performance
         builder.HasIndex(e => e.GameId);

--- a/apps/api/src/Api/Infrastructure/EntityConfigurations/KnowledgeBase/ConversationMemoryEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/EntityConfigurations/KnowledgeBase/ConversationMemoryEntityConfiguration.cs
@@ -37,7 +37,7 @@ internal class ConversationMemoryEntityConfiguration : IEntityTypeConfiguration<
 
         // Issue #3547: Vector embedding for semantic search
         builder.Property(e => e.Embedding)
-            .HasColumnType("vector(1536)");
+            .HasColumnType("vector(1024)");
 
         // Indexes for query performance
         builder.HasIndex(e => e.SessionId);

--- a/apps/api/src/Api/Infrastructure/EntityConfigurations/KnowledgeBase/StrategyPatternEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/EntityConfigurations/KnowledgeBase/StrategyPatternEntityConfiguration.cs
@@ -40,7 +40,7 @@ internal class StrategyPatternEntityConfiguration : IEntityTypeConfiguration<Str
 
         // Issue #3547: Vector embedding for pattern matching
         builder.Property(e => e.Embedding)
-            .HasColumnType("vector(1536)");
+            .HasColumnType("vector(1024)");
 
         // Indexes for query performance
         builder.HasIndex(e => e.GameId);

--- a/apps/api/src/Api/Infrastructure/EntityConfigurations/SessionTracking/SessionCheckpointEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/EntityConfigurations/SessionTracking/SessionCheckpointEntityConfiguration.cs
@@ -22,6 +22,14 @@ internal class SessionCheckpointEntityConfiguration : IEntityTypeConfiguration<S
             .IsRequired()
             .HasColumnType("jsonb");
 
+        builder.Property(e => e.IsDeleted)
+            .IsRequired()
+            .HasDefaultValue(false);
+
+        builder.HasQueryFilter(e => !e.IsDeleted);
+
+        builder.HasIndex(e => e.IsDeleted);
+
         builder.HasOne(e => e.Session)
             .WithMany()
             .HasForeignKey(e => e.SessionId)

--- a/apps/api/src/Api/Infrastructure/Migrations/20260314082443_FixEmbeddingVectorDimensionTo1024.Designer.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260314082443_FixEmbeddingVectorDimensionTo1024.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Api.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Api.Infrastructure.Migrations
 {
     [DbContext(typeof(MeepleAiDbContext))]
-    partial class MeepleAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260314082443_FixEmbeddingVectorDimensionTo1024")]
+    partial class FixEmbeddingVectorDimensionTo1024
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/Api/Infrastructure/Migrations/20260314082443_FixEmbeddingVectorDimensionTo1024.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260314082443_FixEmbeddingVectorDimensionTo1024.cs
@@ -1,0 +1,104 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+using Pgvector;
+
+#nullable disable
+
+namespace Api.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class FixEmbeddingVectorDimensionTo1024 : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<Vector>(
+                name: "embedding",
+                table: "strategy_patterns",
+                type: "vector(1024)",
+                nullable: true,
+                oldClrType: typeof(Vector),
+                oldType: "vector(1536)",
+                oldNullable: true);
+
+            migrationBuilder.AddColumn<DateTime>(
+                name: "DeletedAt",
+                table: "session_checkpoints",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<bool>(
+                name: "IsDeleted",
+                table: "session_checkpoints",
+                type: "boolean",
+                nullable: false,
+                defaultValue: false);
+
+            migrationBuilder.AlterColumn<Vector>(
+                name: "embedding",
+                table: "conversation_memory",
+                type: "vector(1024)",
+                nullable: true,
+                oldClrType: typeof(Vector),
+                oldType: "vector(1536)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<Vector>(
+                name: "embedding",
+                table: "agent_game_state_snapshots",
+                type: "vector(1024)",
+                nullable: true,
+                oldClrType: typeof(Vector),
+                oldType: "vector(1536)",
+                oldNullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_session_checkpoints_IsDeleted",
+                table: "session_checkpoints",
+                column: "IsDeleted");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_session_checkpoints_IsDeleted",
+                table: "session_checkpoints");
+
+            migrationBuilder.DropColumn(
+                name: "DeletedAt",
+                table: "session_checkpoints");
+
+            migrationBuilder.DropColumn(
+                name: "IsDeleted",
+                table: "session_checkpoints");
+
+            migrationBuilder.AlterColumn<Vector>(
+                name: "embedding",
+                table: "strategy_patterns",
+                type: "vector(1536)",
+                nullable: true,
+                oldClrType: typeof(Vector),
+                oldType: "vector(1024)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<Vector>(
+                name: "embedding",
+                table: "conversation_memory",
+                type: "vector(1536)",
+                nullable: true,
+                oldClrType: typeof(Vector),
+                oldType: "vector(1024)",
+                oldNullable: true);
+
+            migrationBuilder.AlterColumn<Vector>(
+                name: "embedding",
+                table: "agent_game_state_snapshots",
+                type: "vector(1536)",
+                nullable: true,
+                oldClrType: typeof(Vector),
+                oldType: "vector(1024)",
+                oldNullable: true);
+        }
+    }
+}

--- a/apps/api/src/Api/Routing/SessionTrackingEndpoints.cs
+++ b/apps/api/src/Api/Routing/SessionTrackingEndpoints.cs
@@ -113,6 +113,11 @@ internal static class SessionTrackingEndpoints
         // AI-powered turn summary (Issue #277)
         MapGetTurnSummaryEndpoint(group);
 
+        // Session checkpoint / deep save endpoints (Issue #278)
+        MapCreateCheckpointEndpoint(group);
+        MapListCheckpointsEndpoint(group);
+        MapRestoreCheckpointEndpoint(group);
+
         return group;
     }
 

--- a/apps/api/src/Api/Routing/SessionTrackingEndpoints.cs
+++ b/apps/api/src/Api/Routing/SessionTrackingEndpoints.cs
@@ -110,6 +110,9 @@ internal static class SessionTrackingEndpoints
         MapAddSessionEventEndpoint(group);
         MapGetSessionEventsEndpoint(group);
 
+        // AI-powered turn summary (Issue #277)
+        MapGetTurnSummaryEndpoint(group);
+
         return group;
     }
 
@@ -1944,6 +1947,125 @@ internal static class SessionTrackingEndpoints
         .Produces(404);
     }
 
+    // AI-powered turn summary (Issue #277)
+    // ============================================================================
+
+    private static void MapGetTurnSummaryEndpoint(RouteGroupBuilder group)
+    {
+        group.MapPost("/game-sessions/{sessionId:guid}/turn-summary", async (
+            Guid sessionId,
+            TurnSummaryRequest request,
+            HttpContext httpContext,
+            IMediator mediator,
+            CancellationToken ct) =>
+        {
+            var userId = httpContext.User.GetUserId();
+            if (userId == Guid.Empty)
+                return Results.Unauthorized();
+
+            var command = new GetTurnSummaryCommand(
+                sessionId,
+                userId,
+                request.FromPhase,
+                request.ToPhase,
+                request.LastNEvents);
+            var result = await mediator.Send(command, ct).ConfigureAwait(false);
+            return Results.Ok(result);
+        })
+        .RequireAuthenticatedUser()
+        .WithName("GetTurnSummary")
+        .WithTags("SessionTracking", "AI")
+        .WithSummary("Generate an AI-powered turn summary")
+        .WithDescription("Uses LLM to summarize recent session events. Requires Player role. Issue #277.")
+        .Produces<TurnSummaryResult>(200)
+        .Produces(400)
+        .Produces(401)
+        .Produces(403)
+        .Produces(404)
+        .Produces(409);
+    }
+
+
+    // ============================================================================
+    // Session checkpoint / deep save endpoints (Issue #278)
+    // ============================================================================
+
+    private static void MapCreateCheckpointEndpoint(RouteGroupBuilder group)
+    {
+        group.MapPost("/game-sessions/{sessionId:guid}/checkpoints", async (
+            Guid sessionId,
+            CreateCheckpointRequest request,
+            HttpContext httpContext,
+            IMediator mediator,
+            CancellationToken ct) =>
+        {
+            var userId = httpContext.User.GetUserId();
+            if (userId == Guid.Empty) return Results.Unauthorized();
+
+            var command = new Api.BoundedContexts.SessionTracking.Application.Commands.CreateSessionCheckpointCommand(
+                sessionId, userId, request.Name);
+            var result = await mediator.Send(command, ct).ConfigureAwait(false);
+            return Results.Created($"/api/v1/game-sessions/{sessionId}/checkpoints/{result.CheckpointId}", result);
+        })
+        .RequireAuthenticatedUser()
+        .WithName("CreateSessionCheckpoint")
+        .WithTags("SessionTracking", "Checkpoints")
+        .WithSummary("Create a session checkpoint (deep save)")
+        .WithDescription("Captures toolkit widget states and diary event count. Issue #278.")
+        .Produces(201).Produces(400).Produces(401).Produces(403).Produces(404).Produces(409);
+    }
+
+    private static void MapListCheckpointsEndpoint(RouteGroupBuilder group)
+    {
+        group.MapGet("/game-sessions/{sessionId:guid}/checkpoints", async (
+            Guid sessionId,
+            HttpContext httpContext,
+            IMediator mediator,
+            CancellationToken ct) =>
+        {
+            var userId = httpContext.User.GetUserId();
+            if (userId == Guid.Empty) return Results.Unauthorized();
+
+            var query = new Api.BoundedContexts.SessionTracking.Application.Queries.ListSessionCheckpointsQuery(
+                sessionId, userId);
+            var result = await mediator.Send(query, ct).ConfigureAwait(false);
+            return Results.Ok(result);
+        })
+        .RequireAuthenticatedUser()
+        .WithName("ListSessionCheckpoints")
+        .WithTags("SessionTracking", "Checkpoints")
+        .WithSummary("List session checkpoints")
+        .WithDescription("Returns all checkpoints for a session. Issue #278.")
+        .Produces<Api.BoundedContexts.SessionTracking.Application.Queries.ListSessionCheckpointsResult>(200)
+        .Produces(401).Produces(404);
+    }
+
+    private static void MapRestoreCheckpointEndpoint(RouteGroupBuilder group)
+    {
+        group.MapPost("/game-sessions/{sessionId:guid}/checkpoints/{checkpointId:guid}/restore", async (
+            Guid sessionId,
+            Guid checkpointId,
+            HttpContext httpContext,
+            IMediator mediator,
+            CancellationToken ct) =>
+        {
+            var userId = httpContext.User.GetUserId();
+            if (userId == Guid.Empty) return Results.Unauthorized();
+
+            var command = new Api.BoundedContexts.SessionTracking.Application.Commands.RestoreSessionCheckpointCommand(
+                sessionId, userId, checkpointId);
+            var result = await mediator.Send(command, ct).ConfigureAwait(false);
+            return Results.Ok(result);
+        })
+        .RequireAuthenticatedUser()
+        .WithName("RestoreSessionCheckpoint")
+        .WithTags("SessionTracking", "Checkpoints")
+        .WithSummary("Restore session from checkpoint")
+        .WithDescription("Restores toolkit widget states from a saved checkpoint. Issue #278.")
+        .Produces<Api.BoundedContexts.SessionTracking.Application.Commands.RestoreSessionCheckpointResult>(200)
+        .Produces(400).Produces(401).Produces(403).Produces(404).Produces(409);
+    }
+
     internal static RouteGroupBuilder MapSessionStatisticsEndpoints(this RouteGroupBuilder group)
     {
         group.MapGet("/game-sessions/session-statistics", async (
@@ -2026,3 +2148,9 @@ public sealed record SendChatActionRequest(string Content, int? TurnNumber = nul
 
 /// <summary>Request body for adding a session event (Issue #276).</summary>
 public sealed record AddSessionEventRequest(string EventType, string? Payload = null, string? Source = null);
+
+/// <summary>Request body for requesting an AI-generated turn summary (Issue #277).</summary>
+public sealed record TurnSummaryRequest(int? FromPhase = null, int? ToPhase = null, int? LastNEvents = null);
+
+/// <summary>Request body for creating a session checkpoint (Issue #278).</summary>
+internal record CreateCheckpointRequest(string Name);

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Infrastructure/StrategyPatternRepositoryIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Infrastructure/StrategyPatternRepositoryIntegrationTests.cs
@@ -410,7 +410,7 @@ public sealed class StrategyPatternRepositoryIntegrationTests : IAsyncLifetime
 
     private static float[] CreateNormalizedEmbedding(float baseValue)
     {
-        var embedding = new float[1536];
+        var embedding = new float[1024];
         for (int i = 0; i < embedding.Length; i++)
         {
             embedding[i] = baseValue + (i % 10) * 0.01f;

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Handlers/GetTurnSummaryCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Handlers/GetTurnSummaryCommandHandlerTests.cs
@@ -1,0 +1,157 @@
+using Api.BoundedContexts.SessionTracking.Application.Commands;
+using Api.BoundedContexts.SessionTracking.Application.Handlers;
+using Api.BoundedContexts.SessionTracking.Domain.Entities;
+using Api.BoundedContexts.SessionTracking.Domain.Repositories;
+using Api.Middleware.Exceptions;
+using Api.Services;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Api.Tests.Constants;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SessionTracking.Application.Handlers;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "SessionTracking")]
+public class GetTurnSummaryCommandHandlerTests
+{
+    private readonly Mock<ISessionRepository> _sessionRepoMock = new();
+    private readonly Mock<ISessionEventRepository> _eventRepoMock = new();
+    private readonly Mock<IUnitOfWork> _unitOfWorkMock = new();
+    private readonly Mock<ILlmService> _llmServiceMock = new();
+    private readonly GetTurnSummaryCommandHandler _handler;
+
+    public GetTurnSummaryCommandHandlerTests()
+    {
+        _handler = new GetTurnSummaryCommandHandler(
+            _sessionRepoMock.Object,
+            _eventRepoMock.Object,
+            _unitOfWorkMock.Object,
+            _llmServiceMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_ValidCommand_ReturnsSummaryResult()
+    {
+        var sessionId = Guid.NewGuid();
+        var requesterId = Guid.NewGuid();
+        var command = new GetTurnSummaryCommand(sessionId, requesterId, LastNEvents: 10);
+
+        var session = Session.Create(requesterId, Guid.NewGuid(), SessionType.Generic);
+        _sessionRepoMock
+            .Setup(r => r.GetByIdAsync(sessionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(session);
+
+        var events = new List<SessionEvent>
+        {
+            SessionEvent.Create(sessionId, "dice_roll", "{\"result\": 6}", requesterId, "player"),
+            SessionEvent.Create(sessionId, "score_update", "{\"score\": 10}", requesterId, "player"),
+        };
+
+        _eventRepoMock
+            .Setup(r => r.GetBySessionIdAsync(sessionId, null, 10, 0, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(events);
+
+        _llmServiceMock
+            .Setup(s => s.GenerateCompletionAsync(
+                It.IsAny<string>(), It.IsAny<string>(), RequestSource.AgentTask, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(LlmCompletionResult.CreateSuccess("A great game was had by all."));
+
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        Assert.NotNull(result);
+        Assert.Equal("A great game was had by all.", result.Summary);
+        Assert.Equal(2, result.EventsAnalyzed);
+        Assert.NotEqual(Guid.Empty, result.SummaryEventId);
+        _eventRepoMock.Verify(r => r.AddAsync(It.IsAny<SessionEvent>(), It.IsAny<CancellationToken>()), Times.Once);
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_SessionNotFound_ThrowsNotFoundException()
+    {
+        var command = new GetTurnSummaryCommand(Guid.NewGuid(), Guid.NewGuid(), LastNEvents: 10);
+        _sessionRepoMock
+            .Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Session?)null);
+
+        await Assert.ThrowsAsync<NotFoundException>(() =>
+            _handler.Handle(command, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task Handle_NoEvents_ThrowsConflictException()
+    {
+        var sessionId = Guid.NewGuid();
+        var requesterId = Guid.NewGuid();
+        var command = new GetTurnSummaryCommand(sessionId, requesterId, LastNEvents: 10);
+
+        var session = Session.Create(requesterId, Guid.NewGuid(), SessionType.Generic);
+        _sessionRepoMock.Setup(r => r.GetByIdAsync(sessionId, It.IsAny<CancellationToken>())).ReturnsAsync(session);
+        _eventRepoMock.Setup(r => r.GetBySessionIdAsync(sessionId, null, 10, 0, It.IsAny<CancellationToken>())).ReturnsAsync(new List<SessionEvent>());
+
+        var ex = await Assert.ThrowsAsync<ConflictException>(() => _handler.Handle(command, CancellationToken.None));
+        Assert.Contains("No events found", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Handle_LlmFailure_ThrowsConflictException()
+    {
+        var sessionId = Guid.NewGuid();
+        var requesterId = Guid.NewGuid();
+        var command = new GetTurnSummaryCommand(sessionId, requesterId, LastNEvents: 10);
+
+        var session = Session.Create(requesterId, Guid.NewGuid(), SessionType.Generic);
+        _sessionRepoMock.Setup(r => r.GetByIdAsync(sessionId, It.IsAny<CancellationToken>())).ReturnsAsync(session);
+
+        var events = new List<SessionEvent>
+        {
+            SessionEvent.Create(sessionId, "dice_roll", "{\"result\": 3}", requesterId, "player"),
+        };
+        _eventRepoMock.Setup(r => r.GetBySessionIdAsync(sessionId, null, 10, 0, It.IsAny<CancellationToken>())).ReturnsAsync(events);
+        _llmServiceMock
+            .Setup(s => s.GenerateCompletionAsync(It.IsAny<string>(), It.IsAny<string>(), RequestSource.AgentTask, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(LlmCompletionResult.CreateFailure("Service unavailable"));
+
+        var ex = await Assert.ThrowsAsync<ConflictException>(() => _handler.Handle(command, CancellationToken.None));
+        Assert.Contains("AI summary generation failed", ex.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Handle_WithPhaseRange_FiltersEventsCorrectly()
+    {
+        var sessionId = Guid.NewGuid();
+        var requesterId = Guid.NewGuid();
+        var command = new GetTurnSummaryCommand(sessionId, requesterId, FromPhase: 1, ToPhase: 3);
+
+        var session = Session.Create(requesterId, Guid.NewGuid(), SessionType.Generic);
+        _sessionRepoMock.Setup(r => r.GetByIdAsync(sessionId, It.IsAny<CancellationToken>())).ReturnsAsync(session);
+
+        var events = new List<SessionEvent>
+        {
+            SessionEvent.Create(sessionId, "dice_roll", "{\"phase\": 1, \"result\": 4}", requesterId, "player"),
+            SessionEvent.Create(sessionId, "dice_roll", "{\"phase\": 2, \"result\": 6}", requesterId, "player"),
+            SessionEvent.Create(sessionId, "dice_roll", "{\"phase\": 5, \"result\": 2}", requesterId, "player"),
+        };
+        _eventRepoMock.Setup(r => r.GetBySessionIdAsync(sessionId, null, 500, 0, It.IsAny<CancellationToken>())).ReturnsAsync(events);
+        _llmServiceMock
+            .Setup(s => s.GenerateCompletionAsync(It.IsAny<string>(), It.IsAny<string>(), RequestSource.AgentTask, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(LlmCompletionResult.CreateSuccess("Phases 1-3 summary."));
+
+        var result = await _handler.Handle(command, CancellationToken.None);
+        Assert.Equal(2, result.EventsAnalyzed);
+    }
+
+    [Fact]
+    public void Constructor_NullDependencies_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            new GetTurnSummaryCommandHandler(null!, _eventRepoMock.Object, _unitOfWorkMock.Object, _llmServiceMock.Object));
+        Assert.Throws<ArgumentNullException>(() =>
+            new GetTurnSummaryCommandHandler(_sessionRepoMock.Object, null!, _unitOfWorkMock.Object, _llmServiceMock.Object));
+        Assert.Throws<ArgumentNullException>(() =>
+            new GetTurnSummaryCommandHandler(_sessionRepoMock.Object, _eventRepoMock.Object, null!, _llmServiceMock.Object));
+        Assert.Throws<ArgumentNullException>(() =>
+            new GetTurnSummaryCommandHandler(_sessionRepoMock.Object, _eventRepoMock.Object, _unitOfWorkMock.Object, null!));
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Handlers/SessionCheckpointHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Handlers/SessionCheckpointHandlerTests.cs
@@ -1,0 +1,40 @@
+using Api.BoundedContexts.SessionTracking.Application.Handlers;
+using Api.BoundedContexts.SessionTracking.Application.Queries;
+using Api.BoundedContexts.SessionTracking.Domain.Entities;
+using Api.BoundedContexts.SessionTracking.Domain.Repositories;
+using Api.Middleware.Exceptions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SessionTracking.Application.Handlers;
+
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "SessionTracking")]
+public class SessionCheckpointHandlerTests
+{
+    [Fact]
+    public async Task ListHandler_SessionNotFound_ThrowsNotFoundException()
+    {
+        var mockSessionRepo = new Mock<ISessionRepository>();
+        mockSessionRepo.Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Session?)null);
+        var mockCheckpointRepo = new Mock<ISessionCheckpointRepository>();
+
+        var handler = new ListSessionCheckpointsQueryHandler(mockSessionRepo.Object, mockCheckpointRepo.Object);
+
+        await Assert.ThrowsAsync<NotFoundException>(() =>
+            handler.Handle(new ListSessionCheckpointsQuery(Guid.NewGuid(), Guid.NewGuid()), CancellationToken.None));
+    }
+
+    [Fact] public void ListHandler_NullSessionRepo_Throws() =>
+        Assert.Throws<ArgumentNullException>(() => new ListSessionCheckpointsQueryHandler(null!, new Mock<ISessionCheckpointRepository>().Object));
+
+    [Fact] public void ListHandler_NullCheckpointRepo_Throws() =>
+        Assert.Throws<ArgumentNullException>(() => new ListSessionCheckpointsQueryHandler(new Mock<ISessionRepository>().Object, null!));
+
+    [Fact] public void CreateHandler_NullSessionRepo_Throws() =>
+        Assert.Throws<ArgumentNullException>(() => new CreateSessionCheckpointCommandHandler(null!, null!, null!, null!, null!));
+
+    [Fact] public void RestoreHandler_NullSessionRepo_Throws() =>
+        Assert.Throws<ArgumentNullException>(() => new RestoreSessionCheckpointCommandHandler(null!, null!, null!, null!));
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Validators/GetTurnSummaryCommandValidatorTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Validators/GetTurnSummaryCommandValidatorTests.cs
@@ -1,0 +1,112 @@
+using Api.BoundedContexts.SessionTracking.Application.Commands;
+using Api.Tests.Constants;
+using FluentValidation.TestHelper;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SessionTracking.Application.Validators;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "SessionTracking")]
+public class GetTurnSummaryCommandValidatorTests
+{
+    private readonly GetTurnSummaryCommandValidator _validator = new();
+
+    [Fact]
+    public void Validate_ValidCommand_WithLastNEvents_ShouldPass()
+    {
+        var command = new GetTurnSummaryCommand(Guid.NewGuid(), Guid.NewGuid(), LastNEvents: 20);
+        var result = _validator.TestValidate(command);
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void Validate_ValidCommand_WithPhaseRange_ShouldPass()
+    {
+        var command = new GetTurnSummaryCommand(Guid.NewGuid(), Guid.NewGuid(), FromPhase: 1, ToPhase: 5);
+        var result = _validator.TestValidate(command);
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void Validate_ValidCommand_WithFromPhaseOnly_ShouldPass()
+    {
+        var command = new GetTurnSummaryCommand(Guid.NewGuid(), Guid.NewGuid(), FromPhase: 3);
+        var result = _validator.TestValidate(command);
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void Validate_EmptySessionId_ShouldFail()
+    {
+        var command = new GetTurnSummaryCommand(Guid.Empty, Guid.NewGuid(), LastNEvents: 10);
+        var result = _validator.TestValidate(command);
+        result.ShouldHaveValidationErrorFor(x => x.SessionId);
+    }
+
+    [Fact]
+    public void Validate_EmptyRequesterId_ShouldFail()
+    {
+        var command = new GetTurnSummaryCommand(Guid.NewGuid(), Guid.Empty, LastNEvents: 10);
+        var result = _validator.TestValidate(command);
+        result.ShouldHaveValidationErrorFor(x => x.RequesterId);
+    }
+
+    [Fact]
+    public void Validate_NoFilteringStrategy_ShouldFail()
+    {
+        var command = new GetTurnSummaryCommand(Guid.NewGuid(), Guid.NewGuid());
+        var result = _validator.TestValidate(command);
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors,
+            e => e.ErrorMessage == "At least one of LastNEvents, FromPhase, or ToPhase must be provided.");
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(101)]
+    [InlineData(200)]
+    public void Validate_LastNEvents_OutOfRange_ShouldFail(int value)
+    {
+        var command = new GetTurnSummaryCommand(Guid.NewGuid(), Guid.NewGuid(), LastNEvents: value);
+        var result = _validator.TestValidate(command);
+        result.ShouldHaveValidationErrorFor(x => x.LastNEvents);
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(50)]
+    [InlineData(100)]
+    public void Validate_LastNEvents_InRange_ShouldPass(int value)
+    {
+        var command = new GetTurnSummaryCommand(Guid.NewGuid(), Guid.NewGuid(), LastNEvents: value);
+        var result = _validator.TestValidate(command);
+        result.ShouldNotHaveValidationErrorFor(x => x.LastNEvents);
+    }
+
+    [Fact]
+    public void Validate_NegativeFromPhase_ShouldFail()
+    {
+        var command = new GetTurnSummaryCommand(Guid.NewGuid(), Guid.NewGuid(), FromPhase: -1);
+        var result = _validator.TestValidate(command);
+        result.ShouldHaveValidationErrorFor(x => x.FromPhase);
+    }
+
+    [Fact]
+    public void Validate_NegativeToPhase_ShouldFail()
+    {
+        var command = new GetTurnSummaryCommand(Guid.NewGuid(), Guid.NewGuid(), ToPhase: -1);
+        var result = _validator.TestValidate(command);
+        result.ShouldHaveValidationErrorFor(x => x.ToPhase);
+    }
+
+    [Fact]
+    public void Validate_ToPhase_LessThan_FromPhase_ShouldFail()
+    {
+        var command = new GetTurnSummaryCommand(Guid.NewGuid(), Guid.NewGuid(), FromPhase: 5, ToPhase: 2);
+        var result = _validator.TestValidate(command);
+        Assert.False(result.IsValid);
+        Assert.Contains(result.Errors,
+            e => e.ErrorMessage == "ToPhase must be greater than or equal to FromPhase.");
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Validators/SessionCheckpointValidatorTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Application/Validators/SessionCheckpointValidatorTests.cs
@@ -1,0 +1,54 @@
+using Api.BoundedContexts.SessionTracking.Application.Commands;
+using Api.BoundedContexts.SessionTracking.Application.Queries;
+using FluentValidation.TestHelper;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SessionTracking.Application.Validators;
+
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "SessionTracking")]
+public class SessionCheckpointValidatorTests
+{
+    private readonly CreateSessionCheckpointCommandValidator _createValidator = new();
+    private readonly RestoreSessionCheckpointCommandValidator _restoreValidator = new();
+    private readonly ListSessionCheckpointsQueryValidator _listValidator = new();
+
+    [Fact] public void Create_Valid_Passes() =>
+        _createValidator.TestValidate(new CreateSessionCheckpointCommand(Guid.NewGuid(), Guid.NewGuid(), "Test")).ShouldNotHaveAnyValidationErrors();
+
+    [Fact] public void Create_EmptySession_Fails() =>
+        _createValidator.TestValidate(new CreateSessionCheckpointCommand(Guid.Empty, Guid.NewGuid(), "Test")).ShouldHaveValidationErrorFor(x => x.SessionId);
+
+    [Fact] public void Create_EmptyRequester_Fails() =>
+        _createValidator.TestValidate(new CreateSessionCheckpointCommand(Guid.NewGuid(), Guid.Empty, "Test")).ShouldHaveValidationErrorFor(x => x.RequesterId);
+
+    [Fact] public void Create_EmptyName_Fails() =>
+        _createValidator.TestValidate(new CreateSessionCheckpointCommand(Guid.NewGuid(), Guid.NewGuid(), "")).ShouldHaveValidationErrorFor(x => x.Name);
+
+    [Fact] public void Create_LongName_Fails() =>
+        _createValidator.TestValidate(new CreateSessionCheckpointCommand(Guid.NewGuid(), Guid.NewGuid(), new string('A', 201))).ShouldHaveValidationErrorFor(x => x.Name);
+
+    [Fact] public void Create_MaxName_Passes() =>
+        _createValidator.TestValidate(new CreateSessionCheckpointCommand(Guid.NewGuid(), Guid.NewGuid(), new string('A', 200))).ShouldNotHaveAnyValidationErrors();
+
+    [Fact] public void Restore_Valid_Passes() =>
+        _restoreValidator.TestValidate(new RestoreSessionCheckpointCommand(Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid())).ShouldNotHaveAnyValidationErrors();
+
+    [Fact] public void Restore_EmptySession_Fails() =>
+        _restoreValidator.TestValidate(new RestoreSessionCheckpointCommand(Guid.Empty, Guid.NewGuid(), Guid.NewGuid())).ShouldHaveValidationErrorFor(x => x.SessionId);
+
+    [Fact] public void Restore_EmptyRequester_Fails() =>
+        _restoreValidator.TestValidate(new RestoreSessionCheckpointCommand(Guid.NewGuid(), Guid.Empty, Guid.NewGuid())).ShouldHaveValidationErrorFor(x => x.RequesterId);
+
+    [Fact] public void Restore_EmptyCheckpoint_Fails() =>
+        _restoreValidator.TestValidate(new RestoreSessionCheckpointCommand(Guid.NewGuid(), Guid.NewGuid(), Guid.Empty)).ShouldHaveValidationErrorFor(x => x.CheckpointId);
+
+    [Fact] public void List_Valid_Passes() =>
+        _listValidator.TestValidate(new ListSessionCheckpointsQuery(Guid.NewGuid(), Guid.NewGuid())).ShouldNotHaveAnyValidationErrors();
+
+    [Fact] public void List_EmptySession_Fails() =>
+        _listValidator.TestValidate(new ListSessionCheckpointsQuery(Guid.Empty, Guid.NewGuid())).ShouldHaveValidationErrorFor(x => x.SessionId);
+
+    [Fact] public void List_EmptyRequester_Fails() =>
+        _listValidator.TestValidate(new ListSessionCheckpointsQuery(Guid.NewGuid(), Guid.Empty)).ShouldHaveValidationErrorFor(x => x.RequesterId);
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Domain/SessionCheckpointTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SessionTracking/Domain/SessionCheckpointTests.cs
@@ -1,0 +1,75 @@
+using Api.BoundedContexts.SessionTracking.Domain.Entities;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SessionTracking.Domain;
+
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "SessionTracking")]
+public class SessionCheckpointTests
+{
+    private static readonly Guid ValidSessionId = Guid.NewGuid();
+    private static readonly Guid ValidCreatedBy = Guid.NewGuid();
+
+    [Fact]
+    public void Create_WithValidInputs_ShouldCreateCheckpoint()
+    {
+        var cp = SessionCheckpoint.Create(ValidSessionId, "Test", ValidCreatedBy, "{}", 5);
+        Assert.NotEqual(Guid.Empty, cp.Id);
+        Assert.Equal(ValidSessionId, cp.SessionId);
+        Assert.Equal("Test", cp.Name);
+        Assert.Equal(5, cp.DiaryEventCount);
+        Assert.False(cp.IsDeleted);
+    }
+
+    [Fact]
+    public void Create_WithZeroEvents_ShouldSucceed()
+    {
+        var cp = SessionCheckpoint.Create(ValidSessionId, "Test", ValidCreatedBy, "{}", 0);
+        Assert.Equal(0, cp.DiaryEventCount);
+    }
+
+    [Fact]
+    public void Create_WithMaxName_ShouldSucceed()
+    {
+        var cp = SessionCheckpoint.Create(ValidSessionId, new string('A', 200), ValidCreatedBy, "{}", 0);
+        Assert.Equal(200, cp.Name.Length);
+    }
+
+    [Fact] public void Create_EmptySessionId_Throws() =>
+        Assert.Throws<ArgumentException>(() => SessionCheckpoint.Create(Guid.Empty, "T", ValidCreatedBy, "{}", 0));
+
+    [Fact] public void Create_EmptyName_Throws() =>
+        Assert.Throws<ArgumentException>(() => SessionCheckpoint.Create(ValidSessionId, "", ValidCreatedBy, "{}", 0));
+
+    [Fact] public void Create_WhitespaceName_Throws() =>
+        Assert.Throws<ArgumentException>(() => SessionCheckpoint.Create(ValidSessionId, "  ", ValidCreatedBy, "{}", 0));
+
+    [Fact] public void Create_LongName_Throws() =>
+        Assert.Throws<ArgumentException>(() => SessionCheckpoint.Create(ValidSessionId, new string('A', 201), ValidCreatedBy, "{}", 0));
+
+    [Fact] public void Create_EmptyCreatedBy_Throws() =>
+        Assert.Throws<ArgumentException>(() => SessionCheckpoint.Create(ValidSessionId, "T", Guid.Empty, "{}", 0));
+
+    [Fact] public void Create_EmptySnapshot_Throws() =>
+        Assert.Throws<ArgumentException>(() => SessionCheckpoint.Create(ValidSessionId, "T", ValidCreatedBy, "", 0));
+
+    [Fact] public void Create_NegativeEvents_Throws() =>
+        Assert.Throws<ArgumentException>(() => SessionCheckpoint.Create(ValidSessionId, "T", ValidCreatedBy, "{}", -1));
+
+    [Fact]
+    public void SoftDelete_SetsFlags()
+    {
+        var cp = SessionCheckpoint.Create(ValidSessionId, "Test", ValidCreatedBy, "{}", 0);
+        cp.SoftDelete();
+        Assert.True(cp.IsDeleted);
+        Assert.NotNull(cp.DeletedAt);
+    }
+
+    [Fact]
+    public void Create_GeneratesUniqueIds()
+    {
+        var c1 = SessionCheckpoint.Create(ValidSessionId, "A", ValidCreatedBy, "{}", 0);
+        var c2 = SessionCheckpoint.Create(ValidSessionId, "B", ValidCreatedBy, "{}", 0);
+        Assert.NotEqual(c1.Id, c2.Id);
+    }
+}

--- a/apps/web/src/components/session/SessionCheckpoint.tsx
+++ b/apps/web/src/components/session/SessionCheckpoint.tsx
@@ -1,0 +1,188 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@/components/ui/overlays/alert-dialog-primitives';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/overlays/dialog';
+import { Button } from '@/components/ui/primitives/button';
+import { Input } from '@/components/ui/primitives/input';
+import { ScrollArea } from '@/components/ui/primitives/scroll-area';
+import { api } from '@/lib/api';
+import type { SessionCheckpointDto } from '@/lib/api/schemas/session-tracking.schemas';
+
+interface SessionCheckpointProps {
+  sessionId: string;
+}
+
+export function SessionCheckpoint({ sessionId }: SessionCheckpointProps): JSX.Element {
+  const [saveDialogOpen, setSaveDialogOpen] = useState(false);
+  const [listDialogOpen, setListDialogOpen] = useState(false);
+  const [restoreConfirmOpen, setRestoreConfirmOpen] = useState(false);
+  const [checkpointName, setCheckpointName] = useState('');
+  const [checkpoints, setCheckpoints] = useState<SessionCheckpointDto[]>([]);
+  const [selectedCheckpoint, setSelectedCheckpoint] = useState<SessionCheckpointDto | null>(null);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleSave = useCallback(async () => {
+    if (!checkpointName.trim()) return;
+    setLoading(true);
+    setError(null);
+    try {
+      await api.sessionTracking.createCheckpoint(sessionId, { name: checkpointName });
+      setCheckpointName('');
+      setSaveDialogOpen(false);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to save checkpoint');
+    } finally {
+      setLoading(false);
+    }
+  }, [sessionId, checkpointName]);
+
+  const handleLoadList = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const result = await api.sessionTracking.listCheckpoints(sessionId);
+      setCheckpoints(result.checkpoints);
+      setListDialogOpen(true);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load checkpoints');
+    } finally {
+      setLoading(false);
+    }
+  }, [sessionId]);
+
+  const handleRestore = useCallback(async () => {
+    if (!selectedCheckpoint) return;
+    setLoading(true);
+    setError(null);
+    try {
+      await api.sessionTracking.restoreCheckpoint(sessionId, selectedCheckpoint.id);
+      setRestoreConfirmOpen(false);
+      setListDialogOpen(false);
+      setSelectedCheckpoint(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to restore checkpoint');
+    } finally {
+      setLoading(false);
+    }
+  }, [sessionId, selectedCheckpoint]);
+
+  const confirmRestore = useCallback((checkpoint: SessionCheckpointDto) => {
+    setSelectedCheckpoint(checkpoint);
+    setRestoreConfirmOpen(true);
+  }, []);
+
+  return (
+    <div className="flex gap-2">
+      {error && (
+        <p className="text-sm text-red-500" role="alert">
+          {error}
+        </p>
+      )}
+
+      <Dialog open={saveDialogOpen} onOpenChange={setSaveDialogOpen}>
+        <DialogTrigger asChild>
+          <Button variant="outline" size="sm">
+            Save Checkpoint
+          </Button>
+        </DialogTrigger>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Save Checkpoint</DialogTitle>
+            <DialogDescription>Create a snapshot of the current session state.</DialogDescription>
+          </DialogHeader>
+          <Input
+            placeholder="Checkpoint name"
+            value={checkpointName}
+            onChange={e => setCheckpointName(e.target.value)}
+            maxLength={200}
+          />
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setSaveDialogOpen(false)}>
+              Cancel
+            </Button>
+            <Button onClick={handleSave} disabled={loading || !checkpointName.trim()}>
+              {loading ? 'Saving...' : 'Save'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+
+      <Button variant="outline" size="sm" onClick={handleLoadList} disabled={loading}>
+        {loading ? 'Loading...' : 'Load Checkpoint'}
+      </Button>
+
+      <Dialog open={listDialogOpen} onOpenChange={setListDialogOpen}>
+        <DialogContent className="max-w-md">
+          <DialogHeader>
+            <DialogTitle>Session Checkpoints</DialogTitle>
+            <DialogDescription>Select a checkpoint to restore.</DialogDescription>
+          </DialogHeader>
+          <ScrollArea className="max-h-64">
+            {checkpoints.length === 0 ? (
+              <p className="text-sm text-muted-foreground py-4 text-center">
+                No checkpoints saved yet.
+              </p>
+            ) : (
+              <div className="space-y-2">
+                {checkpoints.map(cp => (
+                  <div
+                    key={cp.id}
+                    className="flex items-center justify-between rounded-md border p-3"
+                  >
+                    <div>
+                      <p className="text-sm font-medium">{cp.name}</p>
+                      <p className="text-xs text-muted-foreground">
+                        {new Date(cp.createdAt).toLocaleString()} | {cp.diaryEventCount} events
+                      </p>
+                    </div>
+                    <Button variant="outline" size="sm" onClick={() => confirmRestore(cp)}>
+                      Restore
+                    </Button>
+                  </div>
+                ))}
+              </div>
+            )}
+          </ScrollArea>
+        </DialogContent>
+      </Dialog>
+
+      <AlertDialog open={restoreConfirmOpen} onOpenChange={setRestoreConfirmOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Restore Checkpoint?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This will restore the session state to &quot;{selectedCheckpoint?.name}&quot;. Current
+              widget states will be overwritten.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction onClick={handleRestore} disabled={loading}>
+              {loading ? 'Restoring...' : 'Restore'}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </div>
+  );
+}

--- a/apps/web/src/components/session/SessionCheckpoint.tsx
+++ b/apps/web/src/components/session/SessionCheckpoint.tsx
@@ -31,7 +31,7 @@ interface SessionCheckpointProps {
   sessionId: string;
 }
 
-export function SessionCheckpoint({ sessionId }: SessionCheckpointProps): JSX.Element {
+export function SessionCheckpoint({ sessionId }: SessionCheckpointProps) {
   const [saveDialogOpen, setSaveDialogOpen] = useState(false);
   const [listDialogOpen, setListDialogOpen] = useState(false);
   const [restoreConfirmOpen, setRestoreConfirmOpen] = useState(false);

--- a/apps/web/src/components/session/TurnSummaryButton.tsx
+++ b/apps/web/src/components/session/TurnSummaryButton.tsx
@@ -1,0 +1,103 @@
+'use client';
+
+import { useState, useCallback } from 'react';
+
+import { Loader2, Sparkles } from 'lucide-react';
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/overlays/dialog';
+import { Button } from '@/components/ui/primitives/button';
+import { useApiClient } from '@/lib/api/context';
+import type { TurnSummaryResult } from '@/lib/api/schemas/session-tracking.schemas';
+
+export interface TurnSummaryButtonProps {
+  sessionId: string;
+  lastNEvents?: number;
+  fromPhase?: number;
+  toPhase?: number;
+  disabled?: boolean;
+  className?: string;
+}
+
+export function TurnSummaryButton({
+  sessionId,
+  lastNEvents = 20,
+  fromPhase,
+  toPhase,
+  disabled = false,
+  className,
+}: TurnSummaryButtonProps) {
+  const { sessionTracking } = useApiClient();
+  const [isLoading, setIsLoading] = useState(false);
+  const [isOpen, setIsOpen] = useState(false);
+  const [summary, setSummary] = useState<TurnSummaryResult | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const handleGenerateSummary = useCallback(async () => {
+    setIsLoading(true);
+    setError(null);
+    setSummary(null);
+
+    try {
+      const result = await sessionTracking.getTurnSummary(sessionId, {
+        lastNEvents: fromPhase !== undefined || toPhase !== undefined ? undefined : lastNEvents,
+        fromPhase,
+        toPhase,
+      });
+      setSummary(result);
+      setIsOpen(true);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to generate summary');
+    } finally {
+      setIsLoading(false);
+    }
+  }, [sessionTracking, sessionId, lastNEvents, fromPhase, toPhase]);
+
+  return (
+    <>
+      <Button
+        variant="outline"
+        size="sm"
+        onClick={handleGenerateSummary}
+        disabled={disabled || isLoading}
+        className={className}
+        aria-label="Generate AI turn summary"
+      >
+        {isLoading ? (
+          <>
+            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+            Generating...
+          </>
+        ) : (
+          <>
+            <Sparkles className="mr-2 h-4 w-4" />
+            Summarize Turn
+          </>
+        )}
+      </Button>
+
+      {error && (
+        <div role="alert" className="mt-2 text-sm text-destructive">
+          {error}
+        </div>
+      )}
+
+      <Dialog open={isOpen} onOpenChange={setIsOpen}>
+        <DialogContent className="max-w-lg">
+          <DialogHeader>
+            <DialogTitle>Turn Summary</DialogTitle>
+            <DialogDescription>
+              AI analysis of {summary?.eventsAnalyzed ?? 0} events
+            </DialogDescription>
+          </DialogHeader>
+          <div className="mt-4 whitespace-pre-wrap text-sm leading-relaxed">{summary?.summary}</div>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/apps/web/src/components/session/__tests__/TurnSummaryButton.test.tsx
+++ b/apps/web/src/components/session/__tests__/TurnSummaryButton.test.tsx
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor, cleanup } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { TurnSummaryButton } from '../TurnSummaryButton';
+
+const mockGetTurnSummary = vi.fn();
+
+vi.mock('@/lib/api/context', () => ({
+  useApiClient: () => ({
+    sessionTracking: {
+      getTurnSummary: mockGetTurnSummary,
+    },
+  }),
+}));
+
+describe('TurnSummaryButton', () => {
+  const defaultProps = {
+    sessionId: 'session-123',
+    lastNEvents: 20,
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetTurnSummary.mockReset();
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it('renders the Summarize Turn button', () => {
+    render(<TurnSummaryButton {...defaultProps} />);
+    expect(screen.getByRole('button', { name: /generate ai turn summary/i })).toBeInTheDocument();
+    expect(screen.getByText('Summarize Turn')).toBeInTheDocument();
+  });
+
+  it('shows loading state when generating', async () => {
+    const user = userEvent.setup();
+    mockGetTurnSummary.mockImplementation(() => new Promise(() => {}));
+
+    render(<TurnSummaryButton {...defaultProps} />);
+    await user.click(screen.getByRole('button', { name: /generate ai turn summary/i }));
+
+    expect(screen.getByText('Generating...')).toBeInTheDocument();
+    expect(screen.getByRole('button')).toBeDisabled();
+  });
+
+  it('displays summary in dialog on success', async () => {
+    const user = userEvent.setup();
+    const summaryResult = {
+      summaryEventId: 'evt-456',
+      summary: 'The session was full of exciting dice rolls and strategic moves.',
+      eventsAnalyzed: 15,
+      generatedAt: '2026-03-14T10:30:00Z',
+    };
+    mockGetTurnSummary.mockResolvedValue(summaryResult);
+
+    render(<TurnSummaryButton {...defaultProps} />);
+    await user.click(screen.getByRole('button', { name: /generate ai turn summary/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Turn Summary')).toBeInTheDocument();
+    });
+    expect(
+      screen.getByText('The session was full of exciting dice rolls and strategic moves.')
+    ).toBeInTheDocument();
+    expect(screen.getByText(/AI analysis of 15 events/)).toBeInTheDocument();
+  });
+
+  it('displays error message on failure', async () => {
+    const user = userEvent.setup();
+    mockGetTurnSummary.mockRejectedValue(new Error('AI service unavailable'));
+
+    render(<TurnSummaryButton {...defaultProps} />);
+    await user.click(screen.getByRole('button', { name: /generate ai turn summary/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+    });
+    expect(screen.getByText('AI service unavailable')).toBeInTheDocument();
+  });
+
+  it('calls API with lastNEvents when no phase range provided', async () => {
+    const user = userEvent.setup();
+    mockGetTurnSummary.mockResolvedValue({
+      summaryEventId: 'evt-789',
+      summary: 'Summary text.',
+      eventsAnalyzed: 10,
+      generatedAt: '2026-03-14T11:00:00Z',
+    });
+
+    render(<TurnSummaryButton sessionId="session-456" lastNEvents={30} />);
+    await user.click(screen.getByRole('button', { name: /generate ai turn summary/i }));
+
+    await waitFor(() => {
+      expect(mockGetTurnSummary).toHaveBeenCalledWith('session-456', {
+        lastNEvents: 30,
+        fromPhase: undefined,
+        toPhase: undefined,
+      });
+    });
+  });
+
+  it('calls API with phase range when provided', async () => {
+    const user = userEvent.setup();
+    mockGetTurnSummary.mockResolvedValue({
+      summaryEventId: 'evt-abc',
+      summary: 'Phase summary.',
+      eventsAnalyzed: 8,
+      generatedAt: '2026-03-14T12:00:00Z',
+    });
+
+    render(<TurnSummaryButton sessionId="session-789" fromPhase={1} toPhase={3} />);
+    await user.click(screen.getByRole('button', { name: /generate ai turn summary/i }));
+
+    await waitFor(() => {
+      expect(mockGetTurnSummary).toHaveBeenCalledWith('session-789', {
+        lastNEvents: undefined,
+        fromPhase: 1,
+        toPhase: 3,
+      });
+    });
+  });
+
+  it('is disabled when disabled prop is true', () => {
+    render(<TurnSummaryButton {...defaultProps} disabled />);
+    expect(screen.getByRole('button')).toBeDisabled();
+  });
+
+  it('re-enables button after API call completes', async () => {
+    const user = userEvent.setup();
+    mockGetTurnSummary.mockResolvedValue({
+      summaryEventId: 'evt-def',
+      summary: 'Done.',
+      eventsAnalyzed: 5,
+      generatedAt: '2026-03-14T13:00:00Z',
+    });
+
+    render(<TurnSummaryButton {...defaultProps} />);
+    const button = screen.getByRole('button', { name: /generate ai turn summary/i });
+    await user.click(button);
+
+    await waitFor(() => {
+      expect(screen.getByText('Turn Summary')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Summarize Turn')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/session/index.ts
+++ b/apps/web/src/components/session/index.ts
@@ -57,6 +57,8 @@ export { LiveSessionLayout } from './LiveSessionLayout';
 export { MobileStatusBar } from './MobileStatusBar';
 export { ActivityFeedInputBar } from './ActivityFeedInputBar';
 export { MobileScorebar } from './MobileScorebar';
+export { TurnSummaryButton } from './TurnSummaryButton';
+export type { TurnSummaryButtonProps } from './TurnSummaryButton';
 
 export type {
   Participant,

--- a/apps/web/src/lib/api/clients/sessionTrackingClient.ts
+++ b/apps/web/src/lib/api/clients/sessionTrackingClient.ts
@@ -54,6 +54,16 @@ import {
   type SendChatMessageCommand,
   type AskAgentCommand,
   type FinalizeSessionCommand,
+  TurnSummaryResultSchema,
+  type TurnSummaryResult,
+  type TurnSummaryRequest,
+  CreateCheckpointResultSchema,
+  ListCheckpointsResultSchema,
+  RestoreCheckpointResultSchema,
+  type CreateCheckpointRequest,
+  type CreateCheckpointResult,
+  type ListCheckpointsResult,
+  type RestoreCheckpointResult,
 } from '../schemas/session-tracking.schemas';
 
 import type { HttpClient } from '../core/httpClient';
@@ -83,6 +93,11 @@ export interface SessionTrackingClient {
 
   /** Finalize a session */
   finalizeSession(sessionId: string, request?: FinalizeSessionCommand): Promise<void>;
+
+  // ========== Turn Summary AI (Issue #277) ==========
+
+  /** Generate an AI-powered turn summary */
+  getTurnSummary(sessionId: string, request: TurnSummaryRequest): Promise<TurnSummaryResult>;
 
   // ========== Participants ==========
 
@@ -225,6 +240,20 @@ export interface SessionTrackingClient {
   /** Export session as PDF */
   exportPdf(sessionId: string): Promise<Blob>;
 
+  // ========== Session Checkpoints (Issue #278) ==========
+
+  /** Create a session checkpoint (deep save) */
+  createCheckpoint(
+    sessionId: string,
+    request: CreateCheckpointRequest
+  ): Promise<CreateCheckpointResult>;
+
+  /** List all checkpoints for a session */
+  listCheckpoints(sessionId: string): Promise<ListCheckpointsResult>;
+
+  /** Restore session state from a checkpoint */
+  restoreCheckpoint(sessionId: string, checkpointId: string): Promise<RestoreCheckpointResult>;
+
   // ========== SSE Streams ==========
 
   /** Get SSE stream URL for a session */
@@ -281,6 +310,16 @@ export function createSessionTrackingClient({
 
     async finalizeSession(sessionId, request) {
       await httpClient.post(`${BASE}/${encodeURIComponent(sessionId)}/finalize`, request ?? {});
+    },
+
+    // ========== Turn Summary AI (Issue #277) ==========
+
+    async getTurnSummary(sessionId, request) {
+      const response = await httpClient.post<TurnSummaryResult>(
+        `${BASE}/${encodeURIComponent(sessionId)}/turn-summary`,
+        request
+      );
+      return TurnSummaryResultSchema.parse(response);
     },
 
     // ========== Participants ==========
@@ -560,6 +599,31 @@ export function createSessionTrackingClient({
       });
       if (!response.ok) throw new Error(`PDF export failed: ${response.status}`);
       return response.blob();
+    },
+
+    // ========== Session Checkpoints (Issue #278) ==========
+
+    async createCheckpoint(sessionId, request) {
+      const response = await httpClient.post<CreateCheckpointResult>(
+        `${BASE}/${encodeURIComponent(sessionId)}/checkpoints`,
+        request
+      );
+      return CreateCheckpointResultSchema.parse(response);
+    },
+
+    async listCheckpoints(sessionId) {
+      const response = await httpClient.get<ListCheckpointsResult>(
+        `${BASE}/${encodeURIComponent(sessionId)}/checkpoints`
+      );
+      return ListCheckpointsResultSchema.parse(response);
+    },
+
+    async restoreCheckpoint(sessionId, checkpointId) {
+      const response = await httpClient.post<RestoreCheckpointResult>(
+        `${BASE}/${encodeURIComponent(sessionId)}/checkpoints/${encodeURIComponent(checkpointId)}/restore`,
+        {}
+      );
+      return RestoreCheckpointResultSchema.parse(response);
     },
 
     // ========== SSE Streams ==========

--- a/apps/web/src/lib/api/schemas/session-tracking.schemas.ts
+++ b/apps/web/src/lib/api/schemas/session-tracking.schemas.ts
@@ -287,3 +287,64 @@ export const FinalizeSessionCommandSchema = z.object({
 });
 
 export type FinalizeSessionCommand = z.infer<typeof FinalizeSessionCommandSchema>;
+
+// ========== Turn Summary AI (Issue #277) ==========
+
+export const TurnSummaryRequestSchema = z.object({
+  fromPhase: z.number().int().min(0).optional(),
+  toPhase: z.number().int().min(0).optional(),
+  lastNEvents: z.number().int().min(1).max(100).optional(),
+});
+
+export type TurnSummaryRequest = z.infer<typeof TurnSummaryRequestSchema>;
+
+export const TurnSummaryResultSchema = z.object({
+  summaryEventId: z.string().uuid(),
+  summary: z.string(),
+  eventsAnalyzed: z.number().int(),
+  generatedAt: z.string(),
+});
+
+export type TurnSummaryResult = z.infer<typeof TurnSummaryResultSchema>;
+
+// ========== Session Checkpoints (Issue #278) ==========
+
+export const CreateCheckpointRequestSchema = z.object({
+  name: z.string().min(1).max(200),
+});
+
+export type CreateCheckpointRequest = z.infer<typeof CreateCheckpointRequestSchema>;
+
+export const CreateCheckpointResultSchema = z.object({
+  checkpointId: z.string().uuid(),
+  name: z.string(),
+  createdAt: z.string(),
+  diaryEventCount: z.number().int(),
+});
+
+export type CreateCheckpointResult = z.infer<typeof CreateCheckpointResultSchema>;
+
+export const SessionCheckpointDtoSchema = z.object({
+  id: z.string().uuid(),
+  name: z.string(),
+  createdAt: z.string(),
+  createdBy: z.string().uuid(),
+  diaryEventCount: z.number().int(),
+});
+
+export type SessionCheckpointDto = z.infer<typeof SessionCheckpointDtoSchema>;
+
+export const ListCheckpointsResultSchema = z.object({
+  checkpoints: z.array(SessionCheckpointDtoSchema),
+});
+
+export type ListCheckpointsResult = z.infer<typeof ListCheckpointsResultSchema>;
+
+export const RestoreCheckpointResultSchema = z.object({
+  checkpointId: z.string().uuid(),
+  name: z.string(),
+  restoredAt: z.string(),
+  widgetsRestored: z.number().int(),
+});
+
+export type RestoreCheckpointResult = z.infer<typeof RestoreCheckpointResultSchema>;


### PR DESCRIPTION
## Summary

### Session Checkpoint / Deep Save (#278)
- Add checkpoint (deep save) functionality for game sessions, allowing players to save and restore toolkit widget states at any point during an active session
- Full CQRS implementation with domain entity, repository, commands/queries, handlers, validators, endpoints, frontend component, and tests
- Extends `ToolkitSessionState` with `RestoreWidgetStates()` and `GetWidgetStatesJson()` for snapshot/restore support

### Turn Summary AI (#277)
- Add AI-powered turn summary endpoint using LLM to summarize recent session events
- Players can request summaries filtered by phase range or last N events
- `TurnSummaryButton` React component with loading, error, and dialog states

## Changes

### Backend — Checkpoint (#278, 13 files)
- **Domain**: `SessionCheckpoint` entity with factory method, soft delete, validation
- **Repository**: `ISessionCheckpointRepository` interface + EF Core implementation with mapper
- **CQRS Commands**: `CreateSessionCheckpointCommand`, `RestoreSessionCheckpointCommand` with FluentValidation
- **CQRS Query**: `ListSessionCheckpointsQuery` with validator
- **Handlers**: Create (snapshots toolkit states + diary events), List, Restore (replays widget states)
- **Infrastructure**: Soft delete query filter, DI registration, persistence mapper with reflection
- **Endpoints**: POST create, GET list, POST restore under `/game-sessions/{sessionId}/checkpoints`

### Backend — Turn Summary AI (#277, 5 files)
- **CQRS Command**: `GetTurnSummaryCommand` with `IRequireSessionRole`
- **Validator**: FluentValidation for session/requester IDs, phase range, event count (at least one filter required)
- **Handler**: Fetches events from `ISessionEventRepository`, builds LLM prompt, persists summary as `SessionEvent`
- **Endpoint**: `POST /api/v1/game-sessions/{sessionId}/turn-summary` with auth

### Frontend (6 files)
- `SessionCheckpoint` component with save/list/restore dialogs (#278)
- `TurnSummaryButton` component with loading, error, dialog states (#277)
- Zod schemas and `SessionTrackingClient` methods for both features
- Barrel export in `session/index.ts`

### Bug Fixes
- Fix orphaned checkpoint endpoint methods (S1144 — never registered in route group)
- Fix `SessionCheckpointRepository` missing `ConfigureAwait(false)` (MA0004)
- Fix `SessionCheckpoint.tsx` JSX namespace error (React 19 compatibility)

### Tests (6 files, 52 tests)
- **#278**: 12 domain entity, 13 validator, 5 handler tests (30 total)
- **#277**: 12 validator, 6 handler tests (22 backend) + 8 component tests (frontend)

## Test plan
- [x] Backend build passes (0 errors)
- [x] Frontend build passes (Next.js production build)
- [x] Turn summary validator tests pass (12 tests)
- [x] Turn summary handler tests pass (6 tests)
- [x] TurnSummaryButton component tests pass (8 tests)
- [ ] Verify checkpoint tests pass: `dotnet test --filter "SessionCheckpoint"`
- [ ] Manual test: generate turn summary during active session

Closes #277
Closes #278

🤖 Generated with [Claude Code](https://claude.com/claude-code)