### PR TITLE
feat(admin): enhance audit log page with pagination and export

### DIFF
--- a/apps/web/src/app/admin/(dashboard)/users/activity/page.tsx
+++ b/apps/web/src/app/admin/(dashboard)/users/activity/page.tsx
@@ -1,29 +1,89 @@
 'use client';
 
-import { useState } from 'react';
+import { useCallback, useState } from 'react';
+
+import { Download } from 'lucide-react';
 
 import { ActivityFilters } from '@/components/admin/users/activity-filters';
-import { ActivityTable } from '@/components/admin/users/activity-table';
+import { ActivityTable, getDateRange } from '@/components/admin/users/activity-table';
+import { Button } from '@/components/ui/button';
+import { api } from '@/lib/api';
 
 export default function UserActivityPage() {
   const [actionFilter, setActionFilter] = useState('all');
   const [dateRange, setDateRange] = useState('24h');
+  const [page, setPage] = useState(0);
+  const [totalCount, setTotalCount] = useState(0);
+  const [exporting, setExporting] = useState(false);
+
+  // Reset page when filters change
+  const handleActionChange = (value: string) => {
+    setActionFilter(value);
+    setPage(0);
+  };
+  const handleDateChange = (value: string) => {
+    setDateRange(value);
+    setPage(0);
+  };
+
+  const handleTotalCountChange = useCallback((count: number) => {
+    setTotalCount(count);
+  }, []);
+
+  const handleExport = async () => {
+    setExporting(true);
+    try {
+      const blob = await api.admin.exportAuditLogs({
+        action: actionFilter !== 'all' ? actionFilter : undefined,
+        ...getDateRange(dateRange),
+      });
+      const url = URL.createObjectURL(blob);
+      const a = document.createElement('a');
+      a.href = url;
+      a.download = `audit-log-${new Date().toISOString().slice(0, 10)}.csv`;
+      a.click();
+      URL.revokeObjectURL(url);
+    } catch {
+      // export failed silently
+    } finally {
+      setExporting(false);
+    }
+  };
 
   return (
     <div className="space-y-6">
       {/* Page Header */}
-      <div>
-        <h1 className="font-quicksand text-2xl font-bold tracking-tight text-foreground">
-          User Activity Log
-        </h1>
-        <p className="text-sm text-muted-foreground mt-1">Monitor user actions and system events</p>
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="font-quicksand text-2xl font-bold tracking-tight text-foreground">
+            Audit Log
+          </h1>
+          <p className="text-sm text-muted-foreground mt-1">
+            {totalCount > 0
+              ? `${totalCount.toLocaleString()} entries recorded`
+              : 'Monitor user actions and system events'}
+          </p>
+        </div>
+        <Button variant="outline" size="sm" onClick={handleExport} disabled={exporting}>
+          <Download className="mr-2 h-4 w-4" aria-hidden="true" />
+          {exporting ? 'Exporting...' : 'Export CSV'}
+        </Button>
       </div>
 
       {/* Filters */}
-      <ActivityFilters onActionTypeChange={setActionFilter} onDateRangeChange={setDateRange} />
+      <ActivityFilters
+        onActionTypeChange={handleActionChange}
+        onDateRangeChange={handleDateChange}
+      />
 
       {/* Activity Table */}
-      <ActivityTable actionFilter={actionFilter} dateRange={dateRange} />
+      <ActivityTable
+        actionFilter={actionFilter}
+        dateRange={dateRange}
+        page={page}
+        onPageChange={setPage}
+        onTotalCountChange={handleTotalCountChange}
+      />
     </div>
   );
 }

--- a/apps/web/src/components/admin/users/activity-table.tsx
+++ b/apps/web/src/components/admin/users/activity-table.tsx
@@ -1,14 +1,20 @@
 'use client';
 
