### PR TITLE
test(e2e): admin-user onboarding flow E2E test suite

### DIFF
--- a/apps/web/e2e/fixtures/onboarding-flow.fixture.ts
+++ b/apps/web/e2e/fixtures/onboarding-flow.fixture.ts
@@ -1,0 +1,47 @@
+import { test as base, type Page, type BrowserContext } from '@playwright/test';
+
+import { env } from '../helpers/onboarding-environment';
+import { LoginPage } from '../pages/auth/LoginPage';
+
+export interface OnboardingFlowState {
+  adminPage: Page;
+  adminContext: BrowserContext;
+  adminCredentials: { email: string; password: string };
+  invitationToken: string;
+  invitationUrl: string;
+  testUserEmail: string;
+  userPassword: string;
+  userPage: Page;
+  userContext: BrowserContext;
+  testUserId: string;
+  gameId: string;
+  gameTitle: string;
+  agentId: string;
+  gameSessionId: string;
+}
+
+export const sharedState: Partial<OnboardingFlowState> = {};
+
+export async function ensureAdminAuth(page: Page): Promise<void> {
+  const response = await page.request.get(`${env.apiURL}/api/v1/auth/me`);
+
+  if (response.status() === 401) {
+    const loginPage = new LoginPage(page);
+    await loginPage.goto();
+    await loginPage.login(
+      sharedState.adminCredentials!.email,
+      sharedState.adminCredentials!.password
+    );
+    await page.waitForURL('**/admin/**', { timeout: 10_000 });
+  }
+}
+
+export const test = base.extend<{
+  onboardingState: Partial<OnboardingFlowState>;
+}>({
+  onboardingState: async ({}, use) => {
+    await use(sharedState);
+  },
+});
+
+export { expect } from '@playwright/test';

--- a/apps/web/e2e/fixtures/onboarding-flow.fixture.ts
+++ b/apps/web/e2e/fixtures/onboarding-flow.fixture.ts
@@ -20,28 +20,19 @@ export interface OnboardingFlowState {
   gameSessionId: string;
 }
 
