### PR TITLE
fix(holo): activate holo animations and use CSS var for border-radius

### DIFF
--- a/apps/web/e2e/flows/admin-user-onboarding.spec.ts
+++ b/apps/web/e2e/flows/admin-user-onboarding.spec.ts
@@ -238,7 +238,20 @@ test.describe('Admin-User Onboarding Flow', () => {
 
       // Navigate to /library with a fresh load (applies localStorage change)
       await page.goto('/library', { waitUntil: 'networkidle' });
-      await page.waitForTimeout(2000);
+
+      // Cookie consent blocks interactions — dismiss then reload
+      const cookieBtn5 = page.getByRole('button', { name: /essential only|accept all/i });
+      if (
+        await cookieBtn5
+          .first()
+          .isVisible({ timeout: 2_000 })
+          .catch(() => false)
+      ) {
+        await cookieBtn5.first().click();
+        await page.waitForTimeout(500);
+        await page.reload({ waitUntil: 'networkidle' });
+      }
+      await page.waitForTimeout(1000);
     });
 
     await test.step('Search and add game', async () => {

--- a/apps/web/src/components/ui/data-display/holo/HoloOverlay.tsx
+++ b/apps/web/src/components/ui/data-display/holo/HoloOverlay.tsx
@@ -11,7 +11,7 @@ export function HoloOverlay({ disabled = false }: HoloOverlayProps) {
     <>
       {/* Layer 1: Rainbow gradient — mix-blend-mode: screen */}
       <div
-        className="holo-rainbow pointer-events-none absolute inset-0 z-[7] rounded-[inherit] opacity-0 transition-opacity duration-500 group-hover:opacity-100"
+        className="holo-rainbow animate pointer-events-none absolute inset-0 z-[7] rounded-[inherit] opacity-0 transition-opacity duration-500 group-hover:opacity-100"
         style={{
           background: `linear-gradient(115deg, transparent 20%, rgba(236,110,173,0.12) 32%, rgba(52,148,230,0.12) 40%, rgba(103,232,138,0.10) 48%, rgba(233,211,98,0.12) 56%, rgba(236,110,173,0.10) 64%, transparent 80%)`,
           backgroundSize: '200% 100%',
@@ -29,10 +29,10 @@ export function HoloOverlay({ disabled = false }: HoloOverlayProps) {
       />
       {/* Layer 3: Rotating rainbow border via mask-composite */}
       <div
-        className="holo-border pointer-events-none absolute z-[9] opacity-0 transition-opacity duration-500 group-hover:opacity-100"
+        className="holo-border animate pointer-events-none absolute z-[9] opacity-0 transition-opacity duration-500 group-hover:opacity-100"
         style={{
           inset: '-2px',
-          borderRadius: '20px',
+          borderRadius: 'calc(var(--radius-card, 16px) + 2px)',
           background: `conic-gradient(from 0deg, rgba(167,139,250,0.25), rgba(96,165,250,0.2), rgba(52,211,153,0.18), rgba(251,191,36,0.22), rgba(255,107,107,0.18), rgba(236,72,153,0.2), rgba(167,139,250,0.25))`,
           WebkitMask: 'linear-gradient(#fff 0 0) content-box, linear-gradient(#fff 0 0)',
           WebkitMaskComposite: 'xor',


### PR DESCRIPTION
## Summary

- Add `.animate` class to HoloOverlay rainbow and border layers, activating `holo-slide` and `holo-rotate` CSS animations from `globals.css`
- Replace hardcoded `borderRadius: '20px'` with `calc(var(--radius-card, 16px) + 2px)` for consistent radius across card variants

Fixes from code review of the Neon Holo visual redesign implementation.

## Test plan

- [x] HoloOverlay tests pass (3/3)
- [x] useHoloVisibility tests pass (2/2)
- [x] `pnpm typecheck` clean
- [x] Pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)
