### PR TITLE
feat(frontend): add RAG enhancements admin panel and chat cost indicator

### DIFF
--- a/apps/web/src/components/admin/knowledge-base/RagEnhancementsTab.tsx
+++ b/apps/web/src/components/admin/knowledge-base/RagEnhancementsTab.tsx
@@ -1,0 +1,372 @@
+'use client';
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { Brain, Crown, GitBranch, RefreshCwIcon, Search, TreePine, Users, Zap } from 'lucide-react';
+
+import { toast } from '@/components/layout/Toast';
+import { Badge } from '@/components/ui/data-display/badge';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/data-display/tooltip';
+import { Switch } from '@/components/ui/forms/switch';
+import { Button } from '@/components/ui/primitives/button';
+import { HttpClient } from '@/lib/api/core/httpClient';
+import { cn } from '@/lib/utils';
+
+const httpClient = new HttpClient();
+
+interface RagEnhancementDto {
+  name: string;
+  flagKey: string;
+  isGloballyEnabled: boolean;
+  extraCreditsBalanced: number;
+  extraCreditsFast: number;
+  tierAccess?: Record<string, boolean>;
+}
+
+const ENHANCEMENT_META: Record<
+  string,
+  { icon: React.ReactNode; description: string; impact: string }
+> = {
+  AdaptiveRouting: {
+    icon: <Brain className="h-4 w-4" />,
+    description:
+      'Classifica la complessita della query per saltare il retrieval su domande semplici',
+    impact: '+7-10% accuracy, risparmia token',
+  },
+  CragEvaluation: {
+    icon: <Search className="h-4 w-4" />,
+    description: 'Valuta la rilevanza dei chunk prima della generazione, ri-cerca se irrilevanti',
+    impact: '+3-5% accuracy, riduce allucinazioni',
+  },
+  RaptorRetrieval: {
+    icon: <TreePine className="h-4 w-4" />,
+    description: 'Indicizzazione gerarchica per retrieval multi-granularita (overview → dettaglio)',
+    impact: '+5-8% su domande ampie',
+  },
+  RagFusionQueries: {
+    icon: <GitBranch className="h-4 w-4" />,
+    description: 'Genera varianti della query per catturare risultati da angolazioni diverse',
+    impact: '+2-3% su query ambigue',
+  },
+  GraphTraversal: {
+    icon: <Zap className="h-4 w-4" />,
+    description: 'Estrae entita e relazioni per query relazionali (giochi simili, meccaniche)',
+    impact: 'Abilita nuovi tipi di query',
+  },
+};
+
+const TIERS = ['Free', 'Basic', 'Pro'] as const;
+type Tier = (typeof TIERS)[number];
+
+const TIER_ICONS: Record<Tier, React.ReactNode> = {
+  Free: <Users className="h-3.5 w-3.5" />,
+  Basic: <Zap className="h-3.5 w-3.5" />,
+  Pro: <Crown className="h-3.5 w-3.5" />,
+};
+
+const TIER_COLORS: Record<Tier, string> = {
+  Free: 'text-slate-600 dark:text-slate-400',
+  Basic: 'text-blue-600 dark:text-blue-400',
+  Pro: 'text-amber-600 dark:text-amber-400',
+};
+
+const TIER_SWITCH_COLORS: Record<Tier, string> = {
+  Free: 'data-[state=checked]:bg-slate-500',
+  Basic: 'data-[state=checked]:bg-blue-500',
+  Pro: 'data-[state=checked]:bg-amber-500',
+};
+
+function EnhancementSkeleton() {
+  return (
+    <div className="space-y-4">
+      {Array.from({ length: 4 }).map((_, i) => (
+        <div key={i} className="h-36 bg-white/40 dark:bg-zinc-800/40 rounded-xl animate-pulse" />
+      ))}
+    </div>
+  );
+}
+
+export function RagEnhancementsTab() {
+  const queryClient = useQueryClient();
+
+  const {
+    data: enhancements,
+    isLoading,
+    refetch,
+    isRefetching,
+  } = useQuery({
+    queryKey: ['admin', 'rag-enhancements'],
+    queryFn: () => httpClient.get<RagEnhancementDto[]>('/api/v1/admin/rag-enhancements'),
+    staleTime: 300_000,
+  });
+
+  const globalToggleMutation = useMutation({
+    mutationFn: (flagKey: string) =>
+      httpClient.post<void>(`/api/v1/admin/rag-enhancements/${flagKey}/toggle`),
+    onMutate: async flagKey => {
+      await queryClient.cancelQueries({ queryKey: ['admin', 'rag-enhancements'] });
+
+      const previousData = queryClient.getQueryData<RagEnhancementDto[]>([
+        'admin',
+        'rag-enhancements',
+      ]);
+
+      queryClient.setQueryData<RagEnhancementDto[]>(['admin', 'rag-enhancements'], old =>
+        old?.map(e =>
+          e.flagKey === flagKey ? { ...e, isGloballyEnabled: !e.isGloballyEnabled } : e
+        )
+      );
+
+      return { previousData };
+    },
+    onError: (_err, _flagKey, context) => {
+      if (context?.previousData) {
+        queryClient.setQueryData(['admin', 'rag-enhancements'], context.previousData);
+      }
+      toast.error('Failed to toggle enhancement');
+    },
+    onSuccess: (_data, flagKey) => {
+      const updated = queryClient.getQueryData<RagEnhancementDto[]>(['admin', 'rag-enhancements']);
+      const enhancement = updated?.find(e => e.flagKey === flagKey);
+      if (enhancement) {
+        toast.success(
+          `${enhancement.name} ${enhancement.isGloballyEnabled ? 'enabled' : 'disabled'}`
+        );
+      }
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ['admin', 'rag-enhancements'] });
+    },
+  });
+
+  const tierToggleMutation = useMutation({
+    mutationFn: ({ flagKey, tier }: { flagKey: string; tier: string }) =>
+      httpClient.post<void>(`/api/v1/admin/rag-enhancements/${flagKey}/tier/${tier}/toggle`),
+    onMutate: async ({ flagKey, tier }) => {
+      await queryClient.cancelQueries({ queryKey: ['admin', 'rag-enhancements'] });
+
+      const previousData = queryClient.getQueryData<RagEnhancementDto[]>([
+        'admin',
+        'rag-enhancements',
+      ]);
+
+      queryClient.setQueryData<RagEnhancementDto[]>(['admin', 'rag-enhancements'], old =>
+        old?.map(e => {
+          if (e.flagKey !== flagKey) return e;
+          const currentAccess = e.tierAccess ?? {};
+          return {
+            ...e,
+            tierAccess: {
+              ...currentAccess,
+              [tier]: !currentAccess[tier],
+            },
+          };
+        })
+      );
+
+      return { previousData };
+    },
+    onError: (_err, _vars, context) => {
+      if (context?.previousData) {
+        queryClient.setQueryData(['admin', 'rag-enhancements'], context.previousData);
+      }
+      toast.error('Failed to toggle tier access');
+    },
+    onSuccess: (_data, { flagKey, tier }) => {
+      toast.success(`${tier} tier updated for ${flagKey}`);
+    },
+    onSettled: () => {
+      queryClient.invalidateQueries({ queryKey: ['admin', 'rag-enhancements'] });
+    },
+  });
+
+  if (isLoading) {
+    return <EnhancementSkeleton />;
+  }
+
+  if (!enhancements || enhancements.length === 0) {
+    return (
+      <div className="bg-white/70 dark:bg-zinc-800/70 backdrop-blur-md rounded-xl p-6 border border-slate-200/50 dark:border-zinc-700/50">
+        <p className="text-sm text-slate-600 dark:text-zinc-400">
+          No RAG enhancements configured. They will appear here once the backend is set up.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <TooltipProvider>
+      <div className="bg-white/70 dark:bg-zinc-800/70 backdrop-blur-md rounded-xl p-6 border border-slate-200/50 dark:border-zinc-700/50">
+        {/* Header */}
+        <div className="flex items-center justify-between mb-6">
+          <div className="flex items-center gap-2">
+            <Brain className="h-5 w-5 text-purple-500" />
+            <h3 className="font-semibold text-slate-900 dark:text-zinc-100">RAG Enhancements</h3>
+            <Badge variant="outline" className="text-xs">
+              {enhancements.filter(e => e.isGloballyEnabled).length}/{enhancements.length} active
+            </Badge>
+          </div>
+          <Button
+            variant="outline"
+            size="sm"
+            onClick={() => refetch()}
+            disabled={isRefetching}
+            className="gap-2"
+          >
+            <RefreshCwIcon className={cn('h-4 w-4', isRefetching && 'animate-spin')} />
+            Refresh
+          </Button>
+        </div>
+
+        {/* Enhancement Cards */}
+        <div className="space-y-4">
+          {enhancements.map(enhancement => {
+            const meta = ENHANCEMENT_META[enhancement.flagKey] ?? {
+              icon: <Zap className="h-4 w-4" />,
+              description: enhancement.name,
+              impact: 'N/A',
+            };
+
+            return (
+              <div
+                key={enhancement.flagKey}
+                className={cn(
+                  'rounded-lg border p-4 transition-colors',
+                  enhancement.isGloballyEnabled
+                    ? 'border-purple-200/50 dark:border-purple-800/50 bg-purple-50/30 dark:bg-purple-900/10'
+                    : 'border-slate-200/50 dark:border-zinc-700/50 bg-slate-50/30 dark:bg-zinc-900/20'
+                )}
+              >
+                {/* Top row: Icon + Name + Global toggle */}
+                <div className="flex items-center justify-between mb-2">
+                  <div className="flex items-center gap-2">
+                    <span
+                      className={cn(
+                        enhancement.isGloballyEnabled
+                          ? 'text-purple-600 dark:text-purple-400'
+                          : 'text-slate-400 dark:text-zinc-500'
+                      )}
+                    >
+                      {meta.icon}
+                    </span>
+                    <span className="font-medium text-slate-900 dark:text-zinc-100">
+                      {enhancement.name}
+                    </span>
+                  </div>
+                  <Switch
+                    checked={enhancement.isGloballyEnabled}
+                    onCheckedChange={() => globalToggleMutation.mutate(enhancement.flagKey)}
+                    disabled={globalToggleMutation.isPending}
+                    aria-label={`Toggle ${enhancement.name}`}
+                    className={
+                      enhancement.isGloballyEnabled ? 'data-[state=checked]:bg-purple-600' : ''
+                    }
+                  />
+                </div>
+
+                {/* Description */}
+                <p className="text-sm text-slate-600 dark:text-zinc-400 mb-3">{meta.description}</p>
+
+                {/* Tier Access row */}
+                <div className="flex items-center gap-4 mb-3">
+                  <span className="text-xs font-medium text-slate-500 dark:text-zinc-500">
+                    Tier Access:
+                  </span>
+                  <div className="flex items-center gap-3">
+                    {TIERS.map(tier => {
+                      const tierEnabled = enhancement.tierAccess?.[tier] ?? false;
+                      return (
+                        <Tooltip key={tier}>
+                          <TooltipTrigger asChild>
+                            <label
+                              className={cn(
+                                'flex items-center gap-1.5 cursor-pointer',
+                                TIER_COLORS[tier]
+                              )}
+                            >
+                              {TIER_ICONS[tier]}
+                              <span className="text-xs font-medium">{tier}</span>
+                              <Switch
+                                checked={tierEnabled}
+                                onCheckedChange={() =>
+                                  tierToggleMutation.mutate({
+                                    flagKey: enhancement.flagKey,
+                                    tier,
+                                  })
+                                }
+                                disabled={
+                                  !enhancement.isGloballyEnabled || tierToggleMutation.isPending
+                                }
+                                aria-label={`Toggle ${tier} tier for ${enhancement.name}`}
+                                className={cn('scale-75', tierEnabled && TIER_SWITCH_COLORS[tier])}
+                              />
+                            </label>
+                          </TooltipTrigger>
+                          <TooltipContent>
+                            <p>
+                              {tierEnabled ? 'Enabled' : 'Disabled'} for {tier} tier
+                            </p>
+                          </TooltipContent>
+                        </Tooltip>
+                      );
+                    })}
+                  </div>
+                </div>
+
+                {/* Cost and Impact badges */}
+                <div className="flex flex-wrap items-center gap-2">
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Badge
+                        variant="outline"
+                        className="text-xs text-slate-600 dark:text-zinc-400"
+                      >
+                        +{enhancement.extraCreditsFast} credits (FAST)
+                      </Badge>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      <p>Extra credits consumed in FAST mode</p>
+                    </TooltipContent>
+                  </Tooltip>
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Badge
+                        variant="outline"
+                        className="text-xs text-slate-600 dark:text-zinc-400"
+                      >
+                        +{enhancement.extraCreditsBalanced} credits (BALANCED)
+                      </Badge>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      <p>Extra credits consumed in BALANCED mode</p>
+                    </TooltipContent>
+                  </Tooltip>
+                  <Badge variant="secondary" className="text-xs">
+                    {meta.impact}
+                  </Badge>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        {/* Help text */}
+        <div className="mt-6 bg-slate-50/70 dark:bg-zinc-900/50 rounded-lg p-4 border border-slate-200/30 dark:border-zinc-700/30">
+          <h4 className="text-sm font-medium text-slate-700 dark:text-zinc-300 mb-2">
+            RAG Enhancements Guide
+          </h4>
+          <ul className="text-xs text-slate-500 dark:text-zinc-500 space-y-1">
+            <li>Toggle enhancements globally, then control per-tier access</li>
+            <li>Tier toggles are disabled when the enhancement is globally off</li>
+            <li>Credits show the extra cost per query for each mode (FAST vs BALANCED)</li>
+            <li>Impact estimates are approximate and may vary by query type</li>
+          </ul>
+        </div>
+      </div>
+    </TooltipProvider>
+  );
+}

--- a/apps/web/src/components/admin/knowledge-base/kb-settings.tsx
+++ b/apps/web/src/components/admin/knowledge-base/kb-settings.tsx
@@ -20,6 +20,8 @@ import { Button } from '@/components/ui/primitives/button';
 import { createAdminClient } from '@/lib/api/clients/adminClient';
 import { HttpClient } from '@/lib/api/core/httpClient';
 
+import { RagEnhancementsTab } from './RagEnhancementsTab';
+
 const httpClient = new HttpClient();
 const adminClient = createAdminClient({ httpClient });
 
@@ -73,10 +75,14 @@ interface ClearCacheResult {
 }
 
 function SettingRow({ label, value }: { label: string; value: string | number | boolean }) {
-  const displayValue = typeof value === 'boolean' ? (value ? 'Enabled' : 'Disabled') : String(value);
-  const boolColor = typeof value === 'boolean'
-    ? value ? 'text-green-600 dark:text-green-400' : 'text-slate-400 dark:text-zinc-500'
-    : 'text-slate-900 dark:text-zinc-100';
+  const displayValue =
+    typeof value === 'boolean' ? (value ? 'Enabled' : 'Disabled') : String(value);
+  const boolColor =
+    typeof value === 'boolean'
+      ? value
+        ? 'text-green-600 dark:text-green-400'
+        : 'text-slate-400 dark:text-zinc-500'
+      : 'text-slate-900 dark:text-zinc-100';
 
   return (
     <div className="flex items-center justify-between py-2 border-b border-slate-100 dark:border-zinc-800 last:border-0">
@@ -175,8 +181,8 @@ export function KBSettings() {
             Read-only Configuration
           </p>
           <p className="text-xs text-blue-700 dark:text-blue-300 mt-1">
-            These settings are configured via environment variables and config files.
-            To modify them, update the server configuration and restart the API service.
+            These settings are configured via environment variables and config files. To modify
+            them, update the server configuration and restart the API service.
           </p>
         </div>
       </div>
@@ -213,18 +219,30 @@ export function KBSettings() {
 
         {/* Chunking Settings */}
         <SettingsCard title="Text Chunking" icon={LayersIcon}>
-          <SettingRow label="Default Chunk Size" value={`${settings.chunking.defaultChunkSize} chars`} />
+          <SettingRow
+            label="Default Chunk Size"
+            value={`${settings.chunking.defaultChunkSize} chars`}
+          />
           <SettingRow label="Chunk Overlap" value={`${settings.chunking.chunkOverlap} chars`} />
           <SettingRow label="Min Chunk Size" value={`${settings.chunking.minChunkSize} chars`} />
           <SettingRow label="Max Chunk Size" value={`${settings.chunking.maxChunkSize} chars`} />
-          <SettingRow label="Token Limit" value={`${settings.chunking.embeddingTokenLimit} tokens`} />
+          <SettingRow
+            label="Token Limit"
+            value={`${settings.chunking.embeddingTokenLimit} tokens`}
+          />
           <SettingRow label="Chars/Token Ratio" value={settings.chunking.charsPerToken} />
         </SettingsCard>
 
         {/* Cache Settings */}
         <SettingsCard title="Cache Configuration" icon={ServerIcon}>
-          <SettingRow label="Redis Host" value={`${settings.cache.redis.host}:${settings.cache.redis.port}`} />
-          <SettingRow label="HybridCache Expiration" value={settings.cache.hybridCache.defaultExpiration} />
+          <SettingRow
+            label="Redis Host"
+            value={`${settings.cache.redis.host}:${settings.cache.redis.port}`}
+          />
+          <SettingRow
+            label="HybridCache Expiration"
+            value={settings.cache.hybridCache.defaultExpiration}
+          />
           <SettingRow label="HybridCache L2" value={settings.cache.hybridCache.l2Enabled} />
           <SettingRow label="Multi-Tier Cache" value={settings.cache.multiTier.enabled} />
           <SettingRow label="L1 TTL" value={settings.cache.multiTier.l1Ttl} />
@@ -234,9 +252,7 @@ export function KBSettings() {
         {/* Reranker */}
         <SettingsCard title="Reranker Service" icon={BoxIcon}>
           <SettingRow label="Configured" value={settings.reranker.configured} />
-          {settings.reranker.url && (
-            <SettingRow label="URL" value={settings.reranker.url} />
-          )}
+          {settings.reranker.url && <SettingRow label="URL" value={settings.reranker.url} />}
           {!settings.reranker.configured && (
             <p className="text-xs text-amber-600 dark:text-amber-400 mt-2">
               Reranker not configured. Set RERANKER_URL to enable cross-encoder reranking.
@@ -255,6 +271,9 @@ export function KBSettings() {
         </SettingsCard>
       </div>
 
+      {/* RAG Enhancements */}
+      <RagEnhancementsTab />
+
       {/* Danger Zone */}
       <div className="bg-red-50/70 dark:bg-red-900/20 backdrop-blur-md rounded-xl p-6 border-2 border-red-200 dark:border-red-800">
         <div className="flex items-center gap-2 mb-4">
@@ -272,7 +291,9 @@ export function KBSettings() {
           {!showRebuildConfirm ? (
             <div className="flex items-center justify-between">
               <div>
-                <p className="text-sm font-medium text-red-900 dark:text-red-200">Rebuild Vector Index</p>
+                <p className="text-sm font-medium text-red-900 dark:text-red-200">
+                  Rebuild Vector Index
+                </p>
                 <p className="text-xs text-red-600 dark:text-red-400">
                   Triggers reindexing of all Qdrant collections. May temporarily affect search.
                 </p>

--- a/apps/web/src/components/chat-unified/ChatThreadView.tsx
+++ b/apps/web/src/components/chat-unified/ChatThreadView.tsx
@@ -34,6 +34,7 @@ import { ChatThreadHeader } from './ChatThreadHeader';
 import { CitationBadge } from './CitationBadge';
 import { DebugStepCard } from './DebugStepCard';
 import { DebugSummaryBar } from './DebugSummaryBar';
+import { RagEnhancementsBadge } from './RagEnhancementsBadge';
 import { ResponseMetaBadge } from './ResponseMetaBadge';
 import { RuleSourceCard } from './RuleSourceCard';
 import { TechnicalDetailsPanel } from './TechnicalDetailsPanel';
@@ -723,6 +724,11 @@ export function ChatThreadView({ threadId }: ChatThreadViewProps) {
             className="border-t border-border/50 dark:border-border/30 p-4 bg-background/95 backdrop-blur-[12px] dark:bg-card dark:backdrop-blur-none"
             data-testid="chat-input-area"
           >
+            {/* RAG Enhancement Cost Indicator */}
+            <div className="max-w-3xl mx-auto mb-2">
+              <RagEnhancementsBadge />
+            </div>
+
             <div className="flex items-end gap-2 max-w-3xl mx-auto">
               <textarea
                 value={inputValue}

--- a/apps/web/src/components/chat-unified/RagEnhancementsBadge.tsx
+++ b/apps/web/src/components/chat-unified/RagEnhancementsBadge.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { Sparkles } from 'lucide-react';
+
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/data-display/tooltip';
+import { HttpClient } from '@/lib/api/core/httpClient';
+import { cn } from '@/lib/utils';
+
+const httpClient = new HttpClient();
+
+interface EnhancementEstimate {
+  activeEnhancements: string;
+  activeFlags: string[];
+  extraCreditsPerQuery: number;
+  useBalancedAuxModel: boolean;
+}
+
+export function RagEnhancementsBadge() {
+  const { data } = useQuery({
+    queryKey: ['rag', 'enhancements', 'estimate'],
+    queryFn: () => httpClient.get<EnhancementEstimate>('/api/v1/rag/enhancements/estimate'),
+    staleTime: 60_000, // Refresh every minute
+    retry: false, // Don't retry if endpoint doesn't exist yet
+  });
+
+  // Don't render if no enhancements active or fetch failed
+  if (!data || data.activeFlags.length === 0) return null;
+
+  return (
+    <TooltipProvider>
+      <Tooltip>
+        <TooltipTrigger asChild>
+          <div
+            className={cn(
+              'flex items-center gap-1.5 px-2.5 py-1 rounded-lg',
+              'bg-amber-50 dark:bg-amber-900/20 border border-amber-200/50 dark:border-amber-800/50',
+              'text-xs text-amber-700 dark:text-amber-300',
+              'transition-opacity duration-200'
+            )}
+          >
+            <Sparkles className="h-3 w-3" />
+            <span>
+              {data.activeFlags.length} enhancement{data.activeFlags.length > 1 ? 's' : ''}
+              {data.extraCreditsPerQuery > 0 && (
+                <span className="ml-1 font-medium">+{data.extraCreditsPerQuery} credits</span>
+              )}
+            </span>
+          </div>
+        </TooltipTrigger>
+        <TooltipContent side="top" className="max-w-xs">
+          <div className="space-y-1">
+            <p className="font-medium text-xs">RAG Enhancements attivi:</p>
+            <ul className="text-xs space-y-0.5">
+              {data.activeFlags.map(flag => (
+                <li key={flag} className="flex items-center gap-1">
+                  <span className="h-1.5 w-1.5 rounded-full bg-green-400" />
+                  {flag}
+                </li>
+              ))}
+            </ul>
+            {data.extraCreditsPerQuery > 0 && (
+              <p className="text-xs text-muted-foreground pt-1 border-t">
+                +{data.extraCreditsPerQuery} crediti extra per query (
+                {data.useBalancedAuxModel ? 'BALANCED' : 'FAST'} model)
+              </p>
+            )}
+            {data.extraCreditsPerQuery === 0 && (
+              <p className="text-xs text-green-600 dark:text-green-400 pt-1 border-t">
+                Nessun costo aggiuntivo (FAST model)
+              </p>
+            )}
+          </div>
+        </TooltipContent>
+      </Tooltip>
+    </TooltipProvider>
+  );
+}


### PR DESCRIPTION
## Summary

- **Admin RAG Enhancements Tab**: New section in `/admin/knowledge-base/settings` with per-enhancement ON/OFF switches (global + per-tier), cost badges, and impact descriptions
- **Chat Cost Indicator**: Small amber badge above chat input showing active enhancements and extra credits per query (hidden when none active)

## Components

| Component | Location | What it does |
|-----------|----------|-------------|
| `RagEnhancementsTab` | KB Settings page | Toggle 5 enhancements globally or per tier (Free/Basic/Pro) |
| `RagEnhancementsBadge` | Chat input area | Shows active enhancement count + credit cost |

## Endpoints Used

- `GET /api/v1/admin/rag-enhancements` — list enhancements with status
- `POST /api/v1/admin/rag-enhancements/{key}/toggle` — global toggle
- `POST /api/v1/admin/rag-enhancements/{key}/tier/{tier}/toggle` — per-tier toggle
- `GET /api/v1/rag/enhancements/estimate` — user-facing cost estimate

## Test Plan

- [x] TypeScript: 0 errors
- [x] Build: passes
- [ ] Manual: verify admin panel renders with mock data
- [ ] Manual: verify chat badge hidden when no enhancements

🤖 Generated with [Claude Code](https://claude.com/claude-code)