+import { useEffect } from 'react';
+
 import { useQuery } from '@tanstack/react-query';
 
 import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
 import { api } from '@/lib/api';
 import type { AuditLogEntry } from '@/lib/api/schemas/admin.schemas';
 
 interface ActivityTableProps {
   actionFilter?: string;
   dateRange?: string;
+  page?: number;
+  onPageChange?: (page: number) => void;
+  onTotalCountChange?: (count: number) => void;
 }
 
 const actionTypeColors: Record<string, string> = {
@@ -28,7 +34,7 @@ const resultColors: Record<string, string> = {
   Denied: 'bg-amber-100 text-amber-900 dark:bg-amber-900/30 dark:text-amber-300',
 };
 
-function getDateRange(range?: string): { startDate?: string; endDate?: string } {
+export function getDateRange(range?: string): { startDate?: string; endDate?: string } {
   if (!range || range === 'all') return {};
   const now = new Date();
   const end = now.toISOString();
@@ -81,14 +87,23 @@ function formatAction(action: string): string {
     .trim();
 }
 
-export function ActivityTable({ actionFilter, dateRange }: ActivityTableProps) {
+const PAGE_SIZE = 50;
+
+export function ActivityTable({
+  actionFilter,
+  dateRange,
+  page = 0,
+  onPageChange,
+  onTotalCountChange,
+}: ActivityTableProps) {
   const dateParams = getDateRange(dateRange);
 
   const { data, isLoading, isError } = useQuery({
-    queryKey: ['admin', 'audit-log', 'activity', actionFilter, dateRange],
+    queryKey: ['admin', 'audit-log', 'activity', actionFilter, dateRange, page],
     queryFn: () =>
       api.admin.getAuditLogs({
-        limit: 50,
+        limit: PAGE_SIZE,
+        offset: page * PAGE_SIZE,
         action: actionFilter && actionFilter !== 'all' ? actionFilter : undefined,
         ...dateParams,
       }),
@@ -96,6 +111,13 @@ export function ActivityTable({ actionFilter, dateRange }: ActivityTableProps) {
   });
 
   const entries: AuditLogEntry[] = data?.entries ?? [];
+  const totalCount = data?.totalCount ?? 0;
+  const totalPages = Math.ceil(totalCount / PAGE_SIZE);
+
+  // Notify parent of total count changes
+  useEffect(() => {
+    onTotalCountChange?.(totalCount);
+  }, [totalCount, onTotalCountChange]);
 
   if (isLoading) {
     return (
@@ -210,6 +232,34 @@ export function ActivityTable({ actionFilter, dateRange }: ActivityTableProps) {
           </tbody>
         </table>
       </div>
+
+      {/* Pagination */}
+      {totalPages > 1 && (
+        <div className="flex items-center justify-between px-4 py-3 border-t border-amber-200/50 dark:border-zinc-700/50">
+          <p className="text-sm text-muted-foreground">
+            Showing {page * PAGE_SIZE + 1}–{Math.min((page + 1) * PAGE_SIZE, totalCount)} of{' '}
+            {totalCount.toLocaleString()}
+          </p>
+          <div className="flex gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={page === 0}
+              onClick={() => onPageChange?.(page - 1)}
+            >
+              Previous
+            </Button>
+            <Button
+              variant="outline"
+              size="sm"
+              disabled={page >= totalPages - 1}
+              onClick={() => onPageChange?.(page + 1)}
+            >
+              Next
+            </Button>
+          </div>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## Summary
- Add pagination (Previous/Next) with offset-based API calls to `/admin/users/activity`
- Add Export CSV button that respects current action + date range filters
- Display total entry count in page header
- Export `getDateRange` utility for reuse across page and table components
- Remove user search filter that was incorrectly mapped to `adminUserId` (backend only accepts UUID, not text search)

Completes the Admin Invite + Voice Onboarding epic — audit log global page was the last missing piece.

## Test plan
- [ ] Navigate to `/admin/users/activity` and verify pagination appears when >50 entries
- [ ] Change action type filter and verify page resets to 0
- [ ] Change date range filter and verify page resets to 0
- [ ] Click Export CSV and verify downloaded file reflects current filters
- [ ] Verify total count updates in header when filters change

🤖 Generated with [Claude Code](https://claude.com/claude-code)