### PR TITLE
feat(ux): hand drawer, carta estesa, compact icon bar

### DIFF
--- a/apps/web/src/__tests__/integration/hand-drawer-flow.test.tsx
+++ b/apps/web/src/__tests__/integration/hand-drawer-flow.test.tsx
@@ -1,0 +1,330 @@
+import { act } from '@testing-library/react';
+
+import { useCardHand } from '@/stores/use-card-hand';
+
+describe('Hand Drawer Flow', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    sessionStorage.clear();
+    // Reset store to initial state
+    act(() => {
+      useCardHand.setState({
+        cards: [],
+        focusedIdx: -1,
+        pinnedIds: new Set(),
+        isHandCollapsed: false,
+        expandedStack: false,
+        highlightEntity: null,
+        context: 'user',
+      });
+    });
+  });
+
+  describe('useCardHand store integration', () => {
+    it('hand starts empty with no cards', () => {
+      const state = useCardHand.getState();
+      expect(state.cards).toHaveLength(0);
+      expect(state.focusedIdx).toBe(-1);
+    });
+
+    it('drawCard adds a card and focuses it', () => {
+      act(() => {
+        useCardHand.getState().drawCard({
+          id: 'g1',
+          entity: 'game',
+          title: 'Catan',
+          href: '/library/g1',
+        });
+      });
+      const state = useCardHand.getState();
+      expect(state.cards).toHaveLength(1);
+      expect(state.cards[0].title).toBe('Catan');
+      expect(state.focusedIdx).toBe(0);
+    });
+
+    it('drawing duplicate card focuses it instead of adding', () => {
+      act(() => {
+        const { drawCard } = useCardHand.getState();
+        drawCard({
+          id: 'g1',
+          entity: 'game',
+          title: 'Catan',
+          href: '/library/g1',
+        });
+      });
+      act(() => {
+        useCardHand.getState().drawCard({
+          id: 'g2',
+          entity: 'game',
+          title: 'Azul',
+          href: '/library/g2',
+        });
+      });
+      act(() => {
+        useCardHand.getState().drawCard({
+          id: 'g1',
+          entity: 'game',
+          title: 'Catan',
+          href: '/library/g1',
+        });
+      });
+      const state = useCardHand.getState();
+      expect(state.cards).toHaveLength(2);
+      expect(state.focusedIdx).toBe(0); // g1 is at index 0
+    });
+
+    it('collapse/expand cycle preserves cards', () => {
+      act(() => {
+        useCardHand.getState().drawCard({
+          id: 'g1',
+          entity: 'game',
+          title: 'Catan',
+          href: '/library/g1',
+        });
+      });
+      act(() => {
+        useCardHand.getState().collapseHand();
+      });
+      expect(useCardHand.getState().isHandCollapsed).toBe(true);
+      expect(useCardHand.getState().cards).toHaveLength(1);
+
+      act(() => useCardHand.getState().expandHand());
+      expect(useCardHand.getState().isHandCollapsed).toBe(false);
+      expect(useCardHand.getState().cards).toHaveLength(1);
+    });
+
+    it('FIFO eviction removes oldest non-pinned card when at max', () => {
+      act(() => {
+        for (let i = 0; i < 10; i++) {
+          useCardHand.getState().drawCard({
+            id: `g${i}`,
+            entity: 'game',
+            title: `Game ${i}`,
+            href: `/library/g${i}`,
+          });
+        }
+      });
+      expect(useCardHand.getState().cards).toHaveLength(10);
+
+      // Draw 11th card — triggers FIFO eviction of oldest non-pinned
+      act(() => {
+        useCardHand.getState().drawCard({
+          id: 'g10',
+          entity: 'game',
+          title: 'Game 10',
+          href: '/library/g10',
+        });
+      });
+      const state = useCardHand.getState();
+      expect(state.cards).toHaveLength(10);
+      // g0 was evicted (oldest, not pinned)
+      expect(state.cards.find(c => c.id === 'g0')).toBeUndefined();
+      expect(state.cards.find(c => c.id === 'g10')).toBeDefined();
+    });
+
+    it('FIFO eviction skips pinned cards', () => {
+      act(() => {
+        for (let i = 0; i < 10; i++) {
+          useCardHand.getState().drawCard({
+            id: `g${i}`,
+            entity: 'game',
+            title: `Game ${i}`,
+            href: `/library/g${i}`,
+          });
+        }
+        // Pin the oldest card
+        useCardHand.getState().pinCard('g0');
+      });
+
+      // Draw 11th card — g0 is pinned, so g1 (next oldest unpinned) is evicted
+      act(() => {
+        useCardHand.getState().drawCard({
+          id: 'g10',
+          entity: 'game',
+          title: 'Game 10',
+          href: '/library/g10',
+        });
+      });
+      const state = useCardHand.getState();
+      expect(state.cards).toHaveLength(10);
+      expect(state.cards.find(c => c.id === 'g0')).toBeDefined(); // pinned, kept
+      expect(state.cards.find(c => c.id === 'g1')).toBeUndefined(); // evicted
+      expect(state.cards.find(c => c.id === 'g10')).toBeDefined();
+    });
+
+    it('collapse state persists to localStorage', () => {
+      act(() => useCardHand.getState().collapseHand());
+      expect(localStorage.getItem('meeple-hand-collapsed')).toBe('true');
+      act(() => useCardHand.getState().expandHand());
+      expect(localStorage.getItem('meeple-hand-collapsed')).toBe('false');
+    });
+
+    it('cards persist to sessionStorage', () => {
+      act(() => {
+        useCardHand.getState().drawCard({
+          id: 'g1',
+          entity: 'game',
+          title: 'Catan',
+          href: '/library/g1',
+        });
+      });
+      const stored = JSON.parse(sessionStorage.getItem('meeple-card-hand') ?? '[]');
+      expect(stored).toHaveLength(1);
+      expect(stored[0].id).toBe('g1');
+    });
+
+    it('pinned card ids persist to localStorage', () => {
+      act(() => {
+        useCardHand.getState().drawCard({
+          id: 'g1',
+          entity: 'game',
+          title: 'Catan',
+          href: '/library/g1',
+        });
+        useCardHand.getState().pinCard('g1');
+      });
+      const stored = JSON.parse(localStorage.getItem('meeple-card-pins') ?? '[]');
+      expect(stored).toContain('g1');
+    });
+
+    it('discardCard removes card and adjusts focus', () => {
+      act(() => {
+        useCardHand.getState().drawCard({
+          id: 'g1',
+          entity: 'game',
+          title: 'Catan',
+          href: '/library/g1',
+        });
+        useCardHand.getState().drawCard({
+          id: 'g2',
+          entity: 'game',
+          title: 'Azul',
+          href: '/library/g2',
+        });
+      });
+      // Focus is on g2 (index 1) after drawing two cards
+      expect(useCardHand.getState().focusedIdx).toBe(1);
+
+      act(() => useCardHand.getState().discardCard('g2'));
+      const state = useCardHand.getState();
+      expect(state.cards).toHaveLength(1);
+      expect(state.cards[0].id).toBe('g1');
+      expect(state.focusedIdx).toBe(0);
+    });
+
+    it('discarding all cards resets focus to -1', () => {
+      act(() => {
+        useCardHand.getState().drawCard({
+          id: 'g1',
+          entity: 'game',
+          title: 'Catan',
+          href: '/library/g1',
+        });
+      });
+      act(() => useCardHand.getState().discardCard('g1'));
+      expect(useCardHand.getState().cards).toHaveLength(0);
+      expect(useCardHand.getState().focusedIdx).toBe(-1);
+    });
+
+    it('swipeNext/swipePrev navigate focus through hand', () => {
+      act(() => {
+        useCardHand.getState().drawCard({
+          id: 'g1',
+          entity: 'game',
+          title: 'Catan',
+          href: '/library/g1',
+        });
+        useCardHand.getState().drawCard({
+          id: 'g2',
+          entity: 'game',
+          title: 'Azul',
+          href: '/library/g2',
+        });
+        useCardHand.getState().drawCard({
+          id: 'g3',
+          entity: 'game',
+          title: 'Wingspan',
+          href: '/library/g3',
+        });
+      });
+      // Focus is on last drawn (index 2)
+      expect(useCardHand.getState().focusedIdx).toBe(2);
+
+      act(() => useCardHand.getState().swipePrev());
+      expect(useCardHand.getState().focusedIdx).toBe(1);
+
+      act(() => useCardHand.getState().swipePrev());
+      expect(useCardHand.getState().focusedIdx).toBe(0);
+
+      // Cannot go below 0
+      act(() => useCardHand.getState().swipePrev());
+      expect(useCardHand.getState().focusedIdx).toBe(0);
+
+      act(() => useCardHand.getState().swipeNext());
+      expect(useCardHand.getState().focusedIdx).toBe(1);
+
+      act(() => useCardHand.getState().swipeNext());
+      expect(useCardHand.getState().focusedIdx).toBe(2);
+
+      // Cannot go above last index
+      act(() => useCardHand.getState().swipeNext());
+      expect(useCardHand.getState().focusedIdx).toBe(2);
+    });
+
+    it('clear removes unpinned cards but keeps pinned ones', () => {
+      act(() => {
+        useCardHand.getState().drawCard({
+          id: 'g1',
+          entity: 'game',
+          title: 'Catan',
+          href: '/library/g1',
+        });
+        useCardHand.getState().drawCard({
+          id: 'g2',
+          entity: 'game',
+          title: 'Azul',
+          href: '/library/g2',
+        });
+        useCardHand.getState().pinCard('g1');
+      });
+
+      act(() => useCardHand.getState().clear());
+      const state = useCardHand.getState();
+      expect(state.cards).toHaveLength(1);
+      expect(state.cards[0].id).toBe('g1');
+    });
+
+    it('focusByHref sets focus to the card matching the href', () => {
+      act(() => {
+        useCardHand.getState().drawCard({
+          id: 'g1',
+          entity: 'game',
+          title: 'Catan',
+          href: '/library/g1',
+        });
+        useCardHand.getState().drawCard({
+          id: 'g2',
+          entity: 'game',
+          title: 'Azul',
+          href: '/library/g2',
+        });
+      });
+      // Focus is on g2 (index 1)
+      expect(useCardHand.getState().focusedIdx).toBe(1);
+
+      act(() => useCardHand.getState().focusByHref('/library/g1'));
+      expect(useCardHand.getState().focusedIdx).toBe(0);
+    });
+
+    it('toggleExpandStack persists to localStorage', () => {
+      expect(useCardHand.getState().expandedStack).toBe(false);
+      act(() => useCardHand.getState().toggleExpandStack());
+      expect(useCardHand.getState().expandedStack).toBe(true);
+      expect(localStorage.getItem('meeple-card-stack-expanded')).toBe('true');
+
+      act(() => useCardHand.getState().toggleExpandStack());
+      expect(useCardHand.getState().expandedStack).toBe(false);
+      expect(localStorage.getItem('meeple-card-stack-expanded')).toBe('false');
+    });
+  });
+});

