### PR TITLE
fix(email): bridge SMTP_* secret keys to Email:* config keys

### DIFF
--- a/apps/api/src/Api/Services/EmailService.cs
+++ b/apps/api/src/Api/Services/EmailService.cs
@@ -29,13 +29,15 @@ internal class EmailService : IEmailService
 
         _logger = logger;
 
-        // Load email configuration (S1450: configuration used only locally)
-        _fromAddress = configuration["Email:FromAddress"] ?? "noreply@meepleai.dev";
+        // Load email configuration with fallback to SMTP_* env var names from email.secret
+        // email.secret uses SMTP_HOST/SMTP_USER/SMTP_PASSWORD but EmailService originally
+        // expected Email:SmtpHost/Email:SmtpUsername/Email:SmtpPassword — bridge the gap
+        _fromAddress = configuration["Email:FromAddress"] ?? configuration["SMTP_FROM_EMAIL"] ?? "noreply@meepleai.dev";
         _fromName = configuration["Email:FromName"] ?? "MeepleAI";
-        _smtpHost = configuration["Email:SmtpHost"] ?? "localhost";
-        _smtpPort = int.Parse(configuration["Email:SmtpPort"] ?? "587", CultureInfo.InvariantCulture);
-        _smtpUsername = configuration["Email:SmtpUsername"];
-        _smtpPassword = configuration["Email:SmtpPassword"];
+        _smtpHost = configuration["Email:SmtpHost"] ?? configuration["SMTP_HOST"] ?? "localhost";
+        _smtpPort = int.Parse(configuration["Email:SmtpPort"] ?? configuration["SMTP_PORT"] ?? "587", CultureInfo.InvariantCulture);
+        _smtpUsername = configuration["Email:SmtpUsername"] ?? configuration["SMTP_USER"];
+        _smtpPassword = configuration["Email:SmtpPassword"] ?? configuration["SMTP_PASSWORD"] ?? configuration["GMAIL_APP_PASSWORD"];
         _enableSsl = bool.Parse(configuration["Email:EnableSsl"] ?? "true");
         _resetUrlBase = configuration["Email:ResetUrlBase"] ?? DefaultResetUrlBase;
         _frontendBaseUrl = configuration["Frontend:BaseUrl"] ?? DefaultFrontendBaseUrl;


### PR DESCRIPTION
## Summary

- **Root cause**: `EmailService` reads `Email:SmtpHost`/`Email:SmtpUsername`/`Email:SmtpPassword` from IConfiguration, but `email.secret` defines `SMTP_HOST`/`SMTP_USER`/`SMTP_PASSWORD`. `SecretLoader` loads these with raw key names, so `EmailService` never received SMTP credentials
- **Impact**: All emails silently fail on staging — exceptions swallowed by fire-and-forget pattern in `SendInvitationCommandHandler`
- **Fix**: Add fallback chain in `EmailService` constructor: `Email:*` → `SMTP_*` → `GMAIL_APP_PASSWORD` → defaults

## Test plan

- [ ] Deploy to staging and send an invitation email
- [ ] Verify email arrives with correct invitation link
- [ ] Check staging logs for "Invitation email sent successfully" instead of "Failed to send invitation email"

🤖 Generated with [Claude Code](https://claude.com/claude-code)