-export const sharedState: Partial<OnboardingFlowState> = {};
-
-export async function ensureAdminAuth(page: Page): Promise<void> {
+export async function ensureAdminAuth(
+  page: Page,
+  credentials: { email: string; password: string }
+): Promise<void> {
   const response = await page.request.get(`${env.apiURL}/api/v1/auth/me`);
 
   if (response.status() === 401) {
     const loginPage = new LoginPage(page);
     await loginPage.goto();
-    await loginPage.login(
-      sharedState.adminCredentials!.email,
-      sharedState.adminCredentials!.password
-    );
+    await loginPage.login(credentials.email, credentials.password);
     await page.waitForURL('**/admin/**', { timeout: 10_000 });
   }
 }
 
-export const test = base.extend<{
-  onboardingState: Partial<OnboardingFlowState>;
-}>({
-  onboardingState: async ({}, use) => {
-    await use(sharedState);
-  },
-});
-
+export const test = base;
 export { expect } from '@playwright/test';

--- a/apps/web/e2e/flows/admin-user-onboarding.spec.ts
+++ b/apps/web/e2e/flows/admin-user-onboarding.spec.ts
@@ -1,4 +1,5 @@
-import { test, expect, sharedState, ensureAdminAuth } from '../fixtures/onboarding-flow.fixture';
+import { test, expect, ensureAdminAuth } from '../fixtures/onboarding-flow.fixture';
+import { type OnboardingFlowState } from '../fixtures/onboarding-flow.fixture';
 import { extractInvitation } from '../helpers/email-strategy';
 import { cleanupOnboardingTest } from '../helpers/onboarding-cleanup';
 import { env } from '../helpers/onboarding-environment';
@@ -20,20 +21,22 @@ const testUserPassword = `E2eTest!${timestamp}`;
 test.describe.configure({ mode: 'serial' });
 
 test.describe('Admin-User Onboarding Flow', () => {
-  test.afterAll(async ({ browser }) => {
-    if (sharedState.adminPage) {
+  const state: Partial<OnboardingFlowState> = {};
+
+  test.afterAll(async () => {
+    if (state.adminPage) {
       try {
-        await cleanupOnboardingTest(sharedState.adminPage.request, {
-          testUserId: sharedState.testUserId,
-          agentId: sharedState.agentId,
+        await cleanupOnboardingTest(state.adminPage.request, {
+          testUserId: state.testUserId,
+          agentId: state.agentId,
         });
       } catch (e) {
         console.warn('Cleanup failed (orphaned test data may remain):', e);
       }
     }
 
-    if (sharedState.userContext) await sharedState.userContext.close();
-    if (sharedState.adminContext) await sharedState.adminContext.close();
+    if (state.userContext) await state.userContext.close();
+    if (state.adminContext) await state.adminContext.close();
   });
 
   // ── Test 1: Admin Login ──────────────────────────────────────
@@ -53,25 +56,24 @@ test.describe('Admin-User Onboarding Flow', () => {
         { timeout: 15_000 }
       );
 
-      // Verify admin display name visible in navbar
       const userInfo = adminPage
         .locator('[data-testid="user-display-name"], [data-testid="navbar-user"]')
         .or(adminPage.getByText(env.admin.email));
       await expect(userInfo).toBeVisible({ timeout: 5_000 });
 
-      // Verify no error toasts
       const errorToast = adminPage.locator('[data-testid="toast-error"], .toast-error');
       await expect(errorToast).not.toBeVisible();
     });
 
-    sharedState.adminPage = adminPage;
-    sharedState.adminContext = adminContext;
-    sharedState.adminCredentials = env.admin;
+    state.adminPage = adminPage;
+    state.adminContext = adminContext;
+    state.adminCredentials = env.admin;
   });
 
   // ── Test 2: Admin Invites User ───────────────────────────────
   test('2. Admin invites user via email', async () => {
-    const page = sharedState.adminPage!;
+    if (!state.adminPage) test.skip(true, 'Requires test 1 to pass');
+    const page = state.adminPage!;
     const adminUsersPage = new AdminUsersPage(page);
 
     await test.step('Open invite dialog', async () => {
@@ -87,25 +89,26 @@ test.describe('Admin-User Onboarding Flow', () => {
 
     await test.step('Extract invitation token/URL', async () => {
       const result = await extractInvitation(page, testUserEmail);
-      sharedState.invitationToken = result.invitationToken;
-      sharedState.invitationUrl = result.invitationUrl;
-      sharedState.testUserEmail = testUserEmail;
+      state.invitationToken = result.invitationToken;
+      state.invitationUrl = result.invitationUrl;
+      state.testUserEmail = testUserEmail;
     });
 
-    expect(sharedState.invitationToken).toBeTruthy();
+    expect(state.invitationToken).toBeTruthy();
   });
 
   // ── Test 3: User Accepts Invitation ──────────────────────────
   test('3. User accepts invitation and sets password', async ({ browser }) => {
+    if (!state.invitationToken) test.skip(true, 'Requires test 2 to pass');
     const userContext = await browser.newContext();
     const userPage = await userContext.newPage();
     const acceptPage = new AcceptInvitePage(userPage);
 
     await test.step('Navigate to accept-invite page', async () => {
       if (env.email.strategy === 'mailosaur') {
-        await acceptPage.gotoUrl(sharedState.invitationUrl!);
+        await acceptPage.gotoUrl(state.invitationUrl!);
       } else {
-        await acceptPage.gotoWithToken(sharedState.invitationToken!);
+        await acceptPage.gotoWithToken(state.invitationToken!);
       }
     });
 
@@ -119,14 +122,15 @@ test.describe('Admin-User Onboarding Flow', () => {
       await acceptPage.waitForRedirectToOnboarding();
     });
 
-    sharedState.userPassword = testUserPassword;
-    sharedState.userPage = userPage;
-    sharedState.userContext = userContext;
+    state.userPassword = testUserPassword;
+    state.userPage = userPage;
+    state.userContext = userContext;
   });
 
   // ── Test 4: User Logs In ─────────────────────────────────────
   test('4. User logs in with new password', async () => {
-    const page = sharedState.userPage!;
+    if (!state.userPage) test.skip(true, 'Requires test 3 to pass');
+    const page = state.userPage!;
     const loginPage = new LoginPage(page);
 
     await test.step('Navigate to login and authenticate', async () => {
@@ -152,7 +156,7 @@ test.describe('Admin-User Onboarding Flow', () => {
         const meResponse = await page.request.get(`${env.apiURL}/api/v1/auth/me`);
         if (meResponse.ok()) {
           const meData = await meResponse.json();
-          sharedState.testUserId = meData.id ?? meData.userId ?? '';
+          state.testUserId = meData.id ?? meData.userId ?? '';
         }
       } catch {
         console.warn('Could not capture testUserId from /auth/me');
@@ -162,7 +166,8 @@ test.describe('Admin-User Onboarding Flow', () => {
 
   // ── Test 5: User Adds Game to Collection ─────────────────────
   test('5. User adds game to collection', async () => {
-    const page = sharedState.userPage!;
+    if (!state.userPage) test.skip(true, 'Requires test 4 to pass');
+    const page = state.userPage!;
     const libraryPage = new LibraryPage(page);
 
     await test.step('Navigate to library', async () => {
@@ -181,19 +186,20 @@ test.describe('Admin-User Onboarding Flow', () => {
         );
       }
 
-      sharedState.gameId = gameId;
-      sharedState.gameTitle = gameTitle || env.seedGameName;
+      state.gameId = gameId;
+      state.gameTitle = gameTitle || env.seedGameName;
     });
 
     await test.step('Confirm and verify', async () => {
       await libraryPage.confirmAddToCollection();
-      await libraryPage.verifyGameInCollection(sharedState.gameTitle!);
+      await libraryPage.verifyGameInCollection(state.gameTitle!);
     });
   });
 
   // ── Test 6: User Creates Agent ───────────────────────────────
   test('6. User creates agent for the game', async () => {
-    const page = sharedState.userPage!;
+    if (!state.userPage || !state.gameTitle) test.skip(true, 'Requires test 5 to pass');
+    const page = state.userPage!;
     const agentPage = new AgentCreationPage(page);
 
     await test.step('Open agent creation', async () => {
@@ -202,17 +208,17 @@ test.describe('Admin-User Onboarding Flow', () => {
     });
 
     await test.step('Configure agent', async () => {
-      await agentPage.selectGame(sharedState.gameTitle!);
+      await agentPage.selectGame(state.gameTitle!);
       await agentPage.selectStrategy('Tutor');
       await agentPage.selectFreeTier();
     });
 
     await test.step('Submit and capture IDs', async () => {
       const result = await agentPage.submitCreation();
-      sharedState.agentId = result.agentId;
-      sharedState.gameSessionId = result.gameSessionId;
+      state.agentId = result.agentId;
+      state.gameSessionId = result.gameSessionId;
 
-      expect(sharedState.agentId).toBeTruthy();
+      expect(state.agentId).toBeTruthy();
     });
 
     await test.step('Wait for agent ready', async () => {
@@ -222,15 +228,16 @@ test.describe('Admin-User Onboarding Flow', () => {
 
   // ── Test 7: User Chats with Agent ────────────────────────────
   test('7. User asks agent about game scope and turn', async () => {
-    const page = sharedState.userPage!;
+    if (!state.userPage || !state.agentId) test.skip(true, 'Requires test 6 to pass');
+    const page = state.userPage!;
     const chatPage = new AgentChatPage(page);
 
     await test.step('Open chat with agent', async () => {
-      await chatPage.navigateToChat(sharedState.agentId!);
+      await chatPage.navigateToChat(state.agentId!);
     });
 
     await test.step('Send question and wait for response', async () => {
-      const gameTitle = sharedState.gameTitle!;
+      const gameTitle = state.gameTitle!;
       await chatPage.sendMessage(
         `Qual è lo scopo del gioco ${gameTitle}? Descrivimi un turno di gioco.`
       );
@@ -243,9 +250,10 @@ test.describe('Admin-User Onboarding Flow', () => {
 
   // ── Test 8: Admin Changes Role & Checks Audit Log ────────────
   test('8. Admin changes user role and verifies audit log', async () => {
-    const page = sharedState.adminPage!;
+    if (!state.adminPage || !state.testUserEmail) test.skip(true, 'Requires tests 1-2 to pass');
+    const page = state.adminPage!;
 
-    await ensureAdminAuth(page);
+    await ensureAdminAuth(page, state.adminCredentials!);
 
     const adminUsersPage = new AdminUsersPage(page);
     const auditLogPage = new AuditLogPage(page);

--- a/apps/web/e2e/flows/admin-user-onboarding.spec.ts
+++ b/apps/web/e2e/flows/admin-user-onboarding.spec.ts
@@ -1,0 +1,270 @@
+import { test, expect, sharedState, ensureAdminAuth } from '../fixtures/onboarding-flow.fixture';
+import { extractInvitation } from '../helpers/email-strategy';
+import { cleanupOnboardingTest } from '../helpers/onboarding-cleanup';
+import { env } from '../helpers/onboarding-environment';
+import { AdminUsersPage } from '../pages/admin/AdminUsersPage';
+import { AuditLogPage } from '../pages/admin/AuditLogPage';
+import { AgentChatPage } from '../pages/agent/AgentChatPage';
+import { AgentCreationPage } from '../pages/agent/AgentCreationPage';
+import { AcceptInvitePage } from '../pages/auth/AcceptInvitePage';
+import { LoginPage } from '../pages/auth/LoginPage';
+import { LibraryPage } from '../pages/library/LibraryPage';
+
+const timestamp = Date.now();
+const testUserEmail =
+  env.email.strategy === 'mailosaur'
+    ? `e2e-onboarding-${timestamp}@${env.email.mailosaurServerId}.mailosaur.net`
+    : `e2e-onboarding-${timestamp}@test.local`;
+const testUserPassword = `E2eTest!${timestamp}`;
+
+test.describe.configure({ mode: 'serial' });
+
+test.describe('Admin-User Onboarding Flow', () => {
+  test.afterAll(async ({ browser }) => {
+    if (sharedState.adminPage) {
+      try {
+        await cleanupOnboardingTest(sharedState.adminPage.request, {
+          testUserId: sharedState.testUserId,
+          agentId: sharedState.agentId,
+        });
+      } catch (e) {
+        console.warn('Cleanup failed (orphaned test data may remain):', e);
+      }
+    }
+
+    if (sharedState.userContext) await sharedState.userContext.close();
+    if (sharedState.adminContext) await sharedState.adminContext.close();
+  });
+
+  // ── Test 1: Admin Login ──────────────────────────────────────
+  test('1. Admin logs in', async ({ browser }) => {
+    const adminContext = await browser.newContext();
+    const adminPage = await adminContext.newPage();
+
+    await test.step('Navigate to login', async () => {
+      const loginPage = new LoginPage(adminPage);
+      await loginPage.goto();
+      await loginPage.login(env.admin.email, env.admin.password);
+    });
+
+    await test.step('Verify admin dashboard', async () => {
+      await adminPage.waitForURL(
+        url => url.pathname.includes('/admin') || url.pathname.includes('/dashboard'),
+        { timeout: 15_000 }
+      );
+
+      // Verify admin display name visible in navbar
+      const userInfo = adminPage
+        .locator('[data-testid="user-display-name"], [data-testid="navbar-user"]')
+        .or(adminPage.getByText(env.admin.email));
+      await expect(userInfo).toBeVisible({ timeout: 5_000 });
+
+      // Verify no error toasts
+      const errorToast = adminPage.locator('[data-testid="toast-error"], .toast-error');
+      await expect(errorToast).not.toBeVisible();
+    });
+
+    sharedState.adminPage = adminPage;
+    sharedState.adminContext = adminContext;
+    sharedState.adminCredentials = env.admin;
+  });
+
+  // ── Test 2: Admin Invites User ───────────────────────────────
+  test('2. Admin invites user via email', async () => {
+    const page = sharedState.adminPage!;
+    const adminUsersPage = new AdminUsersPage(page);
+
+    await test.step('Open invite dialog', async () => {
+      await adminUsersPage.goto();
+      await adminUsersPage.clickInviteButton();
+    });
+
+    await test.step('Fill and send invitation', async () => {
+      await adminUsersPage.fillInvitationForm(testUserEmail, 'user');
+      await adminUsersPage.submitInvitation();
+      await adminUsersPage.waitForNetworkIdle();
+    });
+
+    await test.step('Extract invitation token/URL', async () => {
+      const result = await extractInvitation(page, testUserEmail);
+      sharedState.invitationToken = result.invitationToken;
+      sharedState.invitationUrl = result.invitationUrl;
+      sharedState.testUserEmail = testUserEmail;
+    });
+
+    expect(sharedState.invitationToken).toBeTruthy();
+  });
+
+  // ── Test 3: User Accepts Invitation ──────────────────────────
+  test('3. User accepts invitation and sets password', async ({ browser }) => {
+    const userContext = await browser.newContext();
+    const userPage = await userContext.newPage();
+    const acceptPage = new AcceptInvitePage(userPage);
+
+    await test.step('Navigate to accept-invite page', async () => {
+      if (env.email.strategy === 'mailosaur') {
+        await acceptPage.gotoUrl(sharedState.invitationUrl!);
+      } else {
+        await acceptPage.gotoWithToken(sharedState.invitationToken!);
+      }
+    });
+
+    await test.step('Set password', async () => {
+      await acceptPage.setPassword(testUserPassword);
+      await acceptPage.verifyStrengthIndicator('Strong');
+    });
+
+    await test.step('Submit and wait for redirect', async () => {
+      await acceptPage.submit();
+      await acceptPage.waitForRedirectToOnboarding();
+    });
+
+    sharedState.userPassword = testUserPassword;
+    sharedState.userPage = userPage;
+    sharedState.userContext = userContext;
+  });
+
+  // ── Test 4: User Logs In ─────────────────────────────────────
+  test('4. User logs in with new password', async () => {
+    const page = sharedState.userPage!;
+    const loginPage = new LoginPage(page);
+
+    await test.step('Navigate to login and authenticate', async () => {
+      await loginPage.goto();
+      await loginPage.login(testUserEmail, testUserPassword);
+    });
+
+    await test.step('Verify dashboard redirect', async () => {
+      await page.waitForURL(
+        url =>
+          url.pathname.includes('/dashboard') ||
+          url.pathname.includes('/library') ||
+          url.pathname.includes('/'),
+        { timeout: 15_000 }
+      );
+
+      const errorToast = page.locator('[data-testid="toast-error"], .toast-error');
+      await expect(errorToast).not.toBeVisible();
+    });
+
+    await test.step('Capture user ID', async () => {
+      try {
+        const meResponse = await page.request.get(`${env.apiURL}/api/v1/auth/me`);
+        if (meResponse.ok()) {
+          const meData = await meResponse.json();
+          sharedState.testUserId = meData.id ?? meData.userId ?? '';
+        }
+      } catch {
+        console.warn('Could not capture testUserId from /auth/me');
+      }
+    });
+  });
+
+  // ── Test 5: User Adds Game to Collection ─────────────────────
+  test('5. User adds game to collection', async () => {
+    const page = sharedState.userPage!;
+    const libraryPage = new LibraryPage(page);
+
+    await test.step('Navigate to library', async () => {
+      await libraryPage.goto();
+    });
+
+    await test.step('Search and add game', async () => {
+      await libraryPage.clickAddGame();
+      await libraryPage.searchGame(env.seedGameName);
+
+      const { gameId, gameTitle } = await libraryPage.selectFirstSearchResult();
+
+      if (!gameId && env.name === 'local') {
+        throw new Error(
+          `Seed game "${env.seedGameName}" not found. Ensure DB is seeded via: dotnet ef database update`
+        );
+      }
+
+      sharedState.gameId = gameId;
+      sharedState.gameTitle = gameTitle || env.seedGameName;
+    });
+
+    await test.step('Confirm and verify', async () => {
+      await libraryPage.confirmAddToCollection();
+      await libraryPage.verifyGameInCollection(sharedState.gameTitle!);
+    });
+  });
+
+  // ── Test 6: User Creates Agent ───────────────────────────────
+  test('6. User creates agent for the game', async () => {
+    const page = sharedState.userPage!;
+    const agentPage = new AgentCreationPage(page);
+
+    await test.step('Open agent creation', async () => {
+      await agentPage.goto();
+      await agentPage.openCreationSheet();
+    });
+
+    await test.step('Configure agent', async () => {
+      await agentPage.selectGame(sharedState.gameTitle!);
+      await agentPage.selectStrategy('Tutor');
+      await agentPage.selectFreeTier();
+    });
+
+    await test.step('Submit and capture IDs', async () => {
+      const result = await agentPage.submitCreation();
+      sharedState.agentId = result.agentId;
+      sharedState.gameSessionId = result.gameSessionId;
+
+      expect(sharedState.agentId).toBeTruthy();
+    });
+
+    await test.step('Wait for agent ready', async () => {
+      await agentPage.waitForAgentReady(env.timeouts.agentReady);
+    });
+  });
+
+  // ── Test 7: User Chats with Agent ────────────────────────────
+  test('7. User asks agent about game scope and turn', async () => {
+    const page = sharedState.userPage!;
+    const chatPage = new AgentChatPage(page);
+
+    await test.step('Open chat with agent', async () => {
+      await chatPage.navigateToChat(sharedState.agentId!);
+    });
+
+    await test.step('Send question and wait for response', async () => {
+      const gameTitle = sharedState.gameTitle!;
+      await chatPage.sendMessage(
+        `Qual è lo scopo del gioco ${gameTitle}? Descrivimi un turno di gioco.`
+      );
+
+      const responseText = await chatPage.waitForAgentResponse(env.timeouts.chatResponse);
+
+      await chatPage.verifyResponseIsValid(responseText);
+    });
+  });
+
+  // ── Test 8: Admin Changes Role & Checks Audit Log ────────────
+  test('8. Admin changes user role and verifies audit log', async () => {
+    const page = sharedState.adminPage!;
+
+    await ensureAdminAuth(page);
+
+    const adminUsersPage = new AdminUsersPage(page);
+    const auditLogPage = new AuditLogPage(page);
+
+    await test.step('Change user role to editor', async () => {
+      await adminUsersPage.goto();
+      await adminUsersPage.changeUserRole(testUserEmail, 'editor');
+      await adminUsersPage.waitForNetworkIdle();
+    });
+
+    await test.step('Verify role changed in UI', async () => {
+      await adminUsersPage.verifyUserRole(testUserEmail, 'editor');
+    });
+
+    await test.step('Verify audit log entry', async () => {
+      await auditLogPage.goto();
+      await auditLogPage.verifyRoleChangeEntry(testUserEmail, {
+        newRole: 'editor',
+      });
+    });
+  });
+});

--- a/apps/web/e2e/helpers/email-strategy.ts
+++ b/apps/web/e2e/helpers/email-strategy.ts
@@ -1,0 +1,71 @@
+import { type Page } from '@playwright/test';
+
+import { env } from './onboarding-environment';
+
+export interface InvitationResult {
+  invitationToken: string;
+  invitationUrl: string;
+}
+
+async function extractInvitationLocal(page: Page, apiURL: string): Promise<InvitationResult> {
+  const response = await page.request.get(
+    `${apiURL}/api/v1/admin/users/invitations?pageSize=1&sortBy=createdAt&sortDirection=desc`
+  );
+
+  if (!response.ok()) {
+    throw new Error(`Failed to fetch invitations: ${response.status()}`);
+  }
+
+  const data = await response.json();
+  const invitation = data.items?.[0] ?? data[0];
+
+  if (!invitation) {
+    throw new Error('No invitation found after sending invite');
+  }
+
+  const token = invitation.token ?? invitation.id;
+  return {
+    invitationToken: token,
+    invitationUrl: `${env.baseURL}/accept-invite?token=${token}`,
+  };
+}
+
+async function extractInvitationMailosaur(testUserEmail: string): Promise<InvitationResult> {
+  const Mailosaur = (await import('mailosaur')).default;
+  const client = new Mailosaur(env.email.mailosaurApiKey!);
+
+  const message = await client.messages.get(
+    env.email.mailosaurServerId!,
+    { sentTo: testUserEmail },
+    { timeout: env.timeouts.email }
+  );
+
+  const html = message.html?.body ?? '';
+  const linkMatch = html.match(/href="([^"]*accept-invite[^"]*)"/);
+
+  if (!linkMatch) {
+    throw new Error('No accept-invite link found in invitation email');
+  }
+
+  const invitationUrl = linkMatch[1];
+  const tokenMatch = invitationUrl.match(/token=([^&"]+)/);
+
+  if (!tokenMatch) {
+    throw new Error('No token found in invitation URL');
+  }
+
+  return {
+    invitationToken: tokenMatch[1],
+    invitationUrl,
+  };
+}
+
+export async function extractInvitation(
+  page: Page,
+  testUserEmail: string
+): Promise<InvitationResult> {
+  if (env.email.strategy === 'mailosaur') {
+    return extractInvitationMailosaur(testUserEmail);
+  }
+  return extractInvitationLocal(page, env.apiURL);
+}

--- a/apps/web/e2e/helpers/onboarding-cleanup.ts
+++ b/apps/web/e2e/helpers/onboarding-cleanup.ts
@@ -1,0 +1,31 @@
+import { type APIRequestContext } from '@playwright/test';
+
+import { env } from './onboarding-environment';
+
+export interface CleanupState {
+  testUserId?: string;
+  agentId?: string;
+}
+
+export async function cleanupOnboardingTest(
+  request: APIRequestContext,
+  state: CleanupState
+): Promise<void> {
+  const apiURL = env.apiURL;
+
+  if (state.agentId) {
+    try {
+      await request.delete(`${apiURL}/api/v1/agents/${state.agentId}`);
+    } catch (e) {
+      console.warn(`Cleanup: failed to delete agent ${state.agentId}`, e);
+    }
+  }
+
+  if (state.testUserId) {
+    try {
+      await request.delete(`${apiURL}/api/v1/admin/users/${state.testUserId}`);
+    } catch (e) {
+      console.warn(`Cleanup: failed to delete user ${state.testUserId}`, e);
+    }
+  }
+}

--- a/apps/web/e2e/helpers/onboarding-environment.ts
+++ b/apps/web/e2e/helpers/onboarding-environment.ts
@@ -44,7 +44,7 @@ function resolveEnvironment(): OnboardingEnvironment {
     apiURL: 'http://localhost:8080',
     admin: {
       email: process.env.E2E_ADMIN_EMAIL ?? 'admin@meepleai.dev',
-      password: process.env.E2E_ADMIN_PASSWORD ?? 'pVKOMQNK0tFNgGlX',
+      password: process.env.E2E_ADMIN_PASSWORD ?? 'changeme', // Set E2E_ADMIN_PASSWORD env var
     },
     email: { strategy: 'api-intercept' },
     seedGameName: 'Pandemic',

--- a/apps/web/e2e/helpers/onboarding-environment.ts
+++ b/apps/web/e2e/helpers/onboarding-environment.ts
@@ -1,0 +1,55 @@
+export interface OnboardingEnvironment {
+  name: 'local' | 'staging';
+  baseURL: string;
+  apiURL: string;
+  admin: { email: string; password: string };
+  email: {
+    strategy: 'api-intercept' | 'mailosaur';
+    mailosaurApiKey?: string;
+    mailosaurServerId?: string;
+  };
+  seedGameName: string;
+  timeouts: {
+    email: number;
+    agentReady: number;
+    chatResponse: number;
+  };
+}
+
+function resolveEnvironment(): OnboardingEnvironment {
+  const isStaging = process.env.E2E_ENV === 'staging';
+
+  if (isStaging) {
+    return {
+      name: 'staging',
+      baseURL: 'https://meepleai.app',
+      apiURL: 'https://api.meepleai.app',
+      admin: {
+        email: process.env.E2E_ADMIN_EMAIL!,
+        password: process.env.E2E_ADMIN_PASSWORD!,
+      },
+      email: {
+        strategy: 'mailosaur',
+        mailosaurApiKey: process.env.E2E_MAILOSAUR_API_KEY!,
+        mailosaurServerId: process.env.E2E_MAILOSAUR_SERVER_ID!,
+      },
+      seedGameName: 'Catan',
+      timeouts: { email: 30_000, agentReady: 30_000, chatResponse: 60_000 },
+    };
+  }
+
+  return {
+    name: 'local',
+    baseURL: 'http://localhost:3000',
+    apiURL: 'http://localhost:8080',
+    admin: {
+      email: process.env.E2E_ADMIN_EMAIL ?? 'admin@meepleai.dev',
+      password: process.env.E2E_ADMIN_PASSWORD ?? 'pVKOMQNK0tFNgGlX',
+    },
+    email: { strategy: 'api-intercept' },
+    seedGameName: 'Pandemic',
+    timeouts: { email: 5_000, agentReady: 30_000, chatResponse: 60_000 },
+  };
+}
+
+export const env = resolveEnvironment();

--- a/apps/web/e2e/pages/admin/AdminUsersPage.ts
+++ b/apps/web/e2e/pages/admin/AdminUsersPage.ts
@@ -26,7 +26,8 @@ export class AdminUsersPage extends BasePage {
       .locator('[data-testid="invite-role-select"]')
       .or(this.page.getByLabel(/role/i));
     if (await roleSelect.isVisible()) {
-      await roleSelect.selectOption(role);
+      await roleSelect.click();
+      await this.page.getByRole('option', { name: new RegExp(role, 'i') }).click();
     }
   }
 

--- a/apps/web/e2e/pages/admin/AdminUsersPage.ts
+++ b/apps/web/e2e/pages/admin/AdminUsersPage.ts
@@ -1,0 +1,60 @@
+import { type Page, expect } from '@playwright/test';
+
+import { BasePage } from '../base/BasePage';
+
+export class AdminUsersPage extends BasePage {
+  constructor(page: Page) {
+    super(page);
+  }
+
+  async goto(): Promise<void> {
+    await this.page.goto('/admin/users');
+    await this.waitForLoad();
+  }
+
+  async clickInviteButton(): Promise<void> {
+    await this.click(
+      this.page
+        .locator('[data-testid="invite-user-button"]')
+        .or(this.page.getByRole('button', { name: /invite/i }))
+    );
+  }
+
+  async fillInvitationForm(email: string, role: string = 'user'): Promise<void> {
+    await this.fill(this.page.getByLabel(/email/i), email);
+    const roleSelect = this.page
+      .locator('[data-testid="invite-role-select"]')
+      .or(this.page.getByLabel(/role/i));
+    if (await roleSelect.isVisible()) {
+      await roleSelect.selectOption(role);
+    }
+  }
+
+  async submitInvitation(): Promise<void> {
+    await this.click(
+      this.page
+        .locator('[data-testid="send-invitation-button"]')
+        .or(this.page.getByRole('button', { name: /send invitation|invite/i }))
+    );
+  }
+
+  async findUserRow(email: string): Promise<ReturnType<Page['locator']>> {
+    return this.page.locator(`tr, [data-testid="user-row"]`).filter({
+      hasText: email,
+    });
+  }
+
+  async changeUserRole(email: string, newRole: string): Promise<void> {
+    const userRow = await this.findUserRow(email);
+    const roleSelect = userRow
+      .locator('[data-testid="inline-role-select"]')
+      .or(userRow.getByRole('combobox'));
+    await roleSelect.click();
+    await this.page.getByRole('option', { name: new RegExp(newRole, 'i') }).click();
+  }
+
+  async verifyUserRole(email: string, expectedRole: string): Promise<void> {
+    const userRow = await this.findUserRow(email);
+    await expect(userRow).toContainText(new RegExp(expectedRole, 'i'));
+  }
+}

--- a/apps/web/e2e/pages/admin/AuditLogPage.ts
+++ b/apps/web/e2e/pages/admin/AuditLogPage.ts
@@ -20,23 +20,13 @@ export class AuditLogPage extends BasePage {
 
     const auditEntries = this.page.locator('[data-testid="audit-log-entry"], tr, [role="row"]');
 
-    let matchingEntry = auditEntries
+    const matchingEntry = auditEntries
       .filter({
         hasText: targetIdentifier,
       })
       .filter({
         hasText: /role/i,
       });
-
-    const hasMatch = await matchingEntry
-      .first()
-      .isVisible()
-      .catch(() => false);
-    if (!hasMatch) {
-      matchingEntry = auditEntries.filter({
-        hasText: /role.*change|change.*role/i,
-      });
-    }
 
     await expect(matchingEntry.first()).toBeVisible({ timeout: 10_000 });
 

--- a/apps/web/e2e/pages/admin/AuditLogPage.ts
+++ b/apps/web/e2e/pages/admin/AuditLogPage.ts
@@ -1,0 +1,47 @@
+import { type Page, expect } from '@playwright/test';
+
+import { BasePage } from '../base/BasePage';
+
+export class AuditLogPage extends BasePage {
+  constructor(page: Page) {
+    super(page);
+  }
+
+  async goto(): Promise<void> {
+    await this.page.goto('/admin/analytics?tab=audit');
+    await this.waitForLoad();
+  }
+
+  async verifyRoleChangeEntry(
+    targetIdentifier: string,
+    options?: { oldRole?: string; newRole?: string }
+  ): Promise<void> {
+    await this.waitForNetworkIdle();
+
+    const auditEntries = this.page.locator('[data-testid="audit-log-entry"], tr, [role="row"]');
+
+    let matchingEntry = auditEntries
+      .filter({
+        hasText: targetIdentifier,
+      })
+      .filter({
+        hasText: /role/i,
+      });
+
+    const hasMatch = await matchingEntry
+      .first()
+      .isVisible()
+      .catch(() => false);
+    if (!hasMatch) {
+      matchingEntry = auditEntries.filter({
+        hasText: /role.*change|change.*role/i,
+      });
+    }
+
+    await expect(matchingEntry.first()).toBeVisible({ timeout: 10_000 });
+
+    if (options?.newRole) {
+      await expect(matchingEntry.first()).toContainText(new RegExp(options.newRole, 'i'));
+    }
+  }
+}

--- a/apps/web/e2e/pages/agent/AgentChatPage.ts
+++ b/apps/web/e2e/pages/agent/AgentChatPage.ts
@@ -1,0 +1,69 @@
+import { type Page, expect } from '@playwright/test';
+
+import { BasePage } from '../base/BasePage';
+
+export class AgentChatPage extends BasePage {
+  constructor(page: Page) {
+    super(page);
+  }
+
+  async goto(): Promise<void> {
+    await this.page.goto('/agents');
+    await this.waitForLoad();
+  }
+
+  async navigateToChat(agentId: string): Promise<void> {
+    await this.page.goto(`/agents/${agentId}`);
+    await this.waitForLoad();
+
+    const chatButton = this.page
+      .locator('[data-testid="start-chat-button"]')
+      .or(this.page.getByRole('button', { name: /chat|ask|start/i }));
+    if (await chatButton.isVisible()) {
+      await chatButton.click();
+      await this.waitForLoad();
+    }
+  }
+
+  async sendMessage(message: string): Promise<void> {
+    const chatInput = this.page
+      .locator('[data-testid="chat-input"]')
+      .or(this.page.getByPlaceholder(/ask|message|type/i));
+
+    await this.fill(chatInput, message);
+
+    await this.click(
+      this.page
+        .locator('[data-testid="chat-send-button"]')
+        .or(this.page.getByRole('button', { name: /send/i }))
+    );
+  }
+
+  async waitForAgentResponse(timeout: number = 60_000): Promise<string> {
+    const responseLocator = this.page
+      .locator('[data-testid="agent-message"], [data-testid="assistant-message"]')
+      .last();
+
+    await expect(responseLocator).toBeVisible({ timeout });
+
+    const streamingIndicator = this.page.locator(
+      '[data-testid="streaming-indicator"], .animate-pulse'
+    );
+
+    try {
+      await streamingIndicator.waitFor({ state: 'detached', timeout });
+    } catch {
+      // Indicator may never appear if response is fast
+    }
+
+    await this.page.waitForTimeout(1000);
+
+    const responseText = (await responseLocator.textContent()) ?? '';
+    return responseText.trim();
+  }
+
+  async verifyResponseIsValid(responseText: string): Promise<void> {
+    expect(responseText.length).toBeGreaterThan(10);
+    expect(responseText).not.toMatch(/error|failed|something went wrong/i);
+  }
+}

--- a/apps/web/e2e/pages/agent/AgentChatPage.ts
+++ b/apps/web/e2e/pages/agent/AgentChatPage.ts
@@ -56,7 +56,8 @@ export class AgentChatPage extends BasePage {
       // Indicator may never appear if response is fast
     }
 
-    await this.page.waitForTimeout(1000);
+    // Wait for response text to be non-empty (deterministic)
+    await expect(responseLocator).not.toBeEmpty({ timeout: 5_000 });
 
     const responseText = (await responseLocator.textContent()) ?? '';
     return responseText.trim();

--- a/apps/web/e2e/pages/agent/AgentCreationPage.ts
+++ b/apps/web/e2e/pages/agent/AgentCreationPage.ts
@@ -1,0 +1,101 @@
+import { type Page, expect } from '@playwright/test';
+
+import { BasePage } from '../base/BasePage';
+
+export interface AgentCreationResult {
+  agentId: string;
+  gameSessionId: string;
+}
+
+export class AgentCreationPage extends BasePage {
+  constructor(page: Page) {
+    super(page);
+  }
+
+  async goto(): Promise<void> {
+    await this.page.goto('/agents');
+    await this.waitForLoad();
+  }
+
+  async openCreationSheet(): Promise<void> {
+    await this.click(
+      this.page
+        .locator('[data-testid="create-agent-button"]')
+        .or(this.page.getByRole('button', { name: /create agent|new agent/i }))
+    );
+    await expect(
+      this.page.locator('[data-testid="agent-creation-sheet"]').or(this.page.getByRole('dialog'))
+    ).toBeVisible();
+  }
+
+  async selectGame(gameTitle: string): Promise<void> {
+    const gameSelector = this.page
+      .locator('[data-testid="game-selector"]')
+      .or(this.page.getByLabel(/game/i));
+    await gameSelector.click();
+    await this.page.getByText(gameTitle, { exact: false }).first().click();
+  }
+
+  async selectStrategy(strategy: string = 'Tutor'): Promise<void> {
+    const strategyOption = this.page
+      .locator(`[data-testid="strategy-${strategy.toLowerCase()}"]`)
+      .or(this.page.getByText(strategy, { exact: false }));
+    await strategyOption.click();
+  }
+
+  async selectFreeTier(): Promise<void> {
+    const freeTier = this.page
+      .locator('[data-testid="tier-free"]')
+      .or(this.page.getByText(/free/i).first());
+    if (await freeTier.isVisible()) {
+      await freeTier.click();
+    }
+  }
+
+  async submitCreation(): Promise<AgentCreationResult> {
+    const responsePromise = this.page.waitForResponse(
+      resp =>
+        resp.url().includes('/agents') &&
+        resp.request().method() === 'POST' &&
+        resp.status() >= 200 &&
+        resp.status() < 300
+    );
+
+    await this.click(
+      this.page
+        .locator('[data-testid="create-agent-submit"]')
+        .or(this.page.getByRole('button', { name: /create|submit/i }))
+    );
+
+    const response = await responsePromise;
+    const data = await response.json();
+
+    let gameSessionId = data.gameSessionId ?? '';
+    if (!gameSessionId) {
+      try {
+        const sessionResponse = await this.page.waitForResponse(
+          resp =>
+            resp.url().includes('/game-sessions') && resp.status() >= 200 && resp.status() < 300,
+          { timeout: 10_000 }
+        );
+        const sessionData = await sessionResponse.json();
+        gameSessionId = sessionData.id ?? sessionData.gameSessionId ?? '';
+      } catch {
+        // gameSessionId may be in the agent response already
+      }
+    }
+
+    return {
+      agentId: data.id ?? data.agentId ?? '',
+      gameSessionId,
+    };
+  }
+
+  async waitForAgentReady(timeout: number = 30_000): Promise<void> {
+    await expect(
+      this.page
+        .locator('[data-testid="agent-status-ready"]')
+        .or(this.page.getByText(/ready|online|active/i))
+    ).toBeVisible({ timeout });
+  }
+}

--- a/apps/web/e2e/pages/agent/AgentCreationPage.ts
+++ b/apps/web/e2e/pages/agent/AgentCreationPage.ts
@@ -53,7 +53,8 @@ export class AgentCreationPage extends BasePage {
   }
 
   async submitCreation(): Promise<AgentCreationResult> {
-    const responsePromise = this.page.waitForResponse(
+    // Register BOTH response interceptors BEFORE clicking
+    const agentResponsePromise = this.page.waitForResponse(
       resp =>
         resp.url().includes('/agents') &&
         resp.request().method() === 'POST' &&
@@ -61,32 +62,35 @@ export class AgentCreationPage extends BasePage {
         resp.status() < 300
     );
 
+    const sessionResponsePromise = this.page
+      .waitForResponse(
+        resp => resp.url().includes('/game-sessions') && resp.status() >= 200 && resp.status() < 300
+      )
+      .catch(() => null); // Optional - may not fire
+
     await this.click(
       this.page
         .locator('[data-testid="create-agent-submit"]')
         .or(this.page.getByRole('button', { name: /create|submit/i }))
     );
 
-    const response = await responsePromise;
-    const data = await response.json();
+    const agentResponse = await agentResponsePromise;
+    const agentData = await agentResponse.json();
 
-    let gameSessionId = data.gameSessionId ?? '';
+    let gameSessionId = agentData.gameSessionId ?? '';
     if (!gameSessionId) {
-      try {
-        const sessionResponse = await this.page.waitForResponse(
-          resp =>
-            resp.url().includes('/game-sessions') && resp.status() >= 200 && resp.status() < 300,
-          { timeout: 10_000 }
-        );
+      const sessionResponse = await Promise.race([
+        sessionResponsePromise,
+        new Promise<null>(resolve => setTimeout(() => resolve(null), 10_000)),
+      ]);
+      if (sessionResponse) {
         const sessionData = await sessionResponse.json();
         gameSessionId = sessionData.id ?? sessionData.gameSessionId ?? '';
-      } catch {
-        // gameSessionId may be in the agent response already
       }
     }
 
     return {
-      agentId: data.id ?? data.agentId ?? '',
+      agentId: agentData.id ?? agentData.agentId ?? '',
       gameSessionId,
     };
   }

--- a/apps/web/e2e/pages/auth/AcceptInvitePage.ts
+++ b/apps/web/e2e/pages/auth/AcceptInvitePage.ts
@@ -1,0 +1,41 @@
+import { type Page, expect } from '@playwright/test';
+
+import { BasePage } from '../base/BasePage';
+
+export class AcceptInvitePage extends BasePage {
+  constructor(page: Page) {
+    super(page);
+  }
+
+  async goto(): Promise<void> {
+    await this.page.goto('/accept-invite');
+    await this.waitForLoad();
+  }
+
+  async gotoWithToken(token: string): Promise<void> {
+    await this.page.goto(`/accept-invite?token=${token}`);
+    await this.waitForLoad();
+  }
+
+  async gotoUrl(url: string): Promise<void> {
+    await this.page.goto(url);
+    await this.waitForLoad();
+  }
+
+  async setPassword(password: string): Promise<void> {
+    await this.fill(this.page.getByLabel(/^password/i), password);
+    await this.fill(this.page.getByLabel(/confirm password/i), password);
+  }
+
+  async verifyStrengthIndicator(expectedLevel: string): Promise<void> {
+    await expect(this.page.getByText(new RegExp(`Strength:.*${expectedLevel}`, 'i'))).toBeVisible();
+  }
+
+  async submit(): Promise<void> {
+    await this.click(this.page.getByRole('button', { name: /create account/i }));
+  }
+
+  async waitForRedirectToOnboarding(): Promise<void> {
+    await this.page.waitForURL('**/onboarding**', { timeout: 10_000 });
+  }
+}

--- a/apps/web/e2e/pages/library/LibraryPage.ts
+++ b/apps/web/e2e/pages/library/LibraryPage.ts
@@ -1,0 +1,59 @@
+import { type Page, expect } from '@playwright/test';
+
+import { BasePage } from '../base/BasePage';
+
+export class LibraryPage extends BasePage {
+  constructor(page: Page) {
+    super(page);
+  }
+
+  async goto(): Promise<void> {
+    await this.page.goto('/library');
+    await this.waitForLoad();
+  }
+
+  async clickAddGame(): Promise<void> {
+    await this.click(
+      this.page
+        .locator('[data-testid="add-game-button"]')
+        .or(this.page.getByRole('button', { name: /add game/i }))
+    );
+  }
+
+  async searchGame(gameName: string): Promise<void> {
+    const searchInput = this.page
+      .locator('[data-testid="game-search-input"]')
+      .or(this.page.getByPlaceholder(/search/i));
+    await this.fill(searchInput, gameName);
+    await this.waitForNetworkIdle();
+  }
+
+  async selectFirstSearchResult(): Promise<{ gameId: string; gameTitle: string }> {
+    const result = this.page
+      .locator('[data-testid="game-search-result"]')
+      .or(this.page.locator('[data-testid^="game-result-"]'))
+      .first();
+
+    await expect(result).toBeVisible();
+
+    const gameTitle =
+      (await result.locator('h3, [data-testid="game-title"]').first().textContent()) ?? 'Unknown';
+    const gameId = (await result.getAttribute('data-game-id')) ?? '';
+
+    await result.click();
+    return { gameId, gameTitle: gameTitle.trim() };
+  }
+
+  async confirmAddToCollection(): Promise<void> {
+    await this.click(
+      this.page
+        .locator('[data-testid="confirm-add-game"]')
+        .or(this.page.getByRole('button', { name: /add to collection|confirm|save/i }))
+    );
+    await this.waitForNetworkIdle();
+  }
+
+  async verifyGameInCollection(gameTitle: string): Promise<void> {
+    await expect(this.page.getByText(gameTitle)).toBeVisible({ timeout: 10_000 });
+  }
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -227,6 +227,7 @@
     "jest-axe": "^10.0.0",
     "jsdom": "^28.1.0",
     "lint-staged": "^16.3.2",
+    "mailosaur": "^11.1.0",
     "msw": "^2.12.10",
     "npm-run-all": "^4.1.5",
     "openapi-zod-client": "^1.18.3",

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -196,6 +196,32 @@ export default defineConfig({
       // globalSetup: require.resolve('./e2e/admin-first-time-setup/setup.ts'),
       // globalTeardown: require.resolve('./e2e/admin-first-time-setup/teardown.ts'),
     },
+
+    // Admin User Onboarding - Serial execution targeting local or staging environments
+    {
+      name: 'onboarding-local',
+      testDir: './e2e/flows',
+      testMatch: /admin-user-onboarding\.spec\.ts/,
+      use: {
+        ...devices['Desktop Chrome'],
+        baseURL: 'http://localhost:3000',
+      },
+      fullyParallel: false,
+      workers: 1,
+      timeout: 180_000,
+    },
+    {
+      name: 'onboarding-staging',
+      testDir: './e2e/flows',
+      testMatch: /admin-user-onboarding\.spec\.ts/,
+      use: {
+        ...devices['Desktop Chrome'],
+        baseURL: 'https://meepleai.app',
+      },
+      fullyParallel: false,
+      workers: 1,
+      timeout: 180_000,
+    },
   ],
 
   // Issue #2008: Disable webServer in parallel mode to prevent port conflicts

--- a/apps/web/pnpm-lock.yaml
+++ b/apps/web/pnpm-lock.yaml
@@ -475,6 +475,9 @@ importers:
       lint-staged:
         specifier: ^16.3.2
         version: 16.3.2
+      mailosaur:
+        specifier: ^11.1.0
+        version: 11.1.0(@types/node@25.3.5)
       msw:
         specifier: ^2.12.10
         version: 2.12.10(@types/node@25.3.5)(typescript@5.9.3)
@@ -7648,6 +7651,15 @@ packages:
 
   magicast@0.3.5:
     resolution: {integrity: sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==}
+
+  mailosaur@11.1.0:
+    resolution: {integrity: sha512-6Yf9dohDbXddOBDLm5x1vcCjaUWMYQbqe0CSgWj2I2mhQppAqhbGxJ0v06QVCpP6oqh4hXSZCSWilY/bvsb8VA==}
+    engines: {node: '>=16'}
+    peerDependencies:
+      '@types/node': '>=16'
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
 
   make-cancellable-promise@2.0.0:
     resolution: {integrity: sha512-3SEQqTpV9oqVsIWqAcmDuaNeo7yBO3tqPtqGRcKkEo0lrzD3wqbKG9mkxO65KoOgXqj+zH2phJ2LiAsdzlogSw==}
@@ -18267,6 +18279,14 @@ snapshots:
       '@babel/parser': 7.28.5
       '@babel/types': 7.28.5
       source-map-js: 1.2.1
+
+  mailosaur@11.1.0(@types/node@25.3.5):
+    dependencies:
+      https-proxy-agent: 7.0.6
+    optionalDependencies:
+      '@types/node': 25.3.5
+    transitivePeerDependencies:
+      - supports-color
 
   make-cancellable-promise@2.0.0: {}
 


### PR DESCRIPTION
## Summary

- Add E2E Playwright test suite validating the complete admin-to-user onboarding journey
- 8 serial tests: admin login → invite user → accept invite → set password → login → add game to collection → create agent → chat with agent → admin role change → audit log verification
- Dual environment support: local (Docker, API intercept for email) and staging (meepleai.app, Mailosaur for real email)
- 6 new page objects: AcceptInvitePage, AdminUsersPage, AuditLogPage, LibraryPage, AgentCreationPage, AgentChatPage
- 3 new helpers: environment config, email strategy, cleanup
- 2 new Playwright projects: `onboarding-local` and `onboarding-staging`

## Test plan

- [x] All 8 tests discovered by Playwright (`--list` shows 8 tests)
- [x] Frontend build passes (Next.js 16 Turbopack)
- [x] Backend build passes (0 errors, only pre-existing warnings)
- [x] TypeScript type-check passes for all new files
- [ ] Run `npx playwright test --project onboarding-local` against local Docker environment
- [ ] Run `npx playwright test --project onboarding-staging` against staging

🤖 Generated with [Claude Code](https://claude.com/claude-code)