--- a/apps/web/src/__tests__/stores/use-card-hand-collapse.test.ts
+++ b/apps/web/src/__tests__/stores/use-card-hand-collapse.test.ts
@@ -1,0 +1,54 @@
+import { renderHook, act } from '@testing-library/react';
+import { useCardHand } from '@/stores/use-card-hand';
+
+describe('useCardHand collapse state', () => {
+  beforeEach(() => {
+    localStorage.clear();
+    sessionStorage.clear();
+    act(() => useCardHand.getState().clear());
+  });
+
+  it('isHandCollapsed defaults to false', () => {
+    const { result } = renderHook(() => useCardHand());
+    expect(result.current.isHandCollapsed).toBe(false);
+  });
+
+  it('collapseHand sets isHandCollapsed to true', () => {
+    const { result } = renderHook(() => useCardHand());
+    act(() => result.current.collapseHand());
+    expect(result.current.isHandCollapsed).toBe(true);
+  });
+
+  it('expandHand sets isHandCollapsed to false', () => {
+    const { result } = renderHook(() => useCardHand());
+    act(() => result.current.collapseHand());
+    act(() => result.current.expandHand());
+    expect(result.current.isHandCollapsed).toBe(false);
+  });
+
+  it('persists collapse state to localStorage', () => {
+    const { result } = renderHook(() => useCardHand());
+    act(() => result.current.collapseHand());
+    expect(localStorage.getItem('meeple-hand-collapsed')).toBe('true');
+  });
+
+  it('restores collapse state from localStorage', () => {
+    localStorage.setItem('meeple-hand-collapsed', 'true');
+    // Force store to re-read localStorage (singleton)
+    act(() =>
+      useCardHand.setState({
+        isHandCollapsed: localStorage.getItem('meeple-hand-collapsed') === 'true',
+      })
+    );
+    const { result } = renderHook(() => useCardHand());
+    expect(result.current.isHandCollapsed).toBe(true);
+  });
+
+  it('isHandCollapsed is independent from expandedStack', () => {
+    const { result } = renderHook(() => useCardHand());
+    act(() => result.current.collapseHand());
+    act(() => result.current.toggleExpandStack());
+    expect(result.current.isHandCollapsed).toBe(true);
+    expect(result.current.expandedStack).toBe(true);
+  });
+});

--- a/apps/web/src/components/layout/AppShell/AppShellClient.tsx
+++ b/apps/web/src/components/layout/AppShell/AppShellClient.tsx
@@ -13,26 +13,32 @@
 
 import { type ReactNode, Suspense } from 'react';
 
+import { usePathname } from 'next/navigation';
+
 import { ErrorBoundary } from '@/components/errors/ErrorBoundary';
+import { OnboardingReminderBanner } from '@/components/onboarding';
 import {
   CardBrowserProvider,
   MeepleCardBrowser,
 } from '@/components/ui/data-display/meeple-card-browser';
-import { OnboardingReminderBanner } from '@/components/onboarding';
 import { ImpersonationBanner } from '@/components/ui/feedback/impersonation-banner';
 import { CardStackPanel } from '@/components/ui/navigation/card-stack-panel';
 import { NavigationProvider } from '@/context/NavigationContext';
 import { useCurrentUser } from '@/hooks/queries/useCurrentUser';
 import { useBottomPadding } from '@/hooks/useBottomPadding';
+import { useResponsive } from '@/hooks/useResponsive';
 import { useSidebarState } from '@/hooks/useSidebarState';
 import { cn } from '@/lib/utils';
 import { useImpersonationStore } from '@/store/impersonation';
+import { useCardHand } from '@/stores/use-card-hand';
 
 import { AdaptiveBottomBar } from '../AdaptiveBottomBar';
 import { FloatingActionBar } from '../FloatingActionBar';
 import { MobileBreadcrumb } from '../MobileBreadcrumb';
 import { Sidebar } from '../Sidebar/Sidebar';
 import { TopNavbar } from '../TopNavbar';
+import { HandDrawer } from '../UnifiedShell/HandDrawer';
+import { NavbarMiniCards } from '../UnifiedShell/NavbarMiniCards';
 
 // ─── Props ──────────────────────────────────────────────────────────────────────
 
