### PR TITLE
feat(mana): add 9 remaining card back block components

### DIFF
--- a/apps/web/src/components/ui/data-display/card-back-blocks/__tests__/blocks.test.tsx
+++ b/apps/web/src/components/ui/data-display/card-back-blocks/__tests__/blocks.test.tsx
@@ -1,0 +1,295 @@
+/**
+ * Card Back Blocks Test Suite
+ * Tests for all 9 block components in card-back-blocks/blocks/
+ */
+
+import React from 'react';
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { ContentsBlock } from '../blocks/ContentsBlock';
+import { DetailLinkBlock } from '../blocks/DetailLinkBlock';
+import { HistoryBlock } from '../blocks/HistoryBlock';
+import { KBPreviewBlock } from '../blocks/KBPreviewBlock';
+import { MembersBlock } from '../blocks/MembersBlock';
+import { NotesBlock } from '../blocks/NotesBlock';
+import { ProgressBlock } from '../blocks/ProgressBlock';
+import { RankingBlock } from '../blocks/RankingBlock';
+import { TimelineBlock } from '../blocks/TimelineBlock';
+
+// Mock next/link for test environment
+vi.mock('next/link', () => ({
+  default: ({ children, href, ...props }: React.PropsWithChildren<{ href: string }>) => (
+    <a href={href} {...props}>
+      {children}
+    </a>
+  ),
+}));
+
+const COLOR = '25 95% 45%';
+
+describe('Card Back Blocks', () => {
+  it('TimelineBlock renders events', () => {
+    render(
+      <TimelineBlock
+        title="Timeline"
+        entityColor={COLOR}
+        data={{ type: 'timeline', events: [{ time: '20:30', label: 'Start', icon: '▶' }] }}
+      />
+    );
+    expect(screen.getByText('20:30')).toBeInTheDocument();
+    expect(screen.getByText('Start')).toBeInTheDocument();
+  });
+
+  it('TimelineBlock renders title', () => {
+    render(
+      <TimelineBlock
+        title="Game Events"
+        entityColor={COLOR}
+        data={{ type: 'timeline', events: [] }}
+      />
+    );
+    expect(screen.getByText('Game Events')).toBeInTheDocument();
+    expect(screen.getByText('No data yet')).toBeInTheDocument();
+  });
+
+  it('RankingBlock renders players with positions', () => {
+    render(
+      <RankingBlock
+        title="Classifica"
+        entityColor={COLOR}
+        data={{
+          type: 'ranking',
+          players: [
+            { name: 'Marco', score: 87, position: 1, isLeader: true },
+            { name: 'Sara', score: 72, position: 2 },
+          ],
+        }}
+      />
+    );
+    expect(screen.getByText('Marco')).toBeInTheDocument();
+    expect(screen.getByText('87')).toBeInTheDocument();
+    expect(screen.getByText('Sara')).toBeInTheDocument();
+    expect(screen.getByText('72')).toBeInTheDocument();
+  });
+
+  it('RankingBlock shows empty state when no players', () => {
+    render(
+      <RankingBlock
+        title="Classifica"
+        entityColor={COLOR}
+        data={{ type: 'ranking', players: [] }}
+      />
+    );
+    expect(screen.getByText('No data yet')).toBeInTheDocument();
+  });
+
+  it('KBPreviewBlock renders doc count and status', () => {
+    render(
+      <KBPreviewBlock
+        title="KB"
+        entityColor={COLOR}
+        data={{ type: 'kbPreview', docsCount: 12, chunksCount: 245, indexStatus: 'indexed' }}
+      />
+    );
+    expect(screen.getByText(/12/)).toBeInTheDocument();
+    expect(screen.getByText(/245/)).toBeInTheDocument();
+    expect(screen.getByText('indexed')).toBeInTheDocument();
+  });
+
+  it('KBPreviewBlock renders optional lastQuery', () => {
+    render(
+      <KBPreviewBlock
+        title="KB"
+        entityColor={COLOR}
+        data={{
+          type: 'kbPreview',
+          docsCount: 5,
+          chunksCount: 100,
+          indexStatus: 'indexed',
+          lastQuery: 'How many players?',
+        }}
+      />
+    );
+    expect(screen.getByText('How many players?')).toBeInTheDocument();
+  });
+
+  it('MembersBlock renders member names', () => {
+    render(
+      <MembersBlock
+        title="Members"
+        entityColor={COLOR}
+        data={{ type: 'members', members: [{ name: 'Luca', role: 'Host' }] }}
+      />
+    );
+    expect(screen.getByText('Luca')).toBeInTheDocument();
+    expect(screen.getByText('Host')).toBeInTheDocument();
+  });
+
+  it('MembersBlock shows empty state when no members', () => {
+    render(
+      <MembersBlock
+        title="Members"
+        entityColor={COLOR}
+        data={{ type: 'members', members: [] }}
+      />
+    );
+    expect(screen.getByText('No data yet')).toBeInTheDocument();
+  });
+
+  it('ContentsBlock renders items with titles', () => {
+    render(
+      <ContentsBlock
+        title="Giochi"
+        entityColor={COLOR}
+        data={{
+          type: 'contents',
+          items: [{ title: 'Catan', entityType: 'game', id: '1' }],
+        }}
+      />
+    );
+    expect(screen.getByText('Catan')).toBeInTheDocument();
+  });
+
+  it('ContentsBlock renders item status when provided', () => {
+    render(
+      <ContentsBlock
+        title="Giochi"
+        entityColor={COLOR}
+        data={{
+          type: 'contents',
+          items: [{ title: 'Pandemic', entityType: 'game', id: '2', status: 'active' }],
+        }}
+      />
+    );
+    expect(screen.getByText('Pandemic')).toBeInTheDocument();
+    expect(screen.getByText('active')).toBeInTheDocument();
+  });
+
+  it('ContentsBlock shows empty state when no items', () => {
+    render(
+      <ContentsBlock
+        title="Contents"
+        entityColor={COLOR}
+        data={{ type: 'contents', items: [] }}
+      />
+    );
+    expect(screen.getByText('No data yet')).toBeInTheDocument();
+  });
+
+  it('HistoryBlock renders entries', () => {
+    render(
+      <HistoryBlock
+        title="History"
+        entityColor={COLOR}
+        data={{
+          type: 'history',
+          entries: [{ timestamp: '14:30', message: 'Query about rules', sender: 'User' }],
+        }}
+      />
+    );
+    expect(screen.getByText('Query about rules')).toBeInTheDocument();
+    expect(screen.getByText('User')).toBeInTheDocument();
+    expect(screen.getByText('14:30')).toBeInTheDocument();
+  });
+
+  it('HistoryBlock shows empty state when no entries', () => {
+    render(
+      <HistoryBlock
+        title="History"
+        entityColor={COLOR}
+        data={{ type: 'history', entries: [] }}
+      />
+    );
+    expect(screen.getByText('No data yet')).toBeInTheDocument();
+  });
+
+  it('ProgressBlock renders progress bar', () => {
+    render(
+      <ProgressBlock
+        title="Progress"
+        entityColor={COLOR}
+        data={{ type: 'progress', current: 7, target: 10, label: 'Level 5' }}
+      />
+    );
+    expect(screen.getByText('Level 5')).toBeInTheDocument();
+    expect(screen.getByText('70%')).toBeInTheDocument();
+  });
+
+  it('ProgressBlock renders milestones when provided', () => {
+    render(
+      <ProgressBlock
+        title="Progress"
+        entityColor={COLOR}
+        data={{
+          type: 'progress',
+          current: 5,
+          target: 10,
+          label: 'Quest',
+          milestones: [{ at: 3, label: 'Checkpoint A' }],
+        }}
+      />
+    );
+    expect(screen.getByText(/Checkpoint A/)).toBeInTheDocument();
+  });
+
+  it('ProgressBlock clamps to 100% when current exceeds target', () => {
+    render(
+      <ProgressBlock
+        title="Progress"
+        entityColor={COLOR}
+        data={{ type: 'progress', current: 15, target: 10, label: 'Done' }}
+      />
+    );
+    expect(screen.getByText('100%')).toBeInTheDocument();
+  });
+
+  it('NotesBlock renders content', () => {
+    render(
+      <NotesBlock
+        title="Notes"
+        entityColor={COLOR}
+        data={{ type: 'notes', content: 'Remember to use blue strategy', updatedAt: '2026-03-15' }}
+      />
+    );
+    expect(screen.getByText('Remember to use blue strategy')).toBeInTheDocument();
+    expect(screen.getByText(/2026-03-15/)).toBeInTheDocument();
+  });
+
+  it('NotesBlock shows empty state when no content', () => {
+    render(
+      <NotesBlock
+        title="Notes"
+        entityColor={COLOR}
+        data={{ type: 'notes', content: '', updatedAt: '2026-03-15' }}
+      />
+    );
+    expect(screen.getByText('No data yet')).toBeInTheDocument();
+  });
+
+  it('DetailLinkBlock renders link', () => {
+    render(
+      <DetailLinkBlock
+        title=""
+        entityColor={COLOR}
+        data={{ type: 'detailLink', href: '/games/1', label: 'Vai al dettaglio' }}
+      />
+    );
+    expect(screen.getByText('Vai al dettaglio')).toBeInTheDocument();
+    const link = screen.getByRole('link');
+    expect(link).toHaveAttribute('href', '/games/1');
+  });
+
+  it('DetailLinkBlock renders with title when provided', () => {
+    render(
+      <DetailLinkBlock
+        title="Dettaglio"
+        entityColor={COLOR}
+        data={{ type: 'detailLink', href: '/games/2', label: 'Apri' }}
+      />
+    );
+    expect(screen.getByText('Dettaglio')).toBeInTheDocument();
+    expect(screen.getByText('Apri')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/ui/data-display/card-back-blocks/blocks/ContentsBlock.tsx
+++ b/apps/web/src/components/ui/data-display/card-back-blocks/blocks/ContentsBlock.tsx
@@ -1,0 +1,92 @@
+'use client';
+
+import { memo } from 'react';
+
+import type { MeepleEntityType } from '../../meeple-card-styles';
+
+interface ContentItem {
+  title: string;
+  entityType: MeepleEntityType;
+  id: string;
+  status?: string;
+}
+
+interface ContentsBlockProps {
+  title: string;
+  entityColor: string;
+  data: {
+    type: 'contents';
+    items: ContentItem[];
+  };
+}
+
+/** Compact entity type color dots instead of full ManaSymbol to avoid circular deps */
+const ENTITY_COLORS: Partial<Record<MeepleEntityType, string>> = {
+  game: '25 95% 45%',
+  player: '262 83% 58%',
+  session: '240 60% 55%',
+  agent: '38 92% 50%',
+  kb: '174 60% 40%',
+  chatSession: '220 80% 55%',
+  event: '350 89% 60%',
+  toolkit: '142 70% 45%',
+  tool: '195 80% 50%',
+  collection: '20 70% 42%',
+  group: '280 50% 48%',
+  location: '200 55% 45%',
+  expansion: '290 65% 50%',
+  achievement: '45 90% 48%',
+  note: '40 30% 42%',
+  custom: '220 15% 45%',
+};
+
+export const ContentsBlock = memo(function ContentsBlock({
+  title,
+  entityColor,
+  data,
+}: ContentsBlockProps) {
+  const { items } = data;
+
+  return (
+    <div className="flex flex-col gap-2">
+      {title && (
+        <>
+          <h4
+            className="text-xs font-semibold uppercase tracking-wide"
+            style={{ color: `hsl(${entityColor})` }}
+          >
+            {title}
+          </h4>
+          <div className="h-px w-full" style={{ backgroundColor: `hsl(${entityColor} / 0.2)` }} />
+        </>
+      )}
+
+      {items.length === 0 ? (
+        <p className="text-xs text-muted-foreground italic">No data yet</p>
+      ) : (
+        <ul className="flex flex-col gap-1">
+          {items.map((item) => {
+            const dotColor = ENTITY_COLORS[item.entityType] ?? entityColor;
+            return (
+              <li key={item.id} className="flex items-center gap-2 text-xs">
+                <span
+                  className="h-2 w-2 shrink-0 rounded-full"
+                  style={{ backgroundColor: `hsl(${dotColor})` }}
+                  aria-label={item.entityType}
+                />
+                <span className="flex-1 truncate text-foreground">{item.title}</span>
+                {item.status && (
+                  <span className="shrink-0 text-[10px] capitalize text-muted-foreground">
+                    {item.status}
+                  </span>
+                )}
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+});
+
+ContentsBlock.displayName = 'ContentsBlock';

--- a/apps/web/src/components/ui/data-display/card-back-blocks/blocks/DetailLinkBlock.tsx
+++ b/apps/web/src/components/ui/data-display/card-back-blocks/blocks/DetailLinkBlock.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import Link from 'next/link';
+import { memo } from 'react';
+
+interface DetailLinkBlockProps {
+  title: string;
+  entityColor: string;
+  data: {
+    type: 'detailLink';
+    href: string;
+    label: string;
+  };
+}
+
+export const DetailLinkBlock = memo(function DetailLinkBlock({
+  title,
+  entityColor,
+  data,
+}: DetailLinkBlockProps) {
+  const { href, label } = data;
+
+  return (
+    <div className="flex flex-col items-center gap-2">
+      {title && (
+        <h4
+          className="text-xs font-semibold uppercase tracking-wide"
+          style={{ color: `hsl(${entityColor})` }}
+        >
+          {title}
+        </h4>
+      )}
+
+      <Link
+        href={href}
+        className="inline-flex items-center gap-1 rounded-md border px-3 py-1.5 text-xs font-medium transition-colors hover:opacity-80"
+        style={{
+          borderColor: `hsl(${entityColor} / 0.5)`,
+          color: `hsl(${entityColor})`,
+          backgroundColor: `hsl(${entityColor} / 0.06)`,
+        }}
+      >
+        {label}
+        <span aria-hidden="true">→</span>
+      </Link>
+    </div>
+  );
+});
+
+DetailLinkBlock.displayName = 'DetailLinkBlock';

--- a/apps/web/src/components/ui/data-display/card-back-blocks/blocks/HistoryBlock.tsx
+++ b/apps/web/src/components/ui/data-display/card-back-blocks/blocks/HistoryBlock.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+import { memo } from 'react';
+
+interface HistoryEntry {
+  timestamp: string;
+  message: string;
+  sender?: string;
+}
+
+interface HistoryBlockProps {
+  title: string;
+  entityColor: string;
+  data: {
+    type: 'history';
+    entries: HistoryEntry[];
+  };
+}
+
+export const HistoryBlock = memo(function HistoryBlock({
+  title,
+  entityColor,
+  data,
+}: HistoryBlockProps) {
+  const { entries } = data;
+
+  return (
+    <div className="flex flex-col gap-2">
+      {title && (
+        <>
+          <h4
+            className="text-xs font-semibold uppercase tracking-wide"
+            style={{ color: `hsl(${entityColor})` }}
+          >
+            {title}
+          </h4>
+          <div className="h-px w-full" style={{ backgroundColor: `hsl(${entityColor} / 0.2)` }} />
+        </>
+      )}
+
+      {entries.length === 0 ? (
+        <p className="text-xs text-muted-foreground italic">No data yet</p>
+      ) : (
+        <ul className="flex flex-col gap-1.5">
+          {entries.map((entry, idx) => (
+            <li key={idx} className="flex flex-col gap-0.5 text-xs">
+              <div className="flex items-baseline gap-1.5">
+                <span className="shrink-0 font-mono text-[10px] tabular-nums text-muted-foreground">
+                  {entry.timestamp}
+                </span>
+                {entry.sender && (
+                  <span className="shrink-0 font-semibold text-foreground">{entry.sender}</span>
+                )}
+              </div>
+              <p className="text-foreground/80">{entry.message}</p>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+});
+
+HistoryBlock.displayName = 'HistoryBlock';

--- a/apps/web/src/components/ui/data-display/card-back-blocks/blocks/KBPreviewBlock.tsx
+++ b/apps/web/src/components/ui/data-display/card-back-blocks/blocks/KBPreviewBlock.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import { memo } from 'react';
+
+import { cn } from '@/lib/utils';
+
+interface KBPreviewBlockProps {
+  title: string;
+  entityColor: string;
+  data: {
+    type: 'kbPreview';
+    docsCount: number;
+    chunksCount: number;
+    lastQuery?: string;
+    indexStatus: string;
+  };
+}
+
+function getStatusVariant(status: string): string {
+  switch (status.toLowerCase()) {
+    case 'indexed':
+      return 'bg-green-100 text-green-800 dark:bg-green-900/30 dark:text-green-400';
+    case 'indexing':
+      return 'bg-yellow-100 text-yellow-800 dark:bg-yellow-900/30 dark:text-yellow-400';
+    case 'error':
+      return 'bg-red-100 text-red-800 dark:bg-red-900/30 dark:text-red-400';
+    default:
+      return 'bg-muted text-muted-foreground';
+  }
+}
+
+export const KBPreviewBlock = memo(function KBPreviewBlock({
+  title,
+  entityColor,
+  data,
+}: KBPreviewBlockProps) {
+  const { docsCount, chunksCount, lastQuery, indexStatus } = data;
+
+  return (
+    <div className="flex flex-col gap-2">
+      {title && (
+        <>
+          <h4
+            className="text-xs font-semibold uppercase tracking-wide"
+            style={{ color: `hsl(${entityColor})` }}
+          >
+            {title}
+          </h4>
+          <div className="h-px w-full" style={{ backgroundColor: `hsl(${entityColor} / 0.2)` }} />
+        </>
+      )}
+
+      <div className="flex flex-col gap-1.5 text-xs">
+        <div className="flex items-center justify-between">
+          <span className="text-muted-foreground">Documenti</span>
+          <span className="font-semibold tabular-nums">{docsCount}</span>
+        </div>
+        <div className="flex items-center justify-between">
+          <span className="text-muted-foreground">Chunks</span>
+          <span className="font-semibold tabular-nums">{chunksCount}</span>
+        </div>
+        <div className="flex items-center justify-between">
+          <span className="text-muted-foreground">Stato</span>
+          <span
+            className={cn(
+              'rounded-full px-2 py-0.5 text-[10px] font-medium capitalize',
+              getStatusVariant(indexStatus)
+            )}
+          >
+            {indexStatus}
+          </span>
+        </div>
+        {lastQuery && (
+          <div className="mt-1 border-t pt-1" style={{ borderColor: `hsl(${entityColor} / 0.15)` }}>
+            <p className="text-[10px] text-muted-foreground">Ultima query</p>
+            <p className="mt-0.5 line-clamp-2 text-foreground">{lastQuery}</p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+});
+
+KBPreviewBlock.displayName = 'KBPreviewBlock';

--- a/apps/web/src/components/ui/data-display/card-back-blocks/blocks/MembersBlock.tsx
+++ b/apps/web/src/components/ui/data-display/card-back-blocks/blocks/MembersBlock.tsx
@@ -1,0 +1,84 @@
+'use client';
+
+import { memo } from 'react';
+
+interface Member {
+  name: string;
+  role?: string;
+  avatarUrl?: string;
+}
+
+interface MembersBlockProps {
+  title: string;
+  entityColor: string;
+  data: {
+    type: 'members';
+    members: Member[];
+  };
+}
+
+function getInitials(name: string): string {
+  return name
+    .split(' ')
+    .map((part) => part[0])
+    .join('')
+    .toUpperCase()
+    .slice(0, 2);
+}
+
+export const MembersBlock = memo(function MembersBlock({
+  title,
+  entityColor,
+  data,
+}: MembersBlockProps) {
+  const { members } = data;
+
+  return (
+    <div className="flex flex-col gap-2">
+      {title && (
+        <>
+          <h4
+            className="text-xs font-semibold uppercase tracking-wide"
+            style={{ color: `hsl(${entityColor})` }}
+          >
+            {title}
+          </h4>
+          <div className="h-px w-full" style={{ backgroundColor: `hsl(${entityColor} / 0.2)` }} />
+        </>
+      )}
+
+      {members.length === 0 ? (
+        <p className="text-xs text-muted-foreground italic">No data yet</p>
+      ) : (
+        <ul className="flex flex-col gap-1.5">
+          {members.map((member, idx) => (
+            <li key={idx} className="flex items-center gap-2 text-xs">
+              {member.avatarUrl ? (
+                // eslint-disable-next-line @next/next/no-img-element
+                <img
+                  src={member.avatarUrl}
+                  alt={member.name}
+                  className="h-6 w-6 shrink-0 rounded-full object-cover"
+                />
+              ) : (
+                <span
+                  className="flex h-6 w-6 shrink-0 items-center justify-center rounded-full text-[10px] font-bold text-white"
+                  style={{ backgroundColor: `hsl(${entityColor})` }}
+                  aria-hidden="true"
+                >
+                  {getInitials(member.name)}
+                </span>
+              )}
+              <span className="flex-1 truncate font-medium text-foreground">{member.name}</span>
+              {member.role && (
+                <span className="shrink-0 text-[10px] text-muted-foreground">{member.role}</span>
+              )}
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+});
+
+MembersBlock.displayName = 'MembersBlock';

--- a/apps/web/src/components/ui/data-display/card-back-blocks/blocks/NotesBlock.tsx
+++ b/apps/web/src/components/ui/data-display/card-back-blocks/blocks/NotesBlock.tsx
@@ -1,0 +1,50 @@
+'use client';
+
+import { memo } from 'react';
+
+interface NotesBlockProps {
+  title: string;
+  entityColor: string;
+  data: {
+    type: 'notes';
+    content: string;
+    updatedAt: string;
+  };
+}
+
+export const NotesBlock = memo(function NotesBlock({
+  title,
+  entityColor,
+  data,
+}: NotesBlockProps) {
+  const { content, updatedAt } = data;
+
+  return (
+    <div className="flex flex-col gap-2">
+      {title && (
+        <>
+          <h4
+            className="text-xs font-semibold uppercase tracking-wide"
+            style={{ color: `hsl(${entityColor})` }}
+          >
+            {title}
+          </h4>
+          <div className="h-px w-full" style={{ backgroundColor: `hsl(${entityColor} / 0.2)` }} />
+        </>
+      )}
+
+      {!content ? (
+        <p className="text-xs text-muted-foreground italic">No data yet</p>
+      ) : (
+        <div className="flex flex-col gap-1.5">
+          <p className="whitespace-pre-wrap text-xs text-foreground">{content}</p>
+          <p className="text-[10px] text-muted-foreground">
+            Aggiornato: {updatedAt}
+          </p>
+        </div>
+      )}
+    </div>
+  );
+});
+
+NotesBlock.displayName = 'NotesBlock';

--- a/apps/web/src/components/ui/data-display/card-back-blocks/blocks/ProgressBlock.tsx
+++ b/apps/web/src/components/ui/data-display/card-back-blocks/blocks/ProgressBlock.tsx
@@ -1,0 +1,93 @@
+'use client';
+
+import { memo } from 'react';
+
+interface Milestone {
+  at: number;
+  label: string;
+}
+
+interface ProgressBlockProps {
+  title: string;
+  entityColor: string;
+  data: {
+    type: 'progress';
+    current: number;
+    target: number;
+    label: string;
+    milestones?: Milestone[];
+  };
+}
+
+export const ProgressBlock = memo(function ProgressBlock({
+  title,
+  entityColor,
+  data,
+}: ProgressBlockProps) {
+  const { current, target, label, milestones } = data;
+
+  const percentage = target > 0 ? Math.min(100, Math.round((current / target) * 100)) : 0;
+
+  return (
+    <div className="flex flex-col gap-2">
+      {title && (
+        <>
+          <h4
+            className="text-xs font-semibold uppercase tracking-wide"
+            style={{ color: `hsl(${entityColor})` }}
+          >
+            {title}
+          </h4>
+          <div className="h-px w-full" style={{ backgroundColor: `hsl(${entityColor} / 0.2)` }} />
+        </>
+      )}
+
+      <div className="flex flex-col gap-1.5 text-xs">
+        <div className="flex items-center justify-between">
+          <span className="font-medium text-foreground">{label}</span>
+          <span className="tabular-nums text-muted-foreground">{percentage}%</span>
+        </div>
+
+        {/* Progress bar */}
+        <div className="relative h-2 w-full overflow-hidden rounded-full bg-muted">
+          <div
+            className="h-full rounded-full transition-all duration-300"
+            style={{
+              width: `${percentage}%`,
+              backgroundColor: `hsl(${entityColor})`,
+            }}
+            role="progressbar"
+            aria-valuenow={current}
+            aria-valuemin={0}
+            aria-valuemax={target}
+          />
+          {/* Milestone markers */}
+          {milestones?.map((milestone) => {
+            const pos = target > 0 ? Math.min(100, (milestone.at / target) * 100) : 0;
+            return (
+              <span
+                key={milestone.at}
+                className="absolute top-0 h-full w-0.5 bg-background/60"
+                style={{ left: `${pos}%` }}
+                title={milestone.label}
+              />
+            );
+          })}
+        </div>
+
+        {/* Milestones legend */}
+        {milestones && milestones.length > 0 && (
+          <ul className="flex flex-wrap gap-x-2 gap-y-0.5 text-[10px] text-muted-foreground">
+            {milestones.map((milestone) => (
+              <li key={milestone.at}>
+                {milestone.at}: {milestone.label}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+    </div>
+  );
+});
+
+ProgressBlock.displayName = 'ProgressBlock';

--- a/apps/web/src/components/ui/data-display/card-back-blocks/blocks/RankingBlock.tsx
+++ b/apps/web/src/components/ui/data-display/card-back-blocks/blocks/RankingBlock.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import { memo } from 'react';
+
+import { cn } from '@/lib/utils';
+
+interface RankingPlayer {
+  name: string;
+  score: number;
+  position: number;
+  isLeader?: boolean;
+}
+
+interface RankingBlockProps {
+  title: string;
+  entityColor: string;
+  data: {
+    type: 'ranking';
+    players: RankingPlayer[];
+  };
+}
+
+export const RankingBlock = memo(function RankingBlock({
+  title,
+  entityColor,
+  data,
+}: RankingBlockProps) {
+  const { players } = data;
+
+  return (
+    <div className="flex flex-col gap-2">
+      {title && (
+        <>
+          <h4
+            className="text-xs font-semibold uppercase tracking-wide"
+            style={{ color: `hsl(${entityColor})` }}
+          >
+            {title}
+          </h4>
+          <div className="h-px w-full" style={{ backgroundColor: `hsl(${entityColor} / 0.2)` }} />
+        </>
+      )}
+
+      {players.length === 0 ? (
+        <p className="text-xs text-muted-foreground italic">No data yet</p>
+      ) : (
+        <ol className="flex flex-col gap-1">
+          {players.map((player) => (
+            <li
+              key={player.position}
+              className={cn(
+                'flex items-center gap-2 rounded px-1.5 py-1 text-xs',
+                player.isLeader && 'font-semibold'
+              )}
+              style={
+                player.isLeader
+                  ? { backgroundColor: `hsl(${entityColor} / 0.12)`, color: `hsl(${entityColor})` }
+                  : undefined
+              }
+            >
+              <span className="w-4 shrink-0 text-center tabular-nums text-muted-foreground">
+                {player.position}
+              </span>
+              <span className="flex-1 truncate">{player.name}</span>
+              <span className="shrink-0 tabular-nums">{player.score}</span>
+            </li>
+          ))}
+        </ol>
+      )}
+    </div>
+  );
+});
+
+RankingBlock.displayName = 'RankingBlock';

--- a/apps/web/src/components/ui/data-display/card-back-blocks/blocks/TimelineBlock.tsx
+++ b/apps/web/src/components/ui/data-display/card-back-blocks/blocks/TimelineBlock.tsx
@@ -1,0 +1,71 @@
+'use client';
+
+import { memo } from 'react';
+
+import { cn } from '@/lib/utils';
+
+interface TimelineEvent {
+  time: string;
+  label: string;
+  icon?: string;
+}
+
+interface TimelineBlockProps {
+  title: string;
+  entityColor: string;
+  data: {
+    type: 'timeline';
+    events: TimelineEvent[];
+  };
+}
+
+export const TimelineBlock = memo(function TimelineBlock({
+  title,
+  entityColor,
+  data,
+}: TimelineBlockProps) {
+  const { events } = data;
+
+  return (
+    <div className="flex flex-col gap-2">
+      {title && (
+        <>
+          <h4
+            className="text-xs font-semibold uppercase tracking-wide"
+            style={{ color: `hsl(${entityColor})` }}
+          >
+            {title}
+          </h4>
+          <div className="h-px w-full" style={{ backgroundColor: `hsl(${entityColor} / 0.2)` }} />
+        </>
+      )}
+
+      {events.length === 0 ? (
+        <p className="text-xs text-muted-foreground italic">No data yet</p>
+      ) : (
+        <ol className="flex flex-col gap-1.5">
+          {events.map((event, idx) => (
+            <li key={idx} className="flex items-start gap-2 text-xs">
+              <span
+                className={cn(
+                  'shrink-0 w-12 text-right font-mono tabular-nums',
+                  'text-muted-foreground'
+                )}
+              >
+                {event.time}
+              </span>
+              {event.icon && (
+                <span className="shrink-0" aria-hidden="true">
+                  {event.icon}
+                </span>
+              )}
+              <span className="text-foreground">{event.label}</span>
+            </li>
+          ))}
+        </ol>
+      )}
+    </div>
+  );
+});
+
+TimelineBlock.displayName = 'TimelineBlock';


### PR DESCRIPTION
## Summary
- 9 remaining block components for modular card backs
- TimelineBlock, RankingBlock, KBPreviewBlock, MembersBlock, ContentsBlock, HistoryBlock, ProgressBlock, NotesBlock, DetailLinkBlock
- 20 tests covering all blocks

Follow-up to #477 — these blocks were created in worktrees but missed the squash merge.

## Test plan
- [x] 20 block tests pass
- [x] TypeScript typecheck clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)