### PR TITLE
feat(auth): invite-only registration (beta0)

### DIFF
--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/AccessRequest/ApproveAccessRequestCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/AccessRequest/ApproveAccessRequestCommand.cs
@@ -1,0 +1,6 @@
+using Api.SharedKernel.Application.Interfaces;
+using MediatR;
+
+namespace Api.BoundedContexts.Authentication.Application.Commands.AccessRequest;
+
+internal record ApproveAccessRequestCommand(Guid Id, Guid AdminId) : ICommand<Unit>;

--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/AccessRequest/ApproveAccessRequestCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/AccessRequest/ApproveAccessRequestCommandHandler.cs
@@ -1,0 +1,39 @@
+using Api.BoundedContexts.Authentication.Domain.Enums;
+using Api.BoundedContexts.Authentication.Domain.Repositories;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Application.Interfaces;
+using MediatR;
+
+namespace Api.BoundedContexts.Authentication.Application.Commands.AccessRequest;
+
+internal class ApproveAccessRequestCommandHandler : ICommandHandler<ApproveAccessRequestCommand, Unit>
+{
+    private readonly IAccessRequestRepository _repository;
+
+    public ApproveAccessRequestCommandHandler(IAccessRequestRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task<Unit> Handle(ApproveAccessRequestCommand request, CancellationToken cancellationToken)
+    {
+        var accessRequest = await _repository.GetByIdAsync(request.Id, cancellationToken).ConfigureAwait(false)
+            ?? throw new NotFoundException($"Access request '{request.Id}' not found.");
+
+        if (accessRequest.Status == AccessRequestStatus.Approved)
+            return Unit.Value; // Idempotent no-op
+
+        try
+        {
+            accessRequest.Approve(request.AdminId);
+        }
+        catch (InvalidOperationException)
+        {
+            throw new ConflictException(
+                $"Cannot approve access request in '{accessRequest.Status}' status.");
+        }
+
+        await _repository.UpdateAsync(accessRequest, cancellationToken).ConfigureAwait(false);
+        return Unit.Value;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/AccessRequest/BulkApproveAccessRequestsCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/AccessRequest/BulkApproveAccessRequestsCommand.cs
@@ -1,0 +1,8 @@
+using Api.BoundedContexts.Authentication.Application.DTOs;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.Authentication.Application.Commands.AccessRequest;
+
+internal record BulkApproveAccessRequestsCommand(
+    IReadOnlyList<Guid> Ids,
+    Guid AdminId) : ICommand<BulkApproveResultDto>;

--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/AccessRequest/BulkApproveAccessRequestsCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/AccessRequest/BulkApproveAccessRequestsCommandHandler.cs
@@ -1,0 +1,62 @@
+using Api.BoundedContexts.Authentication.Application.DTOs;
+using Api.BoundedContexts.Authentication.Domain.Enums;
+using Api.BoundedContexts.Authentication.Domain.Repositories;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.Authentication.Application.Commands.AccessRequest;
+
+internal class BulkApproveAccessRequestsCommandHandler
+    : ICommandHandler<BulkApproveAccessRequestsCommand, BulkApproveResultDto>
+{
+    private readonly IAccessRequestRepository _repository;
+
+    public BulkApproveAccessRequestsCommandHandler(IAccessRequestRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task<BulkApproveResultDto> Handle(
+        BulkApproveAccessRequestsCommand request, CancellationToken cancellationToken)
+    {
+        if (request.Ids.Count > 25)
+            throw new ArgumentException("Batch size cannot exceed 25 items.", nameof(request));
+
+        var results = new List<BulkApproveItemResult>();
+        var succeeded = 0;
+        var failed = 0;
+
+        foreach (var id in request.Ids)
+        {
+            var accessRequest = await _repository.GetByIdAsync(id, cancellationToken).ConfigureAwait(false);
+
+            if (accessRequest is null)
+            {
+                results.Add(new BulkApproveItemResult(id, "Failed", "Not found"));
+                failed++;
+                continue;
+            }
+
+            if (accessRequest.Status == AccessRequestStatus.Approved)
+            {
+                results.Add(new BulkApproveItemResult(id, "AlreadyApproved"));
+                succeeded++;
+                continue;
+            }
+
+            try
+            {
+                accessRequest.Approve(request.AdminId);
+                await _repository.UpdateAsync(accessRequest, cancellationToken).ConfigureAwait(false);
+                results.Add(new BulkApproveItemResult(id, "Approved"));
+                succeeded++;
+            }
+            catch (InvalidOperationException ex)
+            {
+                results.Add(new BulkApproveItemResult(id, "Failed", ex.Message));
+                failed++;
+            }
+        }
+
+        return new BulkApproveResultDto(request.Ids.Count, succeeded, failed, results);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/AccessRequest/RejectAccessRequestCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/AccessRequest/RejectAccessRequestCommand.cs
@@ -1,0 +1,6 @@
+using Api.SharedKernel.Application.Interfaces;
+using MediatR;
+
+namespace Api.BoundedContexts.Authentication.Application.Commands.AccessRequest;
+
+internal record RejectAccessRequestCommand(Guid Id, Guid AdminId, string? Reason = null) : ICommand<Unit>;

--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/AccessRequest/RejectAccessRequestCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/AccessRequest/RejectAccessRequestCommandHandler.cs
@@ -1,0 +1,39 @@
+using Api.BoundedContexts.Authentication.Domain.Enums;
+using Api.BoundedContexts.Authentication.Domain.Repositories;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Application.Interfaces;
+using MediatR;
+
+namespace Api.BoundedContexts.Authentication.Application.Commands.AccessRequest;
+
+internal class RejectAccessRequestCommandHandler : ICommandHandler<RejectAccessRequestCommand, Unit>
+{
+    private readonly IAccessRequestRepository _repository;
+
+    public RejectAccessRequestCommandHandler(IAccessRequestRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task<Unit> Handle(RejectAccessRequestCommand request, CancellationToken cancellationToken)
+    {
+        var accessRequest = await _repository.GetByIdAsync(request.Id, cancellationToken).ConfigureAwait(false)
+            ?? throw new NotFoundException($"Access request '{request.Id}' not found.");
+
+        if (accessRequest.Status == AccessRequestStatus.Rejected)
+            return Unit.Value; // Idempotent no-op
+
+        try
+        {
+            accessRequest.Reject(request.AdminId, request.Reason);
+        }
+        catch (InvalidOperationException)
+        {
+            throw new ConflictException(
+                $"Cannot reject access request in '{accessRequest.Status}' status.");
+        }
+
+        await _repository.UpdateAsync(accessRequest, cancellationToken).ConfigureAwait(false);
+        return Unit.Value;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/AccessRequest/RequestAccessCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/AccessRequest/RequestAccessCommand.cs
@@ -1,0 +1,6 @@
+using Api.SharedKernel.Application.Interfaces;
+using MediatR;
+
+namespace Api.BoundedContexts.Authentication.Application.Commands.AccessRequest;
+
+internal record RequestAccessCommand(string Email) : ICommand<Unit>;

--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/AccessRequest/RequestAccessCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/AccessRequest/RequestAccessCommandHandler.cs
@@ -1,0 +1,44 @@
+using Api.BoundedContexts.Authentication.Domain.Repositories;
+using Api.BoundedContexts.Authentication.Domain.ValueObjects;
+using Api.BoundedContexts.Authentication.Infrastructure.Persistence;
+using Api.SharedKernel.Application.Interfaces;
+using MediatR;
+
+namespace Api.BoundedContexts.Authentication.Application.Commands.AccessRequest;
+
+internal class RequestAccessCommandHandler : ICommandHandler<RequestAccessCommand, Unit>
+{
+    private readonly IAccessRequestRepository _accessRequestRepository;
+    private readonly IUserRepository _userRepository;
+
+    public RequestAccessCommandHandler(
+        IAccessRequestRepository accessRequestRepository,
+        IUserRepository userRepository)
+    {
+        _accessRequestRepository = accessRequestRepository;
+        _userRepository = userRepository;
+    }
+
+    public async Task<Unit> Handle(RequestAccessCommand request, CancellationToken cancellationToken)
+    {
+        var normalizedEmail = request.Email.Trim().ToLowerInvariant();
+
+        // Always perform both lookups for timing equalization (email enumeration prevention)
+        var existingUserTask = _userRepository.GetByEmailAsync(
+            new Email(normalizedEmail), cancellationToken);
+        var pendingRequestTask = _accessRequestRepository.GetPendingByEmailAsync(
+            normalizedEmail, cancellationToken);
+
+        var existingUser = await existingUserTask.ConfigureAwait(false);
+        var pendingRequest = await pendingRequestTask.ConfigureAwait(false);
+
+        // Silent skip: existing account or already pending — same response as success
+        if (existingUser is not null || pendingRequest is not null)
+            return Unit.Value;
+
+        var accessRequest = Domain.Entities.AccessRequest.Create(normalizedEmail);
+        await _accessRequestRepository.AddAsync(accessRequest, cancellationToken).ConfigureAwait(false);
+
+        return Unit.Value;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/AccessRequest/RequestAccessCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/AccessRequest/RequestAccessCommandValidator.cs
@@ -1,0 +1,14 @@
+using FluentValidation;
+
+namespace Api.BoundedContexts.Authentication.Application.Commands.AccessRequest;
+
+internal class RequestAccessCommandValidator : AbstractValidator<RequestAccessCommand>
+{
+    public RequestAccessCommandValidator()
+    {
+        RuleFor(x => x.Email)
+            .NotEmpty().WithMessage("Email is required.")
+            .EmailAddress().WithMessage("A valid email address is required.")
+            .MaximumLength(256).WithMessage("Email must not exceed 256 characters.");
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/AccessRequest/SetRegistrationModeCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/AccessRequest/SetRegistrationModeCommand.cs
@@ -1,0 +1,54 @@
+using Api.BoundedContexts.SystemConfiguration.Application.Commands;
+using Api.Services;
+using Api.SharedKernel.Application.Interfaces;
+using MediatR;
+using MediatRUnit = MediatR.Unit;
+
+namespace Api.BoundedContexts.Authentication.Application.Commands.AccessRequest;
+
+internal record SetRegistrationModeCommand(bool Enabled, Guid AdminId) : ICommand<MediatRUnit>;
+
+internal class SetRegistrationModeCommandHandler : ICommandHandler<SetRegistrationModeCommand, MediatRUnit>
+{
+    private readonly IMediator _mediator;
+    private readonly IConfigurationService _configService;
+
+    public SetRegistrationModeCommandHandler(IMediator mediator, IConfigurationService configService)
+    {
+        _mediator = mediator;
+        _configService = configService;
+    }
+
+    public async Task<MediatRUnit> Handle(SetRegistrationModeCommand request, CancellationToken cancellationToken)
+    {
+        var value = request.Enabled.ToString().ToLowerInvariant();
+        var existing = await _configService.GetConfigurationByKeyAsync(
+            "Registration:PublicEnabled", null, cancellationToken).ConfigureAwait(false);
+
+        if (existing is not null)
+        {
+            await _mediator.Send(
+                new UpdateConfigValueCommand(
+                    Guid.Parse(existing.Id),
+                    value,
+                    request.AdminId),
+                cancellationToken).ConfigureAwait(false);
+        }
+        else
+        {
+            await _mediator.Send(
+                new CreateConfigurationCommand(
+                    "Registration:PublicEnabled",
+                    value,
+                    "Boolean",
+                    "Controls whether public registration is enabled",
+                    "Authentication",
+                    "Production",
+                    false,
+                    request.AdminId),
+                cancellationToken).ConfigureAwait(false);
+        }
+
+        return MediatRUnit.Value;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/DTOs/AccessRequestDto.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/DTOs/AccessRequestDto.cs
@@ -1,0 +1,11 @@
+namespace Api.BoundedContexts.Authentication.Application.DTOs;
+
+public record AccessRequestDto(
+    Guid Id,
+    string Email,
+    string Status,
+    DateTime RequestedAt,
+    DateTime? ReviewedAt,
+    Guid? ReviewedBy,
+    string? RejectionReason,
+    Guid? InvitationId);

--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/DTOs/AccessRequestStatsDto.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/DTOs/AccessRequestStatsDto.cs
@@ -1,0 +1,7 @@
+namespace Api.BoundedContexts.Authentication.Application.DTOs;
+
+public record AccessRequestStatsDto(
+    int Pending,
+    int Approved,
+    int Rejected,
+    int Total);

--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/DTOs/BulkApproveResultDto.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/DTOs/BulkApproveResultDto.cs
@@ -1,0 +1,12 @@
+namespace Api.BoundedContexts.Authentication.Application.DTOs;
+
+public record BulkApproveResultDto(
+    int Processed,
+    int Succeeded,
+    int Failed,
+    IReadOnlyList<BulkApproveItemResult> Results);
+
+public record BulkApproveItemResult(
+    Guid Id,
+    string Status,
+    string? Error = null);

--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/EventHandlers/AccessRequestApprovedEventHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/EventHandlers/AccessRequestApprovedEventHandler.cs
@@ -1,0 +1,67 @@
+using Api.BoundedContexts.Authentication.Application.Commands.Invitation;
+using Api.BoundedContexts.Authentication.Domain.Events;
+using Api.BoundedContexts.Authentication.Domain.Repositories;
+using Api.Infrastructure;
+using Api.SharedKernel.Application.EventHandlers;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.Authentication.Application.EventHandlers;
+
+internal sealed class AccessRequestApprovedEventHandler : DomainEventHandlerBase<AccessRequestApprovedEvent>
+{
+    private readonly IMediator _mediator;
+    private readonly IAccessRequestRepository _repository;
+
+    public AccessRequestApprovedEventHandler(
+        MeepleAiDbContext dbContext,
+        IMediator mediator,
+        IAccessRequestRepository repository,
+        ILogger<AccessRequestApprovedEventHandler> logger)
+        : base(dbContext, logger)
+    {
+        _mediator = mediator;
+        _repository = repository;
+    }
+
+    protected override async Task HandleEventAsync(
+        AccessRequestApprovedEvent domainEvent, CancellationToken cancellationToken)
+    {
+        try
+        {
+            var invitationResult = await _mediator.Send(
+                new SendInvitationCommand(
+                    domainEvent.Email,
+                    "User",
+                    domainEvent.ApprovedByUserId),
+                cancellationToken).ConfigureAwait(false);
+
+            // Set correlation ID linking access request to invitation
+            var accessRequest = await _repository.GetByIdAsync(
+                domainEvent.AccessRequestId, cancellationToken).ConfigureAwait(false);
+            if (accessRequest is not null)
+            {
+                accessRequest.SetInvitationId(invitationResult.Id);
+                await _repository.UpdateAsync(accessRequest, cancellationToken).ConfigureAwait(false);
+            }
+        }
+        catch (Exception ex)
+        {
+            Logger.LogError(ex,
+                "Failed to create invitation for approved access request {AccessRequestId}, email {Email}",
+                domainEvent.AccessRequestId, domainEvent.Email);
+            // Approval stands. Admin can resend via invitation UI.
+        }
+    }
+
+    protected override Guid? GetUserId(AccessRequestApprovedEvent domainEvent)
+        => domainEvent.ApprovedByUserId;
+
+    protected override Dictionary<string, object?>? GetAuditMetadata(
+        AccessRequestApprovedEvent domainEvent)
+        => new(StringComparer.Ordinal)
+        {
+            ["AccessRequestId"] = domainEvent.AccessRequestId,
+            ["Email"] = domainEvent.Email
+        };
+}

--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/EventHandlers/AccessRequestCreatedEventHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/EventHandlers/AccessRequestCreatedEventHandler.cs
@@ -1,0 +1,37 @@
+using Api.BoundedContexts.Authentication.Domain.Events;
+using Api.Infrastructure;
+using Api.SharedKernel.Application.EventHandlers;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.Authentication.Application.EventHandlers;
+
+internal sealed class AccessRequestCreatedEventHandler : DomainEventHandlerBase<AccessRequestCreatedEvent>
+{
+    public AccessRequestCreatedEventHandler(
+        MeepleAiDbContext dbContext,
+        ILogger<AccessRequestCreatedEventHandler> logger)
+        : base(dbContext, logger)
+    {
+    }
+
+    protected override async Task HandleEventAsync(
+        AccessRequestCreatedEvent domainEvent, CancellationToken cancellationToken)
+    {
+        Logger.LogInformation(
+            "New access request {AccessRequestId} created for email {Email}",
+            domainEvent.AccessRequestId, domainEvent.Email);
+
+        await Task.CompletedTask.ConfigureAwait(false);
+    }
+
+    protected override Guid? GetUserId(AccessRequestCreatedEvent domainEvent)
+        => null; // System action, no authenticated user
+
+    protected override Dictionary<string, object?>? GetAuditMetadata(
+        AccessRequestCreatedEvent domainEvent)
+        => new(StringComparer.Ordinal)
+        {
+            ["AccessRequestId"] = domainEvent.AccessRequestId,
+            ["Email"] = domainEvent.Email
+        };
+}

--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/Queries/AccessRequest/GetAccessRequestByIdQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/Queries/AccessRequest/GetAccessRequestByIdQuery.cs
@@ -1,0 +1,35 @@
+using Api.BoundedContexts.Authentication.Application.DTOs;
+using Api.BoundedContexts.Authentication.Domain.Repositories;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.Authentication.Application.Queries.AccessRequest;
+
+internal record GetAccessRequestByIdQuery(Guid Id) : IQuery<AccessRequestDto>;
+
+internal class GetAccessRequestByIdQueryHandler : IQueryHandler<GetAccessRequestByIdQuery, AccessRequestDto>
+{
+    private readonly IAccessRequestRepository _repository;
+
+    public GetAccessRequestByIdQueryHandler(IAccessRequestRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task<AccessRequestDto> Handle(
+        GetAccessRequestByIdQuery request, CancellationToken cancellationToken)
+    {
+        var accessRequest = await _repository.GetByIdAsync(request.Id, cancellationToken).ConfigureAwait(false)
+            ?? throw new NotFoundException($"Access request '{request.Id}' not found.");
+
+        return new AccessRequestDto(
+            accessRequest.Id,
+            accessRequest.Email,
+            accessRequest.Status.ToString(),
+            accessRequest.RequestedAt,
+            accessRequest.ReviewedAt,
+            accessRequest.ReviewedBy,
+            accessRequest.RejectionReason,
+            accessRequest.InvitationId);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/Queries/AccessRequest/GetAccessRequestStatsQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/Queries/AccessRequest/GetAccessRequestStatsQuery.cs
@@ -1,0 +1,29 @@
+using Api.BoundedContexts.Authentication.Application.DTOs;
+using Api.BoundedContexts.Authentication.Domain.Enums;
+using Api.BoundedContexts.Authentication.Domain.Repositories;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.Authentication.Application.Queries.AccessRequest;
+
+internal record GetAccessRequestStatsQuery : IQuery<AccessRequestStatsDto>;
+
+internal class GetAccessRequestStatsQueryHandler : IQueryHandler<GetAccessRequestStatsQuery, AccessRequestStatsDto>
+{
+    private readonly IAccessRequestRepository _repository;
+
+    public GetAccessRequestStatsQueryHandler(IAccessRequestRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task<AccessRequestStatsDto> Handle(
+        GetAccessRequestStatsQuery request, CancellationToken cancellationToken)
+    {
+        var pending = await _repository.CountByStatusAsync(AccessRequestStatus.Pending, cancellationToken).ConfigureAwait(false);
+        var approved = await _repository.CountByStatusAsync(AccessRequestStatus.Approved, cancellationToken).ConfigureAwait(false);
+        var rejected = await _repository.CountByStatusAsync(AccessRequestStatus.Rejected, cancellationToken).ConfigureAwait(false);
+        var total = await _repository.CountAllAsync(cancellationToken).ConfigureAwait(false);
+
+        return new AccessRequestStatsDto(pending, approved, rejected, total);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/Queries/AccessRequest/GetAccessRequestsQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/Queries/AccessRequest/GetAccessRequestsQuery.cs
@@ -1,0 +1,59 @@
+using Api.BoundedContexts.Authentication.Application.DTOs;
+using Api.BoundedContexts.Authentication.Domain.Enums;
+using Api.BoundedContexts.Authentication.Domain.Repositories;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.Authentication.Application.Queries.AccessRequest;
+
+public record GetAccessRequestsResponse(
+    IReadOnlyList<AccessRequestDto> Items,
+    int TotalCount,
+    int Page,
+    int PageSize);
+
+internal record GetAccessRequestsQuery(
+    string? Status = null,
+    int Page = 1,
+    int PageSize = 20) : IQuery<GetAccessRequestsResponse>;
+
+internal class GetAccessRequestsQueryHandler : IQueryHandler<GetAccessRequestsQuery, GetAccessRequestsResponse>
+{
+    private readonly IAccessRequestRepository _repository;
+
+    public GetAccessRequestsQueryHandler(IAccessRequestRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task<GetAccessRequestsResponse> Handle(
+        GetAccessRequestsQuery request, CancellationToken cancellationToken)
+    {
+        var pageSize = Math.Min(request.PageSize, 100);
+
+        AccessRequestStatus? statusFilter = null;
+        if (!string.IsNullOrEmpty(request.Status) &&
+            Enum.TryParse<AccessRequestStatus>(request.Status, true, out var parsed))
+        {
+            statusFilter = parsed;
+        }
+
+        var items = await _repository.GetByStatusAsync(
+            statusFilter, request.Page, pageSize, cancellationToken).ConfigureAwait(false);
+
+        var totalCount = statusFilter.HasValue
+            ? await _repository.CountByStatusAsync(statusFilter.Value, cancellationToken).ConfigureAwait(false)
+            : await _repository.CountAllAsync(cancellationToken).ConfigureAwait(false);
+
+        var dtos = items.Select(r => new AccessRequestDto(
+            r.Id,
+            r.Email,
+            r.Status.ToString(),
+            r.RequestedAt,
+            r.ReviewedAt,
+            r.ReviewedBy,
+            r.RejectionReason,
+            r.InvitationId)).ToList();
+
+        return new GetAccessRequestsResponse(dtos, totalCount, request.Page, pageSize);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/Queries/AccessRequest/GetRegistrationModeQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/Queries/AccessRequest/GetRegistrationModeQuery.cs
@@ -1,0 +1,35 @@
+using Api.Services;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.Authentication.Application.Queries.AccessRequest;
+
+public record RegistrationModeDto(bool PublicRegistrationEnabled);
+
+internal record GetRegistrationModeQuery : IQuery<RegistrationModeDto>;
+
+internal class GetRegistrationModeQueryHandler : IQueryHandler<GetRegistrationModeQuery, RegistrationModeDto>
+{
+    private readonly IConfigurationService _configService;
+
+    public GetRegistrationModeQueryHandler(IConfigurationService configService)
+    {
+        _configService = configService;
+    }
+
+    public async Task<RegistrationModeDto> Handle(GetRegistrationModeQuery request, CancellationToken cancellationToken)
+    {
+        // Fail closed: default false if config not found or service unreachable
+        bool enabled;
+        try
+        {
+            enabled = await _configService.GetValueAsync<bool?>(
+                "Registration:PublicEnabled", false).ConfigureAwait(false) ?? false;
+        }
+        catch
+        {
+            enabled = false; // Fail closed
+        }
+
+        return new RegistrationModeDto(enabled);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/Authentication/Domain/Entities/AccessRequest.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Domain/Entities/AccessRequest.cs
@@ -20,6 +20,12 @@ internal sealed class AccessRequest : AggregateRoot<Guid>
 
     // EF Core constructor
     private AccessRequest() { }
+    private AccessRequest(Guid id) : base(id) { }
+
+    /// <summary>
+    /// Internal constructor for repository materialization (avoids reflection).
+    /// </summary>
+    internal static AccessRequest CreateForHydration(Guid id) => new(id);
 
     /// <summary>
     /// Factory method to create a new access request.
@@ -86,8 +92,30 @@ internal sealed class AccessRequest : AggregateRoot<Guid>
         InvitationId = invitationId;
     }
 
+    #region Persistence Hydration Methods (internal - S3011 fix)
+
     /// <summary>
-    /// Internal constructor for repository materialization (avoids reflection).
+    /// Restores access request state from persistence layer.
+    /// Internal method to avoid reflection in repository (S3011 compliance).
+    /// Should only be called by AccessRequestRepository during entity materialization.
     /// </summary>
-    internal static AccessRequest CreateForHydration() => new();
+    internal void RestoreState(
+        string email,
+        AccessRequestStatus status,
+        DateTime requestedAt,
+        DateTime? reviewedAt,
+        Guid? reviewedBy,
+        string? rejectionReason,
+        Guid? invitationId)
+    {
+        Email = email;
+        Status = status;
+        RequestedAt = requestedAt;
+        ReviewedAt = reviewedAt;
+        ReviewedBy = reviewedBy;
+        RejectionReason = rejectionReason;
+        InvitationId = invitationId;
+    }
+
+    #endregion
 }

--- a/apps/api/src/Api/BoundedContexts/Authentication/Domain/Entities/AccessRequest.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Domain/Entities/AccessRequest.cs
@@ -1,0 +1,93 @@
+using Api.BoundedContexts.Authentication.Domain.Enums;
+using Api.BoundedContexts.Authentication.Domain.Events;
+using Api.SharedKernel.Domain.Entities;
+
+namespace Api.BoundedContexts.Authentication.Domain.Entities;
+
+/// <summary>
+/// Aggregate root representing a user's request for access to the platform.
+/// Tracks the access request lifecycle: pending, approved, or rejected.
+/// </summary>
+internal sealed class AccessRequest : AggregateRoot<Guid>
+{
+    public string Email { get; private set; } = null!;
+    public AccessRequestStatus Status { get; private set; }
+    public DateTime RequestedAt { get; private set; }
+    public DateTime? ReviewedAt { get; private set; }
+    public Guid? ReviewedBy { get; private set; }
+    public string? RejectionReason { get; private set; }
+    public Guid? InvitationId { get; private set; }
+
+    // EF Core constructor
+    private AccessRequest() { }
+
+    /// <summary>
+    /// Factory method to create a new access request.
+    /// </summary>
+    /// <param name="email">Email address of the requesting user</param>
+    /// <returns>New AccessRequest instance in Pending status</returns>
+    public static AccessRequest Create(string email)
+    {
+        var request = new AccessRequest
+        {
+            Id = Guid.NewGuid(),
+            Email = email.Trim().ToLowerInvariant(),
+            Status = AccessRequestStatus.Pending,
+            RequestedAt = DateTime.UtcNow
+        };
+
+        request.AddDomainEvent(new AccessRequestCreatedEvent(request.Id, request.Email));
+        return request;
+    }
+
+    /// <summary>
+    /// Approves the access request, allowing the user to be invited.
+    /// </summary>
+    /// <param name="adminId">The admin user who approved the request</param>
+    public void Approve(Guid adminId)
+    {
+        if (Status != AccessRequestStatus.Pending)
+            throw new InvalidOperationException(
+                $"Cannot approve access request in '{Status}' status. Only Pending requests can be approved.");
+
+        Status = AccessRequestStatus.Approved;
+        ReviewedAt = DateTime.UtcNow;
+        ReviewedBy = adminId;
+
+        AddDomainEvent(new AccessRequestApprovedEvent(Id, Email, adminId));
+    }
+
+    /// <summary>
+    /// Rejects the access request with an optional reason.
+    /// </summary>
+    /// <param name="adminId">The admin user who rejected the request</param>
+    /// <param name="reason">Optional reason for rejection (max 500 characters)</param>
+    public void Reject(Guid adminId, string? reason = null)
+    {
+        if (Status != AccessRequestStatus.Pending)
+            throw new InvalidOperationException(
+                $"Cannot reject access request in '{Status}' status. Only Pending requests can be rejected.");
+
+        if (reason is not null && reason.Length > 500)
+            throw new ArgumentException("Rejection reason cannot exceed 500 characters.", nameof(reason));
+
+        Status = AccessRequestStatus.Rejected;
+        ReviewedAt = DateTime.UtcNow;
+        ReviewedBy = adminId;
+        RejectionReason = reason;
+    }
+
+    /// <summary>
+    /// Associates an invitation token ID with this access request for correlation.
+    /// </summary>
+    /// <param name="invitationId">The ID of the created invitation token</param>
+    public void SetInvitationId(Guid invitationId)
+    {
+        InvitationId = invitationId;
+    }
+
+    /// <summary>
+    /// Internal constructor for repository materialization (avoids reflection).
+    /// </summary>
+    internal static AccessRequest CreateForHydration() => new();
+}

--- a/apps/api/src/Api/BoundedContexts/Authentication/Domain/Enums/AccessRequestStatus.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Domain/Enums/AccessRequestStatus.cs
@@ -1,0 +1,8 @@
+namespace Api.BoundedContexts.Authentication.Domain.Enums;
+
+public enum AccessRequestStatus
+{
+    Pending = 0,
+    Approved = 1,
+    Rejected = 2
+}

--- a/apps/api/src/Api/BoundedContexts/Authentication/Domain/Events/AccessRequestApprovedEvent.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Domain/Events/AccessRequestApprovedEvent.cs
@@ -1,0 +1,17 @@
+using Api.SharedKernel.Domain.Events;
+
+namespace Api.BoundedContexts.Authentication.Domain.Events;
+
+internal sealed class AccessRequestApprovedEvent : DomainEventBase
+{
+    public Guid AccessRequestId { get; }
+    public string Email { get; }
+    public Guid ApprovedByUserId { get; }
+
+    public AccessRequestApprovedEvent(Guid accessRequestId, string email, Guid approvedByUserId)
+    {
+        AccessRequestId = accessRequestId;
+        Email = email;
+        ApprovedByUserId = approvedByUserId;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/Authentication/Domain/Events/AccessRequestCreatedEvent.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Domain/Events/AccessRequestCreatedEvent.cs
@@ -1,0 +1,15 @@
+using Api.SharedKernel.Domain.Events;
+
+namespace Api.BoundedContexts.Authentication.Domain.Events;
+
+internal sealed class AccessRequestCreatedEvent : DomainEventBase
+{
+    public Guid AccessRequestId { get; }
+    public string Email { get; }
+
+    public AccessRequestCreatedEvent(Guid accessRequestId, string email)
+    {
+        AccessRequestId = accessRequestId;
+        Email = email;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/Authentication/Domain/Repositories/IAccessRequestRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Domain/Repositories/IAccessRequestRepository.cs
@@ -1,0 +1,15 @@
+using Api.BoundedContexts.Authentication.Domain.Entities;
+using Api.BoundedContexts.Authentication.Domain.Enums;
+using Api.SharedKernel.Infrastructure.Persistence;
+
+namespace Api.BoundedContexts.Authentication.Domain.Repositories;
+
+internal interface IAccessRequestRepository : IRepository<AccessRequest, Guid>
+{
+    Task<AccessRequest?> GetPendingByEmailAsync(string email, CancellationToken cancellationToken = default);
+    Task<IReadOnlyList<AccessRequest>> GetByStatusAsync(
+        AccessRequestStatus? status, int page, int pageSize,
+        CancellationToken cancellationToken = default);
+    Task<int> CountByStatusAsync(AccessRequestStatus status, CancellationToken cancellationToken = default);
+    Task<int> CountAllAsync(CancellationToken cancellationToken = default);
+}

--- a/apps/api/src/Api/BoundedContexts/Authentication/Infrastructure/DependencyInjection/AuthenticationServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Infrastructure/DependencyInjection/AuthenticationServiceExtensions.cs
@@ -24,6 +24,7 @@ internal static class AuthenticationServiceExtensions
         services.AddScoped<IOAuthAccountRepository, OAuthAccountRepository>();
         services.AddScoped<IShareLinkRepository, ShareLinkRepository>(); // ISSUE-2052
         services.AddScoped<IInvitationTokenRepository, InvitationTokenRepository>(); // ISSUE-124
+        services.AddScoped<IAccessRequestRepository, AccessRequestRepository>(); // ISSUE-124: Access request management
 
         // Register Unit of Work
         services.AddScoped<IUnitOfWork, EfCoreUnitOfWork>();

--- a/apps/api/src/Api/BoundedContexts/Authentication/Infrastructure/Repositories/AccessRequestRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Infrastructure/Repositories/AccessRequestRepository.cs
@@ -1,0 +1,165 @@
+using Api.BoundedContexts.Authentication.Domain.Entities;
+using Api.BoundedContexts.Authentication.Domain.Enums;
+using Api.BoundedContexts.Authentication.Domain.Repositories;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.Authentication;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.Authentication.Infrastructure.Repositories;
+
+/// <summary>
+/// Repository implementation for AccessRequest aggregate.
+/// Handles mapping between domain and infrastructure entities.
+/// </summary>
+internal sealed class AccessRequestRepository : IAccessRequestRepository
+{
+    private readonly MeepleAiDbContext _context;
+
+    public AccessRequestRepository(MeepleAiDbContext context)
+    {
+        ArgumentNullException.ThrowIfNull(context);
+        _context = context;
+    }
+
+    public async Task<AccessRequest?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        var entity = await _context.AccessRequests
+            .FirstOrDefaultAsync(e => e.Id == id, cancellationToken)
+            .ConfigureAwait(false);
+        return entity is null ? null : MapToDomain(entity);
+    }
+
+    public async Task<IReadOnlyList<AccessRequest>> GetAllAsync(CancellationToken cancellationToken = default)
+    {
+        var entities = await _context.AccessRequests
+            .OrderByDescending(e => e.RequestedAt)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+        return entities.Select(MapToDomain).ToList();
+    }
+
+    public async Task AddAsync(AccessRequest entity, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(entity);
+        var infrastructureEntity = MapToInfrastructure(entity);
+        await _context.AccessRequests.AddAsync(infrastructureEntity, cancellationToken).ConfigureAwait(false);
+    }
+
+    public async Task UpdateAsync(AccessRequest entity, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(entity);
+        var existing = await _context.AccessRequests
+            .FindAsync(new object[] { entity.Id }, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (existing is null)
+            throw new InvalidOperationException($"AccessRequest {entity.Id} not found");
+
+        existing.Status = entity.Status.ToString();
+        existing.ReviewedAt = entity.ReviewedAt;
+        existing.ReviewedBy = entity.ReviewedBy;
+        existing.RejectionReason = entity.RejectionReason;
+        existing.InvitationId = entity.InvitationId;
+    }
+
+    public async Task DeleteAsync(AccessRequest entity, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(entity);
+        var existing = await _context.AccessRequests
+            .FindAsync(new object[] { entity.Id }, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (existing is not null)
+            _context.AccessRequests.Remove(existing);
+    }
+
+    public async Task<bool> ExistsAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        return await _context.AccessRequests
+            .AnyAsync(e => e.Id == id, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public async Task<AccessRequest?> GetPendingByEmailAsync(string email, CancellationToken cancellationToken = default)
+    {
+        var normalizedEmail = email.Trim().ToLowerInvariant();
+        var pendingStatus = AccessRequestStatus.Pending.ToString();
+        var entity = await _context.AccessRequests
+            .FirstOrDefaultAsync(e => e.Email == normalizedEmail && e.Status == pendingStatus, cancellationToken)
+            .ConfigureAwait(false);
+        return entity is null ? null : MapToDomain(entity);
+    }
+
+    public async Task<IReadOnlyList<AccessRequest>> GetByStatusAsync(
+        AccessRequestStatus? status, int page, int pageSize, CancellationToken cancellationToken = default)
+    {
+        var query = _context.AccessRequests.AsQueryable();
+        if (status.HasValue)
+        {
+            var statusString = status.Value.ToString();
+            query = query.Where(e => e.Status == statusString);
+        }
+
+        var entities = await query
+            .OrderByDescending(e => e.RequestedAt)
+            .Skip((page - 1) * pageSize)
+            .Take(pageSize)
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        return entities.Select(MapToDomain).ToList();
+    }
+
+    public async Task<int> CountByStatusAsync(AccessRequestStatus status, CancellationToken cancellationToken = default)
+    {
+        var statusString = status.ToString();
+        return await _context.AccessRequests
+            .CountAsync(e => e.Status == statusString, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public async Task<int> CountAllAsync(CancellationToken cancellationToken = default)
+    {
+        return await _context.AccessRequests
+            .CountAsync(cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    /// <summary>
+    /// Maps infrastructure entity to domain aggregate.
+    /// Uses internal factory + RestoreState method (no reflection).
+    /// </summary>
+    private static AccessRequest MapToDomain(AccessRequestEntity entity)
+    {
+        var request = AccessRequest.CreateForHydration(entity.Id);
+
+        request.RestoreState(
+            email: entity.Email,
+            status: Enum.Parse<AccessRequestStatus>(entity.Status),
+            requestedAt: entity.RequestedAt,
+            reviewedAt: entity.ReviewedAt,
+            reviewedBy: entity.ReviewedBy,
+            rejectionReason: entity.RejectionReason,
+            invitationId: entity.InvitationId);
+
+        return request;
+    }
+
+    /// <summary>
+    /// Maps domain aggregate to infrastructure entity.
+    /// </summary>
+    private static AccessRequestEntity MapToInfrastructure(AccessRequest domain)
+    {
+        return new AccessRequestEntity
+        {
+            Id = domain.Id,
+            Email = domain.Email,
+            Status = domain.Status.ToString(),
+            RequestedAt = domain.RequestedAt,
+            ReviewedAt = domain.ReviewedAt,
+            ReviewedBy = domain.ReviewedBy,
+            RejectionReason = domain.RejectionReason,
+            InvitationId = domain.InvitationId
+        };
+    }
+}

--- a/apps/api/src/Api/Extensions/EndpointFilterExtensions.cs
+++ b/apps/api/src/Api/Extensions/EndpointFilterExtensions.cs
@@ -140,4 +140,15 @@ internal static class EndpointFilterExtensions
     {
         return builder.AddEndpointFilter(new RequireFeatureFilterFactory(featureName));
     }
+
+    /// <summary>
+    /// Requires public registration to be enabled for the endpoint.
+    /// Blocks with 403 if Registration:PublicEnabled is false or unreachable (fail-closed).
+    /// </summary>
+    /// <param name="builder">The route handler builder.</param>
+    /// <returns>The builder for method chaining.</returns>
+    public static RouteHandlerBuilder RequirePublicRegistration(this RouteHandlerBuilder builder)
+    {
+        return builder.AddEndpointFilter<RequirePublicRegistrationFilter>();
+    }
 }

--- a/apps/api/src/Api/Filters/RequirePublicRegistrationFilter.cs
+++ b/apps/api/src/Api/Filters/RequirePublicRegistrationFilter.cs
@@ -1,0 +1,39 @@
+using Api.Services;
+
+namespace Api.Filters;
+
+/// <summary>
+/// Endpoint filter that blocks registration when public registration is disabled.
+/// Fail-closed: if configuration service is unreachable, registration is blocked.
+/// </summary>
+internal class RequirePublicRegistrationFilter : IEndpointFilter
+{
+    public async ValueTask<object?> InvokeAsync(
+        EndpointFilterInvocationContext context,
+        EndpointFilterDelegate next)
+    {
+        var configService = context.HttpContext.RequestServices
+            .GetRequiredService<IConfigurationService>();
+
+        // Fail closed: if config unreachable or missing, block registration
+        bool publicEnabled;
+        try
+        {
+            publicEnabled = await configService.GetValueAsync<bool?>(
+                "Registration:PublicEnabled", false).ConfigureAwait(false) ?? false;
+        }
+        catch
+        {
+            publicEnabled = false; // Fail closed
+        }
+
+        if (!publicEnabled)
+        {
+            return Results.Json(
+                new { message = "Registration is currently unavailable." },
+                statusCode: 403);
+        }
+
+        return await next(context).ConfigureAwait(false);
+    }
+}

--- a/apps/api/src/Api/Infrastructure/Entities/Authentication/AccessRequestEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/Authentication/AccessRequestEntity.cs
@@ -1,0 +1,50 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Api.Infrastructure.Entities.Authentication;
+
+/// <summary>
+/// Infrastructure entity for access requests.
+/// Maps to AccessRequest domain aggregate.
+/// </summary>
+[Table("access_requests")]
+public sealed class AccessRequestEntity
+{
+    [Key]
+    [Column("id")]
+    public Guid Id { get; set; }
+
+    [Required]
+    [MaxLength(256)]
+    [Column("email")]
+    public string Email { get; set; } = string.Empty;
+
+    [Required]
+    [MaxLength(20)]
+    [Column("status")]
+    public string Status { get; set; } = "Pending";
+
+    [Required]
+    [Column("requested_at")]
+    public DateTime RequestedAt { get; set; }
+
+    [Column("reviewed_at")]
+    public DateTime? ReviewedAt { get; set; }
+
+    [Column("reviewed_by")]
+    public Guid? ReviewedBy { get; set; }
+
+    [MaxLength(500)]
+    [Column("rejection_reason")]
+    public string? RejectionReason { get; set; }
+
+    [Column("invitation_id")]
+    public Guid? InvitationId { get; set; }
+
+    // Navigation properties
+    [ForeignKey(nameof(ReviewedBy))]
+    public UserEntity? ReviewedByUser { get; set; }
+
+    [ForeignKey(nameof(InvitationId))]
+    public InvitationTokenEntity? Invitation { get; set; }
+}

--- a/apps/api/src/Api/Infrastructure/EntityConfigurations/Authentication/AccessRequestEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/EntityConfigurations/Authentication/AccessRequestEntityConfiguration.cs
@@ -1,0 +1,42 @@
+using Api.Infrastructure.Entities.Authentication;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Api.Infrastructure.EntityConfigurations;
+
+internal class AccessRequestEntityConfiguration : IEntityTypeConfiguration<AccessRequestEntity>
+{
+    public void Configure(EntityTypeBuilder<AccessRequestEntity> builder)
+    {
+        builder.ToTable("access_requests");
+        builder.HasKey(e => e.Id);
+
+        builder.Property(e => e.Email).IsRequired().HasMaxLength(256);
+        builder.Property(e => e.Status).IsRequired().HasMaxLength(20);
+        builder.Property(e => e.RequestedAt).IsRequired();
+        builder.Property(e => e.ReviewedAt);
+        builder.Property(e => e.ReviewedBy);
+        builder.Property(e => e.RejectionReason).HasMaxLength(500);
+        builder.Property(e => e.InvitationId);
+
+        // Unique index: only one pending request per email
+        builder.HasIndex(e => new { e.Email, e.Status })
+            .HasFilter("\"status\" = 'Pending'")
+            .IsUnique();
+
+        builder.HasIndex(e => e.RequestedAt);
+
+        // FK relationships
+        builder.HasOne(e => e.ReviewedByUser)
+            .WithMany()
+            .HasForeignKey(e => e.ReviewedBy)
+            .IsRequired(false)
+            .OnDelete(DeleteBehavior.SetNull);
+
+        builder.HasOne(e => e.Invitation)
+            .WithMany()
+            .HasForeignKey(e => e.InvitationId)
+            .IsRequired(false)
+            .OnDelete(DeleteBehavior.SetNull);
+    }
+}

--- a/apps/api/src/Api/Infrastructure/MeepleAiDbContext.cs
+++ b/apps/api/src/Api/Infrastructure/MeepleAiDbContext.cs
@@ -112,6 +112,7 @@ public class MeepleAiDbContext : DbContext
     public DbSet<ChatThreadCollectionEntity> ChatThreadCollections => Set<ChatThreadCollectionEntity>(); // ISSUE-2051: Chat-collection junction
     public DbSet<ShareLinkEntity> ShareLinks => Set<ShareLinkEntity>(); // ISSUE-2052: Shareable chat links
     public DbSet<InvitationTokenEntity> InvitationTokens => Set<InvitationTokenEntity>(); // ISSUE-124: Admin invitation tokens
+    public DbSet<AccessRequestEntity> AccessRequests => Set<AccessRequestEntity>(); // ISSUE-124: Access request management
     public DbSet<NotificationEntity> Notifications => Set<NotificationEntity>(); // ISSUE-2053: User notifications
     public DbSet<SharedGameEntity> SharedGames => Set<SharedGameEntity>(); // ISSUE-2370: Shared game catalog
     public DbSet<GameDesignerEntity> GameDesigners => Set<GameDesignerEntity>(); // ISSUE-2370: Game designers
@@ -263,6 +264,7 @@ public class MeepleAiDbContext : DbContext
         modelBuilder.Ignore<BoundedContexts.Authentication.Domain.Entities.Session>();
         modelBuilder.Ignore<BoundedContexts.Authentication.Domain.Entities.ApiKey>();
         modelBuilder.Ignore<BoundedContexts.Authentication.Domain.Entities.ShareLink>(); // ISSUE-2052
+        modelBuilder.Ignore<BoundedContexts.Authentication.Domain.Entities.AccessRequest>(); // ISSUE-124: Access request domain entity
         modelBuilder.Ignore<BoundedContexts.GameManagement.Domain.Entities.GameSession>();
         modelBuilder.Ignore<BoundedContexts.GameManagement.Domain.Entities.GameSessionState>(); // ISSUE-2403
         modelBuilder.Ignore<BoundedContexts.GameManagement.Domain.Entities.GameStateSnapshot>(); // ISSUE-2403

--- a/apps/api/src/Api/Program.cs
+++ b/apps/api/src/Api/Program.cs
@@ -549,6 +549,7 @@ app.MapHealthChecks("/health/config", new Microsoft.AspNetCore.Diagnostics.Healt
 var v1Api = app.MapGroup("/api/v1");
 
 v1Api.MapAuthEndpoints();
+v1Api.MapAccessRequestEndpoints(); // Invite-only registration: access requests + registration mode
 v1Api.MapPermissionEndpoints(); // Epic #4068: Permission system endpoints
 v1Api.MapShareLinkEndpoints(); // ISSUE-2052: Shareable chat thread links
 v1Api.MapUserProfileEndpoints();

--- a/apps/api/src/Api/Routing/AccessRequestEndpoints.cs
+++ b/apps/api/src/Api/Routing/AccessRequestEndpoints.cs
@@ -1,0 +1,181 @@
+using Api.BoundedContexts.Authentication.Application.Commands.AccessRequest;
+using Api.BoundedContexts.Authentication.Application.Queries.AccessRequest;
+using Api.Extensions;
+using MediatR;
+using Microsoft.AspNetCore.Mvc;
+
+namespace Api.Routing;
+
+/// <summary>
+/// Access request and registration mode endpoints.
+/// Public: registration-mode, request-access
+/// Admin: access request management, registration mode toggle
+/// </summary>
+internal static class AccessRequestEndpoints
+{
+    public static RouteGroupBuilder MapAccessRequestEndpoints(this RouteGroupBuilder group)
+    {
+        // Public endpoints (no auth required)
+        MapGetRegistrationModeEndpoint(group);
+        MapRequestAccessEndpoint(group);
+
+        // Admin endpoints
+        MapGetAccessRequestsEndpoint(group);
+        MapGetAccessRequestStatsEndpoint(group);
+        MapGetAccessRequestByIdEndpoint(group);
+        MapApproveAccessRequestEndpoint(group);
+        MapRejectAccessRequestEndpoint(group);
+        MapBulkApproveEndpoint(group);
+        MapSetRegistrationModeEndpoint(group);
+
+        return group;
+    }
+
+    // --- Public Endpoints ---
+
+    private static void MapGetRegistrationModeEndpoint(RouteGroupBuilder group)
+    {
+        group.MapGet("/auth/registration-mode", async (IMediator mediator, CancellationToken ct) =>
+        {
+            var result = await mediator.Send(new GetRegistrationModeQuery(), ct).ConfigureAwait(false);
+            return Results.Ok(result);
+        }).WithName("GetRegistrationMode")
+          .RequireRateLimiting("AuthGeneral");
+    }
+
+    private static void MapRequestAccessEndpoint(RouteGroupBuilder group)
+    {
+        group.MapPost("/auth/request-access", async (RequestAccessPayload payload, IMediator mediator, CancellationToken ct) =>
+        {
+            await mediator.Send(new RequestAccessCommand(payload.Email), ct).ConfigureAwait(false);
+            // Always return 202 with identical message (email enumeration prevention)
+            return Results.Accepted(value: new
+            {
+                message = "If this email is eligible, you will receive an invitation when approved."
+            });
+        }).WithName("RequestAccess")
+          .RequireRateLimiting("AuthRegister");
+    }
+
+    // --- Admin Endpoints ---
+
+    private static void MapGetAccessRequestsEndpoint(RouteGroupBuilder group)
+    {
+        group.MapGet("/admin/access-requests", async (
+            HttpContext context, IMediator mediator,
+            [FromQuery] string? status,
+            [FromQuery] int page = 1,
+            [FromQuery] int pageSize = 20,
+            CancellationToken ct = default) =>
+        {
+            var (authorized, _, error) = context.RequireAdminSession();
+            if (!authorized) return error!;
+
+            var result = await mediator.Send(
+                new GetAccessRequestsQuery(status, page, Math.Min(pageSize, 100)), ct)
+                .ConfigureAwait(false);
+            return Results.Ok(result);
+        }).WithName("GetAccessRequests")
+          .RequireAdminSession();
+    }
+
+    private static void MapGetAccessRequestStatsEndpoint(RouteGroupBuilder group)
+    {
+        group.MapGet("/admin/access-requests/stats", async (
+            HttpContext context, IMediator mediator, CancellationToken ct) =>
+        {
+            var (authorized, _, error) = context.RequireAdminSession();
+            if (!authorized) return error!;
+
+            var result = await mediator.Send(new GetAccessRequestStatsQuery(), ct).ConfigureAwait(false);
+            return Results.Ok(result);
+        }).WithName("GetAccessRequestStats")
+          .RequireAdminSession();
+    }
+
+    private static void MapGetAccessRequestByIdEndpoint(RouteGroupBuilder group)
+    {
+        group.MapGet("/admin/access-requests/{id:guid}", async (
+            Guid id, HttpContext context, IMediator mediator, CancellationToken ct) =>
+        {
+            var (authorized, _, error) = context.RequireAdminSession();
+            if (!authorized) return error!;
+
+            var result = await mediator.Send(new GetAccessRequestByIdQuery(id), ct).ConfigureAwait(false);
+            return Results.Ok(result);
+        }).WithName("GetAccessRequestById")
+          .RequireAdminSession();
+    }
+
+    private static void MapApproveAccessRequestEndpoint(RouteGroupBuilder group)
+    {
+        group.MapPost("/admin/access-requests/{id:guid}/approve", async (
+            Guid id, HttpContext context, IMediator mediator, CancellationToken ct) =>
+        {
+            var (authorized, session, error) = context.RequireAdminSession();
+            if (!authorized) return error!;
+
+            await mediator.Send(
+                new ApproveAccessRequestCommand(id, session!.User!.Id), ct).ConfigureAwait(false);
+            return Results.Ok(new { status = "approved" });
+        }).WithName("ApproveAccessRequest")
+          .RequireAdminSession();
+    }
+
+    private static void MapRejectAccessRequestEndpoint(RouteGroupBuilder group)
+    {
+        group.MapPost("/admin/access-requests/{id:guid}/reject", async (
+            Guid id, RejectAccessRequestPayload? payload,
+            HttpContext context, IMediator mediator, CancellationToken ct) =>
+        {
+            var (authorized, session, error) = context.RequireAdminSession();
+            if (!authorized) return error!;
+
+            await mediator.Send(
+                new RejectAccessRequestCommand(id, session!.User!.Id, payload?.Reason), ct)
+                .ConfigureAwait(false);
+            return Results.Ok(new { status = "rejected" });
+        }).WithName("RejectAccessRequest")
+          .RequireAdminSession();
+    }
+
+    private static void MapBulkApproveEndpoint(RouteGroupBuilder group)
+    {
+        group.MapPost("/admin/access-requests/bulk-approve", async (
+            BulkApprovePayload payload,
+            HttpContext context, IMediator mediator, CancellationToken ct) =>
+        {
+            var (authorized, session, error) = context.RequireAdminSession();
+            if (!authorized) return error!;
+
+            var result = await mediator.Send(
+                new BulkApproveAccessRequestsCommand(payload.Ids, session!.User!.Id), ct)
+                .ConfigureAwait(false);
+            return Results.Ok(result);
+        }).WithName("BulkApproveAccessRequests")
+          .RequireAdminSession();
+    }
+
+    private static void MapSetRegistrationModeEndpoint(RouteGroupBuilder group)
+    {
+        group.MapPut("/admin/settings/registration-mode", async (
+            SetRegistrationModePayload payload,
+            HttpContext context, IMediator mediator, CancellationToken ct) =>
+        {
+            var (authorized, session, error) = context.RequireAdminSession();
+            if (!authorized) return error!;
+
+            await mediator.Send(
+                new SetRegistrationModeCommand(payload.Enabled, session!.User!.Id), ct)
+                .ConfigureAwait(false);
+            return Results.Ok(new { publicRegistrationEnabled = payload.Enabled });
+        }).WithName("SetRegistrationMode")
+          .RequireAdminSession();
+    }
+}
+
+// Payload records
+internal record RequestAccessPayload(string Email);
+internal record RejectAccessRequestPayload(string? Reason);
+internal record BulkApprovePayload(IReadOnlyList<Guid> Ids);
+internal record SetRegistrationModePayload(bool Enabled);

--- a/apps/api/src/Api/Routing/AuthenticationEndpoints.cs
+++ b/apps/api/src/Api/Routing/AuthenticationEndpoints.cs
@@ -109,7 +109,8 @@ internal static class AuthenticationEndpoints
             logger.LogInformation("User {UserId} registered successfully with role {Role}", result.User.Id, result.User.Role);
 
             return Results.Json(new { user = result.User, expiresAt = result.ExpiresAt });
-        }).RequireRateLimiting("AuthRegister");
+        }).RequireRateLimiting("AuthRegister")
+          .RequirePublicRegistration();
     }
 
     private static void MapLoginEndpoint(RouteGroupBuilder group)

--- a/apps/api/tests/Api.Tests/BoundedContexts/Authentication/Application/Commands/ApproveAccessRequestCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/Authentication/Application/Commands/ApproveAccessRequestCommandHandlerTests.cs
@@ -1,0 +1,77 @@
+using Api.BoundedContexts.Authentication.Application.Commands.AccessRequest;
+using Api.BoundedContexts.Authentication.Domain.Enums;
+using Api.BoundedContexts.Authentication.Domain.Repositories;
+using Api.Middleware.Exceptions;
+using Api.Tests.Constants;
+using MediatR;
+using Moq;
+using Xunit;
+using AuthAccessRequest = Api.BoundedContexts.Authentication.Domain.Entities.AccessRequest;
+
+namespace Api.Tests.BoundedContexts.Authentication.Application.Commands;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "Authentication")]
+public class ApproveAccessRequestCommandHandlerTests
+{
+    private readonly Mock<IAccessRequestRepository> _repoMock;
+    private readonly ApproveAccessRequestCommandHandler _handler;
+
+    public ApproveAccessRequestCommandHandlerTests()
+    {
+        _repoMock = new Mock<IAccessRequestRepository>();
+        _handler = new ApproveAccessRequestCommandHandler(_repoMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_PendingRequest_ApprovesSuccessfully()
+    {
+        var request = AuthAccessRequest.Create("test@example.com");
+        _repoMock.Setup(x => x.GetByIdAsync(request.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(request);
+
+        var command = new ApproveAccessRequestCommand(request.Id, Guid.NewGuid());
+        await _handler.Handle(command, CancellationToken.None);
+
+        Assert.Equal(AccessRequestStatus.Approved, request.Status);
+        _repoMock.Verify(x => x.UpdateAsync(request, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_AlreadyApproved_ReturnsSuccessWithoutModification()
+    {
+        var request = AuthAccessRequest.Create("test@example.com");
+        request.Approve(Guid.NewGuid());
+        _repoMock.Setup(x => x.GetByIdAsync(request.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(request);
+
+        var command = new ApproveAccessRequestCommand(request.Id, Guid.NewGuid());
+        await _handler.Handle(command, CancellationToken.None);
+
+        _repoMock.Verify(x => x.UpdateAsync(It.IsAny<AuthAccessRequest>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_RejectedRequest_ThrowsConflictException()
+    {
+        var request = AuthAccessRequest.Create("test@example.com");
+        request.Reject(Guid.NewGuid());
+        _repoMock.Setup(x => x.GetByIdAsync(request.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(request);
+
+        var command = new ApproveAccessRequestCommand(request.Id, Guid.NewGuid());
+        await Assert.ThrowsAsync<ConflictException>(
+            () => _handler.Handle(command, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task Handle_NonExistentId_ThrowsNotFoundException()
+    {
+        _repoMock.Setup(x => x.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((AuthAccessRequest?)null);
+
+        var command = new ApproveAccessRequestCommand(Guid.NewGuid(), Guid.NewGuid());
+        await Assert.ThrowsAsync<NotFoundException>(
+            () => _handler.Handle(command, CancellationToken.None));
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/Authentication/Application/Commands/BulkApproveAccessRequestsCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/Authentication/Application/Commands/BulkApproveAccessRequestsCommandHandlerTests.cs
@@ -1,0 +1,68 @@
+using Api.BoundedContexts.Authentication.Application.Commands.AccessRequest;
+using Api.BoundedContexts.Authentication.Domain.Repositories;
+using Api.Tests.Constants;
+using Moq;
+using Xunit;
+using AuthAccessRequest = Api.BoundedContexts.Authentication.Domain.Entities.AccessRequest;
+
+namespace Api.Tests.BoundedContexts.Authentication.Application.Commands;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "Authentication")]
+public class BulkApproveAccessRequestsCommandHandlerTests
+{
+    private readonly Mock<IAccessRequestRepository> _repoMock;
+    private readonly BulkApproveAccessRequestsCommandHandler _handler;
+
+    public BulkApproveAccessRequestsCommandHandlerTests()
+    {
+        _repoMock = new Mock<IAccessRequestRepository>();
+        _handler = new BulkApproveAccessRequestsCommandHandler(_repoMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_ExceedsMaxBatchSize_ThrowsArgumentException()
+    {
+        var ids = Enumerable.Range(0, 26).Select(_ => Guid.NewGuid()).ToList();
+        var command = new BulkApproveAccessRequestsCommand(ids, Guid.NewGuid());
+
+        await Assert.ThrowsAsync<ArgumentException>(
+            () => _handler.Handle(command, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task Handle_MixedStates_ReturnsPerItemResults()
+    {
+        var pending = AuthAccessRequest.Create("a@test.com");
+        var approved = AuthAccessRequest.Create("b@test.com");
+        approved.Approve(Guid.NewGuid());
+
+        _repoMock.Setup(x => x.GetByIdAsync(pending.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(pending);
+        _repoMock.Setup(x => x.GetByIdAsync(approved.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(approved);
+
+        var command = new BulkApproveAccessRequestsCommand(
+            new[] { pending.Id, approved.Id }, Guid.NewGuid());
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        Assert.Equal(2, result.Processed);
+        Assert.Equal(2, result.Succeeded);
+        Assert.Equal(0, result.Failed);
+    }
+
+    [Fact]
+    public async Task Handle_NonExistentId_ReportsFailureForThatItem()
+    {
+        var nonExistentId = Guid.NewGuid();
+        _repoMock.Setup(x => x.GetByIdAsync(nonExistentId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((AuthAccessRequest?)null);
+
+        var command = new BulkApproveAccessRequestsCommand(
+            new[] { nonExistentId }, Guid.NewGuid());
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        Assert.Equal(1, result.Failed);
+        Assert.Equal("Not found", result.Results[0].Error);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/Authentication/Application/Commands/RejectAccessRequestCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/Authentication/Application/Commands/RejectAccessRequestCommandHandlerTests.cs
@@ -1,0 +1,81 @@
+using Api.BoundedContexts.Authentication.Application.Commands.AccessRequest;
+using Api.BoundedContexts.Authentication.Domain.Enums;
+using Api.BoundedContexts.Authentication.Domain.Repositories;
+using Api.Middleware.Exceptions;
+using Api.Tests.Constants;
+using MediatR;
+using Moq;
+using Xunit;
+using AuthAccessRequest = Api.BoundedContexts.Authentication.Domain.Entities.AccessRequest;
+
+namespace Api.Tests.BoundedContexts.Authentication.Application.Commands;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "Authentication")]
+public class RejectAccessRequestCommandHandlerTests
+{
+    private readonly Mock<IAccessRequestRepository> _repoMock;
+    private readonly RejectAccessRequestCommandHandler _handler;
+
+    public RejectAccessRequestCommandHandlerTests()
+    {
+        _repoMock = new Mock<IAccessRequestRepository>();
+        _handler = new RejectAccessRequestCommandHandler(_repoMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_PendingRequest_RejectsWithReason()
+    {
+        var request = AuthAccessRequest.Create("test@example.com");
+        _repoMock.Setup(x => x.GetByIdAsync(request.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(request);
+
+        await _handler.Handle(
+            new RejectAccessRequestCommand(request.Id, Guid.NewGuid(), "Not in beta"),
+            CancellationToken.None);
+
+        Assert.Equal(AccessRequestStatus.Rejected, request.Status);
+        Assert.Equal("Not in beta", request.RejectionReason);
+    }
+
+    [Fact]
+    public async Task Handle_AlreadyRejected_ReturnsSuccessWithoutModification()
+    {
+        var request = AuthAccessRequest.Create("test@example.com");
+        request.Reject(Guid.NewGuid());
+        _repoMock.Setup(x => x.GetByIdAsync(request.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(request);
+
+        await _handler.Handle(
+            new RejectAccessRequestCommand(request.Id, Guid.NewGuid()),
+            CancellationToken.None);
+
+        _repoMock.Verify(x => x.UpdateAsync(It.IsAny<AuthAccessRequest>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_ApprovedRequest_ThrowsConflictException()
+    {
+        var request = AuthAccessRequest.Create("test@example.com");
+        request.Approve(Guid.NewGuid());
+        _repoMock.Setup(x => x.GetByIdAsync(request.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(request);
+
+        await Assert.ThrowsAsync<ConflictException>(
+            () => _handler.Handle(
+                new RejectAccessRequestCommand(request.Id, Guid.NewGuid()),
+                CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task Handle_NonExistentId_ThrowsNotFoundException()
+    {
+        _repoMock.Setup(x => x.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((AuthAccessRequest?)null);
+
+        await Assert.ThrowsAsync<NotFoundException>(
+            () => _handler.Handle(
+                new RejectAccessRequestCommand(Guid.NewGuid(), Guid.NewGuid()),
+                CancellationToken.None));
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/Authentication/Application/Commands/RequestAccessCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/Authentication/Application/Commands/RequestAccessCommandHandlerTests.cs
@@ -1,0 +1,108 @@
+using Api.BoundedContexts.Authentication.Application.Commands.AccessRequest;
+using Api.BoundedContexts.Authentication.Domain.Entities;
+using Api.BoundedContexts.Authentication.Domain.Repositories;
+using Api.BoundedContexts.Authentication.Domain.ValueObjects;
+using Api.BoundedContexts.Authentication.Infrastructure.Persistence;
+using Api.SharedKernel.Domain.ValueObjects;
+using Api.Tests.Constants;
+using Moq;
+using Xunit;
+using AuthAccessRequest = Api.BoundedContexts.Authentication.Domain.Entities.AccessRequest;
+
+namespace Api.Tests.BoundedContexts.Authentication.Application.Commands;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "Authentication")]
+public class RequestAccessCommandHandlerTests
+{
+    private readonly Mock<IAccessRequestRepository> _accessRequestRepoMock;
+    private readonly Mock<IUserRepository> _userRepoMock;
+    private readonly RequestAccessCommandHandler _handler;
+
+    public RequestAccessCommandHandlerTests()
+    {
+        _accessRequestRepoMock = new Mock<IAccessRequestRepository>();
+        _userRepoMock = new Mock<IUserRepository>();
+        _handler = new RequestAccessCommandHandler(
+            _accessRequestRepoMock.Object,
+            _userRepoMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_NewEmail_CreatesAccessRequest()
+    {
+        _accessRequestRepoMock
+            .Setup(x => x.GetPendingByEmailAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((AuthAccessRequest?)null);
+        _userRepoMock
+            .Setup(x => x.GetByEmailAsync(It.IsAny<Email>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((User?)null);
+
+        var command = new RequestAccessCommand("new@example.com");
+        await _handler.Handle(command, CancellationToken.None);
+
+        _accessRequestRepoMock.Verify(
+            x => x.AddAsync(It.Is<AuthAccessRequest>(r => r.Email == "new@example.com"),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ExistingAccount_DoesNotCreateRequest()
+    {
+        var existingUser = new User(
+            Guid.NewGuid(),
+            new Email("existing@example.com"),
+            "Existing User",
+            PasswordHash.Create("Password123!"),
+            Role.User);
+
+        _userRepoMock
+            .Setup(x => x.GetByEmailAsync(It.IsAny<Email>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingUser);
+
+        _accessRequestRepoMock
+            .Setup(x => x.GetPendingByEmailAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((AuthAccessRequest?)null);
+
+        var command = new RequestAccessCommand("existing@example.com");
+        await _handler.Handle(command, CancellationToken.None);
+
+        _accessRequestRepoMock.Verify(
+            x => x.AddAsync(It.IsAny<AuthAccessRequest>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_AlreadyPending_DoesNotCreateDuplicate()
+    {
+        var pendingRequest = AuthAccessRequest.Create("pending@example.com");
+        _accessRequestRepoMock
+            .Setup(x => x.GetPendingByEmailAsync("pending@example.com", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(pendingRequest);
+        _userRepoMock
+            .Setup(x => x.GetByEmailAsync(It.IsAny<Email>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((User?)null);
+
+        var command = new RequestAccessCommand("pending@example.com");
+        await _handler.Handle(command, CancellationToken.None);
+
+        _accessRequestRepoMock.Verify(
+            x => x.AddAsync(It.IsAny<AuthAccessRequest>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_NormalizesEmail()
+    {
+        _accessRequestRepoMock
+            .Setup(x => x.GetPendingByEmailAsync("test@example.com", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((AuthAccessRequest?)null);
+        _userRepoMock
+            .Setup(x => x.GetByEmailAsync(It.IsAny<Email>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((User?)null);
+
+        var command = new RequestAccessCommand("TEST@Example.COM");
+        await _handler.Handle(command, CancellationToken.None);
+
+        _accessRequestRepoMock.Verify(
+            x => x.GetPendingByEmailAsync("test@example.com", It.IsAny<CancellationToken>()), Times.Once);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/Authentication/Domain/Entities/AccessRequestTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/Authentication/Domain/Entities/AccessRequestTests.cs
@@ -1,0 +1,153 @@
+using Api.BoundedContexts.Authentication.Domain.Entities;
+using Api.BoundedContexts.Authentication.Domain.Enums;
+using Api.BoundedContexts.Authentication.Domain.Events;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.Authentication.Domain.Entities;
+
+public class AccessRequestTests
+{
+    [Fact]
+    public void Create_WithValidEmail_ReturnsPendingAccessRequest()
+    {
+        var request = AccessRequest.Create("test@example.com");
+
+        Assert.NotEqual(Guid.Empty, request.Id);
+        Assert.Equal("test@example.com", request.Email);
+        Assert.Equal(AccessRequestStatus.Pending, request.Status);
+        Assert.True(request.RequestedAt <= DateTime.UtcNow);
+        Assert.Null(request.ReviewedAt);
+        Assert.Null(request.ReviewedBy);
+        Assert.Null(request.RejectionReason);
+        Assert.Null(request.InvitationId);
+    }
+
+    [Fact]
+    public void Create_NormalizesEmailToLowercase()
+    {
+        var request = AccessRequest.Create("Test@EXAMPLE.com");
+        Assert.Equal("test@example.com", request.Email);
+    }
+
+    [Fact]
+    public void Approve_FromPending_SetsApprovedState()
+    {
+        var request = AccessRequest.Create("test@example.com");
+        var adminId = Guid.NewGuid();
+
+        request.Approve(adminId);
+
+        Assert.Equal(AccessRequestStatus.Approved, request.Status);
+        Assert.NotNull(request.ReviewedAt);
+        Assert.Equal(adminId, request.ReviewedBy);
+    }
+
+    [Fact]
+    public void Reject_FromPending_SetsRejectedState()
+    {
+        var request = AccessRequest.Create("test@example.com");
+        var adminId = Guid.NewGuid();
+
+        request.Reject(adminId, "Not in beta group");
+
+        Assert.Equal(AccessRequestStatus.Rejected, request.Status);
+        Assert.NotNull(request.ReviewedAt);
+        Assert.Equal(adminId, request.ReviewedBy);
+        Assert.Equal("Not in beta group", request.RejectionReason);
+    }
+
+    [Fact]
+    public void Reject_WithoutReason_SetsNullReason()
+    {
+        var request = AccessRequest.Create("test@example.com");
+        request.Reject(Guid.NewGuid());
+        Assert.Null(request.RejectionReason);
+    }
+
+    [Fact]
+    public void Approve_WhenAlreadyApproved_ThrowsInvalidOperationException()
+    {
+        var request = AccessRequest.Create("test@example.com");
+        request.Approve(Guid.NewGuid());
+
+        Assert.Throws<InvalidOperationException>(() => request.Approve(Guid.NewGuid()));
+    }
+
+    [Fact]
+    public void Approve_WhenRejected_ThrowsInvalidOperationException()
+    {
+        var request = AccessRequest.Create("test@example.com");
+        request.Reject(Guid.NewGuid());
+
+        Assert.Throws<InvalidOperationException>(() => request.Approve(Guid.NewGuid()));
+    }
+
+    [Fact]
+    public void Reject_WhenAlreadyRejected_ThrowsInvalidOperationException()
+    {
+        var request = AccessRequest.Create("test@example.com");
+        request.Reject(Guid.NewGuid());
+
+        Assert.Throws<InvalidOperationException>(() => request.Reject(Guid.NewGuid()));
+    }
+
+    [Fact]
+    public void Reject_WhenApproved_ThrowsInvalidOperationException()
+    {
+        var request = AccessRequest.Create("test@example.com");
+        request.Approve(Guid.NewGuid());
+
+        Assert.Throws<InvalidOperationException>(() => request.Reject(Guid.NewGuid()));
+    }
+
+    [Fact]
+    public void Approve_PublishesAccessRequestApprovedEvent()
+    {
+        var request = AccessRequest.Create("test@example.com");
+        var adminId = Guid.NewGuid();
+
+        request.Approve(adminId);
+
+        var domainEvent = request.DomainEvents
+            .OfType<AccessRequestApprovedEvent>()
+            .SingleOrDefault();
+        Assert.NotNull(domainEvent);
+        Assert.Equal(request.Id, domainEvent.AccessRequestId);
+        Assert.Equal("test@example.com", domainEvent.Email);
+        Assert.Equal(adminId, domainEvent.ApprovedByUserId);
+    }
+
+    [Fact]
+    public void Create_PublishesAccessRequestCreatedEvent()
+    {
+        var request = AccessRequest.Create("test@example.com");
+
+        var domainEvent = request.DomainEvents
+            .OfType<AccessRequestCreatedEvent>()
+            .SingleOrDefault();
+        Assert.NotNull(domainEvent);
+        Assert.Equal(request.Id, domainEvent.AccessRequestId);
+        Assert.Equal("test@example.com", domainEvent.Email);
+    }
+
+    [Fact]
+    public void SetInvitationId_StoresCorrelationId()
+    {
+        var request = AccessRequest.Create("test@example.com");
+        request.Approve(Guid.NewGuid());
+        var invitationId = Guid.NewGuid();
+
+        request.SetInvitationId(invitationId);
+
+        Assert.Equal(invitationId, request.InvitationId);
+    }
+
+    [Fact]
+    public void Reject_WithReasonExceeding500Chars_ThrowsArgumentException()
+    {
+        var request = AccessRequest.Create("test@example.com");
+        var longReason = new string('a', 501);
+
+        Assert.Throws<ArgumentException>(() => request.Reject(Guid.NewGuid(), longReason));
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/Authentication/Integration/AccessRequestIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/Authentication/Integration/AccessRequestIntegrationTests.cs
@@ -1,0 +1,333 @@
+using Api.BoundedContexts.Authentication.Application.Commands.AccessRequest;
+using Api.BoundedContexts.Authentication.Application.Queries.AccessRequest;
+using Api.BoundedContexts.Authentication.Domain.Entities;
+using Api.BoundedContexts.Authentication.Domain.Enums;
+using Api.BoundedContexts.Authentication.Domain.Repositories;
+using Api.BoundedContexts.Authentication.Domain.ValueObjects;
+using Api.BoundedContexts.Authentication.Infrastructure.Persistence;
+using Api.BoundedContexts.Authentication.Infrastructure.Repositories;
+using Api.Infrastructure;
+using Api.Tests.Constants;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using MediatR;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.Authentication.Integration;
+
+/// <summary>
+/// Integration tests for the access request feature — handler + repository lifecycle.
+/// Uses InMemory EF Core (same pattern as OAuthCallbackIntegrationTests) for speed
+/// and simplicity. The AccessRequestRepository is exercised against real EF Core
+/// change-tracking instead of a mock.
+/// </summary>
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "Authentication")]
+public sealed class AccessRequestIntegrationTests : IDisposable
+{
+    private readonly MeepleAiDbContext _dbContext;
+    private readonly IAccessRequestRepository _repository;
+
+    public AccessRequestIntegrationTests()
+    {
+        _dbContext = TestDbContextFactory.CreateInMemoryDbContext();
+        _repository = new AccessRequestRepository(_dbContext);
+    }
+
+    public void Dispose() => _dbContext.Dispose();
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // RequestAccessCommandHandler
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task RequestAccess_WithNewEmail_CreatesAccessRequest()
+    {
+        // Arrange
+        var userRepoMock = new Mock<IUserRepository>();
+        userRepoMock
+            .Setup(r => r.GetByEmailAsync(It.IsAny<Email>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((User?)null);
+
+        var handler = new RequestAccessCommandHandler(_repository, userRepoMock.Object);
+        var command = new RequestAccessCommand("newuser@example.com");
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.Should().Be(MediatR.Unit.Value);
+        await _dbContext.SaveChangesAsync();
+        var stored = await _repository.GetPendingByEmailAsync("newuser@example.com");
+        stored.Should().NotBeNull();
+        stored!.Email.Should().Be("newuser@example.com");
+        stored.Status.Should().Be(AccessRequestStatus.Pending);
+    }
+
+    [Fact]
+    public async Task RequestAccess_WithUppercaseEmail_NormalizesToLowercase()
+    {
+        // Arrange
+        var userRepoMock = new Mock<IUserRepository>();
+        userRepoMock
+            .Setup(r => r.GetByEmailAsync(It.IsAny<Email>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((User?)null);
+
+        var handler = new RequestAccessCommandHandler(_repository, userRepoMock.Object);
+        var command = new RequestAccessCommand("VISITOR@EXAMPLE.COM");
+
+        // Act
+        await handler.Handle(command, CancellationToken.None);
+        await _dbContext.SaveChangesAsync();
+
+        // Assert
+        var stored = await _repository.GetPendingByEmailAsync("visitor@example.com");
+        stored.Should().NotBeNull();
+        stored!.Email.Should().Be("visitor@example.com");
+    }
+
+    [Fact]
+    public async Task RequestAccess_WithExistingPendingRequest_ReturnsSilentlyWithoutDuplicate()
+    {
+        // Arrange — seed an existing pending request
+        var existing = AccessRequest.Create("duplicate@example.com");
+        await _repository.AddAsync(existing);
+        await _dbContext.SaveChangesAsync();
+
+        var userRepoMock = new Mock<IUserRepository>();
+        userRepoMock
+            .Setup(r => r.GetByEmailAsync(It.IsAny<Email>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((User?)null);
+
+        var handler = new RequestAccessCommandHandler(_repository, userRepoMock.Object);
+        var command = new RequestAccessCommand("duplicate@example.com");
+
+        // Act — email enumeration prevention: should not throw even for existing
+        var act = () => handler.Handle(command, CancellationToken.None);
+
+        // Assert — idempotent success, no duplicate created
+        await act.Should().NotThrowAsync();
+        await _dbContext.SaveChangesAsync();
+        var count = await _repository.CountByStatusAsync(AccessRequestStatus.Pending);
+        count.Should().Be(1); // only the original
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // ApproveAccessRequestCommandHandler
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ApproveAccessRequest_WithPendingRequest_SetsStatusToApproved()
+    {
+        // Arrange
+        var request = AccessRequest.Create("pending@example.com");
+        await _repository.AddAsync(request);
+        await _dbContext.SaveChangesAsync();
+
+        var handler = new ApproveAccessRequestCommandHandler(_repository);
+        var adminId = Guid.NewGuid();
+        var command = new ApproveAccessRequestCommand(request.Id, adminId);
+
+        // Act
+        await handler.Handle(command, CancellationToken.None);
+        await _dbContext.SaveChangesAsync();
+
+        // Assert
+        var updated = await _repository.GetByIdAsync(request.Id);
+        updated.Should().NotBeNull();
+        updated!.Status.Should().Be(AccessRequestStatus.Approved);
+        updated.ReviewedBy.Should().Be(adminId);
+        updated.ReviewedAt.Should().NotBeNull();
+    }
+
+    [Fact]
+    public async Task ApproveAccessRequest_WithNonExistentId_ThrowsNotFoundException()
+    {
+        // Arrange
+        var handler = new ApproveAccessRequestCommandHandler(_repository);
+        var command = new ApproveAccessRequestCommand(Guid.NewGuid(), Guid.NewGuid());
+
+        // Act & Assert
+        await Assert.ThrowsAsync<Api.Middleware.Exceptions.NotFoundException>(
+            () => handler.Handle(command, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task ApproveAccessRequest_AlreadyApproved_IsIdempotent()
+    {
+        // Arrange — seed already approved entity
+        var request = AccessRequest.Create("already@example.com");
+        request.Approve(Guid.NewGuid());
+        await _repository.AddAsync(request);
+        await _dbContext.SaveChangesAsync();
+
+        var handler = new ApproveAccessRequestCommandHandler(_repository);
+        var command = new ApproveAccessRequestCommand(request.Id, Guid.NewGuid());
+
+        // Act — approving again should not throw
+        var act = () => handler.Handle(command, CancellationToken.None);
+        await act.Should().NotThrowAsync();
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // RejectAccessRequestCommandHandler
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task RejectAccessRequest_WithPendingRequest_SetsStatusToRejected()
+    {
+        // Arrange
+        var request = AccessRequest.Create("toReject@example.com");
+        await _repository.AddAsync(request);
+        await _dbContext.SaveChangesAsync();
+
+        var handler = new RejectAccessRequestCommandHandler(_repository);
+        var adminId = Guid.NewGuid();
+        var command = new RejectAccessRequestCommand(request.Id, adminId, "Not eligible at this time.");
+
+        // Act
+        await handler.Handle(command, CancellationToken.None);
+        await _dbContext.SaveChangesAsync();
+
+        // Assert
+        var updated = await _repository.GetByIdAsync(request.Id);
+        updated.Should().NotBeNull();
+        updated!.Status.Should().Be(AccessRequestStatus.Rejected);
+        updated.ReviewedBy.Should().Be(adminId);
+        updated.RejectionReason.Should().Be("Not eligible at this time.");
+    }
+
+    [Fact]
+    public async Task RejectAccessRequest_WithNonExistentId_ThrowsNotFoundException()
+    {
+        // Arrange
+        var handler = new RejectAccessRequestCommandHandler(_repository);
+        var command = new RejectAccessRequestCommand(Guid.NewGuid(), Guid.NewGuid(), null);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<Api.Middleware.Exceptions.NotFoundException>(
+            () => handler.Handle(command, CancellationToken.None));
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // BulkApproveAccessRequestsCommandHandler
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task BulkApprove_WithMultiplePendingRequests_ApprovesAll()
+    {
+        // Arrange — create 3 pending requests
+        var req1 = AccessRequest.Create("bulk1@example.com");
+        var req2 = AccessRequest.Create("bulk2@example.com");
+        var req3 = AccessRequest.Create("bulk3@example.com");
+        await _repository.AddAsync(req1);
+        await _repository.AddAsync(req2);
+        await _repository.AddAsync(req3);
+        await _dbContext.SaveChangesAsync();
+
+        var handler = new BulkApproveAccessRequestsCommandHandler(_repository);
+        var adminId = Guid.NewGuid();
+        var command = new BulkApproveAccessRequestsCommand(
+            new List<Guid> { req1.Id, req2.Id, req3.Id },
+            adminId);
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+        await _dbContext.SaveChangesAsync();
+
+        // Assert
+        result.Processed.Should().Be(3);
+        result.Succeeded.Should().Be(3);
+        result.Failed.Should().Be(0);
+
+        var updated1 = await _repository.GetByIdAsync(req1.Id);
+        var updated2 = await _repository.GetByIdAsync(req2.Id);
+        var updated3 = await _repository.GetByIdAsync(req3.Id);
+        updated1!.Status.Should().Be(AccessRequestStatus.Approved);
+        updated2!.Status.Should().Be(AccessRequestStatus.Approved);
+        updated3!.Status.Should().Be(AccessRequestStatus.Approved);
+    }
+
+    [Fact]
+    public async Task BulkApprove_WithMixOfValidAndMissingIds_ReportsFailuresForMissing()
+    {
+        // Arrange — one real, one phantom
+        var realRequest = AccessRequest.Create("real@example.com");
+        await _repository.AddAsync(realRequest);
+        await _dbContext.SaveChangesAsync();
+
+        var phantomId = Guid.NewGuid();
+        var handler = new BulkApproveAccessRequestsCommandHandler(_repository);
+        var command = new BulkApproveAccessRequestsCommand(
+            new List<Guid> { realRequest.Id, phantomId },
+            Guid.NewGuid());
+
+        // Act
+        var result = await handler.Handle(command, CancellationToken.None);
+        await _dbContext.SaveChangesAsync();
+
+        // Assert
+        result.Processed.Should().Be(2);
+        result.Succeeded.Should().Be(1);
+        result.Failed.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task BulkApprove_WithMoreThan25Ids_ThrowsArgumentException()
+    {
+        // Arrange
+        var ids = Enumerable.Range(0, 26).Select(_ => Guid.NewGuid()).ToList();
+        var handler = new BulkApproveAccessRequestsCommandHandler(_repository);
+        var command = new BulkApproveAccessRequestsCommand(ids, Guid.NewGuid());
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ArgumentException>(() => handler.Handle(command, CancellationToken.None));
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // GetAccessRequestsQueryHandler
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetAccessRequests_WithNoFilter_ReturnsAllRequests()
+    {
+        // Arrange
+        var r1 = AccessRequest.Create("list1@example.com");
+        var r2 = AccessRequest.Create("list2@example.com");
+        await _repository.AddAsync(r1);
+        await _repository.AddAsync(r2);
+        await _dbContext.SaveChangesAsync();
+
+        var handler = new GetAccessRequestsQueryHandler(_repository);
+        var query = new GetAccessRequestsQuery();
+
+        // Act
+        var response = await handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        response.Items.Count.Should().BeGreaterThanOrEqualTo(2);
+        response.TotalCount.Should().BeGreaterThanOrEqualTo(2);
+    }
+
+    [Fact]
+    public async Task GetAccessRequests_FilteredByPendingStatus_ReturnsOnlyPending()
+    {
+        // Arrange — one pending, one approved
+        var pending = AccessRequest.Create("onlypending@example.com");
+        var approved = AccessRequest.Create("onlyapproved@example.com");
+        approved.Approve(Guid.NewGuid());
+        await _repository.AddAsync(pending);
+        await _repository.AddAsync(approved);
+        await _dbContext.SaveChangesAsync();
+
+        var handler = new GetAccessRequestsQueryHandler(_repository);
+        var query = new GetAccessRequestsQuery(Status: "Pending");
+
+        // Act
+        var response = await handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        response.Items.Should().OnlyContain(r => r.Status == "Pending");
+    }
+}

--- a/apps/web/__tests__/app/register/page.test.tsx
+++ b/apps/web/__tests__/app/register/page.test.tsx
@@ -1,0 +1,112 @@
+/**
+ * Register Page Content Tests (invite-only registration feature)
+ *
+ * 1. Shows register form (AuthModal) when public registration is enabled
+ * 2. Shows RequestAccessForm when public registration is disabled
+ */
+
+import { render, screen, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ────────────────────────────────────────────────────────────────────────────
+// Mocks
+// ────────────────────────────────────────────────────────────────────────────
+
+const mockGetRegistrationMode = vi.fn();
+
+vi.mock('@/lib/api/context', () => ({
+  useApiClient: vi.fn(),
+}));
+
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => ({
+    t: (key: string, defaultMessage?: string) => defaultMessage ?? key,
+    locale: 'en',
+    formatMessage: vi.fn(),
+    formatNumber: vi.fn(),
+    formatDate: vi.fn(),
+    formatTime: vi.fn(),
+    formatRelativeTime: vi.fn(),
+  }),
+}));
+
+// Mock next/navigation (required by RegisterPageContent)
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn(), replace: vi.fn(), back: vi.fn() }),
+  useSearchParams: () => ({ get: vi.fn().mockReturnValue(null) }),
+  usePathname: () => '/register',
+}));
+
+// Mock AuthModal so we don't render its full internals
+vi.mock('@/components/auth', () => ({
+  AuthModal: ({ isOpen }: { isOpen: boolean }) =>
+    isOpen ? <div data-testid="auth-modal">AuthModal</div> : null,
+}));
+
+// Mock RequestAccessForm to keep the test focused on the page's branching logic
+vi.mock('@/components/auth/RequestAccessForm', () => ({
+  RequestAccessForm: () => <div data-testid="request-access-form">RequestAccessForm</div>,
+}));
+
+// Mock AuthLayout to render children transparently
+vi.mock('@/components/layouts', () => ({
+  AuthLayout: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+// ────────────────────────────────────────────────────────────────────────────
+// Import component under test after mocks
+// ────────────────────────────────────────────────────────────────────────────
+
+import { useApiClient } from '@/lib/api/context';
+import { RegisterPageContent } from '@/app/(auth)/register/_content';
+
+const mockUseApiClient = vi.mocked(useApiClient);
+
+// ────────────────────────────────────────────────────────────────────────────
+// Test suite
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('RegisterPageContent', () => {
+  beforeEach(() => {
+    mockGetRegistrationMode.mockReset();
+    mockUseApiClient.mockReturnValue({
+      accessRequests: { getRegistrationMode: mockGetRegistrationMode },
+    } as any);
+  });
+
+  it('shows AuthModal (register form) when public registration is enabled', async () => {
+    mockGetRegistrationMode.mockResolvedValueOnce({ publicRegistrationEnabled: true });
+
+    render(<RegisterPageContent />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('auth-modal')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByTestId('request-access-form')).not.toBeInTheDocument();
+  });
+
+  it('shows RequestAccessForm when public registration is disabled', async () => {
+    mockGetRegistrationMode.mockResolvedValueOnce({ publicRegistrationEnabled: false });
+
+    render(<RegisterPageContent />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('request-access-form')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByTestId('auth-modal')).not.toBeInTheDocument();
+  });
+
+  it('defaults to RequestAccessForm (invite-only) when API call fails', async () => {
+    mockGetRegistrationMode.mockRejectedValueOnce(new Error('Network error'));
+
+    render(<RegisterPageContent />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('request-access-form')).toBeInTheDocument();
+    });
+
+    expect(screen.queryByTestId('auth-modal')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/__tests__/components/auth/RequestAccessForm.test.tsx
+++ b/apps/web/__tests__/components/auth/RequestAccessForm.test.tsx
@@ -1,0 +1,153 @@
+/**
+ * RequestAccessForm Component Tests
+ *
+ * Tests for the invite-only registration access request form:
+ * 1. Renders email input and submit button
+ * 2. Shows validation error for empty/invalid email
+ * 3. Shows success message after submission
+ * 4. Disables form during submission
+ */
+
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+// ────────────────────────────────────────────────────────────────────────────
+// Hoisted mocks (must be declared before vi.mock calls)
+// ────────────────────────────────────────────────────────────────────────────
+
+const mockRequestAccess = vi.fn();
+
+// Mock useApiClient — hoisted so the factory can reference mockRequestAccess
+vi.mock('@/lib/api/context', () => ({
+  useApiClient: vi.fn(),
+}));
+
+// Mock useTranslation — return the key as the translation (fallback behaviour)
+vi.mock('@/hooks/useTranslation', () => ({
+  useTranslation: () => ({
+    t: (key: string, defaultMessage?: string) => defaultMessage ?? key,
+    locale: 'en',
+    formatMessage: vi.fn(),
+    formatNumber: vi.fn(),
+    formatDate: vi.fn(),
+    formatTime: vi.fn(),
+    formatRelativeTime: vi.fn(),
+  }),
+}));
+
+// ────────────────────────────────────────────────────────────────────────────
+// Import the component after mocks are in place
+// ────────────────────────────────────────────────────────────────────────────
+
+import { useApiClient } from '@/lib/api/context';
+import { RequestAccessForm } from '@/components/auth/RequestAccessForm';
+
+const mockUseApiClient = vi.mocked(useApiClient);
+
+// ────────────────────────────────────────────────────────────────────────────
+// Test suite
+// ────────────────────────────────────────────────────────────────────────────
+
+describe('RequestAccessForm', () => {
+  beforeEach(() => {
+    mockRequestAccess.mockReset();
+    mockUseApiClient.mockReturnValue({
+      accessRequests: { requestAccess: mockRequestAccess },
+    } as any);
+  });
+
+  it('renders email input and submit button', () => {
+    render(<RequestAccessForm />);
+
+    expect(screen.getByTestId('request-access-email')).toBeInTheDocument();
+    expect(screen.getByTestId('request-access-submit')).toBeInTheDocument();
+    // Submit button should be enabled initially
+    expect(screen.getByTestId('request-access-submit')).not.toBeDisabled();
+  });
+
+  it('shows validation error for empty or invalid email', async () => {
+    const user = userEvent.setup();
+    render(<RequestAccessForm />);
+
+    // Submit without entering an email
+    await user.click(screen.getByTestId('request-access-submit'));
+
+    await waitFor(() => {
+      expect(screen.getByText(/email is required/i)).toBeInTheDocument();
+    });
+
+    // Enter an invalid email
+    await user.clear(screen.getByTestId('request-access-email'));
+    await user.type(screen.getByTestId('request-access-email'), 'not-an-email');
+    await user.click(screen.getByTestId('request-access-submit'));
+
+    await waitFor(() => {
+      expect(screen.getByText(/valid email/i)).toBeInTheDocument();
+    });
+
+    // API should NOT have been called
+    expect(mockRequestAccess).not.toHaveBeenCalled();
+  });
+
+  it('shows success message after successful submission', async () => {
+    mockRequestAccess.mockResolvedValueOnce({ message: 'Request received.' });
+
+    const user = userEvent.setup();
+    render(<RequestAccessForm />);
+
+    await user.type(screen.getByTestId('request-access-email'), 'test@example.com');
+    await user.click(screen.getByTestId('request-access-submit'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('request-access-success')).toBeInTheDocument();
+    });
+
+    expect(mockRequestAccess).toHaveBeenCalledWith('test@example.com');
+    // Form should no longer be visible
+    expect(screen.queryByTestId('request-access-form')).not.toBeInTheDocument();
+  });
+
+  it('shows success message even when the API throws (enumeration protection)', async () => {
+    mockRequestAccess.mockRejectedValueOnce(new Error('Network error'));
+
+    const user = userEvent.setup();
+    render(<RequestAccessForm />);
+
+    await user.type(screen.getByTestId('request-access-email'), 'test@example.com');
+    await user.click(screen.getByTestId('request-access-submit'));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('request-access-success')).toBeInTheDocument();
+    });
+  });
+
+  it('disables email input and button during submission', async () => {
+    // Make the API call hang so we can observe the loading state
+    let resolveFn!: () => void;
+    mockRequestAccess.mockReturnValueOnce(
+      new Promise<{ message: string }>(resolve => {
+        resolveFn = () => resolve({ message: 'ok' });
+      })
+    );
+
+    const user = userEvent.setup();
+    render(<RequestAccessForm />);
+
+    await user.type(screen.getByTestId('request-access-email'), 'test@example.com');
+    await user.click(screen.getByTestId('request-access-submit'));
+
+    // While the request is in-flight, input and button should be disabled
+    await waitFor(() => {
+      expect(screen.getByTestId('request-access-email')).toBeDisabled();
+      expect(screen.getByTestId('request-access-submit')).toBeDisabled();
+    });
+
+    // Resolve the request
+    resolveFn();
+
+    await waitFor(() => {
+      expect(screen.getByTestId('request-access-success')).toBeInTheDocument();
+    });
+  });
+});

--- a/apps/web/e2e/invite-only-registration.spec.ts
+++ b/apps/web/e2e/invite-only-registration.spec.ts
@@ -1,0 +1,226 @@
+/**
+ * E2E Tests: Invite-Only Registration Flow
+ *
+ * Covers the invite-only registration feature (access request):
+ * - /register shows RequestAccessForm when public registration is disabled
+ * - Submitting the form shows a success message
+ * - Admin can view the access requests page (requires admin session)
+ * - Admin can toggle registration mode in config (requires admin session + config API)
+ *
+ * Backend configuration assumption:
+ *   Registration:PublicEnabled = false (default for invite-only mode)
+ *
+ * Tests that require admin login are skipped because admin session fixtures
+ * are managed via `authHelper.setupRealSession('admin')` which needs a live
+ * backend. Those tests are marked as skipped with an explanatory message so
+ * they can be enabled in environments with a running backend.
+ */
+
+import { test, expect } from './fixtures';
+import { AuthHelper } from './pages';
+
+test.describe('Invite-Only Registration', () => {
+  test('shows request access form when registration is invite-only', async ({ page }) => {
+    const authHelper = new AuthHelper(page);
+
+    // Ensure the user is not authenticated so middleware doesn't redirect
+    await authHelper.mockUnauthenticatedSession();
+
+    // Mock the /register route to behave as if public registration is disabled:
+    // The backend config endpoint returns PublicEnabled: false, so the frontend
+    // renders the RequestAccessForm instead of the standard registration form.
+    await page.route('**/api/v1/auth/registration-mode', route =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ publicEnabled: false }),
+      })
+    );
+
+    await page.goto('/register');
+
+    // The RequestAccessForm should be rendered instead of the normal registration form
+    await expect(page.getByRole('button', { name: /request access/i })).toBeVisible({
+      timeout: 5000,
+    });
+    await expect(page.getByLabel(/email/i)).toBeVisible({ timeout: 5000 });
+  });
+
+  test('submits access request and shows success message', async ({ page }) => {
+    const authHelper = new AuthHelper(page);
+
+    await authHelper.mockUnauthenticatedSession();
+
+    // Mock the registration mode endpoint
+    await page.route('**/api/v1/auth/registration-mode', route =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ publicEnabled: false }),
+      })
+    );
+
+    // Mock the request-access POST endpoint — returns 202 Accepted
+    await page.route('**/api/v1/auth/request-access', route =>
+      route.fulfill({
+        status: 202,
+        contentType: 'application/json',
+        body: JSON.stringify({ message: 'Access request submitted.' }),
+      })
+    );
+
+    await page.goto('/register');
+
+    // Fill in the email and submit
+    await page.getByLabel(/email/i).fill('visitor@example.com');
+    await page.getByRole('button', { name: /request access/i }).click();
+
+    // Should display a success confirmation message
+    await expect(page.getByText(/submitted|received|eligible|check.*email|thank/i)).toBeVisible({
+      timeout: 5000,
+    });
+  });
+
+  test('shows validation error when email is empty', async ({ page }) => {
+    const authHelper = new AuthHelper(page);
+
+    await authHelper.mockUnauthenticatedSession();
+
+    await page.route('**/api/v1/auth/registration-mode', route =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ publicEnabled: false }),
+      })
+    );
+
+    await page.goto('/register');
+
+    // Submit without filling the email field
+    await page.getByRole('button', { name: /request access/i }).click();
+
+    // Should display an email validation error
+    await expect(page.getByText(/email.*required|valid.*email|please.*enter/i)).toBeVisible({
+      timeout: 3000,
+    });
+  });
+
+  test('shows validation error when email format is invalid', async ({ page }) => {
+    const authHelper = new AuthHelper(page);
+
+    await authHelper.mockUnauthenticatedSession();
+
+    await page.route('**/api/v1/auth/registration-mode', route =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ publicEnabled: false }),
+      })
+    );
+
+    await page.goto('/register');
+
+    await page.getByLabel(/email/i).fill('not-an-email');
+    await page.getByRole('button', { name: /request access/i }).click();
+
+    // Should display an email format validation error
+    await expect(page.getByText(/valid.*email|invalid.*email|email.*format/i)).toBeVisible({
+      timeout: 3000,
+    });
+  });
+
+  test('shows public registration form when public registration is enabled', async ({ page }) => {
+    const authHelper = new AuthHelper(page);
+
+    await authHelper.mockUnauthenticatedSession();
+
+    // Override: public registration is enabled
+    await page.route('**/api/v1/auth/registration-mode', route =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ publicEnabled: true }),
+      })
+    );
+
+    await page.goto('/register');
+
+    // Standard registration form fields should be visible (not the request-access button)
+    // The exact selectors depend on the RegisterPage component implementation
+    const requestAccessBtn = page.getByRole('button', { name: /request access/i });
+    const registerBtn = page.getByRole('button', { name: /register|create.*account|sign up/i });
+
+    // Either the standard form is shown, or we just verify request-access is NOT shown
+    const isRequestAccessVisible = await requestAccessBtn
+      .isVisible({ timeout: 2000 })
+      .catch(() => false);
+
+    if (!isRequestAccessVisible) {
+      // Good: public registration mode is rendering the normal form
+      await expect(registerBtn).toBeVisible({ timeout: 5000 });
+    }
+  });
+
+  test('admin can view access requests page', async ({ page }) => {
+    test.skip(true, 'Requires admin login fixture — enable when backend is running');
+
+    const authHelper = new AuthHelper(page);
+    await authHelper.setupRealSession('admin');
+    await page.goto('/admin/users/access-requests');
+    await expect(page.getByText(/access requests/i)).toBeVisible({ timeout: 5000 });
+  });
+
+  test('admin can toggle registration mode in configuration', async ({ page }) => {
+    test.skip(true, 'Requires admin login fixture and config API — enable when backend is running');
+
+    const authHelper = new AuthHelper(page);
+    await authHelper.setupRealSession('admin');
+    await page.goto('/admin/config');
+    const toggle = page.getByRole('switch', { name: /public registration/i });
+    await expect(toggle).toBeVisible({ timeout: 5000 });
+  });
+
+  test('admin can approve an access request', async ({ page }) => {
+    test.skip(true, 'Requires admin login fixture — enable when backend is running');
+
+    const authHelper = new AuthHelper(page);
+    await authHelper.setupRealSession('admin');
+
+    await page.goto('/admin/users/access-requests');
+    await page.waitForLoadState('networkidle');
+
+    // Find the first pending request's approve button
+    const approveButton = page.getByRole('button', { name: /approve/i }).first();
+
+    if (await approveButton.isVisible({ timeout: 2000 }).catch(() => false)) {
+      await approveButton.click();
+
+      // Should show success feedback
+      await expect(page.getByText(/approved|success/i)).toBeVisible({ timeout: 5000 });
+    }
+  });
+
+  test('admin can reject an access request', async ({ page }) => {
+    test.skip(true, 'Requires admin login fixture — enable when backend is running');
+
+    const authHelper = new AuthHelper(page);
+    await authHelper.setupRealSession('admin');
+
+    await page.goto('/admin/users/access-requests');
+    await page.waitForLoadState('networkidle');
+
+    const rejectButton = page.getByRole('button', { name: /reject|decline/i }).first();
+
+    if (await rejectButton.isVisible({ timeout: 2000 }).catch(() => false)) {
+      await rejectButton.click();
+
+      // Confirm reject (may require reason input)
+      const confirmButton = page.getByRole('button', { name: /confirm|reject/i }).last();
+      if (await confirmButton.isVisible({ timeout: 2000 }).catch(() => false)) {
+        await confirmButton.click();
+      }
+
+      await expect(page.getByText(/rejected|success/i)).toBeVisible({ timeout: 5000 });
+    }
+  });
+});

--- a/apps/web/e2e/onboarding/accept-invite-to-onboarding.spec.ts
+++ b/apps/web/e2e/onboarding/accept-invite-to-onboarding.spec.ts
@@ -1,0 +1,221 @@
+/**
+ * Accept-Invite → Onboarding Wizard E2E Test
+ *
+ * Validates the full journey: accept invitation → set password → redirect
+ * to onboarding wizard → complete wizard steps → dashboard.
+ *
+ * Uses page.context().route() for API mocking (Next.js dev server pattern).
+ * Uses .first() on all locators to avoid Playwright strict mode errors.
+ */
+
+import { test, expect, type BrowserContext } from '@playwright/test';
+
+const API_BASE =
+  process.env.PLAYWRIGHT_API_BASE || process.env.NEXT_PUBLIC_API_BASE || 'http://localhost:8080';
+
+// ========== Helpers ==========
+
+async function mockPublicAuth(context: BrowserContext) {
+  await context.route(`${API_BASE}/api/v1/auth/me`, route =>
+    route.fulfill({
+      status: 401,
+      contentType: 'application/json',
+      body: JSON.stringify({ message: 'Unauthorized' }),
+    })
+  );
+}
+
+async function mockValidToken(context: BrowserContext) {
+  await context.route(`${API_BASE}/api/v1/auth/validate-invitation`, route =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        email: 'invited@example.com',
+        role: 'User',
+        expiresAt: new Date(Date.now() + 7 * 86_400_000).toISOString(),
+      }),
+    })
+  );
+}
+
+async function mockAcceptInvitation(context: BrowserContext) {
+  await context.route(`${API_BASE}/api/v1/auth/accept-invitation`, route =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        user: {
+          id: 'new-user-1',
+          email: 'invited@example.com',
+          displayName: null,
+          role: 'User',
+        },
+        sessionToken: 'mock-session-token',
+        expiresAt: new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString(),
+      }),
+    })
+  );
+}
+
+async function mockOnboardingApis(context: BrowserContext) {
+  // Mock onboarding status
+  await context.route(`${API_BASE}/api/v1/users/me/onboarding-status`, route =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({
+        wizardSeenAt: null,
+        dismissedAt: null,
+        steps: { hasGames: false, hasSessions: false, hasCompletedProfile: false },
+      }),
+    })
+  );
+
+  // Mock profile update
+  await context.route(`${API_BASE}/api/v1/users/profile`, route =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ displayName: 'Test User', email: 'invited@example.com' }),
+    })
+  );
+
+  // Mock interests save
+  await context.route(`${API_BASE}/api/v1/users/interests`, route =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ ok: true }),
+    })
+  );
+
+  // Mock onboarding complete
+  await context.route(`${API_BASE}/api/v1/users/onboarding/complete`, route =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({ ok: true }),
+    })
+  );
+
+  // Mock wizard seen
+  await context.route(`${API_BASE}/api/v1/users/me/onboarding-wizard-seen`, route =>
+    route.fulfill({ status: 200, contentType: 'application/json', body: JSON.stringify({}) })
+  );
+
+  // Catch-all for other API calls
+  await context.route(`${API_BASE}/api/v1/**`, route =>
+    route.fulfill({
+      status: 200,
+      contentType: 'application/json',
+      body: JSON.stringify({}),
+    })
+  );
+}
+
+// ========== Tests ==========
+
+test.describe('Accept-Invite → Onboarding Wizard Journey', () => {
+  test('accept invitation redirects to onboarding wizard', async ({ browser }) => {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+
+    await mockPublicAuth(context);
+    await mockValidToken(context);
+    await mockAcceptInvitation(context);
+    await mockOnboardingApis(context);
+
+    // Navigate to accept-invite
+    await page.goto('/accept-invite?token=valid-test-token', {
+      waitUntil: 'domcontentloaded',
+    });
+
+    // Wait for email field to appear (token validated)
+    const emailInput = page.getByLabel(/email/i).first();
+    await expect(emailInput).toBeVisible({ timeout: 10_000 });
+    await expect(emailInput).toHaveValue('invited@example.com');
+
+    // Fill password (meets all 4 requirements)
+    const passwordInput = page.getByLabel(/^password$/i).first();
+    await passwordInput.fill('SecureP@ss1');
+
+    const confirmInput = page.getByLabel(/confirm password/i).first();
+    await confirmInput.fill('SecureP@ss1');
+
+    // Submit
+    const submitButton = page.getByRole('button', { name: /create account/i }).first();
+    await expect(submitButton).toBeEnabled();
+    await submitButton.click();
+
+    // Success state shows
+    await expect(page.getByText(/account created/i).first()).toBeVisible({ timeout: 10_000 });
+
+    // Should redirect to /onboarding (not /dashboard)
+    await expect(page.getByText(/setting up your account/i).first()).toBeVisible();
+
+    await context.close();
+  });
+
+  test('onboarding wizard starts at step 2 (profile) when accessed directly', async ({
+    browser,
+  }) => {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+
+    // Mock authenticated user
+    await context.route(`${API_BASE}/api/v1/auth/me`, route =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          user: { id: 'user-1', email: 'invited@example.com', displayName: null, role: 'User' },
+          expiresAt: new Date(Date.now() + 3_600_000).toISOString(),
+        }),
+      })
+    );
+    await mockOnboardingApis(context);
+
+    await page.goto('/onboarding', { waitUntil: 'domcontentloaded' });
+
+    // Should show Profile step (step 2), not Password step (step 1)
+    await expect(page.getByText(/Step 2 of 4/).first()).toBeVisible({ timeout: 10_000 });
+    await expect(page.getByText('Profile').first()).toBeVisible();
+
+    // Skip wizard link should be visible (password already completed)
+    await expect(page.getByTestId('skip-wizard')).toBeVisible();
+
+    await context.close();
+  });
+
+  test('skip wizard on onboarding page navigates to dashboard', async ({ browser }) => {
+    const context = await browser.newContext();
+    const page = await context.newPage();
+
+    // Mock authenticated user
+    await context.route(`${API_BASE}/api/v1/auth/me`, route =>
+      route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({
+          user: { id: 'user-1', email: 'invited@example.com', displayName: null, role: 'User' },
+          expiresAt: new Date(Date.now() + 3_600_000).toISOString(),
+        }),
+      })
+    );
+    await mockOnboardingApis(context);
+
+    await page.goto('/onboarding', { waitUntil: 'domcontentloaded' });
+
+    // Wait for wizard to render
+    await expect(page.getByTestId('skip-wizard')).toBeVisible({ timeout: 10_000 });
+
+    // Click skip wizard
+    await page.getByTestId('skip-wizard').click();
+
+    // Should navigate to /dashboard
+    await page.waitForURL(/\/dashboard/, { timeout: 5_000 });
+
+    await context.close();
+  });
+});

--- a/apps/web/src/app/(auth)/register/_content.tsx
+++ b/apps/web/src/app/(auth)/register/_content.tsx
@@ -5,8 +5,20 @@ import { useState, useEffect } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 
 import { AuthModal } from '@/components/auth';
+import { RequestAccessForm } from '@/components/auth/RequestAccessForm';
 import { AuthLayout } from '@/components/layouts';
 import { useTranslation } from '@/hooks/useTranslation';
+import { useApiClient } from '@/lib/api/context';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+type RegistrationMode = 'loading' | 'public' | 'invite-only';
+
+// ============================================================================
+// Fallback (Suspense boundary)
+// ============================================================================
 
 export function RegisterFallback() {
   const { t } = useTranslation();
@@ -17,13 +29,35 @@ export function RegisterFallback() {
   );
 }
 
+// ============================================================================
+// Main content
+// ============================================================================
+
 export function RegisterPageContent() {
   const [mounted, setMounted] = useState(false);
   const [showAuthModal, setShowAuthModal] = useState(true);
+  const [registrationMode, setRegistrationMode] = useState<RegistrationMode>('loading');
+
+  const api = useApiClient();
 
   useEffect(() => {
     setMounted(true);
   }, []);
+
+  // Fetch registration mode on mount (after client hydration)
+  useEffect(() => {
+    if (!mounted) return;
+
+    api.accessRequests
+      .getRegistrationMode()
+      .then(result => {
+        setRegistrationMode(result.publicRegistrationEnabled ? 'public' : 'invite-only');
+      })
+      .catch(() => {
+        // Fail closed: default to invite-only if we cannot determine the mode
+        setRegistrationMode('invite-only');
+      });
+  }, [mounted, api]);
 
   const router = useRouter();
   const searchParams = useSearchParams();
@@ -37,16 +71,30 @@ export function RegisterPageContent() {
   };
 
   // Prevent SSR issues with TanStack Query
-  if (!mounted) {
+  if (!mounted || registrationMode === 'loading') {
     return (
       <AuthLayout title="Loading...">
-        <div className="text-center py-8">
+        <div className="text-center py-8" data-testid="register-loading">
           <div className="animate-pulse text-slate-500">Loading...</div>
         </div>
       </AuthLayout>
     );
   }
 
+  // Invite-only mode: show request access form
+  if (registrationMode === 'invite-only') {
+    return (
+      <AuthLayout
+        title="Request Access"
+        subtitle="Registration is currently by invitation only"
+        data-testid="register-page"
+      >
+        <RequestAccessForm />
+      </AuthLayout>
+    );
+  }
+
+  // Public mode: show the standard registration modal
   return (
     <AuthLayout
       title="Create Account"

--- a/apps/web/src/app/(authenticated)/onboarding/page.tsx
+++ b/apps/web/src/app/(authenticated)/onboarding/page.tsx
@@ -1,0 +1,13 @@
+'use client';
+
+import { OnboardingWizard } from '@/components/onboarding';
+
+export default function OnboardingPage() {
+  return (
+    <div className="flex min-h-[80vh] items-center justify-center px-4">
+      <div className="w-full max-w-lg">
+        <OnboardingWizard token="" role="" startStep={2} />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(public)/accept-invite/page.tsx
+++ b/apps/web/src/app/(public)/accept-invite/page.tsx
@@ -137,7 +137,7 @@ function AcceptInviteContent() {
         }
 
         setState('success');
-        setTimeout(() => router.push('/dashboard'), 1500);
+        setTimeout(() => router.push('/onboarding'), 1500);
       } catch {
         setSubmitError('A network error occurred. Please check your connection and try again.');
         setState('valid');
@@ -209,7 +209,7 @@ function SuccessCard() {
         </div>
         <CardTitle>Account Created!</CardTitle>
         <CardDescription>
-          Your password has been set successfully. Redirecting to your dashboard...
+          Your password has been set successfully. Setting up your account...
         </CardDescription>
       </CardHeader>
     </Card>

--- a/apps/web/src/app/admin/(dashboard)/config/GeneralTab.tsx
+++ b/apps/web/src/app/admin/(dashboard)/config/GeneralTab.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { Settings } from 'lucide-react';
+import { Settings, UserCogIcon } from 'lucide-react';
 
+import { RegistrationModeToggle } from '@/components/admin/settings/RegistrationModeToggle';
 import {
   Card,
   CardContent,
@@ -13,6 +14,24 @@ import {
 export function GeneralTab() {
   return (
     <div className="space-y-6">
+      {/* Registration Mode */}
+      <Card className="bg-white/70 dark:bg-zinc-900/70 backdrop-blur-md border-slate-200/60 dark:border-zinc-700/40">
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 font-quicksand">
+            <UserCogIcon className="h-5 w-5 text-muted-foreground" aria-hidden="true" />
+            Registration Mode
+          </CardTitle>
+          <CardDescription>
+            Control whether new users can register freely or require an invitation or approved
+            access request.
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <RegistrationModeToggle />
+        </CardContent>
+      </Card>
+
+      {/* General Settings (placeholder) */}
       <Card className="bg-white/70 dark:bg-zinc-900/70 backdrop-blur-md border-slate-200/60 dark:border-zinc-700/40">
         <CardHeader>
           <CardTitle className="flex items-center gap-2 font-quicksand">

--- a/apps/web/src/app/admin/(dashboard)/users/access-requests/page.tsx
+++ b/apps/web/src/app/admin/(dashboard)/users/access-requests/page.tsx
@@ -1,0 +1,498 @@
+/**
+ * Admin Access Requests Page
+ *
+ * Manage user access requests for invite-only registration.
+ * Features: KPI stats cards, paginated table, status filters,
+ * approve/reject actions, bulk approve, selection.
+ */
+
+'use client';
+
+import { useState } from 'react';
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import {
+  AlertCircleIcon,
+  CheckCircleIcon,
+  ChevronLeftIcon,
+  ChevronRightIcon,
+  ClockIcon,
+  InboxIcon,
+  RefreshCwIcon,
+  UserCheckIcon,
+  XCircleIcon,
+} from 'lucide-react';
+import { toast } from 'sonner';
+
+import { RejectDialog } from '@/components/admin/access-requests/RejectDialog';
+import { Card, CardContent } from '@/components/ui/data-display/card';
+import { Skeleton } from '@/components/ui/feedback/skeleton';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/overlays/select';
+import { Button } from '@/components/ui/primitives/button';
+import { api } from '@/lib/api';
+import type { AccessRequestDto } from '@/lib/api/clients/accessRequestsClient';
+
+type StatusFilter = 'all' | 'Pending' | 'Approved' | 'Rejected';
+
+const PAGE_SIZE = 20;
+const BULK_APPROVE_MAX = 25;
+
+function formatDate(iso: string | null): string {
+  if (!iso) return '—';
+  return new Date(iso).toLocaleDateString(undefined, {
+    year: 'numeric',
+    month: 'short',
+    day: 'numeric',
+  });
+}
+
+function StatusBadge({ status }: { status: AccessRequestDto['status'] }) {
+  const variants: Record<AccessRequestDto['status'], string> = {
+    Pending: 'bg-amber-100 text-amber-800 dark:bg-amber-900/30 dark:text-amber-300',
+    Approved: 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-300',
+    Rejected: 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-300',
+  };
+  return (
+    <span
+      className={`inline-flex items-center rounded-full px-2 py-0.5 text-xs font-medium ${variants[status]}`}
+    >
+      {status}
+    </span>
+  );
+}
+
+export default function AccessRequestsPage() {
+  const queryClient = useQueryClient();
+  const [statusFilter, setStatusFilter] = useState<StatusFilter>('all');
+  const [page, setPage] = useState(1);
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set());
+  const [rejectTarget, setRejectTarget] = useState<AccessRequestDto | null>(null);
+
+  // Fetch stats
+  const statsQuery = useQuery({
+    queryKey: ['admin', 'access-request-stats'],
+    queryFn: () => api.accessRequests.getAccessRequestStats(),
+    staleTime: 30_000,
+  });
+
+  // Fetch list
+  const {
+    data: listData,
+    isLoading,
+    error,
+    refetch,
+    isRefetching,
+  } = useQuery({
+    queryKey: ['admin', 'access-requests', { page, pageSize: PAGE_SIZE, status: statusFilter }],
+    queryFn: () =>
+      api.accessRequests.getAccessRequests({
+        status: statusFilter === 'all' ? undefined : statusFilter,
+        page,
+        pageSize: PAGE_SIZE,
+      }),
+    staleTime: 30_000,
+  });
+
+  function invalidateAll() {
+    queryClient.invalidateQueries({ queryKey: ['admin', 'access-requests'] });
+    queryClient.invalidateQueries({ queryKey: ['admin', 'access-request-stats'] });
+  }
+
+  // Approve single
+  const approveMutation = useMutation({
+    mutationFn: (id: string) => api.accessRequests.approveAccessRequest(id),
+    onSuccess: () => {
+      toast.success('Access request approved');
+      invalidateAll();
+    },
+    onError: (err: unknown) => {
+      toast.error(err instanceof Error ? err.message : 'Failed to approve request');
+    },
+  });
+
+  // Reject single
+  const rejectMutation = useMutation({
+    mutationFn: ({ id, reason }: { id: string; reason?: string }) =>
+      api.accessRequests.rejectAccessRequest(id, reason),
+    onSuccess: () => {
+      toast.success('Access request rejected');
+      invalidateAll();
+    },
+    onError: (err: unknown) => {
+      toast.error(err instanceof Error ? err.message : 'Failed to reject request');
+    },
+  });
+
+  // Bulk approve
+  const bulkApproveMutation = useMutation({
+    mutationFn: (ids: string[]) => api.accessRequests.bulkApproveAccessRequests(ids),
+    onSuccess: result => {
+      toast.success(
+        `Approved ${result.succeeded} of ${result.processed} requests` +
+          (result.failed > 0 ? ` (${result.failed} failed)` : '')
+      );
+      setSelectedIds(new Set());
+      invalidateAll();
+    },
+    onError: (err: unknown) => {
+      toast.error(err instanceof Error ? err.message : 'Bulk approve failed');
+    },
+  });
+
+  const items = listData?.items ?? [];
+  const totalCount = listData?.totalCount ?? 0;
+  const totalPages = Math.ceil(totalCount / PAGE_SIZE);
+  const stats = statsQuery.data;
+
+  // Selection helpers
+  const pageIds = items.map(i => i.id);
+  const allPageSelected = pageIds.length > 0 && pageIds.every(id => selectedIds.has(id));
+  const somePageSelected = pageIds.some(id => selectedIds.has(id));
+
+  function toggleSelectAll() {
+    if (allPageSelected) {
+      const next = new Set(selectedIds);
+      pageIds.forEach(id => next.delete(id));
+      setSelectedIds(next);
+    } else {
+      const next = new Set(selectedIds);
+      pageIds.forEach(id => next.add(id));
+      setSelectedIds(next);
+    }
+  }
+
+  function toggleSelect(id: string) {
+    const next = new Set(selectedIds);
+    if (next.has(id)) {
+      next.delete(id);
+    } else {
+      next.add(id);
+    }
+    setSelectedIds(next);
+  }
+
+  const selectedCount = selectedIds.size;
+  const bulkDisabled =
+    selectedCount === 0 || selectedCount > BULK_APPROVE_MAX || bulkApproveMutation.isPending;
+
+  async function handleRejectConfirm(reason?: string) {
+    if (!rejectTarget) return;
+    await rejectMutation.mutateAsync({ id: rejectTarget.id, reason });
+    setRejectTarget(null);
+  }
+
+  return (
+    <div className="space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between flex-wrap gap-4">
+        <div>
+          <h1 className="font-quicksand text-2xl font-bold tracking-tight text-foreground">
+            Access Requests
+          </h1>
+          <p className="text-sm text-muted-foreground mt-1">
+            Review and manage user access requests for invite-only registration.
+          </p>
+        </div>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => refetch()}
+            disabled={isRefetching}
+            className="gap-2"
+          >
+            <RefreshCwIcon className={`h-3.5 w-3.5 ${isRefetching ? 'animate-spin' : ''}`} />
+            Refresh
+          </Button>
+          <Button
+            size="sm"
+            onClick={() => bulkApproveMutation.mutate([...selectedIds])}
+            disabled={bulkDisabled}
+            className="gap-2"
+          >
+            <UserCheckIcon className="h-3.5 w-3.5" />
+            Approve Selected
+            {selectedCount > 0 && ` (${selectedCount})`}
+          </Button>
+        </div>
+      </div>
+
+      {/* Stats Cards */}
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <Card className="bg-white/70 dark:bg-zinc-800/70 backdrop-blur-md border-slate-200/60 dark:border-zinc-700/40">
+          <CardContent className="p-4">
+            <div className="flex items-center gap-3">
+              <div className="h-10 w-10 rounded-lg bg-blue-100 dark:bg-blue-900/30 flex items-center justify-center">
+                <InboxIcon className="h-5 w-5 text-blue-600 dark:text-blue-400" />
+              </div>
+              <div>
+                <p className="text-sm text-muted-foreground">Total</p>
+                <span className="text-xl font-bold block">
+                  {stats ? stats.total : <Skeleton className="h-6 w-10 inline-block" />}
+                </span>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card className="bg-white/70 dark:bg-zinc-800/70 backdrop-blur-md border-slate-200/60 dark:border-zinc-700/40">
+          <CardContent className="p-4">
+            <div className="flex items-center gap-3">
+              <div className="h-10 w-10 rounded-lg bg-amber-100 dark:bg-amber-900/30 flex items-center justify-center">
+                <ClockIcon className="h-5 w-5 text-amber-600 dark:text-amber-400" />
+              </div>
+              <div>
+                <p className="text-sm text-muted-foreground">Pending</p>
+                <span className="text-xl font-bold block">
+                  {stats ? stats.pending : <Skeleton className="h-6 w-10 inline-block" />}
+                </span>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card className="bg-white/70 dark:bg-zinc-800/70 backdrop-blur-md border-slate-200/60 dark:border-zinc-700/40">
+          <CardContent className="p-4">
+            <div className="flex items-center gap-3">
+              <div className="h-10 w-10 rounded-lg bg-green-100 dark:bg-green-900/30 flex items-center justify-center">
+                <CheckCircleIcon className="h-5 w-5 text-green-600 dark:text-green-400" />
+              </div>
+              <div>
+                <p className="text-sm text-muted-foreground">Approved</p>
+                <span className="text-xl font-bold block">
+                  {stats ? stats.approved : <Skeleton className="h-6 w-10 inline-block" />}
+                </span>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card className="bg-white/70 dark:bg-zinc-800/70 backdrop-blur-md border-slate-200/60 dark:border-zinc-700/40">
+          <CardContent className="p-4">
+            <div className="flex items-center gap-3">
+              <div className="h-10 w-10 rounded-lg bg-red-100 dark:bg-red-900/30 flex items-center justify-center">
+                <XCircleIcon className="h-5 w-5 text-red-600 dark:text-red-400" />
+              </div>
+              <div>
+                <p className="text-sm text-muted-foreground">Rejected</p>
+                <span className="text-xl font-bold block">
+                  {stats ? stats.rejected : <Skeleton className="h-6 w-10 inline-block" />}
+                </span>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* Status Filter */}
+      <div className="flex items-center gap-3">
+        <Select
+          value={statusFilter}
+          onValueChange={v => {
+            setStatusFilter(v as StatusFilter);
+            setPage(1);
+            setSelectedIds(new Set());
+          }}
+        >
+          <SelectTrigger className="w-44 bg-white/70 dark:bg-zinc-800/70">
+            <SelectValue placeholder="Filter by status" />
+          </SelectTrigger>
+          <SelectContent>
+            <SelectItem value="all">All Statuses</SelectItem>
+            <SelectItem value="Pending">Pending</SelectItem>
+            <SelectItem value="Approved">Approved</SelectItem>
+            <SelectItem value="Rejected">Rejected</SelectItem>
+          </SelectContent>
+        </Select>
+        {selectedCount > BULK_APPROVE_MAX && (
+          <p className="text-sm text-amber-600 dark:text-amber-400">
+            Select up to {BULK_APPROVE_MAX} requests for bulk approve
+          </p>
+        )}
+      </div>
+
+      {/* Error State */}
+      {error && (
+        <div className="bg-red-50 dark:bg-red-900/20 border border-red-200 dark:border-red-800/40 rounded-lg p-4 flex items-center gap-3">
+          <AlertCircleIcon className="h-5 w-5 text-red-500 shrink-0" />
+          <div className="flex-1">
+            <p className="text-sm font-medium text-red-800 dark:text-red-200">
+              Failed to load access requests
+            </p>
+            <p className="text-xs text-red-600 dark:text-red-400 mt-1">
+              {error instanceof Error ? error.message : 'Unknown error'}
+            </p>
+          </div>
+          <Button variant="outline" size="sm" onClick={() => refetch()}>
+            Retry
+          </Button>
+        </div>
+      )}
+
+      {/* Table */}
+      <div className="bg-white/70 dark:bg-zinc-800/70 backdrop-blur-md rounded-xl border border-slate-200/60 dark:border-zinc-700/40 overflow-hidden">
+        <div className="overflow-x-auto">
+          <table className="w-full text-sm">
+            <thead>
+              <tr className="border-b border-slate-200/60 dark:border-zinc-700/40">
+                <th className="p-3 w-10">
+                  <input
+                    type="checkbox"
+                    className="rounded border-border"
+                    checked={allPageSelected && pageIds.length > 0}
+                    ref={el => {
+                      if (el) el.indeterminate = somePageSelected && !allPageSelected;
+                    }}
+                    onChange={toggleSelectAll}
+                    aria-label="Select all on page"
+                  />
+                </th>
+                <th className="text-left p-3 font-medium text-muted-foreground">Email</th>
+                <th className="text-left p-3 font-medium text-muted-foreground">Status</th>
+                <th className="text-left p-3 font-medium text-muted-foreground">Requested At</th>
+                <th className="text-left p-3 font-medium text-muted-foreground">Reviewed By</th>
+                <th className="text-left p-3 font-medium text-muted-foreground">Actions</th>
+              </tr>
+            </thead>
+            <tbody>
+              {isLoading ? (
+                Array.from({ length: 5 }).map((_, i) => (
+                  <tr key={i} className="border-b border-slate-100 dark:border-zinc-800/60">
+                    <td className="p-3">
+                      <Skeleton className="h-4 w-4" />
+                    </td>
+                    <td className="p-3">
+                      <Skeleton className="h-4 w-48" />
+                    </td>
+                    <td className="p-3">
+                      <Skeleton className="h-5 w-20" />
+                    </td>
+                    <td className="p-3">
+                      <Skeleton className="h-4 w-24" />
+                    </td>
+                    <td className="p-3">
+                      <Skeleton className="h-4 w-24" />
+                    </td>
+                    <td className="p-3">
+                      <Skeleton className="h-8 w-32" />
+                    </td>
+                  </tr>
+                ))
+              ) : items.length === 0 ? (
+                <tr>
+                  <td colSpan={6} className="p-8 text-center text-muted-foreground">
+                    <InboxIcon className="mx-auto mb-2 h-8 w-8 opacity-50" />
+                    <p>
+                      {statusFilter !== 'all'
+                        ? 'No requests match this filter'
+                        : 'No access requests yet'}
+                    </p>
+                  </td>
+                </tr>
+              ) : (
+                items.map(item => (
+                  <tr
+                    key={item.id}
+                    className="border-b border-slate-100 dark:border-zinc-800/60 hover:bg-slate-50/50 dark:hover:bg-zinc-800/30"
+                  >
+                    <td className="p-3">
+                      <input
+                        type="checkbox"
+                        className="rounded border-border"
+                        checked={selectedIds.has(item.id)}
+                        onChange={() => toggleSelect(item.id)}
+                        aria-label={`Select ${item.email}`}
+                        disabled={item.status !== 'Pending'}
+                      />
+                    </td>
+                    <td className="p-3 font-medium">{item.email}</td>
+                    <td className="p-3">
+                      <StatusBadge status={item.status} />
+                    </td>
+                    <td className="p-3 text-muted-foreground">{formatDate(item.requestedAt)}</td>
+                    <td className="p-3 text-muted-foreground">{item.reviewedBy ?? '—'}</td>
+                    <td className="p-3">
+                      {item.status === 'Pending' && (
+                        <div className="flex items-center gap-2">
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            className="h-7 text-xs gap-1 text-green-700 border-green-200 hover:bg-green-50 dark:text-green-400 dark:border-green-800 dark:hover:bg-green-900/20"
+                            onClick={() => approveMutation.mutate(item.id)}
+                            disabled={approveMutation.isPending}
+                          >
+                            <CheckCircleIcon className="h-3 w-3" />
+                            Approve
+                          </Button>
+                          <Button
+                            size="sm"
+                            variant="outline"
+                            className="h-7 text-xs gap-1 text-red-700 border-red-200 hover:bg-red-50 dark:text-red-400 dark:border-red-800 dark:hover:bg-red-900/20"
+                            onClick={() => setRejectTarget(item)}
+                            disabled={rejectMutation.isPending}
+                          >
+                            <XCircleIcon className="h-3 w-3" />
+                            Reject
+                          </Button>
+                        </div>
+                      )}
+                    </td>
+                  </tr>
+                ))
+              )}
+            </tbody>
+          </table>
+        </div>
+
+        {/* Pagination */}
+        {totalPages > 1 && (
+          <div className="flex items-center justify-between px-4 py-3 border-t border-slate-200/60 dark:border-zinc-700/40">
+            <p className="text-sm text-muted-foreground">
+              Showing {(page - 1) * PAGE_SIZE + 1}&ndash;
+              {Math.min(page * PAGE_SIZE, totalCount)} of {totalCount}
+            </p>
+            <div className="flex items-center gap-1">
+              <Button
+                variant="outline"
+                size="icon"
+                className="h-8 w-8"
+                disabled={page <= 1}
+                onClick={() => setPage(p => p - 1)}
+              >
+                <ChevronLeftIcon className="h-4 w-4" />
+              </Button>
+              <span className="px-3 text-sm">
+                Page {page} of {totalPages}
+              </span>
+              <Button
+                variant="outline"
+                size="icon"
+                className="h-8 w-8"
+                disabled={page >= totalPages}
+                onClick={() => setPage(p => p + 1)}
+              >
+                <ChevronRightIcon className="h-4 w-4" />
+              </Button>
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* Reject Dialog */}
+      <RejectDialog
+        open={rejectTarget !== null}
+        onOpenChange={open => {
+          if (!open) setRejectTarget(null);
+        }}
+        onConfirm={handleRejectConfirm}
+        email={rejectTarget?.email}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/components/admin/access-requests/RejectDialog.tsx
+++ b/apps/web/src/components/admin/access-requests/RejectDialog.tsx
@@ -1,0 +1,110 @@
+/**
+ * RejectDialog Component
+ *
+ * Dialog for rejecting an access request with an optional reason.
+ */
+
+'use client';
+
+import { useState } from 'react';
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/overlays/dialog';
+import { Button } from '@/components/ui/primitives/button';
+import { Label } from '@/components/ui/primitives/label';
+import { Textarea } from '@/components/ui/primitives/textarea';
+
+const MAX_REASON_LENGTH = 500;
+
+export interface RejectDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onConfirm: (reason?: string) => Promise<void>;
+  email?: string;
+}
+
+export function RejectDialog({ open, onOpenChange, onConfirm, email }: RejectDialogProps) {
+  const [reason, setReason] = useState('');
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  function handleOpenChange(nextOpen: boolean) {
+    if (!nextOpen && !isSubmitting) {
+      setReason('');
+    }
+    onOpenChange(nextOpen);
+  }
+
+  async function handleConfirm() {
+    setIsSubmitting(true);
+    try {
+      await onConfirm(reason.trim() || undefined);
+      setReason('');
+      onOpenChange(false);
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Reject Access Request</DialogTitle>
+          <DialogDescription>
+            {email ? (
+              <>
+                Reject the access request from <strong>{email}</strong>.
+              </>
+            ) : (
+              'Reject this access request.'
+            )}{' '}
+            You may optionally provide a reason.
+          </DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-2">
+          <Label htmlFor="reject-reason">
+            Reason <span className="text-muted-foreground font-normal">(optional)</span>
+          </Label>
+          <Textarea
+            id="reject-reason"
+            placeholder="Enter rejection reason..."
+            value={reason}
+            onChange={e => setReason(e.target.value.slice(0, MAX_REASON_LENGTH))}
+            disabled={isSubmitting}
+            rows={3}
+            className="resize-none"
+          />
+          <p className="text-xs text-muted-foreground text-right">
+            {reason.length}/{MAX_REASON_LENGTH}
+          </p>
+        </div>
+
+        <DialogFooter>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => handleOpenChange(false)}
+            disabled={isSubmitting}
+          >
+            Cancel
+          </Button>
+          <Button
+            type="button"
+            variant="destructive"
+            onClick={handleConfirm}
+            disabled={isSubmitting}
+          >
+            {isSubmitting ? 'Rejecting...' : 'Reject Request'}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/admin/settings/RegistrationModeToggle.tsx
+++ b/apps/web/src/components/admin/settings/RegistrationModeToggle.tsx
@@ -1,0 +1,121 @@
+/**
+ * RegistrationModeToggle Component
+ *
+ * Switch to toggle between invite-only and public registration mode.
+ * Fetches current state on mount, shows a confirmation dialog before changing.
+ */
+
+'use client';
+
+import { useState } from 'react';
+
+import { useQuery, useQueryClient } from '@tanstack/react-query';
+import { toast } from 'sonner';
+
+import { Switch } from '@/components/ui/forms/switch';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/overlays/dialog';
+import { Button } from '@/components/ui/primitives/button';
+import { api } from '@/lib/api';
+
+export function RegistrationModeToggle() {
+  const queryClient = useQueryClient();
+  const [confirmOpen, setConfirmOpen] = useState(false);
+  const [pendingValue, setPendingValue] = useState<boolean | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+
+  const { data, isLoading } = useQuery({
+    queryKey: ['admin', 'registration-mode'],
+    queryFn: () => api.accessRequests.getRegistrationMode(),
+    staleTime: 60_000,
+  });
+
+  const isPublicEnabled = data?.publicRegistrationEnabled ?? false;
+
+  function handleToggleRequest(nextValue: boolean) {
+    setPendingValue(nextValue);
+    setConfirmOpen(true);
+  }
+
+  async function handleConfirm() {
+    if (pendingValue === null) return;
+    setIsSubmitting(true);
+    try {
+      await api.accessRequests.setRegistrationMode(pendingValue);
+      queryClient.invalidateQueries({ queryKey: ['admin', 'registration-mode'] });
+      toast.success(pendingValue ? 'Public registration enabled' : 'Switched to invite-only mode');
+      setConfirmOpen(false);
+    } catch (err) {
+      toast.error(err instanceof Error ? err.message : 'Failed to update registration mode');
+    } finally {
+      setIsSubmitting(false);
+      setPendingValue(null);
+    }
+  }
+
+  function handleCancel() {
+    setConfirmOpen(false);
+    setPendingValue(null);
+  }
+
+  const confirmMessage = pendingValue
+    ? 'This will allow anyone to register without an invitation or access request approval.'
+    : 'New registrations will require an invitation or approved access request.';
+
+  return (
+    <>
+      <div className="flex items-center justify-between gap-4">
+        <div>
+          <p className="text-sm font-medium text-foreground">
+            {isLoading
+              ? 'Loading...'
+              : isPublicEnabled
+                ? 'Public registration enabled'
+                : 'Invite-only mode'}
+          </p>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            {isPublicEnabled
+              ? 'Anyone can create an account.'
+              : 'New users need an invitation or approved access request.'}
+          </p>
+        </div>
+        <Switch
+          checked={isPublicEnabled}
+          onCheckedChange={handleToggleRequest}
+          disabled={isLoading || isSubmitting}
+          aria-label="Toggle public registration"
+        />
+      </div>
+
+      <Dialog
+        open={confirmOpen}
+        onOpenChange={open => {
+          if (!open) handleCancel();
+        }}
+      >
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>
+              {pendingValue ? 'Enable Public Registration?' : 'Enable Invite-Only Mode?'}
+            </DialogTitle>
+            <DialogDescription>{confirmMessage}</DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button variant="outline" onClick={handleCancel} disabled={isSubmitting}>
+              Cancel
+            </Button>
+            <Button onClick={handleConfirm} disabled={isSubmitting}>
+              {isSubmitting ? 'Saving...' : 'Confirm'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  );
+}

--- a/apps/web/src/components/auth/RequestAccessForm.tsx
+++ b/apps/web/src/components/auth/RequestAccessForm.tsx
@@ -1,0 +1,117 @@
+'use client';
+
+/**
+ * RequestAccessForm Component
+ *
+ * Email submission form for invite-only registration mode.
+ * States: form → submitting → success.
+ *
+ * The API always returns 202 (email enumeration-safe), so we always show
+ * the success message on any non-network-error response.
+ */
+
+import { useState } from 'react';
+
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useForm } from 'react-hook-form';
+import * as z from 'zod';
+
+import { AccessibleFormInput } from '@/components/accessible';
+import { LoadingButton } from '@/components/loading/LoadingButton';
+import { useTranslation } from '@/hooks/useTranslation';
+import { useApiClient } from '@/lib/api/context';
+
+// ============================================================================
+// Schema
+// ============================================================================
+
+const requestAccessSchema = z.object({
+  email: z.string().min(1, 'Email is required').email('Please enter a valid email address'),
+});
+
+type RequestAccessFormData = z.infer<typeof requestAccessSchema>;
+
+// ============================================================================
+// Component
+// ============================================================================
+
+export function RequestAccessForm() {
+  const { t } = useTranslation();
+  const { accessRequests } = useApiClient();
+  const [submitted, setSubmitted] = useState(false);
+
+  const {
+    register,
+    handleSubmit,
+    formState: { errors, isSubmitting },
+  } = useForm<RequestAccessFormData>({
+    resolver: zodResolver(requestAccessSchema),
+    defaultValues: { email: '' },
+  });
+
+  const onFormSubmit = async (data: RequestAccessFormData) => {
+    try {
+      await accessRequests.requestAccess(data.email);
+    } catch {
+      // Network-level errors are swallowed intentionally.
+      // The API always returns 202, so we show success on any non-network error too.
+      // Only genuine network failures reach here; still show success to prevent enumeration.
+    }
+    setSubmitted(true);
+  };
+
+  if (submitted) {
+    return (
+      <div
+        className="rounded-md bg-green-50 dark:bg-green-900/20 border border-green-200 dark:border-green-800 p-6 text-center"
+        role="status"
+        aria-live="polite"
+        data-testid="request-access-success"
+      >
+        <p className="text-sm font-medium text-green-800 dark:text-green-200">
+          {t('auth.requestAccess.successTitle', 'Request submitted!')}
+        </p>
+        <p className="mt-1 text-sm text-green-700 dark:text-green-300">
+          {t(
+            'auth.requestAccess.successMessage',
+            "If your email is eligible, you'll receive an invitation shortly."
+          )}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <form
+      onSubmit={handleSubmit(onFormSubmit)}
+      className="space-y-4"
+      noValidate
+      data-testid="request-access-form"
+    >
+      <div className="space-y-2">
+        <AccessibleFormInput
+          label={t('auth.requestAccess.email', 'Email address')}
+          id="request-access-email"
+          type="email"
+          placeholder={t('auth.requestAccess.emailPlaceholder', 'you@example.com')}
+          autoComplete="email"
+          error={errors.email?.message}
+          required
+          disabled={isSubmitting}
+          data-testid="request-access-email"
+          {...register('email')}
+        />
+      </div>
+
+      <LoadingButton
+        type="submit"
+        className="w-full"
+        isLoading={isSubmitting}
+        loadingText={t('auth.requestAccess.submitting', 'Submitting...')}
+        data-testid="request-access-submit"
+      >
+        {t('auth.requestAccess.submit', 'Request Access')}
+      </LoadingButton>
+    </form>
+  );
+}

--- a/apps/web/src/components/onboarding/OnboardingWizard.tsx
+++ b/apps/web/src/components/onboarding/OnboardingWizard.tsx
@@ -28,6 +28,8 @@ import { ProfileStep } from './ProfileStep';
 export interface OnboardingWizardProps {
   token: string;
   role: string;
+  /** Skip to this step (default: 1). Use startStep={2} when password is already set (e.g. from accept-invite page). */
+  startStep?: number;
 }
 
 interface WizardState {
@@ -39,11 +41,13 @@ interface WizardState {
 
 const STEP_LABELS = ['Password', 'Profile', 'Interests', 'First Game', 'First Agent'];
 
-export function OnboardingWizard({ token, role: _role }: OnboardingWizardProps) {
+export function OnboardingWizard({ token, role: _role, startStep = 1 }: OnboardingWizardProps) {
   const router = useRouter();
   const [state, setState] = useState<WizardState>({
-    currentStep: 1,
-    passwordCompleted: false,
+    currentStep: startStep,
+    // When starting past step 1, password is already completed.
+    // This controls: goToPrev() clamping (min step 2) and "Skip wizard" link visibility.
+    passwordCompleted: startStep > 1,
     addedGameId: null,
     addedGameName: null,
   });

--- a/apps/web/src/components/onboarding/__tests__/OnboardingWizard.test.tsx
+++ b/apps/web/src/components/onboarding/__tests__/OnboardingWizard.test.tsx
@@ -193,6 +193,34 @@ describe('OnboardingWizard', () => {
     expect(screen.getByTestId('profile-step')).toBeInTheDocument();
   });
 
+  describe('startStep prop', () => {
+    it('starts at step 2 when startStep=2 is provided', () => {
+      renderWithQuery(<OnboardingWizard token="" role="User" startStep={2} />);
+
+      expect(screen.getByTestId('profile-step')).toBeInTheDocument();
+      expect(screen.getByText(/Step 2 of 4/)).toBeInTheDocument();
+      expect(screen.queryByTestId('password-step')).not.toBeInTheDocument();
+    });
+
+    it('shows skip wizard link immediately when startStep > 1', () => {
+      renderWithQuery(<OnboardingWizard token="" role="User" startStep={2} />);
+
+      expect(screen.getByTestId('skip-wizard')).toBeInTheDocument();
+    });
+
+    it('back button on step 2 does not go to step 1 when startStep=2', async () => {
+      renderWithQuery(<OnboardingWizard token="" role="User" startStep={2} />);
+
+      // Advance to step 3
+      await user.click(screen.getByText('Complete Profile'));
+      expect(screen.getByTestId('interests-step')).toBeInTheDocument();
+
+      // Back → should stay at step 2 (not go to password)
+      await user.click(screen.getByTestId('wizard-back'));
+      expect(screen.getByTestId('profile-step')).toBeInTheDocument();
+    });
+  });
+
   it('does not show back button on step 1', () => {
     renderWithQuery(<OnboardingWizard token="test-token" role="Player" />);
 

--- a/apps/web/src/config/admin-dashboard-navigation.ts
+++ b/apps/web/src/config/admin-dashboard-navigation.ts
@@ -356,6 +356,13 @@ export const DASHBOARD_SECTIONS: DashboardSection[] = [
         icon: MailIcon,
       },
       {
+        href: '/admin/users/access-requests',
+        label: 'Access Requests',
+        icon: ClipboardListIcon,
+        badgeKey: 'accessRequestsPending',
+        activePattern: /^\/admin\/users\/access-requests/,
+      },
+      {
         href: '/admin/users/roles',
         label: 'Roles & Permissions',
         icon: ShieldIcon,

--- a/apps/web/src/lib/api/clients/accessRequestsClient.ts
+++ b/apps/web/src/lib/api/clients/accessRequestsClient.ts
@@ -1,0 +1,158 @@
+/**
+ * Access Requests API Client (Invite-Only Registration)
+ *
+ * API client for access request management (admin) and
+ * registration mode checking / request submission (public).
+ */
+
+import { type HttpClient } from '../core/httpClient';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface AccessRequestDto {
+  id: string;
+  email: string;
+  status: 'Pending' | 'Approved' | 'Rejected';
+  requestedAt: string;
+  reviewedAt: string | null;
+  reviewedBy: string | null;
+  rejectionReason: string | null;
+  invitationId: string | null;
+}
+
+export interface AccessRequestStats {
+  pending: number;
+  approved: number;
+  rejected: number;
+  total: number;
+}
+
+export interface BulkApproveResult {
+  processed: number;
+  succeeded: number;
+  failed: number;
+  results: Array<{ id: string; status: string; error?: string }>;
+}
+
+export interface RegistrationMode {
+  publicRegistrationEnabled: boolean;
+}
+
+export interface GetAccessRequestsParams {
+  status?: string;
+  page?: number;
+  pageSize?: number;
+}
+
+export interface GetAccessRequestsResponse {
+  items: AccessRequestDto[];
+  totalCount: number;
+  page: number;
+  pageSize: number;
+}
+
+// ============================================================================
+// Client Factory
+// ============================================================================
+
+export interface CreateAccessRequestsClientParams {
+  httpClient: HttpClient;
+}
+
+export function createAccessRequestsClient({ httpClient }: CreateAccessRequestsClientParams) {
+  return {
+    // ──────────────────────────────────────────────
+    // Public Endpoints
+    // ──────────────────────────────────────────────
+
+    /**
+     * Get the current registration mode
+     * GET /api/v1/auth/registration-mode
+     */
+    async getRegistrationMode(): Promise<RegistrationMode> {
+      const response = await httpClient.get<RegistrationMode>('/api/v1/auth/registration-mode');
+      return response ?? { publicRegistrationEnabled: false };
+    },
+
+    /**
+     * Submit an access request (email enumeration-safe)
+     * POST /api/v1/auth/request-access
+     *
+     * Always returns 202 with identical message regardless of outcome.
+     */
+    async requestAccess(email: string): Promise<{ message: string }> {
+      return httpClient.post<{ message: string }>('/api/v1/auth/request-access', { email });
+    },
+
+    // ──────────────────────────────────────────────
+    // Admin Endpoints
+    // ──────────────────────────────────────────────
+
+    /**
+     * Get paginated list of access requests
+     * GET /api/v1/admin/access-requests
+     */
+    async getAccessRequests(params?: GetAccessRequestsParams): Promise<GetAccessRequestsResponse> {
+      const searchParams = new URLSearchParams();
+      if (params?.status) searchParams.set('status', params.status);
+      if (params?.page) searchParams.set('page', String(params.page));
+      if (params?.pageSize) searchParams.set('pageSize', String(params.pageSize));
+
+      const qs = searchParams.toString();
+      const url = `/api/v1/admin/access-requests${qs ? `?${qs}` : ''}`;
+      const response = await httpClient.get<GetAccessRequestsResponse>(url);
+      return response ?? { items: [], totalCount: 0, page: 1, pageSize: 20 };
+    },
+
+    /**
+     * Get access request statistics
+     * GET /api/v1/admin/access-requests/stats
+     */
+    async getAccessRequestStats(): Promise<AccessRequestStats> {
+      const response = await httpClient.get<AccessRequestStats>(
+        '/api/v1/admin/access-requests/stats'
+      );
+      return response ?? { pending: 0, approved: 0, rejected: 0, total: 0 };
+    },
+
+    /**
+     * Approve an access request (triggers invitation creation)
+     * POST /api/v1/admin/access-requests/{id}/approve
+     */
+    async approveAccessRequest(id: string): Promise<void> {
+      await httpClient.post(`/api/v1/admin/access-requests/${encodeURIComponent(id)}/approve`);
+    },
+
+    /**
+     * Reject an access request with optional reason
+     * POST /api/v1/admin/access-requests/{id}/reject
+     */
+    async rejectAccessRequest(id: string, reason?: string): Promise<void> {
+      await httpClient.post(`/api/v1/admin/access-requests/${encodeURIComponent(id)}/reject`, {
+        reason,
+      });
+    },
+
+    /**
+     * Bulk approve multiple access requests (max 25)
+     * POST /api/v1/admin/access-requests/bulk-approve
+     */
+    async bulkApproveAccessRequests(ids: string[]): Promise<BulkApproveResult> {
+      return httpClient.post<BulkApproveResult>('/api/v1/admin/access-requests/bulk-approve', {
+        ids,
+      });
+    },
+
+    /**
+     * Toggle public registration mode
+     * PUT /api/v1/admin/settings/registration-mode
+     */
+    async setRegistrationMode(enabled: boolean): Promise<void> {
+      await httpClient.put('/api/v1/admin/settings/registration-mode', { enabled });
+    },
+  };
+}
+
+export type AccessRequestsClient = ReturnType<typeof createAccessRequestsClient>;

--- a/apps/web/src/lib/api/clients/index.ts
+++ b/apps/web/src/lib/api/clients/index.ts
@@ -48,3 +48,4 @@ export * from './playRecordsClient'; // Play Records
 export * from './featureFlagsClient'; // User Feature Flags
 export * from './sandboxClient'; // RAG Sandbox Dashboard
 export * from './onboardingClient'; // First-time user onboarding
+export * from './accessRequestsClient'; // Invite-only registration

--- a/apps/web/src/lib/api/index.ts
+++ b/apps/web/src/lib/api/index.ts
@@ -64,6 +64,7 @@ import {
   createFeatureFlagsClient,
   createSandboxClient,
   createOnboardingClient,
+  createAccessRequestsClient,
   type AuthClient,
   type GamesClient,
   type SessionsClient,
@@ -108,6 +109,7 @@ import {
   type FeatureFlagsClient,
   type SandboxClient,
   type OnboardingClient,
+  type AccessRequestsClient,
 } from './clients';
 import { HttpClient, type HttpClientConfig } from './core/httpClient';
 
@@ -327,6 +329,9 @@ export interface ApiClient {
   /** First-time user onboarding */
   onboarding: OnboardingClient;
 
+  /** Access Requests — invite-only registration */
+  accessRequests: AccessRequestsClient;
+
   /** Generic DELETE helper (used in some legacy tests) */
   delete: (path: string) => Promise<void>;
 }
@@ -421,6 +426,7 @@ export function createApiClient(config?: ApiClientConfig): ApiClient {
     featureFlags: createFeatureFlagsClient({ httpClient }), // User Feature Flags
     sandbox: createSandboxClient({ httpClient }), // RAG Sandbox Dashboard
     onboarding: createOnboardingClient({ httpClient }), // First-time user onboarding
+    accessRequests: createAccessRequestsClient({ httpClient }), // Invite-only registration
     delete: (path: string) => httpClient.delete(path),
   };
 

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -23,6 +23,7 @@ const PUBLIC_PATHS = new Set([
   '/games',
   '/accept-invite',
   '/verify-email',
+  '/onboarding',
 ]);
 
 const EXCLUDED_PREFIXES = [
@@ -52,7 +53,7 @@ export function middleware(request: NextRequest) {
   const onboardingComplete = request.cookies.get('onboarding_completed')?.value;
 
   if (onboardingComplete === 'false') {
-    const onboardingUrl = new URL('/accept-invite', request.url);
+    const onboardingUrl = new URL('/onboarding', request.url);
     onboardingUrl.searchParams.set('redirect', pathname);
     return NextResponse.redirect(onboardingUrl);
   }

--- a/docs/superpowers/plans/2026-03-14-admin-invite-onboarding-integration.md
+++ b/docs/superpowers/plans/2026-03-14-admin-invite-onboarding-integration.md
@@ -1,0 +1,493 @@
+# Admin Invite + Onboarding Integration — Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Connect the existing accept-invite page to the existing onboarding wizard, verify admin UI, and write an E2E test covering the full user journey.
+
+**Architecture:** The accept-invite page (`/accept-invite`) currently redirects to `/dashboard` after password setup. We create a new `/onboarding` route page that renders the existing `OnboardingWizard` component starting at step 2 (skipping password, already done). Admin invitation UI and voice already exist — just verify. One serial E2E Playwright test validates the journey.
+
+**Tech Stack:** Next.js 16 (App Router), React 19, Zustand, React Query, Playwright, Tailwind 4
+
+**Spec:** `docs/superpowers/specs/2026-03-14-admin-invite-voice-onboarding-design.md`
+
+---
+
+## Scope Reality Check
+
+After codebase exploration, most components already exist:
+
+| Component | Status | Work |
+|-----------|--------|------|
+| Accept-invite page | ✅ Exists | Change redirect target |
+| OnboardingWizard (5 steps) | ✅ Exists | Add `startStep` prop |
+| `/onboarding` route | ❌ Missing | Create new page under `(authenticated)` |
+| Middleware | ✅ Exists | Change redirect target from `/accept-invite` to `/onboarding` |
+| Admin invitation UI | ✅ Exists | Verify only |
+| Voice in chat | ✅ Exists | Verify only |
+| Role management | ✅ Exists | Verify only |
+| Audit logs | ✅ Exists | Verify only |
+| E2E test | ❌ Missing | Write new test |
+
+**Actual new code: ~150 lines. Integration + verification + E2E test.**
+
+---
+
+## Chunk 1: Accept-Invite → Onboarding Integration
+
+### Task 1: Add `startStep` prop to OnboardingWizard
+
+**Files:**
+- Modify: `apps/web/src/components/onboarding/OnboardingWizard.tsx`
+- Test: `apps/web/src/components/onboarding/__tests__/OnboardingWizard.test.tsx`
+
+- [ ] **Step 1: Read the existing OnboardingWizard test file**
+
+Check what tests exist already to understand test patterns.
+
+- [ ] **Step 2: Write failing test for startStep prop**
+
+```tsx
+it('starts at step 2 when startStep=2 is provided', () => {
+  render(<OnboardingWizard token="test-token" role="User" startStep={2} />);
+  expect(screen.getByTestId('progress-step-1')).toHaveClass('bg-amber-500'); // completed
+  expect(screen.getByText('Profile')).toBeInTheDocument();
+  expect(screen.queryByText('Password')).not.toBeInTheDocument(); // step label
+});
+```
+
+Run: `cd apps/web && pnpm vitest run src/components/onboarding/__tests__/OnboardingWizard.test.tsx`
+Expected: FAIL
+
+- [ ] **Step 3: Implement startStep prop**
+
+In `OnboardingWizard.tsx`:
+
+```tsx
+export interface OnboardingWizardProps {
+  token: string;
+  role: string;
+  startStep?: number; // NEW: skip to this step (default: 1)
+}
+
+export function OnboardingWizard({ token, role: _role, startStep = 1 }: OnboardingWizardProps) {
+  const router = useRouter();
+  const [state, setState] = useState<WizardState>({
+    currentStep: startStep,
+    // IMPORTANT: passwordCompleted must be true when starting past step 1.
+    // This controls two behaviors:
+    // 1. goToPrev() clamps minimum step to 2 (prevents going back to password)
+    // 2. "Skip wizard" link only renders when passwordCompleted is true
+    passwordCompleted: startStep > 1,
+    addedGameId: null,
+    addedGameName: null,
+  });
+  // ... rest unchanged
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/web && pnpm vitest run src/components/onboarding/__tests__/OnboardingWizard.test.tsx`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/onboarding/OnboardingWizard.tsx apps/web/src/components/onboarding/__tests__/OnboardingWizard.test.tsx
+git commit -m "feat(onboarding): add startStep prop to OnboardingWizard"
+```
+
+---
+
+### Task 2: Create `/onboarding` route page + fix middleware
+
+**Files:**
+- Create: `apps/web/src/app/(authenticated)/onboarding/page.tsx`
+- Modify: `apps/web/src/middleware.ts` (change onboarding redirect target)
+
+The `(authenticated)` route group already exists with 80+ pages (dashboard, library, agents, etc.) so this is the correct location.
+
+- [ ] **Step 1: Fix middleware redirect target**
+
+In `middleware.ts` (line 55), the `onboarding_completed === 'false'` branch currently redirects to `/accept-invite`. This must change to `/onboarding` so that:
+- Users who haven't completed onboarding get redirected to the wizard, not back to accept-invite
+- The accept-invite page is only for initial password setup (one-time)
+
+```tsx
+// Before (line 55):
+const onboardingUrl = new URL('/accept-invite', request.url);
+
+// After:
+const onboardingUrl = new URL('/onboarding', request.url);
+```
+
+Also add `/onboarding` to `PUBLIC_PATHS` to prevent infinite redirect loop (middleware would redirect `/onboarding` → `/onboarding`):
+
+```tsx
+const PUBLIC_PATHS = new Set([
+  '/',
+  '/login',
+  '/register',
+  '/forgot-password',
+  '/reset-password',
+  '/games',
+  '/accept-invite',
+  '/verify-email',
+  '/onboarding', // NEW: prevent redirect loop for onboarding
+]);
+```
+
+**Note**: Adding `/onboarding` to `PUBLIC_PATHS` is safe here because the middleware only does onboarding redirect checks — it does NOT enforce authentication. Auth enforcement happens via the `(authenticated)` route group's layout/server components checking session cookies.
+
+- [ ] **Step 3: Create the onboarding page**
+
+```tsx
+// apps/web/src/app/(authenticated)/onboarding/page.tsx
+'use client';
+
+import { OnboardingWizard } from '@/components/onboarding';
+
+export default function OnboardingPage() {
+  return (
+    <div className="flex min-h-[80vh] items-center justify-center px-4">
+      <div className="w-full max-w-lg">
+        <OnboardingWizard token="" role="" startStep={2} />
+      </div>
+    </div>
+  );
+}
+```
+
+Note: `token` is empty because password is already set. The wizard's PasswordStep won't render since we start at step 2.
+
+- [ ] **Step 4: Verify page renders in dev**
+
+Run: `cd apps/web && pnpm dev` → navigate to `http://localhost:3000/onboarding`
+Expected: Wizard shows Profile step (step 2), "Skip wizard" link visible
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/app/(authenticated)/onboarding/page.tsx apps/web/src/middleware.ts
+git commit -m "feat(onboarding): create /onboarding route page with wizard at step 2"
+```
+
+---
+
+### Task 3: Change accept-invite redirect to `/onboarding`
+
+**Files:**
+- Modify: `apps/web/src/app/(public)/accept-invite/page.tsx`
+
+- [ ] **Step 1: Change redirect target**
+
+In `accept-invite/page.tsx`, inside `handleSubmit` callback (line 140):
+
+```tsx
+// Before:
+setTimeout(() => router.push('/dashboard'), 1500);
+
+// After:
+setTimeout(() => router.push('/onboarding'), 1500);
+```
+
+Also update the `SuccessCard` function body (line 211, same file — it's a local component with hardcoded text):
+
+```tsx
+// Before:
+<CardDescription>
+  Your password has been set successfully. Redirecting to your dashboard...
+</CardDescription>
+
+// After:
+<CardDescription>
+  Your password has been set successfully. Setting up your account...
+</CardDescription>
+```
+
+- [ ] **Step 2: Run existing accept-invite tests**
+
+Run: `cd apps/web && pnpm vitest run --reporter=verbose 2>&1 | head -50`
+Check for any accept-invite tests that assert the `/dashboard` redirect.
+
+- [ ] **Step 3: Update tests if needed**
+
+If tests assert `router.push('/dashboard')`, update to `router.push('/onboarding')`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/src/app/(public)/accept-invite/page.tsx
+git commit -m "feat(onboarding): redirect accept-invite to /onboarding instead of /dashboard"
+```
+
+---
+
+## Chunk 2: Verification
+
+### Task 4: Verify admin invitation UI
+
+**Files:** None to modify (verification only)
+
+- [ ] **Step 1: Verify InviteUserDialog renders**
+
+Run the existing test:
+```bash
+cd apps/web && pnpm vitest run src/components/admin/invitations/__tests__/InviteUserDialog.test.tsx
+```
+
+- [ ] **Step 2: Verify BulkInviteDialog renders**
+
+```bash
+cd apps/web && pnpm vitest run src/components/admin/invitations/__tests__/BulkInviteDialog.test.tsx
+```
+
+- [ ] **Step 3: Verify invitations page renders**
+
+```bash
+cd apps/web && pnpm vitest run src/app/admin/\\(dashboard\\)/users/invitations/__tests__/page.test.tsx
+```
+
+- [ ] **Step 4: Document verification results**
+
+If all pass → no work needed. If any fail → fix and commit.
+
+---
+
+### Task 5: Verify voice integration in ChatThreadView
+
+**Files:** None to modify (verification only)
+
+- [ ] **Step 1: Check VoiceMicButton is rendered in ChatThreadView**
+
+```bash
+cd apps/web && grep -n "VoiceMicButton\|TtsSpeakerButton" src/components/chat-unified/ChatThreadView.tsx
+```
+
+Expected: Both components are imported and rendered.
+
+- [ ] **Step 2: Verify VoiceMicButton data-testid**
+
+The `VoiceMicButton` uses dynamic testid: `data-testid={voice-mic-${state}}` where state is `idle|requesting|listening|processing|error`. In E2E tests, use `[data-testid^="voice-mic-"]` selector to match any state.
+
+- [ ] **Step 3: Run voice hook tests**
+
+```bash
+cd apps/web && pnpm vitest run src/hooks/__tests__/ --reporter=verbose 2>&1 | grep -i voice
+```
+
+- [ ] **Step 4: Document verification results**
+
+Voice is confirmed complete. No new work needed.
+
+---
+
+## Chunk 3: E2E Test
+
+### Task 6: Write E2E Playwright test
+
+**Files:**
+- Create: `apps/web/e2e/admin/admin-invite-onboarding-e2e.spec.ts`
+
+- [ ] **Step 1: Check existing E2E test patterns**
+
+Read existing E2E tests:
+```bash
+ls apps/web/e2e/admin/
+ls apps/web/e2e/onboarding/
+```
+
+Read `apps/web/e2e/admin/admin-invite-flow.spec.ts` and `apps/web/e2e/onboarding/accept-invite.spec.ts` for patterns.
+
+- [ ] **Step 2: Write the serial E2E test**
+
+```typescript
+// apps/web/e2e/admin/admin-invite-onboarding-e2e.spec.ts
+import { expect, test } from '@playwright/test';
+import path from 'path';
+
+const ADMIN_STATE = path.join(__dirname, '../.auth/admin-state.json');
+const USER_STATE = path.join(__dirname, '../.auth/invited-user-state.json');
+
+test.describe.serial('Admin invite → onboarding → voice → audit', () => {
+  const testEmail = `e2e-invite-${Date.now()}@test.meepleai.com`;
+
+  test('Step 1: Admin sends invitation', async ({ page, context }) => {
+    // Login as admin (adapt auth flow from existing E2E patterns)
+    await page.goto('/login');
+    // ... fill admin credentials from env
+    await page.goto('/admin/users');
+
+    // Open invite dialog
+    await page.getByRole('button', { name: /invite/i }).click();
+    await page.getByLabel(/email/i).fill(testEmail);
+    await page.getByRole('button', { name: /send/i }).click();
+
+    // Verify toast success
+    await expect(page.getByText(/invitation sent/i)).toBeVisible();
+
+    // Save admin session for reuse in Step 5
+    await context.storageState({ path: ADMIN_STATE });
+  });
+
+  test('Step 2: User accepts invitation', async ({ page, context }) => {
+    // Get token via admin API or construct URL
+    // Navigate to accept-invite page
+    await page.goto(`/accept-invite?token=test-token`);
+
+    // Fill password
+    await page.getByLabel(/^password$/i).fill('TestPassword1!');
+    await page.getByLabel(/confirm/i).fill('TestPassword1!');
+    await page.getByRole('button', { name: /create account/i }).click();
+
+    // Verify redirect to onboarding
+    await expect(page).toHaveURL(/\/onboarding/);
+
+    // Save user session for reuse in Steps 3-4
+    await context.storageState({ path: USER_STATE });
+  });
+
+  test('Step 3: Onboarding wizard', async ({ browser }) => {
+    // Restore user session
+    const context = await browser.newContext({ storageState: USER_STATE });
+    const page = await context.newPage();
+    await page.goto('/onboarding');
+
+    // Should start at Profile step (step 2)
+    await expect(page.getByText('Profile')).toBeVisible();
+
+    // Fill display name
+    await page.getByLabel(/display name/i).fill('E2E Test User');
+    await page.getByRole('button', { name: /continue|next/i }).click();
+
+    // Skip interests
+    await page.getByTestId('wizard-skip').click();
+
+    // Skip game (or add one)
+    await page.getByTestId('wizard-skip').click();
+
+    // Should redirect to dashboard
+    await expect(page).toHaveURL(/\/dashboard/);
+
+    await context.close();
+  });
+
+  test('Step 4: Voice button visible in chat', async ({ browser }) => {
+    const context = await browser.newContext({ storageState: USER_STATE });
+    const page = await context.newPage();
+
+    // Navigate to ask page (voice-first)
+    await page.goto('/ask');
+
+    // Verify mic button present (testid is dynamic: voice-mic-{state})
+    await expect(page.locator('[data-testid^="voice-mic-"]')).toBeVisible();
+
+    await context.close();
+  });
+
+  test('Step 5: Admin verifies audit log', async ({ browser }) => {
+    // Restore admin session
+    const context = await browser.newContext({ storageState: ADMIN_STATE });
+    const page = await context.newPage();
+
+    // Navigate to admin analytics
+    await page.goto('/admin/analytics');
+
+    // Check audit tab
+    await page.getByRole('tab', { name: /audit/i }).click();
+
+    // Verify invitation accepted entry exists
+    await expect(page.getByText(/invitation/i)).toBeVisible();
+
+    await context.close();
+  });
+});
+```
+
+**Note:** This is a template. Exact selectors and auth flow depend on test infrastructure (seed data, auth helpers). Adapt based on patterns found in existing E2E tests (see `e2e/admin/admin-invite-flow.spec.ts` and `e2e/onboarding/accept-invite.spec.ts`).
+
+- [ ] **Step 3: Run the E2E test in headed mode to debug**
+
+```bash
+cd apps/web && pnpm playwright test e2e/admin/admin-invite-onboarding-e2e.spec.ts --headed
+```
+
+- [ ] **Step 4: Fix any selector/timing issues**
+
+Iterate until test passes reliably.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/e2e/admin/admin-invite-onboarding-e2e.spec.ts
+git commit -m "test(e2e): admin invite → onboarding → voice → audit journey"
+```
+
+---
+
+## Chunk 4: Final
+
+### Task 7: Update spec status + typecheck
+
+- [ ] **Step 1: Run full typecheck**
+
+```bash
+cd apps/web && pnpm typecheck
+```
+
+- [ ] **Step 2: Run lint**
+
+```bash
+cd apps/web && pnpm lint
+```
+
+- [ ] **Step 3: Update spec status to "Implemented"**
+
+In `docs/superpowers/specs/2026-03-14-admin-invite-voice-onboarding-design.md`:
+Change `**Status**: Revised (post spec-review)` to `**Status**: Implemented`
+
+- [ ] **Step 4: Final commit**
+
+```bash
+git add -A
+git commit -m "docs(spec): mark admin-invite-voice-onboarding as implemented"
+```
+
+### Task 8: Create PR
+
+- [ ] **Step 1: Create feature branch from current branch**
+
+```bash
+git checkout -b feature/admin-invite-onboarding-integration
+git config branch.feature/admin-invite-onboarding-integration.parent $(git branch --show-current)
+```
+
+- [ ] **Step 2: Push and create PR to parent branch**
+
+Detect parent branch with `git config branch.feature/admin-invite-onboarding-integration.parent` and use it as `--base`. Do NOT hardcode `main-dev`.
+
+```bash
+PARENT=$(git config branch.feature/admin-invite-onboarding-integration.parent)
+git push -u origin feature/admin-invite-onboarding-integration
+gh pr create --base "$PARENT" --title "feat: connect accept-invite to onboarding wizard" --body "..."
+```
+
+---
+
+## Dependencies
+
+```
+Task 1 (OnboardingWizard startStep) → Task 2 (create /onboarding page) → Task 3 (change redirect)
+Task 4, 5 (verification) → independent, can run in parallel
+Task 6 (E2E) → depends on Tasks 1-3
+Task 7, 8 (final) → depends on all
+```
+
+## Risk Assessment
+
+| Risk | Mitigation |
+|------|-----------|
+| Middleware redirect loop on `/onboarding` | Add to `PUBLIC_PATHS` + change redirect target in Task 2 |
+| Auth cookie not set after accept-invite | Test in headed browser, check Set-Cookie header |
+| E2E test flaky due to token generation | Use admin API to create invitation, extract token |
+| OnboardingWizard PasswordStep renders with empty token | `startStep=2` skips it entirely; add defensive guard comment |
+| PR targets wrong branch | Use `git config branch.<name>.parent` to detect, never hardcode |

--- a/docs/superpowers/plans/2026-03-14-invite-only-registration.md
+++ b/docs/superpowers/plans/2026-03-14-invite-only-registration.md
@@ -1,0 +1,2222 @@
+# Invite-Only Registration (Beta0) — Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Gate self-registration behind a runtime toggle (`Registration:PublicEnabled`), provide a "Request Access" flow for visitors, and give admins tools to review, approve/reject requests and toggle registration mode.
+
+**Architecture:** New `AccessRequest` aggregate in Authentication BC with event-driven invitation on approval. Registration guard as endpoint filter. Frontend conditional rendering on `/register`. Admin panel for request management and mode toggle.
+
+**Tech Stack:** .NET 9, EF Core, MediatR, FluentValidation, Next.js 16, React 19, React Query, Tailwind 4, shadcn/ui, Vitest, Playwright
+
+**Spec:** `docs/superpowers/specs/2026-03-14-invite-only-registration-design.md`
+
+---
+
+## File Map
+
+### Backend — New Files
+
+| File | Responsibility |
+|------|---------------|
+| `BoundedContexts/Authentication/Domain/Entities/AccessRequest.cs` | Aggregate root: state machine, factory method |
+| `BoundedContexts/Authentication/Domain/Enums/AccessRequestStatus.cs` | Pending, Approved, Rejected |
+| `BoundedContexts/Authentication/Domain/Repositories/IAccessRequestRepository.cs` | Repository interface |
+| `BoundedContexts/Authentication/Domain/Events/AccessRequestCreatedEvent.cs` | Domain event |
+| `BoundedContexts/Authentication/Domain/Events/AccessRequestApprovedEvent.cs` | Domain event |
+| `BoundedContexts/Authentication/Application/Commands/AccessRequest/RequestAccessCommand.cs` | Command record |
+| `BoundedContexts/Authentication/Application/Commands/AccessRequest/RequestAccessCommandHandler.cs` | Handler |
+| `BoundedContexts/Authentication/Application/Commands/AccessRequest/RequestAccessCommandValidator.cs` | FluentValidation |
+| `BoundedContexts/Authentication/Application/Commands/AccessRequest/ApproveAccessRequestCommand.cs` | Command record |
+| `BoundedContexts/Authentication/Application/Commands/AccessRequest/ApproveAccessRequestCommandHandler.cs` | Handler |
+| `BoundedContexts/Authentication/Application/Commands/AccessRequest/RejectAccessRequestCommand.cs` | Command record |
+| `BoundedContexts/Authentication/Application/Commands/AccessRequest/RejectAccessRequestCommandHandler.cs` | Handler |
+| `BoundedContexts/Authentication/Application/Commands/AccessRequest/BulkApproveAccessRequestsCommand.cs` | Command record |
+| `BoundedContexts/Authentication/Application/Commands/AccessRequest/BulkApproveAccessRequestsCommandHandler.cs` | Handler |
+| `BoundedContexts/Authentication/Application/Queries/AccessRequest/GetAccessRequestsQuery.cs` | Query + handler |
+| `BoundedContexts/Authentication/Application/Queries/AccessRequest/GetAccessRequestStatsQuery.cs` | Query + handler |
+| `BoundedContexts/Authentication/Application/Queries/AccessRequest/GetAccessRequestByIdQuery.cs` | Query + handler |
+| `BoundedContexts/Authentication/Application/Queries/AccessRequest/GetRegistrationModeQuery.cs` | Query + handler |
+| `BoundedContexts/Authentication/Application/Commands/AccessRequest/SetRegistrationModeCommand.cs` | Command + handler |
+| `BoundedContexts/Authentication/Application/DTOs/AccessRequestDto.cs` | DTO record |
+| `BoundedContexts/Authentication/Application/DTOs/AccessRequestStatsDto.cs` | Stats DTO |
+| `BoundedContexts/Authentication/Application/DTOs/BulkApproveResultDto.cs` | Bulk result DTO |
+| `BoundedContexts/Authentication/Application/EventHandlers/AccessRequestApprovedEventHandler.cs` | Creates invitation on approval |
+| `BoundedContexts/Authentication/Application/EventHandlers/AccessRequestCreatedEventHandler.cs` | Notifies admins |
+| `BoundedContexts/Authentication/Infrastructure/Repositories/AccessRequestRepository.cs` | EF Core implementation |
+| `Routing/AccessRequestEndpoints.cs` | Public + admin endpoints |
+
+### Backend — Modified Files
+
+| File | Change |
+|------|--------|
+| `Infrastructure/Persistence/MeepleAiDbContext.cs` | Add `DbSet<AccessRequest>`, entity config |
+| `Routing/AuthenticationEndpoints.cs` | Add registration guard filter to `POST /register` |
+| `Infrastructure/DependencyInjection.cs` | Register `IAccessRequestRepository` |
+
+### Frontend — New Files
+
+| File | Responsibility |
+|------|---------------|
+| `src/lib/api/clients/accessRequestsClient.ts` | API client for all access request endpoints |
+| `src/components/auth/RequestAccessForm.tsx` | Request access form component |
+| `src/app/admin/(dashboard)/users/access-requests/page.tsx` | Admin access requests list page |
+| `src/components/admin/access-requests/ApproveRejectDialog.tsx` | Reject reason dialog |
+| `src/components/admin/settings/RegistrationModeToggle.tsx` | Toggle switch component |
+
+### Frontend — Modified Files
+
+| File | Change |
+|------|--------|
+| `src/app/(auth)/register/page.tsx` | Conditional rendering based on registration mode |
+| `src/lib/api/clients/index.ts` | Export accessRequestsClient |
+| Admin sidebar nav component | Add "Access Requests" link with badge |
+
+### Test Files
+
+| File | Scope |
+|------|-------|
+| `tests/Api.Tests/BoundedContexts/Authentication/Domain/Entities/AccessRequestTests.cs` | Entity unit tests |
+| `tests/Api.Tests/BoundedContexts/Authentication/Application/Commands/RequestAccessCommandHandlerTests.cs` | Handler tests |
+| `tests/Api.Tests/BoundedContexts/Authentication/Application/Commands/ApproveAccessRequestCommandHandlerTests.cs` | Handler tests |
+| `tests/Api.Tests/BoundedContexts/Authentication/Application/Commands/RejectAccessRequestCommandHandlerTests.cs` | Handler tests |
+| `tests/Api.Tests/BoundedContexts/Authentication/Application/Commands/BulkApproveAccessRequestsCommandHandlerTests.cs` | Handler tests |
+| `apps/web/__tests__/components/auth/RequestAccessForm.test.tsx` | Component tests |
+| `apps/web/__tests__/app/register/page.test.tsx` | Conditional rendering tests |
+| `apps/web/e2e/invite-only-registration.spec.ts` | E2E tests |
+
+---
+
+## Chunk 1: Domain Layer
+
+### Task 1: AccessRequestStatus Enum
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/Authentication/Domain/Enums/AccessRequestStatus.cs`
+
+- [ ] **Step 1: Create the enum**
+
+```csharp
+namespace Api.BoundedContexts.Authentication.Domain.Enums;
+
+public enum AccessRequestStatus
+{
+    Pending = 0,
+    Approved = 1,
+    Rejected = 2
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/Authentication/Domain/Enums/AccessRequestStatus.cs
+git commit -m "feat(auth): add AccessRequestStatus enum"
+```
+
+---
+
+### Task 2: Domain Events
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/Authentication/Domain/Events/AccessRequestCreatedEvent.cs`
+- Create: `apps/api/src/Api/BoundedContexts/Authentication/Domain/Events/AccessRequestApprovedEvent.cs`
+- Reference: `apps/api/src/Api/BoundedContexts/Authentication/Domain/Events/PasswordChangedEvent.cs` (pattern)
+
+- [ ] **Step 1: Create AccessRequestCreatedEvent**
+
+```csharp
+namespace Api.BoundedContexts.Authentication.Domain.Events;
+
+public sealed class AccessRequestCreatedEvent : DomainEventBase
+{
+    public Guid AccessRequestId { get; }
+    public string Email { get; }
+
+    public AccessRequestCreatedEvent(Guid accessRequestId, string email)
+    {
+        AccessRequestId = accessRequestId;
+        Email = email;
+    }
+}
+```
+
+- [ ] **Step 2: Create AccessRequestApprovedEvent**
+
+```csharp
+namespace Api.BoundedContexts.Authentication.Domain.Events;
+
+public sealed class AccessRequestApprovedEvent : DomainEventBase
+{
+    public Guid AccessRequestId { get; }
+    public string Email { get; }
+    public Guid ApprovedByUserId { get; }
+
+    public AccessRequestApprovedEvent(Guid accessRequestId, string email, Guid approvedByUserId)
+    {
+        AccessRequestId = accessRequestId;
+        Email = email;
+        ApprovedByUserId = approvedByUserId;
+    }
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/Authentication/Domain/Events/AccessRequest*.cs
+git commit -m "feat(auth): add AccessRequest domain events"
+```
+
+---
+
+### Task 3: AccessRequest Entity
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/Authentication/Domain/Entities/AccessRequest.cs`
+- Create: `tests/Api.Tests/BoundedContexts/Authentication/Domain/Entities/AccessRequestTests.cs`
+- Reference: `apps/api/src/Api/BoundedContexts/Authentication/Domain/Entities/InvitationToken.cs` (pattern)
+
+- [ ] **Step 1: Write failing tests for the entity**
+
+```csharp
+using Api.BoundedContexts.Authentication.Domain.Entities;
+using Api.BoundedContexts.Authentication.Domain.Enums;
+
+namespace Api.Tests.BoundedContexts.Authentication.Domain.Entities;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "Authentication")]
+public class AccessRequestTests
+{
+    [Fact]
+    public void Create_WithValidEmail_ReturnsPendingAccessRequest()
+    {
+        var request = AccessRequest.Create("test@example.com");
+
+        Assert.NotEqual(Guid.Empty, request.Id);
+        Assert.Equal("test@example.com", request.Email);
+        Assert.Equal(AccessRequestStatus.Pending, request.Status);
+        Assert.True(request.RequestedAt <= DateTime.UtcNow);
+        Assert.Null(request.ReviewedAt);
+        Assert.Null(request.ReviewedBy);
+        Assert.Null(request.RejectionReason);
+        Assert.Null(request.InvitationId);
+    }
+
+    [Fact]
+    public void Create_NormalizesEmailToLowercase()
+    {
+        var request = AccessRequest.Create("Test@EXAMPLE.com");
+        Assert.Equal("test@example.com", request.Email);
+    }
+
+    [Fact]
+    public void Approve_FromPending_SetsApprovedState()
+    {
+        var request = AccessRequest.Create("test@example.com");
+        var adminId = Guid.NewGuid();
+
+        request.Approve(adminId);
+
+        Assert.Equal(AccessRequestStatus.Approved, request.Status);
+        Assert.NotNull(request.ReviewedAt);
+        Assert.Equal(adminId, request.ReviewedBy);
+    }
+
+    [Fact]
+    public void Reject_FromPending_SetsRejectedState()
+    {
+        var request = AccessRequest.Create("test@example.com");
+        var adminId = Guid.NewGuid();
+
+        request.Reject(adminId, "Not in beta group");
+
+        Assert.Equal(AccessRequestStatus.Rejected, request.Status);
+        Assert.NotNull(request.ReviewedAt);
+        Assert.Equal(adminId, request.ReviewedBy);
+        Assert.Equal("Not in beta group", request.RejectionReason);
+    }
+
+    [Fact]
+    public void Reject_WithoutReason_SetsNullReason()
+    {
+        var request = AccessRequest.Create("test@example.com");
+        request.Reject(Guid.NewGuid());
+        Assert.Null(request.RejectionReason);
+    }
+
+    [Fact]
+    public void Approve_WhenAlreadyApproved_ThrowsInvalidOperationException()
+    {
+        var request = AccessRequest.Create("test@example.com");
+        request.Approve(Guid.NewGuid());
+
+        Assert.Throws<InvalidOperationException>(() => request.Approve(Guid.NewGuid()));
+    }
+
+    [Fact]
+    public void Approve_WhenRejected_ThrowsInvalidOperationException()
+    {
+        var request = AccessRequest.Create("test@example.com");
+        request.Reject(Guid.NewGuid());
+
+        Assert.Throws<InvalidOperationException>(() => request.Approve(Guid.NewGuid()));
+    }
+
+    [Fact]
+    public void Reject_WhenAlreadyRejected_ThrowsInvalidOperationException()
+    {
+        var request = AccessRequest.Create("test@example.com");
+        request.Reject(Guid.NewGuid());
+
+        Assert.Throws<InvalidOperationException>(() => request.Reject(Guid.NewGuid()));
+    }
+
+    [Fact]
+    public void Reject_WhenApproved_ThrowsInvalidOperationException()
+    {
+        var request = AccessRequest.Create("test@example.com");
+        request.Approve(Guid.NewGuid());
+
+        Assert.Throws<InvalidOperationException>(() => request.Reject(Guid.NewGuid()));
+    }
+
+    [Fact]
+    public void Approve_PublishesAccessRequestApprovedEvent()
+    {
+        var request = AccessRequest.Create("test@example.com");
+        var adminId = Guid.NewGuid();
+
+        request.Approve(adminId);
+
+        var domainEvent = request.DomainEventBases
+            .OfType<AccessRequestApprovedEvent>()
+            .SingleOrDefault();
+        Assert.NotNull(domainEvent);
+        Assert.Equal(request.Id, domainEvent.AccessRequestId);
+        Assert.Equal("test@example.com", domainEvent.Email);
+        Assert.Equal(adminId, domainEvent.ApprovedByUserId);
+    }
+
+    [Fact]
+    public void Create_PublishesAccessRequestCreatedEvent()
+    {
+        var request = AccessRequest.Create("test@example.com");
+
+        var domainEvent = request.DomainEventBases
+            .OfType<AccessRequestCreatedEvent>()
+            .SingleOrDefault();
+        Assert.NotNull(domainEvent);
+        Assert.Equal(request.Id, domainEvent.AccessRequestId);
+        Assert.Equal("test@example.com", domainEvent.Email);
+    }
+
+    [Fact]
+    public void SetInvitationId_StoresCorrelationId()
+    {
+        var request = AccessRequest.Create("test@example.com");
+        request.Approve(Guid.NewGuid());
+        var invitationId = Guid.NewGuid();
+
+        request.SetInvitationId(invitationId);
+
+        Assert.Equal(invitationId, request.InvitationId);
+    }
+
+    [Fact]
+    public void Reject_WithReasonExceeding500Chars_ThrowsArgumentException()
+    {
+        var request = AccessRequest.Create("test@example.com");
+        var longReason = new string('a', 501);
+
+        Assert.Throws<ArgumentException>(() => request.Reject(Guid.NewGuid(), longReason));
+    }
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd apps/api && dotnet test --filter "FullyQualifiedName~AccessRequestTests" -v minimal
+```
+
+Expected: FAIL — `AccessRequest` class does not exist.
+
+- [ ] **Step 3: Implement the AccessRequest entity**
+
+Follow `InvitationToken.cs` pattern: private setters, factory method, state transition methods, domain events.
+
+```csharp
+using Api.BoundedContexts.Authentication.Domain.Enums;
+using Api.BoundedContexts.Authentication.Domain.Events;
+
+namespace Api.BoundedContexts.Authentication.Domain.Entities;
+
+internal sealed class AccessRequest : AggregateRoot<Guid>
+{
+    public string Email { get; private set; } = null!;
+    public AccessRequestStatus Status { get; private set; }
+    public DateTime RequestedAt { get; private set; }
+    public DateTime? ReviewedAt { get; private set; }
+    public Guid? ReviewedBy { get; private set; }
+    public string? RejectionReason { get; private set; }
+    public Guid? InvitationId { get; private set; }
+
+    private AccessRequest() { } // EF Core
+
+    public static AccessRequest Create(string email)
+    {
+        var request = new AccessRequest
+        {
+            Id = Guid.NewGuid(),
+            Email = email.Trim().ToLowerInvariant(),
+            Status = AccessRequestStatus.Pending,
+            RequestedAt = DateTime.UtcNow,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        };
+
+        request.AddDomainEventBase(new AccessRequestCreatedEvent(request.Id, request.Email));
+        return request;
+    }
+
+    public void Approve(Guid adminId)
+    {
+        if (Status != AccessRequestStatus.Pending)
+            throw new InvalidOperationException(
+                $"Cannot approve access request in '{Status}' status. Only Pending requests can be approved.");
+
+        Status = AccessRequestStatus.Approved;
+        ReviewedAt = DateTime.UtcNow;
+        ReviewedBy = adminId;
+        UpdatedAt = DateTime.UtcNow;
+
+        AddDomainEventBase(new AccessRequestApprovedEvent(Id, Email, adminId));
+    }
+
+    public void Reject(Guid adminId, string? reason = null)
+    {
+        if (Status != AccessRequestStatus.Pending)
+            throw new InvalidOperationException(
+                $"Cannot reject access request in '{Status}' status. Only Pending requests can be rejected.");
+
+        if (reason is not null && reason.Length > 500)
+            throw new ArgumentException("Rejection reason cannot exceed 500 characters.", nameof(reason));
+
+        Status = AccessRequestStatus.Rejected;
+        ReviewedAt = DateTime.UtcNow;
+        ReviewedBy = adminId;
+        RejectionReason = reason;
+        UpdatedAt = DateTime.UtcNow;
+    }
+
+    public void SetInvitationId(Guid invitationId)
+    {
+        InvitationId = invitationId;
+        UpdatedAt = DateTime.UtcNow;
+    }
+
+    // Hydration for EF Core
+    public static AccessRequest CreateForHydration() => new();
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+cd apps/api && dotnet test --filter "FullyQualifiedName~AccessRequestTests" -v minimal
+```
+
+Expected: ALL PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/Authentication/Domain/Entities/AccessRequest.cs \
+        tests/Api.Tests/BoundedContexts/Authentication/Domain/Entities/AccessRequestTests.cs
+git commit -m "feat(auth): add AccessRequest entity with state machine and tests"
+```
+
+---
+
+### Task 4: Repository Interface
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/Authentication/Domain/Repositories/IAccessRequestRepository.cs`
+- Reference: `apps/api/src/Api/BoundedContexts/Authentication/Domain/Repositories/IInvitationTokenRepository.cs`
+
+- [ ] **Step 1: Create repository interface**
+
+```csharp
+using Api.BoundedContexts.Authentication.Domain.Entities;
+using Api.BoundedContexts.Authentication.Domain.Enums;
+
+namespace Api.BoundedContexts.Authentication.Domain.Repositories;
+
+// IRepository<AccessRequest, Guid> already provides: GetByIdAsync, AddAsync, UpdateAsync
+public interface IAccessRequestRepository : IRepository<AccessRequest, Guid>
+{
+    Task<AccessRequest?> GetPendingByEmailAsync(string email, CancellationToken ct = default);
+    Task<IReadOnlyList<AccessRequest>> GetByStatusAsync(
+        AccessRequestStatus? status, int page, int pageSize,
+        CancellationToken ct = default);
+    Task<int> CountByStatusAsync(AccessRequestStatus status, CancellationToken ct = default);
+    Task<int> CountAllAsync(CancellationToken ct = default);
+}
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/Authentication/Domain/Repositories/IAccessRequestRepository.cs
+git commit -m "feat(auth): add IAccessRequestRepository interface"
+```
+
+---
+
+## Chunk 2: Application Layer — Commands
+
+### Task 5: DTOs
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/Authentication/Application/DTOs/AccessRequestDto.cs`
+- Create: `apps/api/src/Api/BoundedContexts/Authentication/Application/DTOs/AccessRequestStatsDto.cs`
+- Create: `apps/api/src/Api/BoundedContexts/Authentication/Application/DTOs/BulkApproveResultDto.cs`
+
+- [ ] **Step 1: Create all three DTOs**
+
+```csharp
+// AccessRequestDto.cs
+namespace Api.BoundedContexts.Authentication.Application.DTOs;
+
+public record AccessRequestDto(
+    Guid Id,
+    string Email,
+    string Status,
+    DateTime RequestedAt,
+    DateTime? ReviewedAt,
+    Guid? ReviewedBy,
+    string? RejectionReason,
+    Guid? InvitationId,
+    DateTime CreatedAt);
+
+// AccessRequestStatsDto.cs
+namespace Api.BoundedContexts.Authentication.Application.DTOs;
+
+public record AccessRequestStatsDto(
+    int Pending,
+    int Approved,
+    int Rejected,
+    int Total);
+
+// BulkApproveResultDto.cs
+namespace Api.BoundedContexts.Authentication.Application.DTOs;
+
+public record BulkApproveResultDto(
+    int Processed,
+    int Succeeded,
+    int Failed,
+    IReadOnlyList<BulkApproveItemResult> Results);
+
+public record BulkApproveItemResult(
+    Guid Id,
+    string Status,
+    string? Error = null);
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/Authentication/Application/DTOs/AccessRequest*.cs \
+        apps/api/src/Api/BoundedContexts/Authentication/Application/DTOs/BulkApproveResultDto.cs
+git commit -m "feat(auth): add AccessRequest DTOs"
+```
+
+---
+
+### Task 6: RequestAccessCommand
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/AccessRequest/RequestAccessCommand.cs`
+- Create: `apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/AccessRequest/RequestAccessCommandValidator.cs`
+- Create: `apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/AccessRequest/RequestAccessCommandHandler.cs`
+- Create: `tests/Api.Tests/BoundedContexts/Authentication/Application/Commands/RequestAccessCommandHandlerTests.cs`
+
+- [ ] **Step 1: Create the command record**
+
+```csharp
+namespace Api.BoundedContexts.Authentication.Application.Commands.AccessRequest;
+
+internal record RequestAccessCommand(string Email) : ICommand<Unit>;
+```
+
+- [ ] **Step 2: Create the validator**
+
+```csharp
+namespace Api.BoundedContexts.Authentication.Application.Commands.AccessRequest;
+
+internal class RequestAccessCommandValidator : AbstractValidator<RequestAccessCommand>
+{
+    public RequestAccessCommandValidator()
+    {
+        RuleFor(x => x.Email)
+            .NotEmpty().WithMessage("Email is required.")
+            .EmailAddress().WithMessage("A valid email address is required.")
+            .MaximumLength(256).WithMessage("Email must not exceed 256 characters.");
+    }
+}
+```
+
+- [ ] **Step 3: Write failing handler tests**
+
+```csharp
+namespace Api.Tests.BoundedContexts.Authentication.Application.Commands;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "Authentication")]
+public class RequestAccessCommandHandlerTests
+{
+    private readonly Mock<IAccessRequestRepository> _accessRequestRepoMock;
+    private readonly Mock<IUserRepository> _userRepoMock;
+    private readonly RequestAccessCommandHandler _handler;
+
+    public RequestAccessCommandHandlerTests()
+    {
+        _accessRequestRepoMock = new Mock<IAccessRequestRepository>();
+        _userRepoMock = new Mock<IUserRepository>();
+        _handler = new RequestAccessCommandHandler(
+            _accessRequestRepoMock.Object,
+            _userRepoMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_NewEmail_CreatesAccessRequest()
+    {
+        _accessRequestRepoMock
+            .Setup(x => x.GetPendingByEmailAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((AccessRequest?)null);
+        _userRepoMock
+            .Setup(x => x.GetByEmailAsync(It.IsAny<Email>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((User?)null);
+
+        var command = new RequestAccessCommand("new@example.com");
+        await _handler.Handle(command, CancellationToken.None);
+
+        _accessRequestRepoMock.Verify(
+            x => x.AddAsync(It.Is<AccessRequest>(r => r.Email == "new@example.com"),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ExistingAccount_DoesNotCreateRequest()
+    {
+        var existingUser = TestUserFactory.CreateUser("existing@example.com");
+        _userRepoMock
+            .Setup(x => x.GetByEmailAsync(It.IsAny<Email>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingUser);
+
+        var command = new RequestAccessCommand("existing@example.com");
+        await _handler.Handle(command, CancellationToken.None);
+
+        _accessRequestRepoMock.Verify(
+            x => x.AddAsync(It.IsAny<AccessRequest>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_AlreadyPending_DoesNotCreateDuplicate()
+    {
+        var pendingRequest = AccessRequest.Create("pending@example.com");
+        _accessRequestRepoMock
+            .Setup(x => x.GetPendingByEmailAsync("pending@example.com", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(pendingRequest);
+
+        var command = new RequestAccessCommand("pending@example.com");
+        await _handler.Handle(command, CancellationToken.None);
+
+        _accessRequestRepoMock.Verify(
+            x => x.AddAsync(It.IsAny<AccessRequest>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_NormalizesEmail()
+    {
+        _accessRequestRepoMock
+            .Setup(x => x.GetPendingByEmailAsync("test@example.com", It.IsAny<CancellationToken>()))
+            .ReturnsAsync((AccessRequest?)null);
+        _userRepoMock
+            .Setup(x => x.GetByEmailAsync(It.IsAny<Email>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((User?)null);
+
+        var command = new RequestAccessCommand("TEST@Example.COM");
+        await _handler.Handle(command, CancellationToken.None);
+
+        _accessRequestRepoMock.Verify(
+            x => x.GetPendingByEmailAsync("test@example.com", It.IsAny<CancellationToken>()), Times.Once);
+    }
+}
+```
+
+- [ ] **Step 4: Run tests to verify they fail**
+
+```bash
+cd apps/api && dotnet test --filter "FullyQualifiedName~RequestAccessCommandHandlerTests" -v minimal
+```
+
+- [ ] **Step 5: Implement the handler**
+
+Key behavior: Always performs ALL DB lookups (email exists? pending exists?) regardless of outcome for timing equalization. Never throws — always returns `Unit.Value`.
+
+```csharp
+namespace Api.BoundedContexts.Authentication.Application.Commands.AccessRequest;
+
+internal class RequestAccessCommandHandler : ICommandHandler<RequestAccessCommand, Unit>
+{
+    private readonly IAccessRequestRepository _accessRequestRepository;
+    private readonly IUserRepository _userRepository;
+
+    public RequestAccessCommandHandler(
+        IAccessRequestRepository accessRequestRepository,
+        IUserRepository userRepository)
+    {
+        _accessRequestRepository = accessRequestRepository;
+        _userRepository = userRepository;
+    }
+
+    public async Task<Unit> Handle(RequestAccessCommand request, CancellationToken ct)
+    {
+        var normalizedEmail = request.Email.Trim().ToLowerInvariant();
+
+        // Always perform both lookups for timing equalization
+        var existingUserTask = _userRepository.GetByEmailAsync(
+            Email.Create(normalizedEmail), ct);
+        var pendingRequestTask = _accessRequestRepository.GetPendingByEmailAsync(
+            normalizedEmail, ct);
+
+        var existingUser = await existingUserTask.ConfigureAwait(false);
+        var pendingRequest = await pendingRequestTask.ConfigureAwait(false);
+
+        // Silent skip: existing account or already pending
+        if (existingUser is not null || pendingRequest is not null)
+            return Unit.Value;
+
+        var accessRequest = Domain.Entities.AccessRequest.Create(normalizedEmail);
+        await _accessRequestRepository.AddAsync(accessRequest, ct).ConfigureAwait(false);
+
+        return Unit.Value;
+    }
+}
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+```bash
+cd apps/api && dotnet test --filter "FullyQualifiedName~RequestAccessCommandHandlerTests" -v minimal
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/AccessRequest/Request*.cs \
+        tests/Api.Tests/BoundedContexts/Authentication/Application/Commands/RequestAccessCommandHandlerTests.cs
+git commit -m "feat(auth): add RequestAccessCommand with enumeration prevention"
+```
+
+---
+
+### Task 7: ApproveAccessRequestCommand
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/AccessRequest/ApproveAccessRequestCommand.cs`
+- Create: `apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/AccessRequest/ApproveAccessRequestCommandHandler.cs`
+- Create: `tests/Api.Tests/BoundedContexts/Authentication/Application/Commands/ApproveAccessRequestCommandHandlerTests.cs`
+
+- [ ] **Step 1: Create the command**
+
+```csharp
+namespace Api.BoundedContexts.Authentication.Application.Commands.AccessRequest;
+
+internal record ApproveAccessRequestCommand(Guid Id, Guid AdminId) : ICommand<Unit>;
+```
+
+- [ ] **Step 2: Write failing handler tests**
+
+Test idempotency semantics: domain throws on non-Pending, handler catches for idempotent cases (already Approved → 200), rethrows for illegal transitions (Rejected → 409).
+
+```csharp
+namespace Api.Tests.BoundedContexts.Authentication.Application.Commands;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "Authentication")]
+public class ApproveAccessRequestCommandHandlerTests
+{
+    private readonly Mock<IAccessRequestRepository> _repoMock;
+    private readonly ApproveAccessRequestCommandHandler _handler;
+
+    public ApproveAccessRequestCommandHandlerTests()
+    {
+        _repoMock = new Mock<IAccessRequestRepository>();
+        _handler = new ApproveAccessRequestCommandHandler(_repoMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_PendingRequest_ApprovesSuccessfully()
+    {
+        var request = AccessRequest.Create("test@example.com");
+        _repoMock.Setup(x => x.GetByIdAsync(request.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(request);
+
+        var command = new ApproveAccessRequestCommand(request.Id, Guid.NewGuid());
+        await _handler.Handle(command, CancellationToken.None);
+
+        Assert.Equal(AccessRequestStatus.Approved, request.Status);
+        _repoMock.Verify(x => x.UpdateAsync(request, It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_AlreadyApproved_ReturnsSuccessWithoutModification()
+    {
+        var request = AccessRequest.Create("test@example.com");
+        request.Approve(Guid.NewGuid()); // Already approved
+        _repoMock.Setup(x => x.GetByIdAsync(request.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(request);
+
+        var command = new ApproveAccessRequestCommand(request.Id, Guid.NewGuid());
+        // Should NOT throw — idempotent no-op
+        await _handler.Handle(command, CancellationToken.None);
+
+        _repoMock.Verify(x => x.UpdateAsync(It.IsAny<AccessRequest>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_RejectedRequest_ThrowsConflictException()
+    {
+        var request = AccessRequest.Create("test@example.com");
+        request.Reject(Guid.NewGuid());
+        _repoMock.Setup(x => x.GetByIdAsync(request.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(request);
+
+        var command = new ApproveAccessRequestCommand(request.Id, Guid.NewGuid());
+        await Assert.ThrowsAsync<ConflictException>(
+            () => _handler.Handle(command, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task Handle_NonExistentId_ThrowsNotFoundException()
+    {
+        _repoMock.Setup(x => x.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((AccessRequest?)null);
+
+        var command = new ApproveAccessRequestCommand(Guid.NewGuid(), Guid.NewGuid());
+        await Assert.ThrowsAsync<NotFoundException>(
+            () => _handler.Handle(command, CancellationToken.None));
+    }
+}
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+```bash
+cd apps/api && dotnet test --filter "FullyQualifiedName~ApproveAccessRequestCommandHandlerTests" -v minimal
+```
+
+- [ ] **Step 4: Implement the handler**
+
+```csharp
+namespace Api.BoundedContexts.Authentication.Application.Commands.AccessRequest;
+
+internal class ApproveAccessRequestCommandHandler : ICommandHandler<ApproveAccessRequestCommand, Unit>
+{
+    private readonly IAccessRequestRepository _repository;
+
+    public ApproveAccessRequestCommandHandler(IAccessRequestRepository repository)
+    {
+        _repository = repository;
+    }
+
+    public async Task<Unit> Handle(ApproveAccessRequestCommand request, CancellationToken ct)
+    {
+        var accessRequest = await _repository.GetByIdAsync(request.Id, ct).ConfigureAwait(false)
+            ?? throw new NotFoundException($"Access request '{request.Id}' not found.");
+
+        if (accessRequest.Status == AccessRequestStatus.Approved)
+            return Unit.Value; // Idempotent no-op
+
+        try
+        {
+            accessRequest.Approve(request.AdminId);
+        }
+        catch (InvalidOperationException)
+        {
+            throw new ConflictException(
+                $"Cannot approve access request in '{accessRequest.Status}' status.");
+        }
+
+        await _repository.UpdateAsync(accessRequest, ct).ConfigureAwait(false);
+        return Unit.Value;
+    }
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```bash
+cd apps/api && dotnet test --filter "FullyQualifiedName~ApproveAccessRequestCommandHandlerTests" -v minimal
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/AccessRequest/Approve*.cs \
+        tests/Api.Tests/BoundedContexts/Authentication/Application/Commands/ApproveAccessRequestCommandHandlerTests.cs
+git commit -m "feat(auth): add ApproveAccessRequestCommand with idempotency"
+```
+
+---
+
+### Task 8: RejectAccessRequestCommand
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/AccessRequest/RejectAccessRequestCommand.cs`
+- Create: `apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/AccessRequest/RejectAccessRequestCommandHandler.cs`
+- Create: `tests/Api.Tests/BoundedContexts/Authentication/Application/Commands/RejectAccessRequestCommandHandlerTests.cs`
+
+- [ ] **Step 1: Create the command**
+
+```csharp
+namespace Api.BoundedContexts.Authentication.Application.Commands.AccessRequest;
+
+internal record RejectAccessRequestCommand(Guid Id, Guid AdminId, string? Reason = null) : ICommand<Unit>;
+```
+
+- [ ] **Step 2: Write failing tests**
+
+Same idempotency pattern: Already Rejected → no-op, Approved → ConflictException.
+
+```csharp
+namespace Api.Tests.BoundedContexts.Authentication.Application.Commands;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "Authentication")]
+public class RejectAccessRequestCommandHandlerTests
+{
+    private readonly Mock<IAccessRequestRepository> _repoMock;
+    private readonly RejectAccessRequestCommandHandler _handler;
+
+    public RejectAccessRequestCommandHandlerTests()
+    {
+        _repoMock = new Mock<IAccessRequestRepository>();
+        _handler = new RejectAccessRequestCommandHandler(_repoMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_PendingRequest_RejectsWithReason()
+    {
+        var request = AccessRequest.Create("test@example.com");
+        _repoMock.Setup(x => x.GetByIdAsync(request.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(request);
+
+        await _handler.Handle(
+            new RejectAccessRequestCommand(request.Id, Guid.NewGuid(), "Not in beta"),
+            CancellationToken.None);
+
+        Assert.Equal(AccessRequestStatus.Rejected, request.Status);
+        Assert.Equal("Not in beta", request.RejectionReason);
+    }
+
+    [Fact]
+    public async Task Handle_AlreadyRejected_ReturnsSuccessWithoutModification()
+    {
+        var request = AccessRequest.Create("test@example.com");
+        request.Reject(Guid.NewGuid());
+        _repoMock.Setup(x => x.GetByIdAsync(request.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(request);
+
+        await _handler.Handle(
+            new RejectAccessRequestCommand(request.Id, Guid.NewGuid()),
+            CancellationToken.None);
+
+        _repoMock.Verify(x => x.UpdateAsync(It.IsAny<AccessRequest>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_ApprovedRequest_ThrowsConflictException()
+    {
+        var request = AccessRequest.Create("test@example.com");
+        request.Approve(Guid.NewGuid());
+        _repoMock.Setup(x => x.GetByIdAsync(request.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(request);
+
+        await Assert.ThrowsAsync<ConflictException>(
+            () => _handler.Handle(
+                new RejectAccessRequestCommand(request.Id, Guid.NewGuid()),
+                CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task Handle_NonExistentId_ThrowsNotFoundException()
+    {
+        _repoMock.Setup(x => x.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((AccessRequest?)null);
+
+        await Assert.ThrowsAsync<NotFoundException>(
+            () => _handler.Handle(
+                new RejectAccessRequestCommand(Guid.NewGuid(), Guid.NewGuid()),
+                CancellationToken.None));
+    }
+}
+```
+
+- [ ] **Step 3: Run tests to verify they fail, implement handler, run tests to verify they pass**
+
+Handler follows same pattern as ApproveAccessRequestCommandHandler but checks for `AccessRequestStatus.Rejected` as idempotent state.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/AccessRequest/Reject*.cs \
+        tests/Api.Tests/BoundedContexts/Authentication/Application/Commands/RejectAccessRequestCommandHandlerTests.cs
+git commit -m "feat(auth): add RejectAccessRequestCommand with idempotency"
+```
+
+---
+
+### Task 9: BulkApproveAccessRequestsCommand
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/AccessRequest/BulkApproveAccessRequestsCommand.cs`
+- Create: `apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/AccessRequest/BulkApproveAccessRequestsCommandHandler.cs`
+- Create: `tests/Api.Tests/BoundedContexts/Authentication/Application/Commands/BulkApproveAccessRequestsCommandHandlerTests.cs`
+
+- [ ] **Step 1: Create the command**
+
+```csharp
+namespace Api.BoundedContexts.Authentication.Application.Commands.AccessRequest;
+
+internal record BulkApproveAccessRequestsCommand(
+    IReadOnlyList<Guid> Ids,
+    Guid AdminId) : ICommand<BulkApproveResultDto>;
+```
+
+- [ ] **Step 2: Write failing tests**
+
+Key tests: max 25 limit, per-item results, mixed states, non-existent IDs.
+
+```csharp
+namespace Api.Tests.BoundedContexts.Authentication.Application.Commands;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "Authentication")]
+public class BulkApproveAccessRequestsCommandHandlerTests
+{
+    private readonly Mock<IAccessRequestRepository> _repoMock;
+    private readonly Mock<IMediator> _mediatorMock;
+    private readonly BulkApproveAccessRequestsCommandHandler _handler;
+
+    public BulkApproveAccessRequestsCommandHandlerTests()
+    {
+        _repoMock = new Mock<IAccessRequestRepository>();
+        _mediatorMock = new Mock<IMediator>();
+        _handler = new BulkApproveAccessRequestsCommandHandler(
+            _repoMock.Object, _mediatorMock.Object);
+    }
+
+    [Fact]
+    public async Task Handle_ExceedsMaxBatchSize_ThrowsValidationException()
+    {
+        var ids = Enumerable.Range(0, 26).Select(_ => Guid.NewGuid()).ToList();
+        var command = new BulkApproveAccessRequestsCommand(ids, Guid.NewGuid());
+
+        await Assert.ThrowsAsync<ValidationException>(
+            () => _handler.Handle(command, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task Handle_MixedStates_ReturnsPerItemResults()
+    {
+        var pending = AccessRequest.Create("a@test.com");
+        var approved = AccessRequest.Create("b@test.com");
+        approved.Approve(Guid.NewGuid());
+
+        _repoMock.Setup(x => x.GetByIdAsync(pending.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(pending);
+        _repoMock.Setup(x => x.GetByIdAsync(approved.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(approved);
+
+        var command = new BulkApproveAccessRequestsCommand(
+            new[] { pending.Id, approved.Id }, Guid.NewGuid());
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        Assert.Equal(2, result.Processed);
+        Assert.Equal(2, result.Succeeded); // Already approved = success (idempotent)
+        Assert.Equal(0, result.Failed);
+    }
+
+    [Fact]
+    public async Task Handle_NonExistentId_ReportsFailureForThatItem()
+    {
+        var nonExistentId = Guid.NewGuid();
+        _repoMock.Setup(x => x.GetByIdAsync(nonExistentId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((AccessRequest?)null);
+
+        var command = new BulkApproveAccessRequestsCommand(
+            new[] { nonExistentId }, Guid.NewGuid());
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        Assert.Equal(1, result.Failed);
+        Assert.Equal("Not found", result.Results[0].Error);
+    }
+}
+```
+
+- [ ] **Step 3: Run tests to verify they fail, implement handler, run tests to verify they pass**
+
+Handler iterates IDs, dispatches individual `ApproveAccessRequestCommand` via MediatR, catches exceptions, collects per-item results.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/AccessRequest/BulkApprove*.cs \
+        tests/Api.Tests/BoundedContexts/Authentication/Application/Commands/BulkApproveAccessRequestsCommandHandlerTests.cs
+git commit -m "feat(auth): add BulkApproveAccessRequestsCommand (max 25, per-item results)"
+```
+
+---
+
+### Task 10: SetRegistrationModeCommand + GetRegistrationModeQuery
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/AccessRequest/SetRegistrationModeCommand.cs`
+- Create: `apps/api/src/Api/BoundedContexts/Authentication/Application/Queries/AccessRequest/GetRegistrationModeQuery.cs`
+
+- [ ] **Step 1: Create SetRegistrationModeCommand**
+
+This command delegates to the SystemConfiguration BC via MediatR `UpdateConfigValueCommand`. `IConfigurationService` is read-only — writes go through SystemConfiguration's own commands.
+
+```csharp
+namespace Api.BoundedContexts.Authentication.Application.Commands.AccessRequest;
+
+internal record SetRegistrationModeCommand(bool Enabled, Guid AdminId) : ICommand<Unit>;
+
+internal class SetRegistrationModeCommandHandler : ICommandHandler<SetRegistrationModeCommand, Unit>
+{
+    private readonly IMediator _mediator;
+
+    public SetRegistrationModeCommandHandler(IMediator mediator)
+    {
+        _mediator = mediator;
+    }
+
+    public async Task<Unit> Handle(SetRegistrationModeCommand request, CancellationToken ct)
+    {
+        // Delegate to SystemConfiguration BC's own command via MediatR
+        await _mediator.Send(
+            new UpdateConfigValueCommand(
+                "Registration:PublicEnabled",
+                request.Enabled.ToString().ToLowerInvariant()),
+            ct).ConfigureAwait(false);
+
+        return Unit.Value;
+    }
+}
+```
+
+> **Note**: If `UpdateConfigValueCommand` does not exist, use `CreateConfigurationCommand` from the SystemConfiguration BC. Check `BoundedContexts/SystemConfiguration/Application/Commands/` for the exact command name and signature.
+
+- [ ] **Step 2: Create GetRegistrationModeQuery**
+
+```csharp
+namespace Api.BoundedContexts.Authentication.Application.Queries.AccessRequest;
+
+public record GetRegistrationModeQuery : IQuery<RegistrationModeDto>;
+
+public record RegistrationModeDto(bool PublicRegistrationEnabled);
+
+internal class GetRegistrationModeQueryHandler : IQueryHandler<GetRegistrationModeQuery, RegistrationModeDto>
+{
+    private readonly IConfigurationService _configService;
+
+    public GetRegistrationModeQueryHandler(IConfigurationService configService)
+    {
+        _configService = configService;
+    }
+
+    public async Task<RegistrationModeDto> Handle(GetRegistrationModeQuery request, CancellationToken ct)
+    {
+        // Fail closed: default false if config not found or service unreachable
+        // GetValueAsync signature: GetValueAsync<T>(string key, T? defaultValue, string? environment = null)
+        bool enabled;
+        try
+        {
+            enabled = await _configService.GetValueAsync<bool?>(
+                "Registration:PublicEnabled", false).ConfigureAwait(false) ?? false;
+        }
+        catch
+        {
+            enabled = false; // Fail closed
+        }
+
+        return new RegistrationModeDto(enabled);
+    }
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/AccessRequest/SetRegistrationMode*.cs \
+        apps/api/src/Api/BoundedContexts/Authentication/Application/Queries/AccessRequest/GetRegistrationMode*.cs
+git commit -m "feat(auth): add registration mode toggle command and query (fail-closed)"
+```
+
+---
+
+### Task 11: Access Request Queries
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/Authentication/Application/Queries/AccessRequest/GetAccessRequestsQuery.cs`
+- Create: `apps/api/src/Api/BoundedContexts/Authentication/Application/Queries/AccessRequest/GetAccessRequestStatsQuery.cs`
+- Create: `apps/api/src/Api/BoundedContexts/Authentication/Application/Queries/AccessRequest/GetAccessRequestByIdQuery.cs`
+
+- [ ] **Step 1: Create queries with handlers**
+
+Follow existing `GetInvitationsQuery` pattern. Defaults: page=1, pageSize=20 (max 100), sortBy=RequestedAt desc.
+
+```csharp
+// GetAccessRequestsQuery.cs
+namespace Api.BoundedContexts.Authentication.Application.Queries.AccessRequest;
+
+public record GetAccessRequestsQuery(
+    string? Status = null,
+    int Page = 1,
+    int PageSize = 20) : IQuery<GetAccessRequestsResponse>;
+
+public record GetAccessRequestsResponse(
+    IReadOnlyList<AccessRequestDto> Items,
+    int TotalCount,
+    int Page,
+    int PageSize);
+
+// GetAccessRequestStatsQuery.cs
+public record GetAccessRequestStatsQuery : IQuery<AccessRequestStatsDto>;
+
+// GetAccessRequestByIdQuery.cs
+public record GetAccessRequestByIdQuery(Guid Id) : IQuery<AccessRequestDto>;
+```
+
+Handlers query `IAccessRequestRepository` and map to DTOs.
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/Authentication/Application/Queries/AccessRequest/*.cs
+git commit -m "feat(auth): add access request list, stats, and detail queries"
+```
+
+---
+
+### Task 12: Event Handlers
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/Authentication/Application/EventHandlers/AccessRequestApprovedEventHandler.cs`
+- Create: `apps/api/src/Api/BoundedContexts/Authentication/Application/EventHandlers/AccessRequestCreatedEventHandler.cs`
+- Reference: `apps/api/src/Api/BoundedContexts/Authentication/Application/EventHandlers/PasswordChangedEventHandler.cs`
+
+- [ ] **Step 1: Create AccessRequestApprovedEventHandler**
+
+Fires `SendInvitationCommand(email, "User", approvedByUserId)` — reuses existing invitation infrastructure.
+
+```csharp
+namespace Api.BoundedContexts.Authentication.Application.EventHandlers;
+
+internal class AccessRequestApprovedEventHandler : DomainEventHandlerBase<AccessRequestApprovedEvent>
+{
+    private readonly IMediator _mediator;
+    private readonly IAccessRequestRepository _repository;
+    private readonly ILogger<AccessRequestApprovedEventHandler> _logger;
+
+    public AccessRequestApprovedEventHandler(
+        IMediator mediator,
+        IAccessRequestRepository repository,
+        ILogger<AccessRequestApprovedEventHandler> logger)
+    {
+        _mediator = mediator;
+        _repository = repository;
+        _logger = logger;
+    }
+
+    protected override async Task HandleEventAsync(
+        AccessRequestApprovedEvent domainEvent, CancellationToken ct)
+    {
+        try
+        {
+            var invitationResult = await _mediator.Send(
+                new SendInvitationCommand(
+                    domainEvent.Email,
+                    "User",
+                    domainEvent.ApprovedByUserId),
+                ct).ConfigureAwait(false);
+
+            // Update correlation ID
+            var accessRequest = await _repository.GetByIdAsync(
+                domainEvent.AccessRequestId, ct).ConfigureAwait(false);
+            if (accessRequest is not null)
+            {
+                accessRequest.SetInvitationId(invitationResult.Id);
+                await _repository.UpdateAsync(accessRequest, ct).ConfigureAwait(false);
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "Failed to create invitation for approved access request {AccessRequestId}, email {Email}",
+                domainEvent.AccessRequestId, domainEvent.Email);
+            // Approval stands. Admin can resend via invitation UI.
+        }
+    }
+
+    protected override Guid GetUserId(AccessRequestApprovedEvent domainEvent)
+        => domainEvent.ApprovedByUserId;
+
+    protected override Dictionary<string, object> GetAuditMetadata(
+        AccessRequestApprovedEvent domainEvent)
+        => new()
+        {
+            ["AccessRequestId"] = domainEvent.AccessRequestId,
+            ["Email"] = domainEvent.Email
+        };
+}
+```
+
+- [ ] **Step 2: Create AccessRequestCreatedEventHandler**
+
+Sends notification to all admins. Uses existing notification patterns.
+
+```csharp
+namespace Api.BoundedContexts.Authentication.Application.EventHandlers;
+
+internal class AccessRequestCreatedEventHandler : DomainEventHandlerBase<AccessRequestCreatedEvent>
+{
+    // TODO: Check BoundedContexts/UserNotifications/ for the correct notification service interface
+    // Likely IPushNotificationService or similar. INotificationService does NOT exist.
+    private readonly IPushNotificationService _notificationService;
+    private readonly ILogger<AccessRequestCreatedEventHandler> _logger;
+
+    // Constructor...
+
+    protected override async Task HandleEventAsync(
+        AccessRequestCreatedEvent domainEvent, CancellationToken ct)
+    {
+        try
+        {
+            await _notificationService.NotifyAdminsAsync(
+                "New Access Request",
+                $"New access request from {domainEvent.Email}",
+                "/admin/users/access-requests",
+                ct).ConfigureAwait(false);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "Failed to notify admins about access request {AccessRequestId}",
+                domainEvent.AccessRequestId);
+            // Request creation still succeeds
+        }
+    }
+
+    protected override Guid GetUserId(AccessRequestCreatedEvent domainEvent)
+        => Guid.Empty; // System action, no user
+
+    protected override Dictionary<string, object> GetAuditMetadata(
+        AccessRequestCreatedEvent domainEvent)
+        => new() { ["Email"] = domainEvent.Email };
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/Authentication/Application/EventHandlers/AccessRequest*.cs
+git commit -m "feat(auth): add event handlers for access request approval and creation"
+```
+
+---
+
+## Chunk 3: Infrastructure & Routing
+
+### Task 13: EF Core Configuration + Repository + Migration
+
+**Files:**
+- Modify: `apps/api/src/Api/Infrastructure/Persistence/MeepleAiDbContext.cs`
+- Create: `apps/api/src/Api/BoundedContexts/Authentication/Infrastructure/Repositories/AccessRequestRepository.cs`
+- Modify: `apps/api/src/Api/Infrastructure/DependencyInjection.cs`
+
+- [ ] **Step 1: Add DbSet and entity configuration to MeepleAiDbContext**
+
+```csharp
+// In MeepleAiDbContext.cs — add DbSet
+public DbSet<AccessRequest> AccessRequests => Set<AccessRequest>();
+
+// In OnModelCreating — add entity config
+modelBuilder.Entity<AccessRequest>(entity =>
+{
+    entity.ToTable("access_requests");
+    entity.HasKey(e => e.Id);
+    entity.Property(e => e.Email).HasMaxLength(256).IsRequired();
+    entity.Property(e => e.Status)
+        .HasConversion<string>()
+        .HasMaxLength(20)
+        .IsRequired();
+    entity.Property(e => e.RejectionReason).HasMaxLength(500);
+    entity.HasIndex(e => new { e.Email, e.Status })
+        .HasFilter("\"Status\" = 'Pending'")
+        .IsUnique();
+});
+```
+
+- [ ] **Step 2: Implement AccessRequestRepository**
+
+Follow `InvitationTokenRepository` pattern with EF Core queries.
+
+- [ ] **Step 3: Register in DI**
+
+```csharp
+// In DependencyInjection.cs
+services.AddScoped<IAccessRequestRepository, AccessRequestRepository>();
+```
+
+- [ ] **Step 4: Create migration**
+
+```bash
+cd apps/api/src/Api && dotnet ef migrations add AddAccessRequests
+```
+
+- [ ] **Step 5: Verify migration SQL looks correct**
+
+Review generated migration file. Verify: table name, column types, unique index on (Email, Status) with Pending filter.
+
+- [ ] **Step 6: Seed Registration:PublicEnabled config key**
+
+Add to seed data: `Registration:PublicEnabled` = `false`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/api/src/Api/Infrastructure/ \
+        apps/api/src/Api/BoundedContexts/Authentication/Infrastructure/ \
+        apps/api/src/Api/Migrations/
+git commit -m "feat(auth): add AccessRequest EF Core config, repository, and migration"
+```
+
+---
+
+### Task 14: Registration Guard Endpoint Filter
+
+**Files:**
+- Create: `apps/api/src/Api/Routing/Filters/RequirePublicRegistrationFilter.cs`
+- Modify: `apps/api/src/Api/Routing/AuthenticationEndpoints.cs`
+
+- [ ] **Step 1: Create the endpoint filter**
+
+Follows `RequireAdminSessionFilter` pattern. Reads config via query-side service. Short-circuits with 403.
+
+```csharp
+namespace Api.Routing.Filters;
+
+public class RequirePublicRegistrationFilter : IEndpointFilter
+{
+    public async ValueTask<object?> InvokeAsync(
+        EndpointFilterInvocationContext context,
+        EndpointFilterDelegate next)
+    {
+        var configService = context.HttpContext.RequestServices
+            .GetRequiredService<IConfigurationService>();
+
+        // Fail closed: if config unreachable or missing, block registration
+        bool publicEnabled;
+        try
+        {
+            publicEnabled = await configService.GetValueAsync<bool?>(
+                "Registration:PublicEnabled", false).ConfigureAwait(false) ?? false;
+        }
+        catch
+        {
+            publicEnabled = false; // Fail closed
+        }
+
+        if (!publicEnabled)
+        {
+            return Results.Json(
+                new { message = "Registration is currently unavailable." },
+                statusCode: 403);
+        }
+
+        return await next(context).ConfigureAwait(false);
+    }
+}
+```
+
+- [ ] **Step 2: Apply filter to register endpoint**
+
+In `AuthenticationEndpoints.cs`, find `MapPost("/register"...)` and add:
+
+```csharp
+.AddEndpointFilter<RequirePublicRegistrationFilter>()
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/api/src/Api/Routing/Filters/RequirePublicRegistrationFilter.cs \
+        apps/api/src/Api/Routing/AuthenticationEndpoints.cs
+git commit -m "feat(auth): add registration guard endpoint filter (fail-closed)"
+```
+
+---
+
+### Task 15: Access Request Endpoints
+
+**Files:**
+- Create: `apps/api/src/Api/Routing/AccessRequestEndpoints.cs`
+
+- [ ] **Step 1: Create endpoints file with public and admin routes**
+
+```csharp
+namespace Api.Routing;
+
+public static class AccessRequestEndpoints
+{
+    public static void MapAccessRequestEndpoints(this IEndpointRouteBuilder app)
+    {
+        // Public endpoints
+        var publicGroup = app.MapGroup("/api/v1/auth")
+            .WithTags("Authentication");
+
+        publicGroup.MapGet("/registration-mode", HandleGetRegistrationMode)
+            .WithName("GetRegistrationMode")
+            .RequireRateLimiting("AuthGeneral"); // 30/min
+
+        publicGroup.MapPost("/request-access", HandleRequestAccess)
+            .WithName("RequestAccess")
+            .RequireRateLimiting("AuthRegister"); // 3/min
+
+        // Admin endpoints
+        var adminGroup = app.MapGroup("/api/v1/admin/access-requests")
+            .WithTags("Admin - Access Requests");
+
+        adminGroup.MapGet("/", HandleGetAccessRequests).WithName("GetAccessRequests");
+        adminGroup.MapGet("/stats", HandleGetAccessRequestStats).WithName("GetAccessRequestStats");
+        adminGroup.MapPost("/{id:guid}/approve", HandleApproveAccessRequest).WithName("ApproveAccessRequest");
+        adminGroup.MapPost("/{id:guid}/reject", HandleRejectAccessRequest).WithName("RejectAccessRequest");
+        adminGroup.MapPost("/bulk-approve", HandleBulkApprove).WithName("BulkApproveAccessRequests");
+
+        // Registration mode toggle (admin)
+        var settingsGroup = app.MapGroup("/api/v1/admin/settings")
+            .WithTags("Admin - Settings");
+
+        settingsGroup.MapPut("/registration-mode", HandleSetRegistrationMode)
+            .WithName("SetRegistrationMode");
+    }
+
+    // Public handlers
+    private static async Task<IResult> HandleGetRegistrationMode(
+        IMediator mediator, CancellationToken ct)
+    {
+        var result = await mediator.Send(new GetRegistrationModeQuery(), ct).ConfigureAwait(false);
+        return Results.Ok(result);
+    }
+
+    private static async Task<IResult> HandleRequestAccess(
+        RequestAccessPayload payload,
+        IMediator mediator,
+        CancellationToken ct)
+    {
+        await mediator.Send(new RequestAccessCommand(payload.Email), ct).ConfigureAwait(false);
+        // Always return 202 with identical message (enumeration prevention)
+        return Results.Accepted(value: new
+        {
+            message = "If this email is eligible, you will receive an invitation when approved."
+        });
+    }
+
+    // Admin handlers — all require RequireAdminSession()
+    private static async Task<IResult> HandleGetAccessRequests(
+        HttpContext context, IMediator mediator,
+        [FromQuery] string? status, [FromQuery] int page = 1, [FromQuery] int pageSize = 20,
+        CancellationToken ct = default)
+    {
+        var (authorized, session, error) = context.RequireAdminSession();
+        if (!authorized) return error!;
+
+        var result = await mediator.Send(
+            new GetAccessRequestsQuery(status, page, Math.Min(pageSize, 100)), ct)
+            .ConfigureAwait(false);
+        return Results.Ok(result);
+    }
+
+    private static async Task<IResult> HandleGetAccessRequestStats(
+        HttpContext context, IMediator mediator, CancellationToken ct)
+    {
+        var (authorized, session, error) = context.RequireAdminSession();
+        if (!authorized) return error!;
+
+        var result = await mediator.Send(new GetAccessRequestStatsQuery(), ct).ConfigureAwait(false);
+        return Results.Ok(result);
+    }
+
+    private static async Task<IResult> HandleApproveAccessRequest(
+        Guid id, HttpContext context, IMediator mediator, CancellationToken ct)
+    {
+        var (authorized, session, error) = context.RequireAdminSession();
+        if (!authorized) return error!;
+
+        await mediator.Send(
+            new ApproveAccessRequestCommand(id, session!.UserId), ct).ConfigureAwait(false);
+        return Results.Ok(new { status = "approved" });
+    }
+
+    private static async Task<IResult> HandleRejectAccessRequest(
+        Guid id, RejectPayload? payload,
+        HttpContext context, IMediator mediator, CancellationToken ct)
+    {
+        var (authorized, session, error) = context.RequireAdminSession();
+        if (!authorized) return error!;
+
+        await mediator.Send(
+            new RejectAccessRequestCommand(id, session!.UserId, payload?.Reason), ct)
+            .ConfigureAwait(false);
+        return Results.Ok(new { status = "rejected" });
+    }
+
+    private static async Task<IResult> HandleBulkApprove(
+        BulkApprovePayload payload,
+        HttpContext context, IMediator mediator, CancellationToken ct)
+    {
+        var (authorized, session, error) = context.RequireAdminSession();
+        if (!authorized) return error!;
+
+        var result = await mediator.Send(
+            new BulkApproveAccessRequestsCommand(payload.Ids, session!.UserId), ct)
+            .ConfigureAwait(false);
+        return Results.Ok(result);
+    }
+
+    private static async Task<IResult> HandleSetRegistrationMode(
+        SetRegistrationModePayload payload,
+        HttpContext context, IMediator mediator, CancellationToken ct)
+    {
+        var (authorized, session, error) = context.RequireAdminSession();
+        if (!authorized) return error!;
+
+        await mediator.Send(
+            new SetRegistrationModeCommand(payload.Enabled, session!.UserId), ct)
+            .ConfigureAwait(false);
+        return Results.Ok(new { publicRegistrationEnabled = payload.Enabled });
+    }
+}
+
+// Payload records
+internal record RequestAccessPayload(string Email);
+internal record RejectPayload(string? Reason);
+internal record BulkApprovePayload(IReadOnlyList<Guid> Ids);
+internal record SetRegistrationModePayload(bool Enabled);
+```
+
+- [ ] **Step 2: Register endpoints in Program.cs or routing setup**
+
+Find where `MapAuthenticationEndpoints()` is called and add `app.MapAccessRequestEndpoints()`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/api/src/Api/Routing/AccessRequestEndpoints.cs
+git commit -m "feat(auth): add access request public and admin endpoints"
+```
+
+---
+
+## Chunk 4: Frontend
+
+### Task 16: API Client
+
+**Files:**
+- Create: `apps/web/src/lib/api/clients/accessRequestsClient.ts`
+- Modify: `apps/web/src/lib/api/clients/index.ts`
+- Reference: `apps/web/src/lib/api/clients/invitationsClient.ts` (pattern)
+
+- [ ] **Step 1: Create the API client**
+
+```typescript
+// accessRequestsClient.ts
+import type { HttpClient } from '../httpClient';
+
+export interface AccessRequestDto {
+  id: string;
+  email: string;
+  status: 'Pending' | 'Approved' | 'Rejected';
+  requestedAt: string;
+  reviewedAt: string | null;
+  reviewedBy: string | null;
+  rejectionReason: string | null;
+  invitationId: string | null;
+}
+
+export interface AccessRequestStats {
+  pending: number;
+  approved: number;
+  rejected: number;
+  total: number;
+}
+
+export interface BulkApproveResult {
+  processed: number;
+  succeeded: number;
+  failed: number;
+  results: Array<{ id: string; status: string; error?: string }>;
+}
+
+export interface RegistrationMode {
+  publicRegistrationEnabled: boolean;
+}
+
+export interface GetAccessRequestsParams {
+  status?: string;
+  page?: number;
+  pageSize?: number;
+}
+
+export interface GetAccessRequestsResponse {
+  items: AccessRequestDto[];
+  totalCount: number;
+  page: number;
+  pageSize: number;
+}
+
+export interface CreateAccessRequestsClientParams {
+  httpClient: HttpClient;
+}
+
+export function createAccessRequestsClient({ httpClient }: CreateAccessRequestsClientParams) {
+  return {
+    // Public
+    getRegistrationMode(): Promise<RegistrationMode> {
+      return httpClient.get('/api/v1/auth/registration-mode');
+    },
+
+    requestAccess(email: string): Promise<{ message: string }> {
+      return httpClient.post('/api/v1/auth/request-access', { email });
+    },
+
+    // Admin
+    getAccessRequests(params?: GetAccessRequestsParams): Promise<GetAccessRequestsResponse> {
+      const searchParams = new URLSearchParams();
+      if (params?.status) searchParams.set('status', params.status);
+      if (params?.page) searchParams.set('page', params.page.toString());
+      if (params?.pageSize) searchParams.set('pageSize', params.pageSize.toString());
+      return httpClient.get(`/api/v1/admin/access-requests?${searchParams}`);
+    },
+
+    getAccessRequestStats(): Promise<AccessRequestStats> {
+      return httpClient.get('/api/v1/admin/access-requests/stats');
+    },
+
+    approveAccessRequest(id: string): Promise<void> {
+      return httpClient.post(`/api/v1/admin/access-requests/${id}/approve`);
+    },
+
+    rejectAccessRequest(id: string, reason?: string): Promise<void> {
+      return httpClient.post(`/api/v1/admin/access-requests/${id}/reject`, { reason });
+    },
+
+    bulkApproveAccessRequests(ids: string[]): Promise<BulkApproveResult> {
+      return httpClient.post('/api/v1/admin/access-requests/bulk-approve', { ids });
+    },
+
+    setRegistrationMode(enabled: boolean): Promise<void> {
+      return httpClient.put('/api/v1/admin/settings/registration-mode', { enabled });
+    },
+  };
+}
+```
+
+- [ ] **Step 2: Export from index**
+
+Add to `apps/web/src/lib/api/clients/index.ts`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/src/lib/api/clients/accessRequestsClient.ts apps/web/src/lib/api/clients/index.ts
+git commit -m "feat(web): add accessRequests API client"
+```
+
+---
+
+### Task 17: RequestAccessForm Component
+
+**Files:**
+- Create: `apps/web/src/components/auth/RequestAccessForm.tsx`
+- Create: `apps/web/__tests__/components/auth/RequestAccessForm.test.tsx`
+
+- [ ] **Step 1: Write failing component tests**
+
+```typescript
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { RequestAccessForm } from '@/components/auth/RequestAccessForm';
+
+// Mock API client
+const mockRequestAccess = vi.fn();
+vi.mock('@/lib/api', () => ({
+  useApi: () => ({
+    accessRequests: { requestAccess: mockRequestAccess },
+  }),
+}));
+
+describe('RequestAccessForm', () => {
+  beforeEach(() => {
+    mockRequestAccess.mockReset();
+  });
+
+  it('renders email input and submit button', () => {
+    render(<RequestAccessForm />);
+    expect(screen.getByLabelText(/email/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /request access/i })).toBeInTheDocument();
+  });
+
+  it('shows validation error for empty email', async () => {
+    render(<RequestAccessForm />);
+    fireEvent.click(screen.getByRole('button', { name: /request access/i }));
+    await waitFor(() => {
+      expect(screen.getByText(/valid email/i)).toBeInTheDocument();
+    });
+  });
+
+  it('shows success message after submission', async () => {
+    mockRequestAccess.mockResolvedValueOnce({ message: 'ok' });
+    render(<RequestAccessForm />);
+
+    fireEvent.change(screen.getByLabelText(/email/i), {
+      target: { value: 'test@example.com' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /request access/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/submitted/i)).toBeInTheDocument();
+    });
+    // Form should be replaced by success message
+    expect(screen.queryByLabelText(/email/i)).not.toBeInTheDocument();
+  });
+
+  it('disables form during submission', async () => {
+    mockRequestAccess.mockImplementation(() => new Promise(() => {})); // Never resolves
+    render(<RequestAccessForm />);
+
+    fireEvent.change(screen.getByLabelText(/email/i), {
+      target: { value: 'test@example.com' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /request access/i }));
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/email/i)).toBeDisabled();
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+cd apps/web && pnpm test -- RequestAccessForm
+```
+
+- [ ] **Step 3: Implement RequestAccessForm**
+
+Same card layout as `RegisterForm`. React Hook Form + Zod validation. Uses `useMutation` from React Query. Shows success state with `aria-live="polite"`.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/auth/RequestAccessForm.tsx \
+        apps/web/__tests__/components/auth/RequestAccessForm.test.tsx
+git commit -m "feat(web): add RequestAccessForm component with success/error states"
+```
+
+---
+
+### Task 18: Conditional Register Page
+
+**Files:**
+- Modify: `apps/web/src/app/(auth)/register/page.tsx`
+- Create: `apps/web/__tests__/app/register/page.test.tsx`
+
+- [ ] **Step 1: Write failing tests for conditional rendering**
+
+```typescript
+import { render, screen, waitFor } from '@testing-library/react';
+import RegisterPage from '@/app/(auth)/register/page';
+
+const mockGetRegistrationMode = vi.fn();
+vi.mock('@/lib/api', () => ({
+  useApi: () => ({
+    accessRequests: { getRegistrationMode: mockGetRegistrationMode },
+  }),
+}));
+
+describe('RegisterPage', () => {
+  it('shows RegisterForm when public registration enabled', async () => {
+    mockGetRegistrationMode.mockResolvedValueOnce({ publicRegistrationEnabled: true });
+    render(<RegisterPage />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/create.*account/i)).toBeInTheDocument();
+    });
+  });
+
+  it('shows RequestAccessForm when public registration disabled', async () => {
+    mockGetRegistrationMode.mockResolvedValueOnce({ publicRegistrationEnabled: false });
+    render(<RegisterPage />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /request access/i })).toBeInTheDocument();
+    });
+  });
+});
+```
+
+- [ ] **Step 2: Run tests, implement conditional rendering, verify tests pass**
+
+Page calls `GET /registration-mode` on mount via `useQuery`. Renders `RegisterForm` or `RequestAccessForm` based on result. Shows loading skeleton during fetch.
+
+On 403 from register API: re-fetches registration mode to distinguish real toggle vs transient failure.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/src/app/\\(auth\\)/register/page.tsx \
+        apps/web/__tests__/app/register/page.test.tsx
+git commit -m "feat(web): conditional register page (RegisterForm vs RequestAccessForm)"
+```
+
+---
+
+### Task 19: Admin Access Requests Page
+
+**Files:**
+- Create: `apps/web/src/app/admin/(dashboard)/users/access-requests/page.tsx`
+- Create: `apps/web/src/components/admin/access-requests/ApproveRejectDialog.tsx`
+- Reference: `apps/web/src/app/admin/(dashboard)/users/invitations/page.tsx` (pattern)
+
+- [ ] **Step 1: Create the admin page**
+
+Follow invitations page pattern exactly:
+- `useQuery` for list + stats
+- KPI cards (Pending / Approved / Rejected / Total)
+- Status filter tabs
+- Paginated table with row actions
+- Approve button (direct action with confirmation)
+- Reject button (opens dialog with optional reason textarea, max 500 chars)
+- "Approve Selected" toolbar button (disabled if > 25 selected)
+- `useMutation` for approve/reject/bulk-approve with toast notifications
+- Invalidate queries on mutation success
+
+- [ ] **Step 2: Create ApproveRejectDialog**
+
+Dialog with textarea for rejection reason (optional, max 500 chars). Cancel / Reject buttons.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/src/app/admin/\\(dashboard\\)/users/access-requests/ \
+        apps/web/src/components/admin/access-requests/
+git commit -m "feat(web): add admin access requests page with KPIs, filtering, bulk approve"
+```
+
+---
+
+### Task 20: Registration Mode Toggle in Admin Settings
+
+**Files:**
+- Create: `apps/web/src/components/admin/settings/RegistrationModeToggle.tsx`
+- Modify: Admin settings page (find existing settings page and add section)
+
+- [ ] **Step 1: Create RegistrationModeToggle**
+
+- `useQuery` for current mode
+- Switch component (shadcn/ui)
+- Confirmation dialog: "Are you sure? This will [enable/disable] public registration."
+- `useMutation` for toggle with toast notification
+- Status text: "Invite-only mode" / "Public registration enabled"
+
+- [ ] **Step 2: Add to admin settings page**
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/src/components/admin/settings/RegistrationModeToggle.tsx
+git commit -m "feat(web): add registration mode toggle in admin settings"
+```
+
+---
+
+### Task 21: Admin Sidebar Navigation
+
+**Files:**
+- Modify: Admin sidebar navigation component (find via `apps/web/src/components/admin/` or layout)
+
+- [ ] **Step 1: Add "Access Requests" link under Users section**
+
+- Link to `/admin/users/access-requests`
+- Pending count badge (fetched via stats query)
+- Icon consistent with existing sidebar items
+
+- [ ] **Step 2: Commit**
+
+```bash
+git commit -m "feat(web): add access requests link with pending badge to admin sidebar"
+```
+
+---
+
+## Chunk 5: Integration & E2E Tests
+
+### Task 22: Backend Integration Tests
+
+**Files:**
+- Create: `tests/Api.Tests/BoundedContexts/Authentication/Integration/AccessRequestIntegrationTests.cs`
+
+- [ ] **Step 1: Write integration tests using Testcontainers**
+
+Key journeys to test:
+1. Request access → approve → invitation created → accept invitation → user account exists
+2. Bulk approve 3 requests → 3 invitations created
+3. Config toggle persists and affects `POST /register` immediately
+4. Concurrent approve: two threads approve same request → only one invitation
+5. Rate limit: 4th request-access within 60s → 429
+
+```csharp
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "Authentication")]
+public class AccessRequestIntegrationTests : IntegrationTestBase
+{
+    [Fact]
+    public async Task FullFlow_RequestApproveAccept_CreatesUser()
+    {
+        // 1. Request access
+        var requestResponse = await Client.PostAsJsonAsync(
+            "/api/v1/auth/request-access",
+            new { email = "newuser@test.com" });
+        Assert.Equal(HttpStatusCode.Accepted, requestResponse.StatusCode);
+
+        // 2. Admin approves
+        var requests = await AdminClient.GetFromJsonAsync<GetAccessRequestsResponse>(
+            "/api/v1/admin/access-requests?status=Pending");
+        var accessRequest = requests!.Items.Single(r => r.Email == "newuser@test.com");
+
+        var approveResponse = await AdminClient.PostAsync(
+            $"/api/v1/admin/access-requests/{accessRequest.Id}/approve", null);
+        Assert.Equal(HttpStatusCode.OK, approveResponse.StatusCode);
+
+        // 3. Verify invitation was created (eventual via event handler)
+        // ... poll or check directly via DB
+    }
+
+    [Fact]
+    public async Task Register_WhenPublicDisabled_Returns403()
+    {
+        // Ensure Registration:PublicEnabled = false (default)
+        var response = await Client.PostAsJsonAsync(
+            "/api/v1/auth/register",
+            new { email = "test@test.com", password = "Test1234!", displayName = "Test" });
+        Assert.Equal(HttpStatusCode.Forbidden, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Register_WhenPublicEnabled_Succeeds()
+    {
+        // Admin enables public registration
+        await AdminClient.PutAsJsonAsync(
+            "/api/v1/admin/settings/registration-mode",
+            new { enabled = true });
+
+        var response = await Client.PostAsJsonAsync(
+            "/api/v1/auth/register",
+            new { email = "public@test.com", password = "Test1234!", displayName = "Test" });
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+    }
+}
+```
+
+- [ ] **Step 2: Run integration tests**
+
+```bash
+cd apps/api && dotnet test --filter "Category=Integration&FullyQualifiedName~AccessRequest" -v minimal
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/Api.Tests/BoundedContexts/Authentication/Integration/AccessRequestIntegrationTests.cs
+git commit -m "test(auth): add access request integration tests"
+```
+
+---
+
+### Task 23: Frontend E2E Tests
+
+**Files:**
+- Create: `apps/web/e2e/invite-only-registration.spec.ts`
+
+- [ ] **Step 1: Write E2E tests**
+
+```typescript
+import { test, expect } from '@playwright/test';
+
+test.describe('Invite-Only Registration', () => {
+  test('shows request access form when registration is invite-only', async ({ page }) => {
+    // Default: Registration:PublicEnabled = false
+    await page.goto('/register');
+    await expect(page.getByRole('button', { name: /request access/i })).toBeVisible();
+    await expect(page.getByLabel(/email/i)).toBeVisible();
+  });
+
+  test('submits access request and shows success message', async ({ page }) => {
+    await page.goto('/register');
+    await page.getByLabel(/email/i).fill('visitor@example.com');
+    await page.getByRole('button', { name: /request access/i }).click();
+    await expect(page.getByText(/submitted/i)).toBeVisible();
+  });
+
+  test('admin can toggle registration mode', async ({ page }) => {
+    // Login as admin
+    await page.goto('/login');
+    // ... admin login flow
+    await page.goto('/admin/settings');
+    // Toggle public registration
+    const toggle = page.getByRole('switch', { name: /public registration/i });
+    await toggle.click();
+    // Confirm dialog
+    await page.getByRole('button', { name: /confirm/i }).click();
+    await expect(page.getByText(/public registration enabled/i)).toBeVisible();
+  });
+
+  test('admin can approve access request', async ({ page }) => {
+    // Navigate to access requests page
+    await page.goto('/admin/users/access-requests');
+    // Find pending request and approve
+    await page.getByRole('button', { name: /approve/i }).first().click();
+    await expect(page.getByText(/approved/i)).toBeVisible();
+  });
+});
+```
+
+- [ ] **Step 2: Run E2E tests**
+
+```bash
+cd apps/web && pnpm test:e2e -- invite-only-registration
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/e2e/invite-only-registration.spec.ts
+git commit -m "test(e2e): add invite-only registration E2E tests"
+```
+
+---
+
+## Chunk 6: Final Validation
+
+### Task 24: Build & Lint Verification
+
+- [ ] **Step 1: Backend build**
+
+```bash
+cd apps/api/src/Api && dotnet build
+```
+
+- [ ] **Step 2: Run all backend tests**
+
+```bash
+cd apps/api && dotnet test --filter "FullyQualifiedName~AccessRequest" -v minimal
+```
+
+- [ ] **Step 3: Frontend build + typecheck + lint**
+
+```bash
+cd apps/web && pnpm typecheck && pnpm lint && pnpm build
+```
+
+- [ ] **Step 4: Run frontend tests**
+
+```bash
+cd apps/web && pnpm test
+```
+
+- [ ] **Step 5: Final commit if any fixes needed**
+
+---
+
+### Task 25: PR Creation
+
+- [ ] **Step 1: Detect parent branch**
+
+```bash
+git config branch.$(git branch --show-current).parent
+```
+
+- [ ] **Step 2: Push and create PR to parent branch**
+
+```bash
+git push -u origin $(git branch --show-current)
+gh pr create --base <parent-branch> --title "feat(auth): invite-only registration (beta0)" --body "..."
+```
+
+PR body should reference the spec: `docs/superpowers/specs/2026-03-14-invite-only-registration-design.md`
+
+---
+
+## Summary
+
+| Chunk | Tasks | Focus |
+|-------|-------|-------|
+| 1 | 1-4 | Domain layer: entity, enum, events, repository interface |
+| 2 | 5-12 | Application layer: commands, queries, DTOs, event handlers |
+| 3 | 13-15 | Infrastructure: EF Core, migration, endpoint filter, routing |
+| 4 | 16-21 | Frontend: API client, forms, pages, admin UI |
+| 5 | 22-23 | Integration and E2E tests |
+| 6 | 24-25 | Build verification and PR |
+
+**Total**: 25 tasks, ~60 steps, TDD throughout.
+
+---
+
+## Addendum: Implementation Notes (from plan review)
+
+### Missing Tests — Add During Implementation
+
+The following tasks lack tests and MUST have them added during implementation:
+
+**Task 10 (SetRegistrationMode + GetRegistrationMode):**
+- Test `GetRegistrationModeQuery`: config returns true → DTO true, config returns false → DTO false, config unreachable → DTO false (fail-closed)
+- Test `SetRegistrationModeCommand`: dispatches `UpdateConfigValueCommand` with correct key/value
+
+**Task 11 (Queries):**
+- Test `GetAccessRequestsQuery`: pagination defaults, max pageSize cap at 100, status filtering, empty results
+- Test `GetAccessRequestStatsQuery`: counts by status, zero counts
+- Test `GetAccessRequestByIdQuery`: found → returns DTO, not found → throws NotFoundException
+
+**Task 12 (Event Handlers):**
+- Test `AccessRequestApprovedEventHandler`: successful invitation creation → sets InvitationId, invitation failure → logs error, does not throw
+- Test `AccessRequestCreatedEventHandler`: notification failure → logs warning, does not throw
+
+### Codebase Pattern Notes
+
+1. **Entity base class**: Use `internal sealed class AccessRequest : AggregateRoot<Guid>` (not `AggregateRoot`)
+2. **Event base class**: Use `DomainEventBase` (not `DomainEvent`)
+3. **Config writes**: `IConfigurationService` is read-only. Write via MediatR `UpdateConfigValueCommand` from SystemConfiguration BC
+4. **`GetValueAsync` signature**: `GetValueAsync<T>(string key, T? defaultValue, string? environment = null)` — do NOT pass CancellationToken as 3rd arg
+5. **Repository interface**: `IRepository<T, TId>` already provides `GetByIdAsync`, `AddAsync`, `UpdateAsync` — do not redeclare
+6. **Notification service**: No `INotificationService` exists. Check `BoundedContexts/UserNotifications/` for actual interface (likely `IPushNotificationService`)
+7. **Rate limit policies**: Verify that `"AuthRegister"` (3/min) and `"AuthGeneral"` (30/min) rate limit policies exist. If not, add them in rate limit configuration.
+8. **`sortBy` query param**: Add to `GetAccessRequestsQuery` record — default `RequestedAt` desc per spec

--- a/docs/superpowers/specs/2026-03-14-admin-invite-voice-onboarding-design.md
+++ b/docs/superpowers/specs/2026-03-14-admin-invite-voice-onboarding-design.md
@@ -1,7 +1,7 @@
 # Admin Invite + Voice Onboarding — Design Spec
 
 **Date**: 2026-03-14
-**Status**: Revised (post spec-review)
+**Status**: Implemented
 
 ## Summary
 
@@ -210,4 +210,4 @@ No duplicate issues found in the 26 open GitHub issues. Related but different:
 | **Voice UI in chat card** | ✅ Complete | `VoiceMicButton`, `TtsSpeakerButton`, `VoiceSettingsPopover` in `ChatThreadView`. Also `/ask` voice-first page. **No new work needed** |
 | **Premium voice toggle** | ⚠️ Architecture ready | Provider factory exists (`provider-factory.ts`), Zustand store persists prefs. **Deepgram/ElevenLabs providers not yet implemented** (deferred with #312) |
 | **Admin UI completion** | ⚠️ Partial | **Verify/complete role + audit UI** |
-| **E2E Playwright test** | ❌ Missing | **New test file** |
+| **E2E Playwright test** | ✅ Complete | `e2e/onboarding/accept-invite-to-onboarding.spec.ts` |

--- a/docs/superpowers/specs/2026-03-14-admin-invite-voice-onboarding-design.md
+++ b/docs/superpowers/specs/2026-03-14-admin-invite-voice-onboarding-design.md
@@ -1,11 +1,11 @@
 # Admin Invite + Voice Onboarding — Design Spec
 
 **Date**: 2026-03-14
-**Status**: Approved
+**Status**: Revised (post spec-review)
 
 ## Summary
 
-Admin invites users via email. Invited users accept, set password, go through a skippable onboarding wizard (profile → add game → create agent), then interact with the agent via voice. Admin can change user roles and view audit logs. A single E2E Playwright test validates the entire user story.
+Admin invites users via email. Invited users accept, set password, go through a skippable onboarding wizard (profile → interests → add game → create agent), then interact with the agent via voice. Admin can change user roles and view audit logs. A single E2E Playwright test validates the entire user story.
 
 ## User Story
 
@@ -27,7 +27,7 @@ Admin invites users via email. Invited users accept, set password, go through a 
 
 ### Email
 
-Contains link: `/auth/accept-invite?token=<token>` (7-day expiry)
+Contains link: `/accept-invite?token=<token>` (7-day expiry, route under `(public)` group)
 
 ### Backend: Already Implemented
 
@@ -39,26 +39,36 @@ Contains link: `/auth/accept-invite?token=<token>` (7-day expiry)
 
 ## 2. Invitation Acceptance + Onboarding
 
-### Step 1: Password Setup — `/auth/accept-invite?token=<token>`
+### Password Setup — `/accept-invite?token=<token>` (EXISTS)
 
-1. Page validates token via `GET /api/v1/auth/invitations/validate`
-2. If valid, shows form:
-   - Email (pre-filled, readonly)
-   - Password + confirm password
-3. Submit calls `POST /api/v1/auth/invitations/accept`
-4. User auto-authenticated (session cookie) → redirect to onboarding wizard
+Page already exists at `apps/web/src/app/(public)/accept-invite/page.tsx`:
 
-### Step 2: Onboarding Wizard (skippable, one-shot)
+1. Page validates token via `POST /api/v1/auth/validate-invitation`
+2. If valid, shows form: email (pre-filled, readonly) + password + confirm password + strength meter
+3. Submit calls `POST /api/v1/auth/accept-invitation`
+4. User auto-authenticated → **currently redirects to `/dashboard`**
 
-Each step has a "Salta" (Skip) button. Wizard is not recoverable after skip.
+**Work needed**: Change redirect from `/dashboard` to onboarding wizard route (e.g. `/onboarding?token=<token>`)
 
-1. **Profile**: Avatar upload + display name
-2. **Add first game**: Search catalog (autocomplete) → add to collection
-   - If skipped → step 3 is auto-skipped
-3. **Create first agent**: For the game added in step 2. Agent name + select typology
-   - Only available if step 2 was completed
+### Onboarding Wizard (EXISTS — needs integration)
 
+The `OnboardingWizard` component already exists at `apps/web/src/components/onboarding/OnboardingWizard.tsx` with **5 steps** (not 3):
+
+1. **Password** (required) — handled by `PasswordStep` component
+2. **Profile** (skippable) — display name via `ProfileStep`
+3. **Interests** (skippable) — interests selection via `InterestsStep`
+4. **First Game** (skippable) — search catalog, add to collection via `FirstGameStep`
+   - If skipped → step 5 is auto-skipped
+5. **First Agent** (only if step 4 completed) — agent name + typology via `FirstAgentStep`
+
+Each step after Password has a "Skip" button. Wizard can be skipped entirely after password.
 After completion or skip → redirect to dashboard.
+
+**Work needed**: Since the accept-invite page already handles password setup, the wizard integration should either:
+- (A) Route to wizard starting at step 2 (skip password step, already done), OR
+- (B) Create a dedicated `/onboarding` page that renders the wizard from step 2
+
+The wizard component, all 5 step components, and the API client (`api.auth.completeOnboarding`) already exist.
 
 ---
 
@@ -137,7 +147,7 @@ Both features have existing APIs. Only frontend UI verification/completion neede
 #### Step 2: User accepts invitation
 
 - Intercept email or construct URL with token from API
-- Navigate to `/auth/accept-invite?token=...`
+- Navigate to `/accept-invite?token=...`
 - Fill password + confirm
 - Submit → verify redirect to onboarding
 - Save user `storageState`
@@ -194,9 +204,9 @@ No duplicate issues found in the 26 open GitHub issues. Related but different:
 | Audit log API | ✅ Complete | None |
 | Email queue | ✅ Complete | None |
 | Role management API | ✅ Complete | None |
-| **Admin invitation UI** | ❌ Missing | **New frontend page/modal** |
-| **Accept invite page** | ❌ Missing | **New frontend page** |
-| **Onboarding wizard** | ❌ Missing | **New frontend flow** |
+| **Admin invitation UI** | ✅ Complete | `InviteUserDialog`, `BulkInviteDialog`, invitations page exist. **Verify/complete** role dropdown + pending list |
+| **Accept invite page** | ✅ Complete | `(public)/accept-invite/page.tsx` exists. **Modify**: redirect to wizard instead of `/dashboard` |
+| **Onboarding wizard** | ✅ Complete (5 steps) | `OnboardingWizard.tsx` + all step components exist. **Integrate**: connect to accept-invite flow, skip password step |
 | **Voice UI in chat card** | ❌ Missing | **New frontend component** |
 | **Premium voice toggle** | ❌ Missing | **New frontend component** |
 | **Admin UI completion** | ⚠️ Partial | **Verify/complete role + audit UI** |

--- a/docs/superpowers/specs/2026-03-14-admin-invite-voice-onboarding-design.md
+++ b/docs/superpowers/specs/2026-03-14-admin-invite-voice-onboarding-design.md
@@ -207,7 +207,7 @@ No duplicate issues found in the 26 open GitHub issues. Related but different:
 | **Admin invitation UI** | ✅ Complete | `InviteUserDialog`, `BulkInviteDialog`, invitations page exist. **Verify/complete** role dropdown + pending list |
 | **Accept invite page** | ✅ Complete | `(public)/accept-invite/page.tsx` exists. **Modify**: redirect to wizard instead of `/dashboard` |
 | **Onboarding wizard** | ✅ Complete (5 steps) | `OnboardingWizard.tsx` + all step components exist. **Integrate**: connect to accept-invite flow, skip password step |
-| **Voice UI in chat card** | ❌ Missing | **New frontend component** |
-| **Premium voice toggle** | ❌ Missing | **New frontend component** |
+| **Voice UI in chat card** | ✅ Complete | `VoiceMicButton`, `TtsSpeakerButton`, `VoiceSettingsPopover` in `ChatThreadView`. Also `/ask` voice-first page. **No new work needed** |
+| **Premium voice toggle** | ⚠️ Architecture ready | Provider factory exists (`provider-factory.ts`), Zustand store persists prefs. **Deepgram/ElevenLabs providers not yet implemented** (deferred with #312) |
 | **Admin UI completion** | ⚠️ Partial | **Verify/complete role + audit UI** |
 | **E2E Playwright test** | ❌ Missing | **New test file** |

--- a/docs/superpowers/specs/2026-03-14-invite-only-registration-design.md
+++ b/docs/superpowers/specs/2026-03-14-invite-only-registration-design.md
@@ -3,7 +3,7 @@
 **Status**: Approved (Revised after spec-panel review)
 **Date**: 2026-03-14
 **Scope**: Authentication, Administration, SystemConfiguration bounded contexts + Frontend
-**Revision**: 2 — addresses 8 critical and 10 major issues from expert review
+**Revision**: 3 — addresses spec review loop issues (config key convention, command signatures, idempotency semantics, registration guard architecture)
 
 ## Problem
 
@@ -11,7 +11,7 @@ In the beta0 staging environment, public self-registration must be disabled. Use
 
 ### Success Criteria
 
-- 100% of `POST /auth/register` attempts return 403 when `registration.public_enabled` is `false`
+- 100% of `POST /auth/register` attempts return 403 when `Registration:PublicEnabled` is `false`
 - Admin approval-to-invitation delivery completes within 10 seconds
 - Zero access requests are lost during config toggle transitions
 - Email enumeration: response body and timing are identical for all request-access outcomes
@@ -19,9 +19,9 @@ In the beta0 staging environment, public self-registration must be disabled. Use
 
 ## Solution
 
-A runtime configuration flag `registration.public_enabled` (default: `false`) gates self-registration. When disabled, the `/register` page shows a "Request Access" form instead. Admins review requests and approve (auto-sending invitations) or reject them. Admins can toggle public registration on from the admin panel at any time.
+A runtime configuration flag `Registration:PublicEnabled` (default: `false`) gates self-registration. When disabled, the `/register` page shows a "Request Access" form instead. Admins review requests and approve (auto-sending invitations) or reject them. Admins can toggle public registration on from the admin panel at any time.
 
-**Fail-closed default**: If SystemConfiguration is unreachable when checking `registration.public_enabled`, registration is blocked (403). Security-gating features always fail closed.
+**Fail-closed default**: If SystemConfiguration is unreachable when checking `Registration:PublicEnabled`, registration is blocked (403). Security-gating features always fail closed.
 
 ## Data Model
 
@@ -76,10 +76,11 @@ Aggregate root following existing DDD patterns (same as `InvitationToken`). Fact
 
 ### New Config Key
 
-- Key: `registration.public_enabled`
+- Key: `Registration:PublicEnabled` (follows existing colon-separated hierarchy convention, e.g., `RateLimit:Admin:MaxTokens`)
 - Type: `bool`
 - Default: `false`
 - Managed via: SystemConfiguration bounded context (runtime, no restart)
+- **Seeding**: Migration seeds this key with value `false`. If key does not exist at runtime, treated as `false` (fail-closed).
 
 ## API Endpoints
 
@@ -96,9 +97,11 @@ Rate limits are **per IP address**. Exceeded → 429 with `Retry-After` header.
 
 | Method | Path | Change |
 |--------|------|--------|
-| `POST` | `/api/v1/auth/register` | Check `registration.public_enabled` at command execution time. If `false` → 403 "Registration is currently unavailable" (generic message, does not reveal invite-only mode exists) |
+| `POST` | `/api/v1/auth/register` | Check `Registration:PublicEnabled` at command execution time. If `false` → 403 "Registration is currently unavailable" (generic message, does not reveal invite-only mode exists) |
 
 **Note**: Invited users registering via `POST /auth/accept-invitation` are NOT affected by this flag. Invitation-based registration always works regardless of the toggle.
+
+**Registration Guard Architecture**: Implemented as an endpoint filter (following `RequireAdminSessionFilter` pattern), NOT inside the `RegisterCommandHandler`. This avoids a cross-BC dependency (Authentication handler depending on SystemConfiguration repository). The filter reads the config value via `IConfigurationQueryService` (read-only, query-side) and short-circuits with 403 before the command reaches the handler.
 
 ### Admin Endpoints
 
@@ -109,7 +112,7 @@ Rate limits are **per IP address**. Exceeded → 429 with `Retry-After` header.
 | `POST` | `/api/v1/admin/access-requests/{id}/approve` | Approve → publishes domain event → invitation created async |
 | `POST` | `/api/v1/admin/access-requests/{id}/reject` | Reject with optional reason |
 | `POST` | `/api/v1/admin/access-requests/bulk-approve` | Approve up to 25 requests, returns per-item results |
-| `PUT` | `/api/v1/admin/settings/registration-mode` | Toggle `registration.public_enabled` (lives in SystemConfiguration surface area) |
+| `PUT` | `/api/v1/admin/settings/registration-mode` | Toggle `Registration:PublicEnabled` (lives in SystemConfiguration surface area) |
 
 ### Response Examples
 
@@ -144,8 +147,8 @@ HTTP 202 Accepted — same body, same timing for: new request, existing account,
 | Command | Handler Logic | Idempotency |
 |---------|---------------|-------------|
 | `RequestAccessCommand(email)` | Validate email, check duplicate Pending (skip silently), check existing account (skip silently), create AccessRequest. Publishes `AccessRequestCreatedEvent`. | Natural: duplicate email check. Always returns 202. |
-| `ApproveAccessRequestCommand(id, adminId)` | Guard: status must be Pending. Set Approved. Publish `AccessRequestApprovedEvent`. **Does NOT create invitation directly.** | Status guard: approving non-Pending is a no-op with success response. |
-| `RejectAccessRequestCommand(id, adminId, reason?)` | Guard: status must be Pending. Set Rejected. | Status guard: rejecting non-Pending is a no-op. |
+| `ApproveAccessRequestCommand(id, adminId)` | Guard: status must be Pending. Set Approved. Publish `AccessRequestApprovedEvent`. **Does NOT create invitation directly.** | Already Approved → 200 no-op. Rejected → 409. See Idempotency Semantics section. |
+| `RejectAccessRequestCommand(id, adminId, reason?)` | Guard: status must be Pending. Set Rejected. | Already Rejected → 200 no-op. Approved → 409. See Idempotency Semantics section. |
 | `BulkApproveAccessRequestsCommand(ids[], adminId)` | Max 25 IDs. Dispatches individual `ApproveAccessRequestCommand` per item. Each is its own unit of work. Returns per-item results. | Per-item idempotency via status guard. |
 | `SetRegistrationModeCommand(enabled, adminId)` | Routes to SystemConfiguration BC endpoint. Admin audit logged. | Setting same value is a no-op. |
 
@@ -154,19 +157,39 @@ HTTP 202 Accepted — same body, same timing for: new request, existing account,
 ```
 ApproveAccessRequestCommand
   → Handler sets status = Approved, publishes AccessRequestApprovedEvent
-    → Event handler subscribes, fires SendInvitationCommand(email, role: User)
+    → Event handler subscribes, fires SendInvitationCommand:
+        - email: from AccessRequest.Email
+        - role: Role.User (hardcoded, not configurable per approval)
+        - invitedBy: the approving admin's userId (from command's adminId)
       → On success: updates AccessRequest.InvitationId (eventual consistency)
-      → On failure: logs error, admin can see "Approved (invitation pending)" status
-                    and manually trigger resend via existing invitation UI
+      → On failure: logs error, retries 3x with exponential backoff
+                    On final failure: admin sees "Approved (invitation pending)"
+                    and can manually trigger resend via existing invitation UI
 ```
 
+The existing `SendInvitationCommand(email, role, adminUserId)` is reused as-is — no modifications needed. The event handler constructs it from the event payload + approving admin context.
+
 This decouples the approval operation from invitation creation. Approval is atomic. Invitation is eventual.
+
+### Idempotency Semantics (Domain vs Handler)
+
+The **domain entity** enforces strict state transitions:
+- `AccessRequest.Approve()` on non-Pending → throws `InvalidOperationException`
+- `AccessRequest.Reject()` on non-Pending → throws `InvalidOperationException`
+
+The **command handler** wraps domain exceptions for idempotent API behavior:
+- `ApproveAccessRequestCommand` on Already Approved → catches exception, returns 200 (no-op, idempotent)
+- `ApproveAccessRequestCommand` on Rejected → returns 409 Conflict (illegal transition, not idempotent)
+- `RejectAccessRequestCommand` on Already Rejected → catches exception, returns 200 (no-op, idempotent)
+- `RejectAccessRequestCommand` on Approved → returns 409 Conflict (illegal transition, not idempotent)
+
+This separation keeps the domain model strict while the API layer provides graceful handling for concurrent operations.
 
 ### Queries
 
 | Query | Returns |
 |-------|---------|
-| `GetAccessRequestsQuery(page, pageSize, statusFilter?)` | Paginated `AccessRequestDto` list |
+| `GetAccessRequestsQuery(page, pageSize, statusFilter?, sortBy?)` | Paginated `AccessRequestDto` list. Defaults: page=1, pageSize=20 (max 100), sortBy=RequestedAt desc. Follows existing pagination conventions. |
 | `GetAccessRequestByIdQuery(id)` | Single `AccessRequestDto` |
 | `GetAccessRequestStatsQuery` | `{ pending, approved, rejected, total }` |
 | `GetRegistrationModeQuery` | `{ publicRegistrationEnabled: bool }` |
@@ -181,7 +204,10 @@ GET /api/v1/auth/registration-mode
 └── false → New RequestAccessForm
 ```
 
-Registration mode check happens on page mount. If mode changes after page load and user submits the register form, backend returns 403 and frontend shows an inline error: "Registration is currently unavailable. You can request access instead." with a link/button to switch to the RequestAccessForm.
+Registration mode check happens on page mount. If mode changes after page load and user submits the register form, backend returns 403 and frontend:
+1. Re-fetches `GET /registration-mode` to confirm mode actually changed (vs transient config failure)
+2. If mode is now invite-only → shows inline error "Registration is currently unavailable" + switches to RequestAccessForm
+3. If mode is still public (transient 403) → shows generic "Something went wrong. Please try again."
 
 ### New Component: `RequestAccessForm`
 
@@ -226,7 +252,7 @@ On new access request:
 | Concern | Mitigation |
 |---------|------------|
 | Request spam | Rate limit: 3 req/min per IP on `request-access`. 429 + `Retry-After` header. |
-| Email enumeration | All outcomes return identical 202 response (body + timing). No AccessRequest created for existing accounts. |
+| Email enumeration | All outcomes return identical 202 response (body + timing). No AccessRequest created for existing accounts. **Timing equalization**: handler always performs the same DB lookups (email exists? pending exists?) regardless of outcome, ensuring consistent response time. No artificial delay needed — the code path is naturally similar. |
 | Config endpoint abuse | Rate limit: 30/min per IP on `registration-mode` |
 | Unauthorized toggle | `RequireAdminSession()` on all admin endpoints |
 | Email normalization | Lowercase normalization (same as invite system) |
@@ -389,10 +415,10 @@ And the user's password input is cleared (security)
 - Config unreachable → `POST /register` returns 403 (fail closed)
 - `POST /accept-invitation` unaffected by config
 
-**ApproveAccessRequestCommand:**
-- Pending → Approved, event published
-- Already Approved → no-op, success
-- Rejected → error (illegal transition)
+**ApproveAccessRequestCommand (handler level):**
+- Pending → Approved, event published, 200
+- Already Approved → no-op (catches domain exception), 200 (idempotent)
+- Rejected → 409 Conflict (illegal transition)
 - Non-existent ID → 404
 
 ### Integration Tests

--- a/docs/superpowers/specs/2026-03-14-invite-only-registration-design.md
+++ b/docs/superpowers/specs/2026-03-14-invite-only-registration-design.md
@@ -1,0 +1,449 @@
+# Invite-Only Registration (Beta0)
+
+**Status**: Approved (Revised after spec-panel review)
+**Date**: 2026-03-14
+**Scope**: Authentication, Administration, SystemConfiguration bounded contexts + Frontend
+**Revision**: 2 — addresses 8 critical and 10 major issues from expert review
+
+## Problem
+
+In the beta0 staging environment, public self-registration must be disabled. Users can only join via admin invitation. Admins need a runtime toggle to enable public registration when ready. Users who find the app should be able to request access.
+
+### Success Criteria
+
+- 100% of `POST /auth/register` attempts return 403 when `registration.public_enabled` is `false`
+- Admin approval-to-invitation delivery completes within 10 seconds
+- Zero access requests are lost during config toggle transitions
+- Email enumeration: response body and timing are identical for all request-access outcomes
+- Bulk approve processes up to 25 items with per-item success/failure reporting
+
+## Solution
+
+A runtime configuration flag `registration.public_enabled` (default: `false`) gates self-registration. When disabled, the `/register` page shows a "Request Access" form instead. Admins review requests and approve (auto-sending invitations) or reject them. Admins can toggle public registration on from the admin panel at any time.
+
+**Fail-closed default**: If SystemConfiguration is unreachable when checking `registration.public_enabled`, registration is blocked (403). Security-gating features always fail closed.
+
+## Data Model
+
+### New Entity: `AccessRequest` (Authentication Bounded Context)
+
+Aggregate root following existing DDD patterns (same as `InvitationToken`). Factory method: `AccessRequest.Create(email)`.
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `Id` | `Guid` | Primary key |
+| `Email` | `string` | Normalized lowercase, unique among Pending |
+| `Status` | `AccessRequestStatus` | Pending, Approved, Rejected |
+| `RequestedAt` | `DateTime` | Submission timestamp |
+| `ReviewedAt` | `DateTime?` | Admin action timestamp |
+| `ReviewedBy` | `Guid?` | Admin user ID |
+| `RejectionReason` | `string?` | Optional, max 500 chars |
+| `InvitationId` | `Guid?` | Correlation ID to InvitationToken (informational, not ownership) |
+| `CreatedAt` | `DateTime` | Audit |
+| `UpdatedAt` | `DateTime` | Audit |
+
+### State Machine
+
+```
+         ┌──────────┐
+         │ Pending   │
+         └────┬──┬───┘
+    Approve   │  │   Reject
+              ▼  ▼
+    ┌─────────┐  ┌──────────┐
+    │ Approved│  │ Rejected │
+    └─────────┘  └────┬─────┘
+                      │ Re-request (new entity)
+                      ▼
+                ┌──────────┐
+                │ Pending   │ (new AccessRequest)
+                └──────────┘
+```
+
+**Legal transitions:**
+- `Pending → Approved` (admin approve)
+- `Pending → Rejected` (admin reject)
+- No other transitions allowed. Approved/Rejected are terminal states.
+- Re-request after rejection creates a **new** AccessRequest entity. The rejected record is preserved for audit.
+
+**Data retention**: Rejected requests are retained for 90 days, then soft-deleted. Users can request deletion of their access request (GDPR).
+
+### New Enum: `AccessRequestStatus`
+
+- `Pending` — submitted, awaiting review
+- `Approved` — admin approved, invitation sent
+- `Rejected` — admin rejected
+
+### New Config Key
+
+- Key: `registration.public_enabled`
+- Type: `bool`
+- Default: `false`
+- Managed via: SystemConfiguration bounded context (runtime, no restart)
+
+## API Endpoints
+
+### Public Endpoints
+
+| Method | Path | Purpose | Rate Limit |
+|--------|------|---------|------------|
+| `GET` | `/api/v1/auth/registration-mode` | Returns `{ publicRegistrationEnabled: bool }` | 30/min per IP |
+| `POST` | `/api/v1/auth/request-access` | Submit access request (email) | 3/min per IP |
+
+Rate limits are **per IP address**. Exceeded → 429 with `Retry-After` header.
+
+### Modified Endpoint
+
+| Method | Path | Change |
+|--------|------|--------|
+| `POST` | `/api/v1/auth/register` | Check `registration.public_enabled` at command execution time. If `false` → 403 "Registration is currently unavailable" (generic message, does not reveal invite-only mode exists) |
+
+**Note**: Invited users registering via `POST /auth/accept-invitation` are NOT affected by this flag. Invitation-based registration always works regardless of the toggle.
+
+### Admin Endpoints
+
+| Method | Path | Purpose |
+|--------|------|---------|
+| `GET` | `/api/v1/admin/access-requests` | List requests (paginated, filterable by status) |
+| `GET` | `/api/v1/admin/access-requests/stats` | Count by status (see example below) |
+| `POST` | `/api/v1/admin/access-requests/{id}/approve` | Approve → publishes domain event → invitation created async |
+| `POST` | `/api/v1/admin/access-requests/{id}/reject` | Reject with optional reason |
+| `POST` | `/api/v1/admin/access-requests/bulk-approve` | Approve up to 25 requests, returns per-item results |
+| `PUT` | `/api/v1/admin/settings/registration-mode` | Toggle `registration.public_enabled` (lives in SystemConfiguration surface area) |
+
+### Response Examples
+
+**GET /admin/access-requests/stats:**
+```json
+{ "pending": 15, "approved": 42, "rejected": 3, "total": 60 }
+```
+
+**POST /admin/access-requests/bulk-approve (response):**
+```json
+{
+  "processed": 10,
+  "succeeded": 9,
+  "failed": 1,
+  "results": [
+    { "id": "...", "status": "approved" },
+    { "id": "...", "status": "failed", "error": "Already approved" }
+  ]
+}
+```
+
+**POST /auth/request-access (all outcomes return identical response):**
+```json
+{ "message": "If this email is eligible, you will receive an invitation when approved." }
+```
+HTTP 202 Accepted — same body, same timing for: new request, existing account, already pending, re-request after rejection.
+
+## CQRS Commands & Queries
+
+### Commands
+
+| Command | Handler Logic | Idempotency |
+|---------|---------------|-------------|
+| `RequestAccessCommand(email)` | Validate email, check duplicate Pending (skip silently), check existing account (skip silently), create AccessRequest. Publishes `AccessRequestCreatedEvent`. | Natural: duplicate email check. Always returns 202. |
+| `ApproveAccessRequestCommand(id, adminId)` | Guard: status must be Pending. Set Approved. Publish `AccessRequestApprovedEvent`. **Does NOT create invitation directly.** | Status guard: approving non-Pending is a no-op with success response. |
+| `RejectAccessRequestCommand(id, adminId, reason?)` | Guard: status must be Pending. Set Rejected. | Status guard: rejecting non-Pending is a no-op. |
+| `BulkApproveAccessRequestsCommand(ids[], adminId)` | Max 25 IDs. Dispatches individual `ApproveAccessRequestCommand` per item. Each is its own unit of work. Returns per-item results. | Per-item idempotency via status guard. |
+| `SetRegistrationModeCommand(enabled, adminId)` | Routes to SystemConfiguration BC endpoint. Admin audit logged. | Setting same value is a no-op. |
+
+### Event-Driven Invitation Flow (fixes cross-BC coupling)
+
+```
+ApproveAccessRequestCommand
+  → Handler sets status = Approved, publishes AccessRequestApprovedEvent
+    → Event handler subscribes, fires SendInvitationCommand(email, role: User)
+      → On success: updates AccessRequest.InvitationId (eventual consistency)
+      → On failure: logs error, admin can see "Approved (invitation pending)" status
+                    and manually trigger resend via existing invitation UI
+```
+
+This decouples the approval operation from invitation creation. Approval is atomic. Invitation is eventual.
+
+### Queries
+
+| Query | Returns |
+|-------|---------|
+| `GetAccessRequestsQuery(page, pageSize, statusFilter?)` | Paginated `AccessRequestDto` list |
+| `GetAccessRequestByIdQuery(id)` | Single `AccessRequestDto` |
+| `GetAccessRequestStatsQuery` | `{ pending, approved, rejected, total }` |
+| `GetRegistrationModeQuery` | `{ publicRegistrationEnabled: bool }` |
+
+## Frontend Changes
+
+### `/register` Page — Conditional Rendering
+
+```
+GET /api/v1/auth/registration-mode
+├── true  → Existing RegisterForm (unchanged)
+└── false → New RequestAccessForm
+```
+
+Registration mode check happens on page mount. If mode changes after page load and user submits the register form, backend returns 403 and frontend shows an inline error: "Registration is currently unavailable. You can request access instead." with a link/button to switch to the RequestAccessForm.
+
+### New Component: `RequestAccessForm`
+
+- **Fields**: Email input (required, validated)
+- **Button**: "Request Access"
+- **Loading state**: Spinner on button, input disabled
+- **Success state**: "Your request has been submitted. You'll receive an email when approved." (replaces form)
+- **Duplicate pending**: Same success message (enumeration prevention — identical response)
+- **Validation error**: Inline "Please enter a valid email address"
+- **Rate limit hit**: "Too many requests. Please try again in a moment."
+- **Network error**: "Something went wrong. Please try again."
+- **Layout**: Same card layout and branding as existing auth pages (LoginForm, RegisterForm)
+- **Accessibility**: All inputs labeled, success/error announced via `aria-live="polite"`, keyboard navigable
+
+### Admin Panel Additions
+
+**1. Registration Settings** (admin settings section)
+- Toggle switch: "Public Registration" (on/off)
+- Current status indicator: "Invite-only mode" / "Public registration enabled"
+- Confirmation dialog on toggle: "Are you sure? This will [enable/disable] public registration."
+
+**2. Access Requests Page** (`/admin/users/access-requests`)
+- KPI cards: Pending / Approved / Rejected / Total (same pattern as invitations page)
+- Table columns: email, status, requested date, reviewed by, actions
+- Row actions: "Approve" button / "Reject" button (opens dialog with optional reason, max 500 chars)
+- Toolbar: "Approve Selected" bulk action (max 25, disabled if > 25 selected)
+- Status filter tabs: All / Pending / Approved / Rejected
+- Pending count badge on sidebar nav link
+
+**3. Navigation**
+- "Access Requests" link in admin sidebar under Users section
+- Pending count badge (live-updated)
+
+### Notifications
+
+On new access request:
+- **In-app**: Notification to all users with Admin role. Content: "New access request from {email}". Links to access requests page.
+- **Email**: Digest — batched every 15 minutes if > 1 pending request, immediate if first request in window. To: all admin email addresses. Content: "{count} new access request(s) pending review."
+
+## Security
+
+| Concern | Mitigation |
+|---------|------------|
+| Request spam | Rate limit: 3 req/min per IP on `request-access`. 429 + `Retry-After` header. |
+| Email enumeration | All outcomes return identical 202 response (body + timing). No AccessRequest created for existing accounts. |
+| Config endpoint abuse | Rate limit: 30/min per IP on `registration-mode` |
+| Unauthorized toggle | `RequireAdminSession()` on all admin endpoints |
+| Email normalization | Lowercase normalization (same as invite system) |
+| Registration bypass | Backend enforces 403 on `POST /register` when disabled. Generic message (no operational state leakage). |
+| Config unavailability | Fail closed: if config service unreachable, registration blocked |
+| Invite bypass | `POST /auth/accept-invitation` is NOT affected by toggle — invitations always work |
+
+## Edge Cases
+
+| Scenario | Behavior | HTTP |
+|----------|----------|------|
+| Email already has account | Return success silently, no entity created | 202 |
+| Already pending request | Return success silently (identical response) | 202 |
+| Previously rejected, requests again | Create new AccessRequest entity. Old rejected record preserved. | 202 |
+| Approve succeeds, invite creation fails | AccessRequest marked Approved. Event handler retries 3x with exponential backoff. On final failure: admin sees "Approved (invitation pending)" and can resend. | 200 |
+| Toggle ON while pending requests exist | Requests remain, can still be approved or ignored | — |
+| Toggle OFF mid-registration (form submitted) | Backend rejects at command execution time with 403. Frontend shows inline error with option to switch to RequestAccessForm. User's entered data is NOT preserved (security: don't cache credentials client-side). | 403 |
+| Approved request, invitation expires | Normal 7-day invite expiration. Admin can resend via existing invitation management UI. | — |
+| Two admins approve same request simultaneously | Status guard: only first succeeds (Pending → Approved). Second is a no-op returning success. | 200 |
+| Bulk approve with mixed states | Per-item processing. Already-approved items return success. Non-existent IDs return failure. | 200 |
+| Config service unreachable | Fail closed: registration blocked (403) | 403 |
+
+## Observability
+
+### Metrics
+
+| Metric | Type | Labels |
+|--------|------|--------|
+| `access_requests_total` | Counter | `status: pending\|approved\|rejected` |
+| `registration_mode_toggles` | Counter | `enabled: true\|false` |
+| `invitation_send_failures` | Counter | `source: access_request_approval` |
+| `registration_attempts_blocked` | Counter | — |
+
+### Structured Logging
+
+All AccessRequest state transitions logged with:
+- `correlationId`, `requestId`, `email` (hashed), `status`, `adminId` (if applicable), `timestamp`
+
+### Alerts
+
+- Invitation failure rate > 10% over 5 minutes → alert ops
+- Access request spike > 50 in 5 minutes → potential abuse alert
+- Registration mode changed → audit notification to all admins
+
+## Concrete Scenarios
+
+### Scenario 1: Complete Happy Path
+
+```gherkin
+Given registration mode is "invite-only"
+And admin "admin@meeple.ai" is authenticated
+
+# Phase 1: Request
+When visitor submits access request with email "newuser@example.com"
+Then an AccessRequest is created with status "Pending"
+And response is 202 with body: { "message": "If this email is eligible..." }
+And admin receives in-app notification "New access request from newuser@example.com"
+
+# Phase 2: Approval
+When admin approves the access request for "newuser@example.com"
+Then the AccessRequest status changes to "Approved"
+And an AccessRequestApprovedEvent is published
+And an InvitationToken is created with 7-day expiration
+And an invitation email is sent to "newuser@example.com"
+And AccessRequest.InvitationId is set to the invitation's ID
+
+# Phase 3: Registration
+When "newuser@example.com" clicks the invitation link
+Then they are directed to /accept-invite?token={token}
+And they can complete registration (accept-invitation bypasses registration toggle)
+And they proceed through the onboarding wizard
+```
+
+### Scenario 2: Email Enumeration Prevention
+
+```gherkin
+Scenario: Existing user requests access
+  When "existing@example.com" (already registered) submits access request
+  Then response is 202 with body: { "message": "If this email is eligible..." }
+  And no AccessRequest entity is created
+  And response timing is identical to a genuine new request
+
+Scenario: New user requests access
+  When "new@example.com" submits access request
+  Then response is 202 with body: { "message": "If this email is eligible..." }
+  And an AccessRequest entity is created with status "Pending"
+  And response body is identical to existing-user response
+```
+
+### Scenario 3: Re-request After Rejection
+
+```gherkin
+Given user "alice@example.com" submitted an access request on 2026-03-01
+And the request was rejected on 2026-03-05 with reason "Not in beta group"
+When "alice@example.com" submits a new access request on 2026-03-14
+Then a NEW AccessRequest entity is created with status "Pending"
+And the previous rejected request remains unchanged (audit trail)
+And response is 202 (identical to all other outcomes)
+```
+
+### Scenario 4: Registration Mode Decision Table
+
+| `public_enabled` | Has valid invite token | Endpoint | Result |
+|---|---|---|---|
+| `true` | no | `POST /register` | Allow registration |
+| `true` | yes | `POST /accept-invitation` | Allow registration |
+| `false` | no | `POST /register` | 403 Forbidden |
+| `false` | yes | `POST /accept-invitation` | Allow registration |
+| unreachable | any | `POST /register` | 403 (fail closed) |
+
+### Scenario 5: Bulk Approve Partial Failure
+
+```gherkin
+Given 3 pending access requests: [req-1, req-2, req-3]
+And req-2 was already approved by another admin
+When admin submits bulk-approve for [req-1, req-2, req-3]
+Then response contains:
+  | id    | status   | error              |
+  | req-1 | approved |                    |
+  | req-2 | approved |                    |  (no-op, already approved)
+  | req-3 | approved |                    |
+And processed=3, succeeded=3, failed=0
+```
+
+### Scenario 6: Toggle OFF Mid-Registration
+
+```gherkin
+Given registration mode is "public"
+And user has loaded /register and is filling out the form
+When admin toggles registration to "invite-only"
+And user submits the registration form
+Then POST /register returns 403
+And frontend displays inline error: "Registration is currently unavailable"
+And a "Request Access" link/button appears
+And the user's password input is cleared (security)
+```
+
+## Testing Strategy
+
+### Unit Tests
+
+**AccessRequest Entity:**
+- `Create()` factory → status is Pending, RequestedAt is set
+- `Approve(adminId)` → status Approved, ReviewedAt/ReviewedBy set
+- `Reject(adminId, reason)` → status Rejected, reason stored
+- `Approve()` on non-Pending → throws `InvalidOperationException`
+- `Reject()` on non-Pending → throws `InvalidOperationException`
+- RejectionReason max 500 chars validation
+
+**RequestAccessCommand:**
+- Valid email → creates entity, returns 202
+- Invalid email format → 400
+- Empty email → 400
+- Duplicate pending email → returns 202 (no new entity)
+- Existing account email → returns 202 (no new entity)
+
+**Registration Mode Guard:**
+- Config `false` → `POST /register` returns 403
+- Config `true` → `POST /register` proceeds normally
+- Config unreachable → `POST /register` returns 403 (fail closed)
+- `POST /accept-invitation` unaffected by config
+
+**ApproveAccessRequestCommand:**
+- Pending → Approved, event published
+- Already Approved → no-op, success
+- Rejected → error (illegal transition)
+- Non-existent ID → 404
+
+### Integration Tests
+
+- Full flow: request → approve → event → invitation created → accept invitation → user account exists
+- Bulk approve 5 requests → 5 invitations created, per-item results
+- Bulk approve with mixed states → correct per-item reporting
+- Config toggle persists across requests
+- Config toggle affects `POST /register` immediately
+- Notification delivery on new request (event assertion)
+- Concurrent approve: two admins approve same request → only one invitation created
+- Rate limit: 4th request-access within 60s → 429
+
+### E2E Tests
+
+**Journey 1 — Happy Path:**
+- Navigate to /register → see RequestAccessForm (mode is invite-only)
+- Submit email → success message shown
+- Admin navigates to /admin/users/access-requests → sees pending request
+- Admin clicks Approve → request moves to Approved
+- (Invitation sent — verified in integration test)
+
+**Journey 2 — Admin Toggle:**
+- Admin enables public registration from settings
+- Navigate to /register → see RegisterForm
+- Admin disables public registration
+- Navigate to /register → see RequestAccessForm
+
+**Journey 3 — Bulk Approve:**
+- Admin selects multiple pending requests → clicks "Approve Selected"
+- All selected move to Approved status
+- KPI cards update
+
+**Accessibility:**
+- RequestAccessForm: screen reader announces form purpose, success/error states via aria-live
+- Admin toggle: keyboard navigable, confirmation dialog accessible
+- Access requests table: sortable, filterable, keyboard navigable
+
+### Test Data Setup
+
+- Seed admin account via existing test infrastructure
+- Create pending/approved/rejected AccessRequests via factory helpers
+- Use Testcontainers PostgreSQL (existing pattern)
+- Test isolation: database cleanup between tests
+
+## Architecture Notes
+
+- `AccessRequest` lives in Authentication bounded context alongside `InvitationToken`
+- Approval publishes `AccessRequestApprovedEvent` → event handler creates invitation (decoupled, eventual consistency)
+- `SetRegistrationModeCommand` routes to SystemConfiguration BC endpoint directly (admin endpoint lives in SystemConfiguration surface area, no cross-BC write)
+- `InvitationId` on AccessRequest is a correlation ID for traceability, not an ownership reference
+- Frontend uses a single API call on `/register` mount to determine which form to render
+- All endpoints follow CQRS pattern: commands/queries via MediatR only
+- Audit logging for all admin actions (approve, reject, toggle) via existing Administration BC patterns


### PR DESCRIPTION
## Summary

- **Invite-only registration** for beta0 staging: users cannot self-register via email, only through admin invitations
- **Access request flow**: public `/register` page shows a "Request Access" form when `Registration:PublicEnabled` is false (default)
- **Admin management**: approve/reject/bulk-approve access requests with KPI dashboard, status filtering, and pending badge in sidebar
- **Registration mode toggle**: admin can enable/disable public registration at runtime via settings
- **Fail-closed security**: registration blocked if config service is unreachable

### Backend (16 commits)
- `AccessRequest` aggregate root with state machine (Pending → Approved/Rejected)
- CQRS commands: RequestAccess, Approve, Reject, BulkApprove (max 25), SetRegistrationMode
- Queries: GetAccessRequests (paginated), GetAccessRequestStats, GetRegistrationMode, GetAccessRequestById
- Event handlers: AccessRequestApproved → auto-sends invitation; AccessRequestCreated → admin notification
- `RequirePublicRegistrationFilter` endpoint filter on POST /register (fail-closed)
- EF Core infrastructure: entity, configuration, repository with domain↔infra mapping
- Email enumeration prevention: all request-access outcomes return identical 202 responses
- 38 unit + integration tests passing

### Frontend (5 commits)
- `accessRequestsClient.ts` API client with all endpoints
- `RequestAccessForm` component (email input → success state, enumeration-safe)
- Conditional register page: checks registration mode on mount, shows RegisterForm or RequestAccessForm
- Admin access requests page with KPIs, status filter, paginated table, bulk approve
- `RegistrationModeToggle` in admin settings with confirmation dialog
- Admin sidebar "Access Requests" nav item with pending badge
- E2E tests for invite-only registration flow

### Spec
- `docs/superpowers/specs/2026-03-14-invite-only-registration-design.md`
- `docs/superpowers/plans/2026-03-14-invite-only-registration.md`

## Test plan

- [x] Backend builds with 0 errors, 0 warnings
- [x] Frontend builds and typechecks cleanly
- [x] 38 AccessRequest unit + integration tests pass
- [x] RequestAccessForm component tests pass
- [x] Register page conditional rendering tests pass
- [ ] E2E tests (require running server)
- [ ] Manual: visit `/register` → see Request Access form
- [ ] Manual: admin approve request → invitation email sent
- [ ] Manual: admin toggle registration mode → `/register` shows normal form

🤖 Generated with [Claude Code](https://claude.com/claude-code)