@@ -60,83 +66,103 @@ export function AppShellClient({
     useImpersonationStore();
   const { isCollapsed, toggle } = useSidebarState(initialSidebarCollapsed);
   const bottomPadding = useBottomPadding();
+  const { isDesktop } = useResponsive();
+  const pathname = usePathname();
+  const isAdminContext = pathname?.startsWith('/admin') ?? false;
+  const { cards, isHandCollapsed, expandHand, focusCard } = useCardHand();
 
   return (
     <NavigationProvider>
       <CardBrowserProvider>
-      <div className="min-h-screen flex flex-col bg-background" data-testid="app-shell">
-        {/* Impersonation Banner (fixed at top when active) */}
-        <ImpersonationBanner
-          isImpersonating={isImpersonating}
-          impersonatedUser={impersonatedUser}
-          onEndImpersonation={endImpersonation}
-          isLoading={isLoading}
-        />
+        <div className="min-h-screen flex flex-col bg-background" data-testid="app-shell">
+          {/* Impersonation Banner (fixed at top when active) */}
+          <ImpersonationBanner
+            isImpersonating={isImpersonating}
+            impersonatedUser={impersonatedUser}
+            onEndImpersonation={endImpersonation}
+            isLoading={isLoading}
+          />
 
-        {/* L1: TopNavbar (always visible) */}
-        <TopNavbar />
+          {/* L1: TopNavbar (always visible) */}
+          <TopNavbar
+            miniCards={
+              !isDesktop && isHandCollapsed && cards.length > 0 ? (
+                <NavbarMiniCards
+                  cards={cards}
+                  onExpand={id => {
+                    expandHand();
+                    const idx = cards.findIndex(c => c.id === id);
+                    if (idx >= 0) focusCard(idx);
+                  }}
+                />
+              ) : undefined
+            }
+          />
 
-        {/* Issue #326: Reminder banner for users who skipped onboarding */}
-        {isAuthenticated && user?.onboardingSkipped && <OnboardingReminderBanner />}
+          {/* HandDrawer for mobile (non-admin routes) */}
+          {!isDesktop && !isAdminContext && <HandDrawer />}
 
-        {/* Desktop Sidebar (authenticated only) */}
-        {isAuthenticated && <Sidebar isCollapsed={isCollapsed} onToggle={toggle} />}
+          {/* Issue #326: Reminder banner for users who skipped onboarding */}
+          {isAuthenticated && user?.onboardingSkipped && <OnboardingReminderBanner />}
 
-        {/* Content area (offset by sidebar width when authenticated) */}
-        <div
-          className={cn(
-            'flex flex-col flex-1',
-            'transition-[margin] duration-200 ease-in-out',
-            isAuthenticated &&
-              (isCollapsed
-                ? 'md:ml-[var(--sidebar-width-collapsed)]'
-                : 'md:ml-[var(--sidebar-width-expanded)]')
-          )}
-          data-testid="app-shell-content"
-        >
-          {/* Mobile Breadcrumb (mobile only) */}
-          <MobileBreadcrumb />
+          {/* Desktop Sidebar (authenticated only) */}
+          {isAuthenticated && <Sidebar isCollapsed={isCollapsed} onToggle={toggle} />}
 
-          {/* Main content */}
-          <main
-            id="main-content"
-            tabIndex={-1}
-            style={{ viewTransitionName: 'page-content' }}
+          {/* Content area (offset by sidebar width when authenticated) */}
+          <div
             className={cn(
-              'flex-1',
-              !fullWidth && 'px-4 sm:px-6 lg:px-8',
-              bottomPadding,
-              'pt-4',
-              className
+              'flex flex-col flex-1',
+              'transition-[margin] duration-200 ease-in-out',
+              isAuthenticated &&
+                (isCollapsed
+                  ? 'md:ml-[var(--sidebar-width-collapsed)]'
+                  : 'md:ml-[var(--sidebar-width-expanded)]')
             )}
+            data-testid="app-shell-content"
           >
-            {children}
-          </main>
+            {/* Mobile Breadcrumb (mobile only) */}
+            <MobileBreadcrumb />
 
-          {/* L3: Desktop FloatingActionBar (hidden on mobile) */}
-          <ErrorBoundary fallback={null} componentName="FloatingActionBar">
-            <Suspense>
-              <div className="hidden md:block">
-                <FloatingActionBar />
-              </div>
-            </Suspense>
+            {/* Main content */}
+            <main
+              id="main-content"
+              tabIndex={-1}
+              style={{ viewTransitionName: 'page-content' }}
+              className={cn(
+                'flex-1',
+                !fullWidth && 'px-4 sm:px-6 lg:px-8',
+                bottomPadding,
+                'pt-4',
+                className
+              )}
+            >
+              {children}
+            </main>
+
+            {/* L3: Desktop FloatingActionBar (hidden on mobile) */}
+            <ErrorBoundary fallback={null} componentName="FloatingActionBar">
+              <Suspense>
+                <div className="hidden md:block">
+                  <FloatingActionBar />
+                </div>
+              </Suspense>
+            </ErrorBoundary>
+          </div>
+
+          {/* Mobile: AdaptiveBottomBar (replaces MobileTabBar + SmartFAB) */}
+          <ErrorBoundary fallback={null} componentName="AdaptiveBottomBar">
+            <AdaptiveBottomBar />
+          </ErrorBoundary>
+
+          {/* Card Stack Panel */}
+          <ErrorBoundary fallback={null} componentName="CardStackPanel">
+            <CardStackPanel />
+          </ErrorBoundary>
+          {/* Card Browser Overlay */}
+          <ErrorBoundary fallback={null} componentName="MeepleCardBrowser">
+            <MeepleCardBrowser />
           </ErrorBoundary>
         </div>
-
-        {/* Mobile: AdaptiveBottomBar (replaces MobileTabBar + SmartFAB) */}
-        <ErrorBoundary fallback={null} componentName="AdaptiveBottomBar">
-          <AdaptiveBottomBar />
-        </ErrorBoundary>
-
-        {/* Card Stack Panel */}
-        <ErrorBoundary fallback={null} componentName="CardStackPanel">
-          <CardStackPanel />
-        </ErrorBoundary>
-        {/* Card Browser Overlay */}
-        <ErrorBoundary fallback={null} componentName="MeepleCardBrowser">
-          <MeepleCardBrowser />
-        </ErrorBoundary>
-      </div>
       </CardBrowserProvider>
     </NavigationProvider>
   );

--- a/apps/web/src/components/layout/TopNavbar/TopNavbar.tsx
+++ b/apps/web/src/components/layout/TopNavbar/TopNavbar.tsx
@@ -10,7 +10,7 @@
 
 'use client';
 
-import { Suspense } from 'react';
+import { type ReactNode, Suspense } from 'react';
 
 import { ChevronDown, LogOut, Search, Settings, User } from 'lucide-react';
 import Link from 'next/link';
@@ -112,9 +112,11 @@ function UserMenu({ userName, userRole }: UserMenuProps) {
 
 export interface TopNavbarProps {
   className?: string;
+  /** Optional mini-cards slot rendered between center and right sections */
+  miniCards?: ReactNode;
 }
 
-export function TopNavbar({ className }: TopNavbarProps) {
+export function TopNavbar({ className, miniCards }: TopNavbarProps) {
   const { user } = useAuthUser();
   const { isScrolled: scrolled } = useScrollState({ scrolledThreshold: 4 });
   const commandPalette = useCommandPalette();
@@ -160,6 +162,9 @@ export function TopNavbar({ className }: TopNavbarProps) {
             </div>
             <DesktopBreadcrumb className="hidden md:flex ml-2" />
           </div>
+
+          {/* ── CENTER: Mini cards (mobile, collapsed hand) ── */}
+          {miniCards && <div className="flex items-center gap-1 overflow-x-auto">{miniCards}</div>}
 
           {/* ── RIGHT: Search + Notifications + Avatar ── */}
           <div className="flex items-center gap-1 shrink-0">

--- a/apps/web/src/components/layout/UnifiedShell/HandDrawer.tsx
+++ b/apps/web/src/components/layout/UnifiedShell/HandDrawer.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { useCardHand } from '@/stores/use-card-hand';
+
+import { HandDrawerCard } from './HandDrawerCard';
+
+export function HandDrawer() {
+  const { cards, focusedIdx, isHandCollapsed, focusCard, maxHandSize, collapseHand } =
+    useCardHand();
+
+  if (cards.length === 0 || isHandCollapsed) {
+    return null;
+  }
+
+  return (
+    <nav
+      role="navigation"
+      aria-label="Carte in mano"
+      className="bg-white/55 backdrop-blur-[12px] border-b border-[rgba(180,130,80,0.1)] px-2.5 py-1 pb-1.5"
+    >
+      {/* Grip handle */}
+      <div
+        role="button"
+        aria-label="Espandi/comprimi mano"
+        onClick={() => collapseHand()}
+        className="mx-auto mb-1.5 cursor-pointer"
+        style={{ width: 36, height: 4, borderRadius: 2, background: 'rgba(180,130,80,0.2)' }}
+      />
+
+      {/* Horizontal scroll area */}
+      <div
+        className="flex gap-1.5 overflow-x-auto"
+        style={{
+          scrollbarWidth: 'none',
+          msOverflowStyle: 'none',
+        }}
+      >
+        {cards.map((card, idx) => (
+          <HandDrawerCard
+            key={card.id}
+            card={card}
+            isFocused={idx === focusedIdx}
+            onClick={() => focusCard(idx)}
+          />
+        ))}
+      </div>
+
+      {/* Card count */}
+      <div className="text-[8px] text-black/20 font-quicksand text-center mt-0.5">
+        {cards.length}/{maxHandSize}
+      </div>
+    </nav>
+  );
+}

--- a/apps/web/src/components/layout/UnifiedShell/HandDrawer.tsx
+++ b/apps/web/src/components/layout/UnifiedShell/HandDrawer.tsx
@@ -19,11 +19,11 @@ export function HandDrawer() {
       className="bg-white/55 backdrop-blur-[12px] border-b border-[rgba(180,130,80,0.1)] px-2.5 py-1 pb-1.5"
     >
       {/* Grip handle */}
-      <div
-        role="button"
+      <button
+        type="button"
         aria-label="Espandi/comprimi mano"
         onClick={() => collapseHand()}
-        className="mx-auto mb-1.5 cursor-pointer"
+        className="mx-auto mb-1.5 block cursor-pointer border-none bg-transparent p-0"
         style={{ width: 36, height: 4, borderRadius: 2, background: 'rgba(180,130,80,0.2)' }}
       />
 

--- a/apps/web/src/components/layout/UnifiedShell/HandDrawerCard.tsx
+++ b/apps/web/src/components/layout/UnifiedShell/HandDrawerCard.tsx
@@ -1,0 +1,88 @@
+'use client';
+
+import Link from 'next/link';
+
+import type { HandCard } from '@/stores/use-card-hand';
+
+const ENTITY_COLORS: Record<string, string> = {
+  game: '25 95% 45%',
+  player: '262 83% 58%',
+  session: '240 60% 55%',
+  agent: '38 92% 50%',
+  kb: '174 60% 40%',
+  chatSession: '220 80% 55%',
+  event: '350 89% 60%',
+  toolkit: '142 70% 45%',
+  tool: '195 80% 50%',
+  custom: '220 70% 50%',
+};
+
+const ENTITY_EMOJIS: Record<string, string> = {
+  game: '\uD83C\uDFB2',
+  player: '\uD83D\uDC64',
+  session: '\uD83C\uDFAE',
+  agent: '\uD83E\uDD16',
+  kb: '\uD83D\uDCC4',
+  chatSession: '\uD83D\uDCAC',
+  event: '\uD83D\uDCC5',
+  toolkit: '\uD83D\uDD27',
+  tool: '\uD83D\uDD28',
+  custom: '\uD83D\uDCCC',
+};
+
+interface HandDrawerCardProps {
+  card: HandCard;
+  isFocused: boolean;
+  onClick: () => void;
+}
+
+export function HandDrawerCard({ card, isFocused, onClick }: HandDrawerCardProps) {
+  const entityColor = ENTITY_COLORS[card.entity] ?? ENTITY_COLORS.custom;
+  const entityEmoji = ENTITY_EMOJIS[card.entity] ?? ENTITY_EMOJIS.custom;
+
+  const focusedStyle: React.CSSProperties = isFocused
+    ? {
+        opacity: 1,
+        border: `1.5px solid hsl(${entityColor} / 0.6)`,
+        boxShadow: `0 0 8px hsl(${entityColor} / 0.2)`,
+      }
+    : {
+        opacity: 0.45,
+        border: '1.5px solid transparent',
+      };
+
+  return (
+    <Link
+      href={card.href}
+      role="link"
+      onClick={onClick}
+      aria-current={isFocused ? 'page' : undefined}
+      className="block rounded-lg transition-all duration-200 ease-in-out hover:opacity-70 hover:-translate-y-0.5"
+      style={{
+        width: 36,
+        height: 36,
+        overflow: 'hidden',
+        ...focusedStyle,
+      }}
+    >
+      {card.imageUrl ? (
+        <img
+          src={card.imageUrl}
+          alt={card.title}
+          className="h-full w-full object-cover rounded-lg"
+          style={{ display: 'block' }}
+        />
+      ) : (
+        <span
+          aria-label={card.title}
+          className="flex h-full w-full items-center justify-center rounded-lg text-sm"
+          style={{
+            background: `linear-gradient(135deg, hsl(${entityColor} / 0.25), hsl(${entityColor} / 0.45))`,
+          }}
+        >
+          {entityEmoji}
+        </span>
+      )}
+    </Link>
+  );
+}

--- a/apps/web/src/components/layout/UnifiedShell/HandDrawerCard.tsx
+++ b/apps/web/src/components/layout/UnifiedShell/HandDrawerCard.tsx
@@ -4,31 +4,7 @@ import Link from 'next/link';
 
 import type { HandCard } from '@/stores/use-card-hand';
 
-const ENTITY_COLORS: Record<string, string> = {
-  game: '25 95% 45%',
-  player: '262 83% 58%',
-  session: '240 60% 55%',
-  agent: '38 92% 50%',
-  kb: '174 60% 40%',
-  chatSession: '220 80% 55%',
-  event: '350 89% 60%',
-  toolkit: '142 70% 45%',
-  tool: '195 80% 50%',
-  custom: '220 70% 50%',
-};
-
-const ENTITY_EMOJIS: Record<string, string> = {
-  game: '\uD83C\uDFB2',
-  player: '\uD83D\uDC64',
-  session: '\uD83C\uDFAE',
-  agent: '\uD83E\uDD16',
-  kb: '\uD83D\uDCC4',
-  chatSession: '\uD83D\uDCAC',
-  event: '\uD83D\uDCC5',
-  toolkit: '\uD83D\uDD27',
-  tool: '\uD83D\uDD28',
-  custom: '\uD83D\uDCCC',
-};
+import { ENTITY_COLORS, ENTITY_EMOJIS } from './entity-hand-constants';
 
 interface HandDrawerCardProps {
   card: HandCard;

--- a/apps/web/src/components/layout/UnifiedShell/NavbarMiniCards.tsx
+++ b/apps/web/src/components/layout/UnifiedShell/NavbarMiniCards.tsx
@@ -1,0 +1,63 @@
+'use client';
+
+import type { HandCard } from '@/stores/use-card-hand';
+
+const ENTITY_COLORS: Record<string, string> = {
+  game: '25 95% 45%',
+  player: '262 83% 58%',
+  session: '240 60% 55%',
+  agent: '38 92% 50%',
+  kb: '174 60% 40%',
+  chatSession: '220 80% 55%',
+  event: '350 89% 60%',
+  toolkit: '142 70% 45%',
+  tool: '195 80% 50%',
+  custom: '220 70% 50%',
+};
+
+const ENTITY_EMOJI: Record<string, string> = {
+  game: '\uD83C\uDFB2',
+  player: '\uD83D\uDC64',
+  session: '\uD83D\uDCCB',
+  agent: '\uD83E\uDD16',
+  kb: '\uD83D\uDCDA',
+  chatSession: '\uD83D\uDCAC',
+  event: '\uD83C\uDF89',
+  toolkit: '\uD83D\uDD27',
+  tool: '\u2699\uFE0F',
+  custom: '\u2B50',
+};
+
+interface NavbarMiniCardsProps {
+  cards: HandCard[];
+  onExpand: (cardId: string) => void;
+}
+
+export function NavbarMiniCards({ cards, onExpand }: NavbarMiniCardsProps) {
+  return (
+    <div className="flex items-center gap-0.5">
+      {cards.map(card => (
+        <button
+          key={card.id}
+          type="button"
+          aria-label={card.title}
+          className="min-w-[44px] min-h-[44px] flex items-center justify-center opacity-70 hover:opacity-100 transition-opacity"
+          onClick={() => onExpand(card.id)}
+        >
+          {card.imageUrl ? (
+            <img src={card.imageUrl} alt="" className="w-5 h-5 rounded-full object-cover" />
+          ) : (
+            <span
+              className="w-5 h-5 rounded-full flex items-center justify-center text-[10px]"
+              style={{
+                backgroundColor: `hsl(${ENTITY_COLORS[card.entity] ?? ENTITY_COLORS.custom})`,
+              }}
+            >
+              {ENTITY_EMOJI[card.entity] ?? ENTITY_EMOJI.custom}
+            </span>
+          )}
+        </button>
+      ))}
+    </div>
+  );
+}

--- a/apps/web/src/components/layout/UnifiedShell/NavbarMiniCards.tsx
+++ b/apps/web/src/components/layout/UnifiedShell/NavbarMiniCards.tsx
@@ -2,31 +2,7 @@
 
 import type { HandCard } from '@/stores/use-card-hand';
 
-const ENTITY_COLORS: Record<string, string> = {
-  game: '25 95% 45%',
-  player: '262 83% 58%',
-  session: '240 60% 55%',
-  agent: '38 92% 50%',
-  kb: '174 60% 40%',
-  chatSession: '220 80% 55%',
-  event: '350 89% 60%',
-  toolkit: '142 70% 45%',
-  tool: '195 80% 50%',
-  custom: '220 70% 50%',
-};
-
-const ENTITY_EMOJI: Record<string, string> = {
-  game: '\uD83C\uDFB2',
-  player: '\uD83D\uDC64',
-  session: '\uD83D\uDCCB',
-  agent: '\uD83E\uDD16',
-  kb: '\uD83D\uDCDA',
-  chatSession: '\uD83D\uDCAC',
-  event: '\uD83C\uDF89',
-  toolkit: '\uD83D\uDD27',
-  tool: '\u2699\uFE0F',
-  custom: '\u2B50',
-};
+import { ENTITY_COLORS, ENTITY_EMOJIS } from './entity-hand-constants';
 
 interface NavbarMiniCardsProps {
   cards: HandCard[];
@@ -53,7 +29,7 @@ export function NavbarMiniCards({ cards, onExpand }: NavbarMiniCardsProps) {
                 backgroundColor: `hsl(${ENTITY_COLORS[card.entity] ?? ENTITY_COLORS.custom})`,
               }}
             >
-              {ENTITY_EMOJI[card.entity] ?? ENTITY_EMOJI.custom}
+              {ENTITY_EMOJIS[card.entity] ?? ENTITY_EMOJIS.custom}
             </span>
           )}
         </button>

--- a/apps/web/src/components/layout/UnifiedShell/__tests__/HandDrawer.test.tsx
+++ b/apps/web/src/components/layout/UnifiedShell/__tests__/HandDrawer.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen } from '@testing-library/react';
+import { HandDrawer } from '../HandDrawer';
+import { useCardHand } from '@/stores/use-card-hand';
+
+vi.mock('@/stores/use-card-hand');
+
+describe('HandDrawer', () => {
+  beforeEach(() => {
+    vi.resetAllMocks();
+  });
+
+  it('renders nothing when no cards in hand', () => {
+    vi.mocked(useCardHand).mockReturnValue({
+      cards: [],
+      focusedIdx: -1,
+      isHandCollapsed: false,
+      focusCard: vi.fn(),
+      maxHandSize: 10,
+    } as any);
+    const { container } = render(<HandDrawer />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders cards when hand has cards', () => {
+    vi.mocked(useCardHand).mockReturnValue({
+      cards: [
+        { id: 'g1', entity: 'game', title: 'Catan', href: '/library/g1' },
+        { id: 'g2', entity: 'game', title: 'Azul', href: '/library/g2' },
+      ],
+      focusedIdx: 0,
+      isHandCollapsed: false,
+      focusCard: vi.fn(),
+      maxHandSize: 10,
+    } as any);
+    render(<HandDrawer />);
+    expect(screen.getByLabelText('Catan')).toBeInTheDocument();
+    expect(screen.getByLabelText('Azul')).toBeInTheDocument();
+  });
+
+  it('renders nothing when collapsed', () => {
+    vi.mocked(useCardHand).mockReturnValue({
+      cards: [{ id: 'g1', entity: 'game', title: 'Catan', href: '/library/g1' }],
+      focusedIdx: 0,
+      isHandCollapsed: true,
+      focusCard: vi.fn(),
+      maxHandSize: 10,
+    } as any);
+    const { container } = render(<HandDrawer />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('has navigation role and aria-label', () => {
+    vi.mocked(useCardHand).mockReturnValue({
+      cards: [{ id: 'g1', entity: 'game', title: 'Catan', href: '/library/g1' }],
+      focusedIdx: 0,
+      isHandCollapsed: false,
+      focusCard: vi.fn(),
+      maxHandSize: 10,
+    } as any);
+    render(<HandDrawer />);
+    expect(screen.getByRole('navigation')).toHaveAttribute('aria-label', 'Carte in mano');
+  });
+
+  it('shows card count', () => {
+    vi.mocked(useCardHand).mockReturnValue({
+      cards: [{ id: 'g1', entity: 'game', title: 'Catan', href: '/library/g1' }],
+      focusedIdx: 0,
+      isHandCollapsed: false,
+      focusCard: vi.fn(),
+      maxHandSize: 10,
+    } as any);
+    render(<HandDrawer />);
+    expect(screen.getByText('1/10')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/layout/UnifiedShell/__tests__/HandDrawerCard.test.tsx
+++ b/apps/web/src/components/layout/UnifiedShell/__tests__/HandDrawerCard.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { HandDrawerCard } from '../HandDrawerCard';
+
+describe('HandDrawerCard', () => {
+  const card = {
+    id: 'g1',
+    entity: 'game' as const,
+    title: 'Catan',
+    href: '/library/g1',
+    imageUrl: 'https://example.com/catan.jpg',
+  };
+
+  it('renders card with image', () => {
+    render(<HandDrawerCard card={card} isFocused={false} onClick={vi.fn()} />);
+    expect(screen.getByAltText('Catan')).toBeInTheDocument();
+  });
+
+  it('renders entity emoji fallback when no imageUrl', () => {
+    render(
+      <HandDrawerCard card={{ ...card, imageUrl: undefined }} isFocused={false} onClick={vi.fn()} />
+    );
+    expect(screen.getByLabelText('Catan')).toBeInTheDocument();
+  });
+
+  it('applies focused styles when isFocused', () => {
+    render(<HandDrawerCard card={card} isFocused={true} onClick={vi.fn()} />);
+    const btn = screen.getByRole('link');
+    expect(btn).toHaveAttribute('aria-current', 'page');
+  });
+
+  it('does not set aria-current when not focused', () => {
+    render(<HandDrawerCard card={card} isFocused={false} onClick={vi.fn()} />);
+    const btn = screen.getByRole('link');
+    expect(btn).not.toHaveAttribute('aria-current');
+  });
+
+  it('calls onClick when clicked', async () => {
+    const onClick = vi.fn();
+    render(<HandDrawerCard card={card} isFocused={false} onClick={onClick} />);
+    await userEvent.click(screen.getByRole('link'));
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+});

--- a/apps/web/src/components/layout/UnifiedShell/__tests__/NavbarMiniCards.test.tsx
+++ b/apps/web/src/components/layout/UnifiedShell/__tests__/NavbarMiniCards.test.tsx
@@ -1,0 +1,42 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+
+import { NavbarMiniCards } from '../NavbarMiniCards';
+
+describe('NavbarMiniCards', () => {
+  const cards = [
+    {
+      id: 'g1',
+      entity: 'game' as const,
+      title: 'Catan',
+      href: '/library/g1',
+      imageUrl: 'https://example.com/catan.jpg',
+    },
+    {
+      id: 'g2',
+      entity: 'game' as const,
+      title: 'Azul',
+      href: '/library/g2',
+    },
+  ];
+
+  it('renders mini icons for each card', () => {
+    render(<NavbarMiniCards cards={cards} onExpand={vi.fn()} />);
+    expect(screen.getByLabelText('Catan')).toBeInTheDocument();
+    expect(screen.getByLabelText('Azul')).toBeInTheDocument();
+  });
+
+  it('each mini icon has minimum 44px tap target', () => {
+    render(<NavbarMiniCards cards={cards} onExpand={vi.fn()} />);
+    const btn = screen.getByLabelText('Catan');
+    // Check the button has minimum tap target sizing
+    expect(btn.className).toMatch(/min-w-\[44px\]|min-h-\[44px\]|p-3|p-\[12px\]/);
+  });
+
+  it('calls onExpand with card id when icon is tapped', async () => {
+    const onExpand = vi.fn();
+    render(<NavbarMiniCards cards={cards} onExpand={onExpand} />);
+    await userEvent.click(screen.getByLabelText('Catan'));
+    expect(onExpand).toHaveBeenCalledWith('g1');
+  });
+});

--- a/apps/web/src/components/layout/UnifiedShell/entity-hand-constants.ts
+++ b/apps/web/src/components/layout/UnifiedShell/entity-hand-constants.ts
@@ -1,0 +1,30 @@
+/**
+ * Shared entity color and emoji constants for hand drawer components.
+ * Colors match the MeepleCard entity color system (HSL without wrapper).
+ */
+
+export const ENTITY_COLORS: Record<string, string> = {
+  game: '25 95% 45%',
+  player: '262 83% 58%',
+  session: '240 60% 55%',
+  agent: '38 92% 50%',
+  kb: '174 60% 40%',
+  chatSession: '220 80% 55%',
+  event: '350 89% 60%',
+  toolkit: '142 70% 45%',
+  tool: '195 80% 50%',
+  custom: '220 70% 50%',
+};
+
+export const ENTITY_EMOJIS: Record<string, string> = {
+  game: '\uD83C\uDFB2',
+  player: '\uD83D\uDC64',
+  session: '\uD83C\uDFAE',
+  agent: '\uD83E\uDD16',
+  kb: '\uD83D\uDCC4',
+  chatSession: '\uD83D\uDCAC',
+  event: '\uD83D\uDCC5',
+  toolkit: '\uD83D\uDD27',
+  tool: '\uD83D\uDD28',
+  custom: '\uD83D\uDCCC',
+};

--- a/apps/web/src/components/layout/__tests__/AppShellClient.test.tsx
+++ b/apps/web/src/components/layout/__tests__/AppShellClient.test.tsx
@@ -90,6 +90,37 @@ vi.mock('@/hooks/useBottomPadding', () => ({
   useBottomPadding: () => 'pb-6',
 }));
 
+vi.mock('@/hooks/useResponsive', () => ({
+  useResponsive: () => ({
+    isDesktop: true,
+    isMobile: false,
+    isTablet: false,
+    deviceType: 'desktop',
+    viewportWidth: 1280,
+  }),
+}));
+
+vi.mock('next/navigation', () => ({
+  usePathname: () => '/library',
+}));
+
+vi.mock('@/stores/use-card-hand', () => ({
+  useCardHand: () => ({
+    cards: [],
+    isHandCollapsed: false,
+    expandHand: vi.fn(),
+    focusCard: vi.fn(),
+  }),
+}));
+
+vi.mock('@/components/layout/UnifiedShell/HandDrawer', () => ({
+  HandDrawer: () => <div data-testid="hand-drawer" />,
+}));
+
+vi.mock('@/components/layout/UnifiedShell/NavbarMiniCards', () => ({
+  NavbarMiniCards: () => <div data-testid="navbar-mini-cards" />,
+}));
+
 // ─── Import after mocks ──────────────────────────────────────────────────────
 
 import { AppShellClient } from '../AppShell/AppShellClient';

--- a/apps/web/src/components/ui/data-display/entity-link/__tests__/compact-icon-bar.test.tsx
+++ b/apps/web/src/components/ui/data-display/entity-link/__tests__/compact-icon-bar.test.tsx
@@ -1,0 +1,35 @@
+import { render, screen } from '@testing-library/react';
+import { CompactIconBar } from '../compact-icon-bar';
+import type { EntityLinkGroup } from '../use-entity-link-groups';
+
+describe('CompactIconBar', () => {
+  const groups: EntityLinkGroup[] = [
+    { entityType: 'Session', count: 12 },
+    { entityType: 'KbCard', count: 3 },
+    { entityType: 'Agent', count: 1 },
+  ];
+
+  it('renders icon buttons for each group', () => {
+    render(<CompactIconBar groups={groups} onIconClick={vi.fn()} />);
+    expect(screen.getByLabelText('12 Sessioni')).toBeInTheDocument();
+    expect(screen.getByLabelText('3 Documenti KB')).toBeInTheDocument();
+    expect(screen.getByLabelText('1 Agent')).toBeInTheDocument();
+  });
+
+  it('renders nothing when groups is empty', () => {
+    const { container } = render(<CompactIconBar groups={[]} onIconClick={vi.fn()} />);
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('has toolbar role and aria-label', () => {
+    render(<CompactIconBar groups={groups} onIconClick={vi.fn()} />);
+    expect(screen.getByRole('toolbar')).toHaveAttribute('aria-label', 'Entità collegate');
+  });
+
+  it('renders dot separators between groups', () => {
+    render(<CompactIconBar groups={groups} onIconClick={vi.fn()} />);
+    const bar = screen.getByRole('toolbar');
+    const separators = bar.querySelectorAll('[data-separator]');
+    expect(separators.length).toBeGreaterThan(0);
+  });
+});

--- a/apps/web/src/components/ui/data-display/entity-link/__tests__/compact-icon-button.test.tsx
+++ b/apps/web/src/components/ui/data-display/entity-link/__tests__/compact-icon-button.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { CompactIconButton } from '../compact-icon-button';
+import { Gamepad2 } from 'lucide-react';
+
+describe('CompactIconButton', () => {
+  it('renders icon with badge count', () => {
+    render(
+      <CompactIconButton icon={Gamepad2} count={12} label="Sessioni" entityColor="240 60% 55%" />
+    );
+    expect(screen.getByText('12')).toBeInTheDocument();
+    expect(screen.getByLabelText('12 Sessioni')).toBeInTheDocument();
+  });
+
+  it('shows tooltip on hover', async () => {
+    render(
+      <CompactIconButton icon={Gamepad2} count={3} label="Documenti KB" entityColor="174 60% 40%" />
+    );
+    await userEvent.hover(screen.getByLabelText('3 Documenti KB'));
+    expect(screen.getByText('3 Documenti KB')).toBeVisible();
+  });
+
+  it('calls onClick when tapped', async () => {
+    const onClick = vi.fn();
+    render(
+      <CompactIconButton
+        icon={Gamepad2}
+        count={1}
+        label="Agent"
+        entityColor="38 92% 50%"
+        onClick={onClick}
+      />
+    );
+    await userEvent.click(screen.getByLabelText('1 Agent'));
+    expect(onClick).toHaveBeenCalledOnce();
+  });
+
+  it('does not render when count is 0', () => {
+    const { container } = render(
+      <CompactIconButton icon={Gamepad2} count={0} label="Test" entityColor="0 0% 50%" />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+});

--- a/apps/web/src/components/ui/data-display/entity-link/__tests__/use-entity-link-groups.test.ts
+++ b/apps/web/src/components/ui/data-display/entity-link/__tests__/use-entity-link-groups.test.ts
@@ -1,0 +1,80 @@
+import { groupEntityLinks } from '../use-entity-link-groups';
+import type { EntityLinkDto } from '@/lib/api/schemas/entity-links.schemas';
+
+/**
+ * Helper to build a minimal EntityLinkDto for testing.
+ * Only sourceEntityType, sourceEntityId, targetEntityType, targetEntityId,
+ * linkType, isOwner, and isBggImported are semantically relevant to grouping;
+ * remaining fields use sensible defaults.
+ */
+function makeLink(
+  overrides: Partial<EntityLinkDto> &
+    Pick<EntityLinkDto, 'id' | 'targetEntityType' | 'targetEntityId'>
+): EntityLinkDto {
+  return {
+    sourceEntityType: 'Game',
+    sourceEntityId: 'g1',
+    linkType: 'RelatedTo',
+    isBidirectional: false,
+    scope: 'User',
+    ownerUserId: '00000000-0000-0000-0000-000000000001',
+    metadata: null,
+    isAdminApproved: false,
+    isBggImported: false,
+    isOwner: false,
+    createdAt: '2026-01-01T00:00:00Z',
+    updatedAt: '2026-01-01T00:00:00Z',
+    ...overrides,
+  };
+}
+
+describe('groupEntityLinks', () => {
+  it('returns empty array for empty links', () => {
+    expect(groupEntityLinks([])).toEqual([]);
+  });
+
+  it('groups links by targetEntityType with count', () => {
+    const links: EntityLinkDto[] = [
+      makeLink({ id: '1', targetEntityType: 'Session', targetEntityId: 's1' }),
+      makeLink({ id: '2', targetEntityType: 'Session', targetEntityId: 's2' }),
+      makeLink({ id: '3', targetEntityType: 'Agent', targetEntityId: 'a1' }),
+    ];
+    const groups = groupEntityLinks(links);
+    expect(groups).toHaveLength(2);
+    expect(groups).toContainEqual(expect.objectContaining({ entityType: 'Session', count: 2 }));
+    expect(groups).toContainEqual(expect.objectContaining({ entityType: 'Agent', count: 1 }));
+  });
+
+  it('excludes entity types with count 0', () => {
+    const groups = groupEntityLinks([]);
+    expect(groups.find(g => g.count === 0)).toBeUndefined();
+  });
+
+  it('includes KbCard entity type', () => {
+    const links: EntityLinkDto[] = [
+      makeLink({ id: '1', targetEntityType: 'KbCard', targetEntityId: 'k1' }),
+    ];
+    const groups = groupEntityLinks(links);
+    expect(groups).toContainEqual(expect.objectContaining({ entityType: 'KbCard', count: 1 }));
+  });
+
+  it('uses metadata as firstTargetName for the first link in a group', () => {
+    const links: EntityLinkDto[] = [
+      makeLink({ id: '1', targetEntityType: 'Game', targetEntityId: 'g2', metadata: 'Catan' }),
+      makeLink({ id: '2', targetEntityType: 'Game', targetEntityId: 'g3', metadata: 'Wingspan' }),
+    ];
+    const groups = groupEntityLinks(links);
+    const gameGroup = groups.find(g => g.entityType === 'Game');
+    expect(gameGroup).toBeDefined();
+    expect(gameGroup!.count).toBe(2);
+    expect(gameGroup!.firstTargetName).toBe('Catan');
+  });
+
+  it('sets firstTargetName to undefined when metadata is null', () => {
+    const links: EntityLinkDto[] = [
+      makeLink({ id: '1', targetEntityType: 'Document', targetEntityId: 'd1', metadata: null }),
+    ];
+    const groups = groupEntityLinks(links);
+    expect(groups[0].firstTargetName).toBeUndefined();
+  });
+});

--- a/apps/web/src/components/ui/data-display/entity-link/compact-icon-bar.tsx
+++ b/apps/web/src/components/ui/data-display/entity-link/compact-icon-bar.tsx
@@ -1,0 +1,94 @@
+'use client';
+
+import type { LucideIcon } from 'lucide-react';
+import {
+  Bot,
+  Calendar,
+  FileText,
+  Gamepad2,
+  MessageCircle,
+  PlayCircle,
+  User,
+  Wrench,
+} from 'lucide-react';
+
+import type { LinkEntityType } from './entity-link-types';
+import type { EntityLinkGroup } from './use-entity-link-groups';
+
+import { CompactIconButton } from './compact-icon-button';
+
+const ENTITY_ICON_CONFIG: Record<
+  string,
+  { icon: LucideIcon; label: string; color: string; group: number }
+> = {
+  Session: { icon: PlayCircle, label: 'Sessioni', color: '240 60% 55%', group: 0 },
+  KbCard: { icon: FileText, label: 'Documenti KB', color: '174 60% 40%', group: 0 },
+  Document: { icon: FileText, label: 'Documenti', color: '210 40% 55%', group: 0 },
+  Agent: { icon: Bot, label: 'Agent', color: '38 92% 50%', group: 1 },
+  ChatSession: { icon: MessageCircle, label: 'Chat AI', color: '220 80% 55%', group: 1 },
+  Game: { icon: Gamepad2, label: 'Espansioni', color: '25 95% 45%', group: 2 },
+  Toolkit: { icon: Wrench, label: 'Toolkit', color: '142 70% 45%', group: 2 },
+  Player: { icon: User, label: 'Giocatori', color: '262 83% 58%', group: 2 },
+  Event: { icon: Calendar, label: 'Eventi', color: '350 89% 60%', group: 2 },
+};
+
+interface CompactIconBarProps {
+  groups: EntityLinkGroup[];
+  onIconClick: (entityType: LinkEntityType) => void;
+  className?: string;
+}
+
+export function CompactIconBar({ groups, onIconClick, className }: CompactIconBarProps) {
+  if (groups.length === 0) return null;
+
+  const sorted = [...groups]
+    .filter((g) => ENTITY_ICON_CONFIG[g.entityType])
+    .sort((a, b) => {
+      const ga = ENTITY_ICON_CONFIG[a.entityType]?.group ?? 99;
+      const gb = ENTITY_ICON_CONFIG[b.entityType]?.group ?? 99;
+      return ga - gb;
+    });
+
+  if (sorted.length === 0) return null;
+
+  const elements: React.ReactNode[] = [];
+  let lastGroup = -1;
+
+  for (const item of sorted) {
+    const config = ENTITY_ICON_CONFIG[item.entityType];
+    if (!config) continue;
+
+    if (lastGroup !== -1 && config.group !== lastGroup) {
+      elements.push(
+        <div
+          key={`sep-${config.group}`}
+          data-separator
+          className="mx-0.5 h-[3px] w-[3px] shrink-0 rounded-full"
+          style={{ background: 'rgba(180,130,80,0.15)' }}
+        />
+      );
+    }
+    lastGroup = config.group;
+
+    elements.push(
+      <CompactIconButton
+        key={item.entityType}
+        icon={config.icon}
+        count={item.count}
+        label={config.label}
+        entityColor={config.color}
+        onClick={() => onIconClick(item.entityType as LinkEntityType)}
+      />
+    );
+  }
+
+  return (
+    <div
+      role="toolbar"
+      aria-label="Entità collegate"
+      className={`flex items-center justify-center gap-1 rounded-b-[20px] border-t border-[rgba(180,130,80,0.08)] bg-[hsl(var(--muted)/0.5)] px-3 py-2 ${className ?? ''}`}
+    >
+      {elements}
+    </div>
+  );
+}

--- a/apps/web/src/components/ui/data-display/entity-link/compact-icon-bar.tsx
+++ b/apps/web/src/components/ui/data-display/entity-link/compact-icon-bar.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import type { LucideIcon } from 'lucide-react';
 import {
   Bot,
   Calendar,
@@ -12,10 +11,11 @@ import {
   Wrench,
 } from 'lucide-react';
 
+import { CompactIconButton } from './compact-icon-button';
+
 import type { LinkEntityType } from './entity-link-types';
 import type { EntityLinkGroup } from './use-entity-link-groups';
-
-import { CompactIconButton } from './compact-icon-button';
+import type { LucideIcon } from 'lucide-react';
 
 const ENTITY_ICON_CONFIG: Record<
   string,
@@ -42,7 +42,7 @@ export function CompactIconBar({ groups, onIconClick, className }: CompactIconBa
   if (groups.length === 0) return null;
 
   const sorted = [...groups]
-    .filter((g) => ENTITY_ICON_CONFIG[g.entityType])
+    .filter(g => ENTITY_ICON_CONFIG[g.entityType])
     .sort((a, b) => {
       const ga = ENTITY_ICON_CONFIG[a.entityType]?.group ?? 99;
       const gb = ENTITY_ICON_CONFIG[b.entityType]?.group ?? 99;

--- a/apps/web/src/components/ui/data-display/entity-link/compact-icon-button.tsx
+++ b/apps/web/src/components/ui/data-display/entity-link/compact-icon-button.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { cn } from '@/lib/utils';
+
+import type { LucideIcon } from 'lucide-react';
+
+interface CompactIconButtonProps {
+  icon: LucideIcon;
+  count: number;
+  label: string;
+  entityColor: string; // HSL without hsl() wrapper, e.g. "240 60% 55%"
+  onClick?: () => void;
+  className?: string;
+}
+
+export function CompactIconButton({
+  icon: Icon,
+  count,
+  label,
+  entityColor,
+  onClick,
+  className,
+}: CompactIconButtonProps) {
+  if (count <= 0) return null;
+  const ariaLabel = `${count} ${label}`;
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      aria-label={ariaLabel}
+      className={cn(
+        'group/ib relative flex h-9 w-9 items-center justify-center rounded-[10px]',
+        'border border-transparent bg-transparent',
+        'cursor-pointer transition-all duration-200',
+        'hover:-translate-y-0.5 hover:bg-white/60 hover:shadow-[var(--shadow-warm-sm)]',
+        'active:scale-[0.92]',
+        className
+      )}
+      style={{ color: `hsl(${entityColor})` }}
+    >
+      <Icon className="h-4 w-4" />
+      <span
+        className="absolute -right-1 -top-1 flex h-3.5 min-w-[14px] items-center justify-center rounded-full px-1 text-[8px] font-bold font-quicksand leading-none text-white"
+        style={{ backgroundColor: `hsl(${entityColor})`, border: '1.5px solid hsl(var(--card))' }}
+      >
+        {count}
+      </span>
+      <span className="pointer-events-none absolute bottom-full left-1/2 mb-1.5 -translate-x-1/2 whitespace-nowrap rounded-md bg-foreground px-2 py-1 text-[9px] font-semibold font-quicksand text-background opacity-0 transition-opacity duration-150 group-hover/ib:opacity-100">
+        {ariaLabel}
+        <span className="absolute left-1/2 top-full -translate-x-1/2 border-4 border-transparent border-t-foreground" />
+      </span>
+    </button>
+  );
+}

--- a/apps/web/src/components/ui/data-display/entity-link/use-entity-link-groups.ts
+++ b/apps/web/src/components/ui/data-display/entity-link/use-entity-link-groups.ts
@@ -1,0 +1,65 @@
+'use client';
+
+/**
+ * useEntityLinkGroups — derived hook for grouped entity link counts
+ *
+ * Pure function `groupEntityLinks` groups EntityLinkDto[] by targetEntityType.
+ * Hook `useEntityLinkGroups` wraps useEntityLinks + groupEntityLinks.
+ *
+ * Used by CompactIconBar to show which entity type icons and their counts.
+ *
+ * Issue #448 — Service Health Monitoring
+ */
+
+import { useMemo } from 'react';
+
+import { useEntityLinks } from './use-entity-links';
+
+import type { EntityLinkDto, LinkEntityType } from './entity-link-types';
+
+export interface EntityLinkGroup {
+  entityType: LinkEntityType;
+  count: number;
+  firstTargetName?: string;
+}
+
+/**
+ * Groups an array of entity links by their targetEntityType.
+ *
+ * @param links - Array of EntityLinkDto to group
+ * @returns Array of EntityLinkGroup with counts and optional first target name
+ */
+export function groupEntityLinks(links: EntityLinkDto[]): EntityLinkGroup[] {
+  const map = new Map<LinkEntityType, { count: number; firstTargetName?: string }>();
+
+  for (const link of links) {
+    const existing = map.get(link.targetEntityType);
+    if (existing) {
+      existing.count++;
+    } else {
+      map.set(link.targetEntityType, {
+        count: 1,
+        firstTargetName: link.metadata ?? undefined,
+      });
+    }
+  }
+
+  return Array.from(map.entries()).map(([entityType, data]) => ({
+    entityType,
+    count: data.count,
+    firstTargetName: data.firstTargetName,
+  }));
+}
+
+/**
+ * React hook that fetches entity links and returns them grouped by target entity type.
+ *
+ * @param entityType - The source entity type
+ * @param entityId - The source entity ID
+ * @returns Grouped links, loading state, and error
+ */
+export function useEntityLinkGroups(entityType: LinkEntityType, entityId: string) {
+  const { links, loading, error } = useEntityLinks(entityType, entityId);
+  const groups = useMemo(() => groupEntityLinks(links), [links]);
+  return { groups, loading, error };
+}

--- a/apps/web/src/components/ui/data-display/meeple-card/CartaEstesa.tsx
+++ b/apps/web/src/components/ui/data-display/meeple-card/CartaEstesa.tsx
@@ -1,0 +1,143 @@
+'use client';
+
+import { cn } from '@/lib/utils';
+
+interface CartaEstesaStat {
+  label: string;
+  value: string;
+  color: string; // HSL without wrapper, e.g. "25 95% 45%"
+}
+
+interface CartaEstesaProps {
+  title: string;
+  subtitle?: string;
+  imageUrl?: string;
+  rating?: number;
+  entityColor: string; // HSL without wrapper
+  stats?: CartaEstesaStat[];
+  tags?: string[];
+  description?: string;
+  linkCount?: number;
+  children?: React.ReactNode; // Slot for CompactIconBar
+  className?: string;
+}
+
+export function CartaEstesa({
+  title,
+  subtitle,
+  imageUrl,
+  rating,
+  entityColor,
+  stats,
+  tags,
+  description,
+  linkCount,
+  children,
+  className,
+}: CartaEstesaProps) {
+  return (
+    <div
+      data-testid="carta-estesa"
+      className={cn(
+        'flex flex-col overflow-hidden rounded-[20px] border border-[rgba(180,130,80,0.1)] bg-card',
+        'shadow-[var(--shadow-warm-lg)]',
+        className
+      )}
+    >
+      {/* Cover Hero */}
+      <div className="relative h-[200px] w-full overflow-hidden lg:h-[180px]">
+        {imageUrl ? (
+          <img src={imageUrl} alt={title} className="h-full w-full object-cover" />
+        ) : (
+          <div
+            className="flex h-full w-full items-center justify-center"
+            style={{
+              background: `linear-gradient(135deg, hsl(${entityColor}), hsl(${entityColor} / 0.7))`,
+            }}
+          >
+            <span className="text-5xl opacity-30">🎲</span>
+          </div>
+        )}
+        {/* Gradient overlay */}
+        <div className="absolute bottom-0 left-0 right-0 h-[100px] bg-gradient-to-t from-black/65 to-transparent" />
+        {/* Title area */}
+        <div className="absolute bottom-3 left-4">
+          <h1 className="font-quicksand text-2xl font-extrabold text-white [text-shadow:0_2px_8px_rgba(0,0,0,0.4)]">
+            {title}
+          </h1>
+          {subtitle && (
+            <p className="text-[11px] text-white/80 [text-shadow:0_1px_4px_rgba(0,0,0,0.3)]">
+              {subtitle}
+            </p>
+          )}
+        </div>
+        {/* Rating badge */}
+        {rating !== undefined && (
+          <div className="absolute right-3 top-3 flex items-center gap-1 rounded-[14px] bg-black/40 px-3 py-1 backdrop-blur-[8px]">
+            <span className="text-xs text-amber-300">⭐</span>
+            <span className="font-quicksand text-[13px] font-bold text-white">{rating}</span>
+          </div>
+        )}
+        {/* Link badge */}
+        {linkCount !== undefined && linkCount > 0 && (
+          <div className="absolute left-3 top-3 flex items-center gap-1 rounded-[14px] border border-white/50 bg-white/80 px-2.5 py-0.5 shadow-sm backdrop-blur-[8px]">
+            <span className="text-[11px]">🔗</span>
+            <span className="font-nunito text-[11px] font-semibold text-slate-700">
+              {linkCount}
+            </span>
+          </div>
+        )}
+      </div>
+
+      {/* Body */}
+      <div className="flex flex-1 flex-col gap-2.5 p-3.5 pt-3.5 sm:p-4">
+        {/* Stats row */}
+        {stats && stats.length > 0 && (
+          <div className="flex gap-1.5">
+            {stats.map(stat => (
+              <div
+                key={stat.label}
+                className="flex-1 rounded-xl border bg-white/70 px-1 py-2 text-center"
+                style={{ borderColor: `hsl(${stat.color} / 0.15)` }}
+              >
+                <div
+                  className="font-quicksand text-base font-bold"
+                  style={{ color: `hsl(${stat.color})` }}
+                >
+                  {stat.value}
+                </div>
+                <div className="mt-0.5 text-[8px] text-muted-foreground">{stat.label}</div>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {/* Tags */}
+        {tags && tags.length > 0 && (
+          <div className="flex flex-wrap gap-1.5">
+            {tags.map(tag => (
+              <span
+                key={tag}
+                className="rounded-[14px] px-2.5 py-0.5 font-quicksand text-[10px] font-semibold"
+                style={{
+                  backgroundColor: `hsl(${entityColor} / 0.08)`,
+                  color: `hsl(${entityColor})`,
+                }}
+              >
+                {tag}
+              </span>
+            ))}
+          </div>
+        )}
+
+        {/* Description */}
+        {description && (
+          <p className="text-xs leading-relaxed text-muted-foreground">{description}</p>
+        )}
+      </div>
+
+      {/* Children slot (CompactIconBar) */}
+      {children}
+    </div>
+  );
+}

--- a/apps/web/src/components/ui/data-display/meeple-card/__tests__/CartaEstesa.test.tsx
+++ b/apps/web/src/components/ui/data-display/meeple-card/__tests__/CartaEstesa.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from '@testing-library/react';
+import { CartaEstesa } from '../CartaEstesa';
+
+describe('CartaEstesa', () => {
+  const props = {
+    title: 'Catan',
+    subtitle: 'Kosmos • Klaus Teuber • 1995',
+    imageUrl: 'https://example.com/catan.jpg',
+    rating: 7.1,
+    entityColor: '25 95% 45%',
+    stats: [
+      { label: 'Giocatori', value: '3-4', color: '25 95% 45%' },
+      { label: 'Sessioni', value: '12', color: '240 60% 55%' },
+    ],
+    tags: ['Strategy', 'Trading'],
+    description: 'Build settlements and trade resources...',
+  };
+
+  it('renders cover with title and rating', () => {
+    render(<CartaEstesa {...props} />);
+    expect(screen.getByText('Catan')).toBeInTheDocument();
+    expect(screen.getByText('7.1')).toBeInTheDocument();
+  });
+
+  it('renders stats chips', () => {
+    render(<CartaEstesa {...props} />);
+    expect(screen.getByText('3-4')).toBeInTheDocument();
+    expect(screen.getByText('Giocatori')).toBeInTheDocument();
+  });
+
+  it('renders tags', () => {
+    render(<CartaEstesa {...props} />);
+    expect(screen.getByText('Strategy')).toBeInTheDocument();
+    expect(screen.getByText('Trading')).toBeInTheDocument();
+  });
+
+  it('renders description', () => {
+    render(<CartaEstesa {...props} />);
+    expect(screen.getByText(/Build settlements/)).toBeInTheDocument();
+  });
+
+  it('renders children (for icon bar slot)', () => {
+    render(
+      <CartaEstesa {...props}>
+        <div data-testid="icon-bar">bar</div>
+      </CartaEstesa>
+    );
+    expect(screen.getByTestId('icon-bar')).toBeInTheDocument();
+  });
+
+  it('applies card styling with rounded corners', () => {
+    render(<CartaEstesa {...props} />);
+    const card = screen.getByTestId('carta-estesa');
+    expect(card).toHaveClass('rounded-[20px]');
+  });
+});

--- a/apps/web/src/components/ui/data-display/meeple-card/variants/MeepleCardGrid.tsx
+++ b/apps/web/src/components/ui/data-display/meeple-card/variants/MeepleCardGrid.tsx
@@ -13,7 +13,6 @@ import React, { useState } from 'react';
 
 import { cn } from '@/lib/utils';
 
-import { EntityLinkPreviewRow } from '../../entity-link/entity-link-preview-row';
 import { ExtraMeepleCardDrawer } from '../../extra-meeple-card/ExtraMeepleCardDrawer';
 import { AgentModelInfo } from '../../meeple-card-features/AgentModelInfo';
 import { AgentStatsDisplay } from '../../meeple-card-features/AgentStatsDisplay';
@@ -485,16 +484,6 @@ export const MeepleCardGrid = React.memo(function MeepleCardGrid(props: MeepleCa
 
       {/* Navigation footer */}
       {navigateTo && navigateTo.length > 0 && <CardNavigationFooter links={navigateTo} />}
-
-      {/* EntityLink preview row */}
-      {firstLinkPreview && linkCount !== undefined && linkCount > 0 && (
-        <EntityLinkPreviewRow
-          linkType={firstLinkPreview.linkType}
-          targetName={firstLinkPreview.targetName}
-          totalCount={linkCount}
-          onClick={onLinksClick}
-        />
-      )}
 
       {/* Drawer */}
       {entityId && drawerEntityType && (

--- a/apps/web/src/components/ui/data-display/meeple-card/variants/MeepleCardGrid.tsx
+++ b/apps/web/src/components/ui/data-display/meeple-card/variants/MeepleCardGrid.tsx
@@ -115,7 +115,7 @@ export const MeepleCardGrid = React.memo(function MeepleCardGrid(props: MeepleCa
     onTimeTravelToggle,
     documentStatus,
     linkCount,
-    firstLinkPreview,
+    firstLinkPreview: _firstLinkPreview,
     onLinksClick,
     kbCards,
   } = props;

--- a/apps/web/src/stores/use-card-hand.ts
+++ b/apps/web/src/stores/use-card-hand.ts
@@ -1,0 +1,257 @@
+'use client';
+
+import { create } from 'zustand';
+
+import type { MeepleEntityType } from '@/components/ui/data-display/meeple-card';
+
+export interface HandCard {
+  id: string;
+  entity: MeepleEntityType;
+  title: string;
+  href: string;
+  subtitle?: string;
+  imageUrl?: string;
+}
+
+const MAX_HAND_SIZE = 10;
+const STORAGE_KEY = 'meeple-card-hand';
+const PINS_KEY = 'meeple-card-pins';
+const EXPANDED_KEY = 'meeple-card-stack-expanded';
+const HAND_COLLAPSED_KEY = 'meeple-hand-collapsed';
+
+// ---------------------------------------------------------------------------
+// sessionStorage helpers
+// ---------------------------------------------------------------------------
+
+function readCards(): HandCard[] {
+  if (typeof window === 'undefined') return [];
+  try {
+    const raw = sessionStorage.getItem(STORAGE_KEY);
+    return raw ? (JSON.parse(raw) as HandCard[]) : [];
+  } catch {
+    return [];
+  }
+}
+
+function writeCards(cards: HandCard[]): void {
+  if (typeof window === 'undefined') return;
+  try {
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(cards));
+  } catch {
+    /* full or unavailable */
+  }
+  window.dispatchEvent(new Event('card-hand-change'));
+}
+
+function readPins(): Set<string> {
+  if (typeof window === 'undefined') return new Set();
+  try {
+    const raw = localStorage.getItem(PINS_KEY);
+    return raw ? new Set(JSON.parse(raw) as string[]) : new Set();
+  } catch {
+    return new Set();
+  }
+}
+
+function writePins(pins: Set<string>): void {
+  if (typeof window === 'undefined') return;
+  try {
+    localStorage.setItem(PINS_KEY, JSON.stringify([...pins]));
+  } catch {
+    /* ignore */
+  }
+}
+
+function readExpanded(): boolean {
+  if (typeof window === 'undefined') return false;
+  return localStorage.getItem(EXPANDED_KEY) === 'true';
+}
+
+function writeExpanded(expanded: boolean): void {
+  if (typeof window === 'undefined') return;
+  localStorage.setItem(EXPANDED_KEY, String(expanded));
+}
+
+function readHandCollapsed(): boolean {
+  if (typeof window === 'undefined') return false;
+  return localStorage.getItem(HAND_COLLAPSED_KEY) === 'true';
+}
+
+function writeHandCollapsed(collapsed: boolean): void {
+  if (typeof window === 'undefined') return;
+  localStorage.setItem(HAND_COLLAPSED_KEY, String(collapsed));
+}
+
+// ---------------------------------------------------------------------------
+// Store
+// ---------------------------------------------------------------------------
+
+interface CardHandState {
+  cards: HandCard[];
+  focusedIdx: number;
+  pinnedIds: Set<string>;
+  maxHandSize: number;
+  context: 'user' | 'admin';
+  expandedStack: boolean;
+  isHandCollapsed: boolean;
+  highlightEntity: MeepleEntityType | null;
+
+  drawCard: (card: HandCard) => void;
+  discardCard: (id: string) => void;
+  focusCard: (index: number) => void;
+  focusByHref: (href: string) => void;
+  pinCard: (id: string) => void;
+  unpinCard: (id: string) => void;
+  swipeNext: () => void;
+  swipePrev: () => void;
+  toggleContext: () => void;
+  toggleExpandStack: () => void;
+  collapseHand: () => void;
+  expandHand: () => void;
+  setHighlightEntity: (entity: MeepleEntityType | null) => void;
+  clear: () => void;
+}
+
+export const useCardHand = create<CardHandState>((set, get) => ({
+  cards: readCards(),
+  focusedIdx: -1,
+  pinnedIds: readPins(),
+  maxHandSize: MAX_HAND_SIZE,
+  context: 'user',
+  expandedStack: readExpanded(),
+  isHandCollapsed: readHandCollapsed(),
+  highlightEntity: null,
+
+  drawCard: card => {
+    const { cards, pinnedIds, maxHandSize } = get();
+
+    // Duplicate check — focus existing card
+    const existingIdx = cards.findIndex(c => c.id === card.id);
+    if (existingIdx >= 0) {
+      set({ focusedIdx: existingIdx });
+      return;
+    }
+
+    let next = [...cards, card];
+
+    // FIFO eviction if over limit
+    if (next.length > maxHandSize) {
+      const evictIdx = next.findIndex(c => !pinnedIds.has(c.id));
+      if (evictIdx >= 0) {
+        next = [...next.slice(0, evictIdx), ...next.slice(evictIdx + 1)];
+      } else {
+        // All cards pinned — drop the oldest pinned (edge case)
+        next = next.slice(1);
+      }
+    }
+
+    writeCards(next);
+    set({ cards: next, focusedIdx: next.length - 1 });
+  },
+
+  discardCard: id => {
+    const { cards, focusedIdx, pinnedIds } = get();
+    const idx = cards.findIndex(c => c.id === id);
+    if (idx === -1) return;
+
+    const next = cards.filter(c => c.id !== id);
+    const newPins = new Set(pinnedIds);
+    newPins.delete(id);
+
+    let newFocused: number;
+    if (next.length === 0) {
+      newFocused = -1;
+    } else if (focusedIdx >= next.length) {
+      newFocused = next.length - 1;
+    } else if (focusedIdx > idx) {
+      newFocused = focusedIdx - 1;
+    } else if (focusedIdx === idx) {
+      // Discarding focused card — move to next (or previous if last)
+      newFocused = Math.min(focusedIdx, next.length - 1);
+    } else {
+      newFocused = focusedIdx;
+    }
+
+    writeCards(next);
+    writePins(newPins);
+    set({ cards: next, focusedIdx: newFocused, pinnedIds: newPins });
+  },
+
+  focusCard: index => {
+    const { cards } = get();
+    if (index >= 0 && index < cards.length) {
+      set({ focusedIdx: index });
+    }
+  },
+
+  focusByHref: href => {
+    const { cards } = get();
+    const idx = cards.findIndex(c => c.href === href);
+    if (idx >= 0) {
+      set({ focusedIdx: idx });
+    }
+  },
+
+  pinCard: id => {
+    const { pinnedIds } = get();
+    const next = new Set(pinnedIds);
+    next.add(id);
+    writePins(next);
+    set({ pinnedIds: next });
+  },
+
+  unpinCard: id => {
+    const { pinnedIds } = get();
+    const next = new Set(pinnedIds);
+    next.delete(id);
+    writePins(next);
+    set({ pinnedIds: next });
+  },
+
+  swipeNext: () => {
+    const { focusedIdx, cards } = get();
+    if (focusedIdx < cards.length - 1) {
+      set({ focusedIdx: focusedIdx + 1 });
+    }
+  },
+
+  swipePrev: () => {
+    const { focusedIdx } = get();
+    if (focusedIdx > 0) {
+      set({ focusedIdx: focusedIdx - 1 });
+    }
+  },
+
+  toggleContext: () => {
+    const { context } = get();
+    set({ context: context === 'user' ? 'admin' : 'user' });
+  },
+
+  toggleExpandStack: () => {
+    const { expandedStack } = get();
+    writeExpanded(!expandedStack);
+    set({ expandedStack: !expandedStack });
+  },
+
+  collapseHand: () => {
+    writeHandCollapsed(true);
+    set({ isHandCollapsed: true });
+  },
+
+  expandHand: () => {
+    writeHandCollapsed(false);
+    set({ isHandCollapsed: false });
+  },
+
+  setHighlightEntity: entity => set({ highlightEntity: entity }),
+
+  clear: () => {
+    const { cards, pinnedIds } = get();
+    const pinned = cards.filter(c => pinnedIds.has(c.id));
+    writeCards(pinned);
+    set({
+      cards: pinned,
+      focusedIdx: pinned.length > 0 ? pinned.length - 1 : -1,
+    });
+  },
+}));


### PR DESCRIPTION
## Summary

- **Hand Drawer** (mobile): horizontal card strip below navbar, shows card thumbnails (36px) with entity-colored focus glow, grip handle for collapse/expand
- **NavbarMiniCards**: when hand collapsed, cards migrate to navbar as 20px mini-icons with 44px WCAG tap targets
- **CartaEstesa**: detail page wrapper rendering entity as expanded card (cover hero + stats + tags + description)
- **CompactIconBar**: toolbar of entity-type icons (36px) with badge counts at card bottom, replaces EntityLinkPreviewRow
- **useCardHand** extended with `isHandCollapsed` / `collapseHand()` / `expandHand()`
- **useEntityLinkGroups**: derived hook grouping EntityLinkDto by targetEntityType

## New Components (7)
- `HandDrawer`, `HandDrawerCard`, `NavbarMiniCards` (layout/UnifiedShell/)
- `CartaEstesa` (meeple-card/)
- `CompactIconBar`, `CompactIconButton`, `useEntityLinkGroups` (entity-link/)

## Modified Components (3)
- `AppShellClient` — HandDrawer between navbar and content on mobile
- `TopNavbar` — accepts miniCards slot for collapsed hand
- `MeepleCardGrid` — removed EntityLinkPreviewRow from footer

## Tests
- 40+ new tests (unit + integration)
- 15 integration tests for full draw/focus/collapse/FIFO flow
- All 16,480 existing tests pass

## Test plan
- [ ] Verify hand drawer appears on first card draw (mobile viewport)
- [ ] Verify collapse migrates cards to navbar mini-icons
- [ ] Verify CartaEstesa renders game detail with cover, stats, tags
- [ ] Verify CompactIconBar shows linked entity icons with counts
- [ ] Verify admin toggle hides hand drawer
- [ ] Verify desktop shows vertical CardStack (unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)