### PR TITLE
fix(ci): reduce MaxPoolSize for CI service containers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -525,6 +525,7 @@ jobs:
           REDIS_URL: "localhost:6379"
           QDRANT_URL: "http://localhost:6333"
           OPENROUTER_API_KEY: "test-key-for-ci-placeholder"
+          LOCAL_EMBEDDING_URL: "http://localhost:8000"  # Override default docker hostname
 
       - name: Wait for API Health
         working-directory: .

--- a/apps/api/tests/Api.Tests/Infrastructure/IntegrationTestBase.cs
+++ b/apps/api/tests/Api.Tests/Infrastructure/IntegrationTestBase.cs
@@ -55,7 +55,7 @@ public abstract class IntegrationTestBase<TRepository> : IAsyncLifetime
                 KeepAlive = 10,
                 Pooling = true,
                 MinPoolSize = 1,
-                MaxPoolSize = 5,
+                MaxPoolSize = 2, // CI service containers have max_connections=100 (default)
                 ConnectionIdleLifetime = 30,
                 ConnectionPruningInterval = 5,
                 Timeout = 30,

--- a/apps/api/tests/Api.Tests/Infrastructure/SharedTestcontainersFixture.cs
+++ b/apps/api/tests/Api.Tests/Infrastructure/SharedTestcontainersFixture.cs
@@ -741,7 +741,12 @@ public sealed class SharedTestcontainersFixture : IAsyncLifetime
                 builder.Database = databaseName;
                 builder.Timeout = 60; // Increase timeout to 60s for long-running integration tests
                 builder.CommandTimeout = 60;
-                builder.MaxPoolSize = 5; // CI: Keep pool small — 4 threads × N test classes × 5 pool ≤ 500 max_connections
+                // CI service containers use default max_connections=100 (can't be changed),
+                // while testcontainers set max_connections=500.
+                // MaxPoolSize=2 keeps us within 100: 4 threads × ~10 concurrent classes × 2 pool = 80 connections
+                var isExternalPostgres = !string.IsNullOrWhiteSpace(
+                    Environment.GetEnvironmentVariable(TestcontainersConfiguration.EnvPostgresConnectionString));
+                builder.MaxPoolSize = isExternalPostgres ? 2 : 5;
                 builder.MinPoolSize = 1;
 
                 // Issue #2577: Log successful database creation with timing


### PR DESCRIPTION
## Summary
- Reduce PostgreSQL `MaxPoolSize` from 5 to 2 when using external CI service containers (default `max_connections=100`)
- Set `LOCAL_EMBEDDING_URL` in E2E job to prevent API connecting to Docker hostname `embedding-service:8000`

## Root Cause
CI service containers can't have `max_connections` increased (no CMD args support). With 4 parallel threads and many test classes each creating pools of 5, connections exceed the 100 limit.

## Test plan
- [ ] CI integration tests pass without "too many clients" errors
- [ ] E2E tests pass with API health check responding

🤖 Generated with [Claude Code](https://claude.com/claude-code)