### PR TITLE
feat: Game Night Improvvisata vertical slice

### DIFF
--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNight/CreatePauseSnapshotCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNight/CreatePauseSnapshotCommand.cs
@@ -9,6 +9,7 @@ using Api.Middleware.Exceptions;
 using FluentValidation;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 
 namespace Api.BoundedContexts.GameManagement.Application.Commands.GameNight;
 
@@ -85,7 +86,14 @@ internal sealed class CreatePauseSnapshotCommandHandler
             .ConfigureAwait(false)
             ?? throw new NotFoundException("LiveGameSession", request.SessionId.ToString());
 
-        // 2. Verify session is InProgress
+        // 2. Authorization: only the session host/creator can pause the session
+        if (session.CreatedByUserId != request.SavedByUserId)
+        {
+            throw new ForbiddenException(
+                "Only the session host can save and pause the session.");
+        }
+
+        // 3. Verify session is InProgress
         if (session.Status != LiveSessionStatus.InProgress)
         {
             throw new ConflictException(

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNight/CreatePauseSnapshotCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNight/CreatePauseSnapshotCommand.cs
@@ -1,0 +1,238 @@
+using System.Text.Json;
+using Api.BoundedContexts.GameManagement.Domain.Entities;
+using Api.BoundedContexts.GameManagement.Domain.Entities.PauseSnapshot;
+using Api.BoundedContexts.GameManagement.Domain.Enums;
+using Api.BoundedContexts.GameManagement.Domain.Events;
+using Api.BoundedContexts.GameManagement.Domain.Repositories;
+using Api.Infrastructure;
+using Api.Middleware.Exceptions;
+using FluentValidation;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.GameManagement.Application.Commands.GameNight;
+
+/// <summary>
+/// Command that captures the full state of an in-progress live game session
+/// into a PauseSnapshot and transitions the session to Paused status.
+/// Game Night Improvvisata — E4: Save/Resume flow.
+/// </summary>
+public sealed record CreatePauseSnapshotCommand(
+    Guid SessionId,
+    Guid SavedByUserId,
+    List<Guid>? FinalPhotoIds = null) : IRequest<Guid>;
+
+/// <summary>
+/// Validates <see cref="CreatePauseSnapshotCommand"/> inputs.
+/// </summary>
+public sealed class CreatePauseSnapshotCommandValidator : AbstractValidator<CreatePauseSnapshotCommand>
+{
+    public CreatePauseSnapshotCommandValidator()
+    {
+        RuleFor(x => x.SessionId)
+            .NotEmpty()
+            .WithMessage("Session ID is required");
+
+        RuleFor(x => x.SavedByUserId)
+            .NotEmpty()
+            .WithMessage("User ID is required");
+    }
+}
+
+/// <summary>
+/// Handles <see cref="CreatePauseSnapshotCommand"/>.
+/// Captures session state, creates a PauseSnapshot, pauses the session,
+/// then publishes <see cref="SessionSaveRequestedEvent"/> (for async AI summary)
+/// and <see cref="SessionPausedEvent"/> (for SignalR broadcast).
+/// </summary>
+internal sealed class CreatePauseSnapshotCommandHandler
+    : IRequestHandler<CreatePauseSnapshotCommand, Guid>
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    private readonly ILiveSessionRepository _sessionRepository;
+    private readonly IPauseSnapshotRepository _snapshotRepository;
+    private readonly MeepleAiDbContext _dbContext;
+    private readonly IPublisher _publisher;
+    private readonly ILogger<CreatePauseSnapshotCommandHandler> _logger;
+
+    public CreatePauseSnapshotCommandHandler(
+        ILiveSessionRepository sessionRepository,
+        IPauseSnapshotRepository snapshotRepository,
+        MeepleAiDbContext dbContext,
+        IPublisher publisher,
+        ILogger<CreatePauseSnapshotCommandHandler> logger)
+    {
+        _sessionRepository = sessionRepository ?? throw new ArgumentNullException(nameof(sessionRepository));
+        _snapshotRepository = snapshotRepository ?? throw new ArgumentNullException(nameof(snapshotRepository));
+        _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+        _publisher = publisher ?? throw new ArgumentNullException(nameof(publisher));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<Guid> Handle(
+        CreatePauseSnapshotCommand request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        // 1. Load LiveGameSession — throws NotFoundException if missing
+        var session = await _sessionRepository
+            .GetByIdAsync(request.SessionId, cancellationToken)
+            .ConfigureAwait(false)
+            ?? throw new NotFoundException("LiveGameSession", request.SessionId.ToString());
+
+        // 2. Verify session is InProgress
+        if (session.Status != LiveSessionStatus.InProgress)
+        {
+            throw new ConflictException(
+                $"Cannot create a pause snapshot for session in {session.Status} status. " +
+                "Session must be InProgress.");
+        }
+
+        _logger.LogInformation(
+            "CreatePauseSnapshotCommand: SessionId={SessionId}, SavedByUserId={UserId}",
+            request.SessionId, request.SavedByUserId);
+
+        // 3. Capture player scores from the live session
+        var playerScores = session.Players
+            .Where(p => p.IsActive)
+            .Select(p => new PlayerScoreSnapshot(
+                PlayerName: p.DisplayName,
+                Score: p.TotalScore))
+            .ToList();
+
+        // 4. Capture current phase name
+        var currentPhase = session.GetCurrentPhaseName();
+
+        // 5. Create PauseSnapshot via factory (IsAutoSave = false)
+        var snapshot = PauseSnapshot.Create(
+            liveGameSessionId: session.Id,
+            currentTurn: session.CurrentTurnIndex,
+            currentPhase: currentPhase,
+            playerScores: playerScores,
+            savedByUserId: request.SavedByUserId,
+            isAutoSave: false,
+            attachmentIds: request.FinalPhotoIds,
+            disputes: session.Disputes.ToList());
+
+        // 6. Save snapshot via repository
+        await _snapshotRepository.AddAsync(snapshot, cancellationToken).ConfigureAwait(false);
+
+        // 7. Pause the session (domain method handles validation)
+        session.Pause();
+
+        // 8. Persist session status change to DB
+        await PersistSessionStatusAsync(session, cancellationToken).ConfigureAwait(false);
+
+        // 9. Update in-memory repository
+        await _sessionRepository.UpdateAsync(session, cancellationToken).ConfigureAwait(false);
+
+        // 10. Save snapshot to DB
+        await _dbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        // 11. Collect last messages for async summary (from ChatSessionId if available)
+        var lastMessages = await CollectLastMessagesAsync(session, cancellationToken).ConfigureAwait(false);
+
+        // 12. Publish SessionSaveRequestedEvent for async AI summary generation
+        //     Only publish if session has an active agent with a chat session
+        if (session.AgentMode != AgentSessionMode.None && session.ChatSessionId.HasValue)
+        {
+            // We use ChatSessionId as a proxy for AgentDefinitionId in the event;
+            // the actual agent definition ID must be resolved by the handler
+            await _publisher
+                .Publish(new SessionSaveRequestedEvent(
+                    pauseSnapshotId: snapshot.Id,
+                    liveGameSessionId: session.Id,
+                    agentDefinitionId: session.ChatSessionId.Value,
+                    lastMessages: lastMessages), cancellationToken)
+                .ConfigureAwait(false);
+        }
+
+        // 13. Publish SessionPausedEvent for SignalR broadcast
+        await _publisher
+            .Publish(new SessionPausedEvent(session.Id), cancellationToken)
+            .ConfigureAwait(false);
+
+        _logger.LogInformation(
+            "Session {SessionId} paused. Snapshot {SnapshotId} created with {PlayerCount} player scores.",
+            session.Id, snapshot.Id, playerScores.Count);
+
+        return snapshot.Id;
+    }
+
+    // ── Helpers ─────────────────────────────────────────────────────────────
+
+    private async Task PersistSessionStatusAsync(
+        LiveGameSession session,
+        CancellationToken cancellationToken)
+    {
+        var entity = await _dbContext.LiveGameSessions
+            .FirstOrDefaultAsync(e => e.Id == session.Id, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (entity is null)
+        {
+            _logger.LogWarning(
+                "LiveGameSessionEntity not found in DB for SessionId={SessionId}. " +
+                "Status will not be persisted to database.",
+                session.Id);
+            return;
+        }
+
+        entity.Status = (int)session.Status;
+        entity.PausedAt = session.PausedAt;
+        entity.UpdatedAt = session.UpdatedAt;
+        entity.DisputesJson = JsonSerializer.Serialize(session.Disputes, JsonOptions);
+    }
+
+    private async Task<List<string>> CollectLastMessagesAsync(
+        LiveGameSession session,
+        CancellationToken cancellationToken)
+    {
+        if (!session.ChatSessionId.HasValue)
+            return new List<string>();
+
+        try
+        {
+            // ChatSessionEntity stores messages as a JSON blob (MessagesJson)
+            var chatSession = await _dbContext.ChatSessions
+                .AsNoTracking()
+                .FirstOrDefaultAsync(cs => cs.Id == session.ChatSessionId.Value, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (chatSession is null || string.IsNullOrWhiteSpace(chatSession.MessagesJson))
+                return new List<string>();
+
+            // Deserialise the message array to extract role+content pairs
+            var rawMessages = System.Text.Json.JsonSerializer
+                .Deserialize<List<System.Text.Json.JsonElement>>(chatSession.MessagesJson, JsonOptions)
+                ?? new List<System.Text.Json.JsonElement>();
+
+            // Take the last 50 messages; include role and content
+            return rawMessages
+                .TakeLast(50)
+                .Select(m =>
+                {
+                    var role = m.TryGetProperty("role", out var r) ? r.GetString() ?? "unknown" : "unknown";
+                    var content = m.TryGetProperty("content", out var c) ? c.GetString() ?? string.Empty : string.Empty;
+                    return $"[{role}] {content}";
+                })
+                .ToList();
+        }
+#pragma warning disable CA1031
+        catch (Exception ex)
+        {
+            _logger.LogWarning(
+                ex,
+                "Could not collect last messages for ChatSessionId={ChatSessionId}. " +
+                "Summary will be generated without message history.",
+                session.ChatSessionId.Value);
+            return new List<string>();
+        }
+#pragma warning restore CA1031
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNight/ResumeSessionFromSnapshotCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNight/ResumeSessionFromSnapshotCommand.cs
@@ -1,0 +1,209 @@
+using Api.BoundedContexts.GameManagement.Domain.Entities;
+using Api.BoundedContexts.GameManagement.Domain.Enums;
+using Api.BoundedContexts.GameManagement.Domain.Events;
+using Api.BoundedContexts.GameManagement.Domain.Repositories;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.GameManagement;
+using Api.Middleware.Exceptions;
+using FluentValidation;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.GameManagement.Application.Commands.GameNight;
+
+/// <summary>
+/// Command to resume a paused live game session from its most recent PauseSnapshot.
+/// Creates a new SessionInvite (old one may be expired), deletes stale auto-saves,
+/// and returns an optional agent recap for context.
+/// Game Night Improvvisata — E4: Save/Resume flow.
+/// </summary>
+public sealed record ResumeSessionFromSnapshotCommand(
+    Guid SessionId,
+    Guid ResumedByUserId) : IRequest<ResumeSessionResponse>;
+
+/// <summary>
+/// Response returned after a successful session resume.
+/// </summary>
+public sealed record ResumeSessionResponse(
+    Guid SessionId,
+    string InviteCode,
+    string ShareLink,
+    string? AgentRecap);
+
+/// <summary>
+/// Validates <see cref="ResumeSessionFromSnapshotCommand"/> inputs.
+/// </summary>
+public sealed class ResumeSessionFromSnapshotCommandValidator
+    : AbstractValidator<ResumeSessionFromSnapshotCommand>
+{
+    public ResumeSessionFromSnapshotCommandValidator()
+    {
+        RuleFor(x => x.SessionId)
+            .NotEmpty()
+            .WithMessage("Session ID is required");
+
+        RuleFor(x => x.ResumedByUserId)
+            .NotEmpty()
+            .WithMessage("User ID is required");
+    }
+}
+
+/// <summary>
+/// Handles <see cref="ResumeSessionFromSnapshotCommand"/>.
+/// Orchestrates the resume flow:
+///   1. Load latest PauseSnapshot.
+///   2. Load LiveGameSession and verify it's Paused.
+///   3. Resume session via domain method.
+///   4. Issue a fresh SessionInvite.
+///   5. Delete auto-save PauseSnapshots.
+///   6. Build recap from agent summary (or fallback).
+///   7. Publish <see cref="SessionResumedEvent"/>.
+/// </summary>
+internal sealed class ResumeSessionFromSnapshotCommandHandler
+    : IRequestHandler<ResumeSessionFromSnapshotCommand, ResumeSessionResponse>
+{
+    private const int InviteMaxUses = 10;
+    private const int InviteExpiryMinutes = 24 * 60; // 24 hours
+
+    private readonly ILiveSessionRepository _sessionRepository;
+    private readonly IPauseSnapshotRepository _snapshotRepository;
+    private readonly MeepleAiDbContext _dbContext;
+    private readonly IPublisher _publisher;
+    private readonly ILogger<ResumeSessionFromSnapshotCommandHandler> _logger;
+
+    public ResumeSessionFromSnapshotCommandHandler(
+        ILiveSessionRepository sessionRepository,
+        IPauseSnapshotRepository snapshotRepository,
+        MeepleAiDbContext dbContext,
+        IPublisher publisher,
+        ILogger<ResumeSessionFromSnapshotCommandHandler> logger)
+    {
+        _sessionRepository = sessionRepository ?? throw new ArgumentNullException(nameof(sessionRepository));
+        _snapshotRepository = snapshotRepository ?? throw new ArgumentNullException(nameof(snapshotRepository));
+        _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+        _publisher = publisher ?? throw new ArgumentNullException(nameof(publisher));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<ResumeSessionResponse> Handle(
+        ResumeSessionFromSnapshotCommand request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        // 1. Load latest PauseSnapshot — throws NotFoundException if none exists
+        var snapshot = await _snapshotRepository
+            .GetLatestBySessionIdAsync(request.SessionId, cancellationToken)
+            .ConfigureAwait(false)
+            ?? throw new NotFoundException("PauseSnapshot", request.SessionId.ToString());
+
+        // 2. Load LiveGameSession
+        var session = await _sessionRepository
+            .GetByIdAsync(request.SessionId, cancellationToken)
+            .ConfigureAwait(false)
+            ?? throw new NotFoundException("LiveGameSession", request.SessionId.ToString());
+
+        // 3. Verify session is Paused
+        if (session.Status != LiveSessionStatus.Paused)
+        {
+            throw new ConflictException(
+                $"Cannot resume session in {session.Status} status. Session must be Paused.");
+        }
+
+        _logger.LogInformation(
+            "ResumeSessionFromSnapshotCommand: SessionId={SessionId}, SnapshotId={SnapshotId}",
+            request.SessionId, snapshot.Id);
+
+        // 4. Resume the session via domain method
+        session.Resume();
+
+        // 5. Create a new SessionInvite (old one may have expired)
+        var invite = SessionInvite.Create(
+            sessionId: session.Id,
+            createdByUserId: request.ResumedByUserId,
+            maxUses: InviteMaxUses,
+            expiryMinutes: InviteExpiryMinutes);
+
+        // 6. Delete auto-save PauseSnapshots to keep history clean
+        await _snapshotRepository
+            .DeleteAutoSavesBySessionIdAsync(request.SessionId, cancellationToken)
+            .ConfigureAwait(false);
+
+        // 7. Get agent recap from the snapshot's conversation summary (may be null — that's OK)
+        var recap = BuildRecap(snapshot.AgentConversationSummary, snapshot.CurrentTurn);
+
+        // 8. Persist session status change to DB
+        await PersistSessionStatusAsync(session, cancellationToken).ConfigureAwait(false);
+
+        // 9. Persist new SessionInvite to DB
+        _dbContext.SessionInvites.Add(new SessionInviteEntity
+        {
+            Id = invite.Id,
+            SessionId = invite.SessionId,
+            CreatedByUserId = invite.CreatedByUserId,
+            Pin = invite.Pin,
+            LinkToken = invite.LinkToken,
+            MaxUses = invite.MaxUses,
+            CurrentUses = invite.CurrentUses,
+            CreatedAt = invite.CreatedAt,
+            ExpiresAt = invite.ExpiresAt,
+            IsRevoked = invite.IsRevoked
+        });
+
+        // 10. Update in-memory repository
+        await _sessionRepository.UpdateAsync(session, cancellationToken).ConfigureAwait(false);
+
+        // 11. Save everything atomically
+        await _dbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        // 12. Publish SessionResumedEvent for SignalR broadcast
+        await _publisher
+            .Publish(new SessionResumedEvent(session.Id, recap), cancellationToken)
+            .ConfigureAwait(false);
+
+        _logger.LogInformation(
+            "Session {SessionId} resumed. New invite {InvitePin} created. Recap available: {HasRecap}",
+            session.Id, invite.Pin, recap is not null);
+
+        var shareLink = $"/join/{invite.LinkToken}";
+
+        return new ResumeSessionResponse(
+            SessionId: session.Id,
+            InviteCode: invite.Pin,
+            ShareLink: shareLink,
+            AgentRecap: recap);
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private static string BuildRecap(string? agentSummary, int currentTurn)
+    {
+        if (!string.IsNullOrWhiteSpace(agentSummary))
+            return agentSummary;
+
+        // Fallback when no AI summary is available
+        return $"Sessione ripresa dal turno {currentTurn}.";
+    }
+
+    private async Task PersistSessionStatusAsync(
+        LiveGameSession session,
+        CancellationToken cancellationToken)
+    {
+        var entity = await _dbContext.LiveGameSessions
+            .FirstOrDefaultAsync(e => e.Id == session.Id, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (entity is null)
+        {
+            _logger.LogWarning(
+                "LiveGameSessionEntity not found in DB for SessionId={SessionId}. " +
+                "Status will not be persisted to database.",
+                session.Id);
+            return;
+        }
+
+        entity.Status = (int)session.Status;
+        entity.PausedAt = session.PausedAt;
+        entity.UpdatedAt = session.UpdatedAt;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNight/StartImprovvisataSessionCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNight/StartImprovvisataSessionCommand.cs
@@ -1,0 +1,171 @@
+using Api.BoundedContexts.GameManagement.Domain.Entities;
+using Api.BoundedContexts.GameManagement.Domain.Enums;
+using Api.BoundedContexts.GameManagement.Domain.Repositories;
+using Api.BoundedContexts.UserLibrary.Domain.Repositories;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.GameManagement;
+using Api.Middleware.Exceptions;
+using FluentValidation;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.GameManagement.Application.Commands.GameNight;
+
+/// <summary>
+/// Shortcut command that creates a LiveGameSession + SessionInvite in one transaction
+/// for the Game Night Improvvisata quick-start flow.
+/// Game Night Improvvisata - E2-1: Start session from PrivateGame.
+/// </summary>
+public sealed record StartImprovvisataSessionCommand(
+    Guid UserId,
+    Guid PrivateGameId) : IRequest<StartImprovvisataSessionResponse>;
+
+/// <summary>
+/// Response returned after a successful session start.
+/// </summary>
+public sealed record StartImprovvisataSessionResponse(
+    Guid SessionId,
+    string InviteCode,
+    string ShareLink);
+
+/// <summary>
+/// Validates StartImprovvisataSessionCommand inputs.
+/// </summary>
+public sealed class StartImprovvisataSessionValidator : AbstractValidator<StartImprovvisataSessionCommand>
+{
+    public StartImprovvisataSessionValidator()
+    {
+        RuleFor(x => x.UserId)
+            .NotEmpty()
+            .WithMessage("User ID is required");
+
+        RuleFor(x => x.PrivateGameId)
+            .NotEmpty()
+            .WithMessage("Private game ID is required");
+    }
+}
+
+/// <summary>
+/// Handles the StartImprovvisataSessionCommand.
+/// Creates a LiveGameSession + SessionInvite atomically.
+/// </summary>
+internal sealed class StartImprovvisataSessionCommandHandler
+    : IRequestHandler<StartImprovvisataSessionCommand, StartImprovvisataSessionResponse>
+{
+    private const int InviteMaxUses = 10;
+    private const int InviteExpiryMinutes = 24 * 60; // 24 hours
+
+    private readonly MeepleAiDbContext _dbContext;
+    private readonly ILiveSessionRepository _sessionRepository;
+    private readonly TimeProvider _timeProvider;
+    private readonly ILogger<StartImprovvisataSessionCommandHandler> _logger;
+
+    public StartImprovvisataSessionCommandHandler(
+        MeepleAiDbContext dbContext,
+        ILiveSessionRepository sessionRepository,
+        TimeProvider timeProvider,
+        ILogger<StartImprovvisataSessionCommandHandler> logger)
+    {
+        _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+        _sessionRepository = sessionRepository ?? throw new ArgumentNullException(nameof(sessionRepository));
+        _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<StartImprovvisataSessionResponse> Handle(
+        StartImprovvisataSessionCommand request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        // 1. Load PrivateGame — throws NotFoundException if missing
+        var privateGame = await _dbContext.PrivateGames
+            .FirstOrDefaultAsync(g => g.Id == request.PrivateGameId && !g.IsDeleted, cancellationToken)
+            .ConfigureAwait(false)
+            ?? throw new NotFoundException("PrivateGame", request.PrivateGameId.ToString());
+
+        // 2. Verify current user owns the game
+        if (privateGame.OwnerId != request.UserId)
+        {
+            throw new ForbiddenException(
+                $"User {request.UserId} does not own PrivateGame {request.PrivateGameId}");
+        }
+
+        // 3. Create LiveGameSession domain object
+        var sessionId = Guid.NewGuid();
+        var session = LiveGameSession.Create(
+            id: sessionId,
+            createdByUserId: request.UserId,
+            gameName: privateGame.Title,
+            timeProvider: _timeProvider,
+            gameId: null); // PrivateGames are not in the shared catalog
+
+        // 4. Add current user as host/first player
+        session.AddPlayer(
+            userId: request.UserId,
+            displayName: "Host",
+            color: PlayerColor.Red,
+            timeProvider: _timeProvider,
+            role: PlayerRole.Host);
+
+        // 5. Register the session in the in-memory repository (for real-time tracking)
+        await _sessionRepository.AddAsync(session, cancellationToken).ConfigureAwait(false);
+
+        // 6. Create SessionInvite domain object (24h expiry, max 10 uses)
+        var invite = SessionInvite.Create(
+            sessionId: sessionId,
+            createdByUserId: request.UserId,
+            maxUses: InviteMaxUses,
+            expiryMinutes: InviteExpiryMinutes);
+
+        // 7. Persist LiveGameSession entity to database
+        _dbContext.LiveGameSessions.Add(new LiveGameSessionEntity
+        {
+            Id = session.Id,
+            SessionCode = session.SessionCode,
+            GameId = session.GameId,
+            GameName = session.GameName,
+            ToolkitId = session.ToolkitId,
+            CreatedByUserId = session.CreatedByUserId,
+            Visibility = (int)session.Visibility,
+            GroupId = session.GroupId,
+            Status = (int)session.Status,
+            CurrentTurnIndex = session.CurrentTurnIndex,
+            CreatedAt = session.CreatedAt,
+            UpdatedAt = session.UpdatedAt,
+            AgentMode = (int)session.AgentMode,
+            ScoringConfigJson = "{}",
+            RowVersion = new byte[] { 1 }
+        });
+
+        // 8. Persist SessionInvite entity to database
+        _dbContext.SessionInvites.Add(new SessionInviteEntity
+        {
+            Id = invite.Id,
+            SessionId = invite.SessionId,
+            CreatedByUserId = invite.CreatedByUserId,
+            Pin = invite.Pin,
+            LinkToken = invite.LinkToken,
+            MaxUses = invite.MaxUses,
+            CurrentUses = invite.CurrentUses,
+            CreatedAt = invite.CreatedAt,
+            ExpiresAt = invite.ExpiresAt,
+            IsRevoked = invite.IsRevoked
+        });
+
+        // 9. Save atomically
+        await _dbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        // 10. Build share link
+        var shareLink = $"/join/{invite.LinkToken}";
+
+        _logger.LogInformation(
+            "User {UserId} started improvvisata session {SessionId} from PrivateGame {PrivateGameId} with invite {InvitePin}",
+            request.UserId, sessionId, request.PrivateGameId, invite.Pin);
+
+        return new StartImprovvisataSessionResponse(
+            SessionId: sessionId,
+            InviteCode: invite.Pin,
+            ShareLink: shareLink);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNight/SubmitRuleDisputeCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNight/SubmitRuleDisputeCommand.cs
@@ -11,6 +11,7 @@ using Api.Services;
 using FluentValidation;
 using MediatR;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
 
 namespace Api.BoundedContexts.GameManagement.Application.Commands.GameNight;
 
@@ -23,6 +24,7 @@ namespace Api.BoundedContexts.GameManagement.Application.Commands.GameNight;
 /// </summary>
 public sealed record SubmitRuleDisputeCommand(
     Guid SessionId,
+    Guid CallerUserId,
     string Description,
     string RaisedByPlayerName) : IRequest<RuleDisputeResponse>;
 
@@ -45,6 +47,10 @@ public sealed class SubmitRuleDisputeCommandValidator : AbstractValidator<Submit
         RuleFor(x => x.SessionId)
             .NotEmpty()
             .WithMessage("Session ID is required");
+
+        RuleFor(x => x.CallerUserId)
+            .NotEmpty()
+            .WithMessage("Caller user ID is required");
 
         RuleFor(x => x.Description)
             .NotEmpty()
@@ -116,7 +122,16 @@ internal sealed class SubmitRuleDisputeCommandHandler
             .ConfigureAwait(false)
             ?? throw new NotFoundException("LiveGameSession", request.SessionId.ToString());
 
-        // 2. Verify session is InProgress
+        // 2. Authorization: caller must be the host or an active participant
+        var isHost = session.CreatedByUserId == request.CallerUserId;
+        var isParticipant = session.Players.Any(p => p.UserId == request.CallerUserId && p.IsActive);
+        if (!isHost && !isParticipant)
+        {
+            throw new ForbiddenException(
+                "You must be a participant or host of this session to submit a rule dispute.");
+        }
+
+        // 3. Verify session is InProgress
         if (session.Status != LiveSessionStatus.InProgress)
         {
             throw new ConflictException(

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNight/SubmitRuleDisputeCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/GameNight/SubmitRuleDisputeCommand.cs
@@ -1,0 +1,344 @@
+using System.Text;
+using System.Text.Json;
+using Api.BoundedContexts.GameManagement.Domain.Entities;
+using Api.BoundedContexts.GameManagement.Domain.Enums;
+using Api.BoundedContexts.GameManagement.Domain.Events;
+using Api.BoundedContexts.GameManagement.Domain.Repositories;
+using Api.BoundedContexts.GameManagement.Domain.ValueObjects;
+using Api.Infrastructure;
+using Api.Middleware.Exceptions;
+using Api.Services;
+using FluentValidation;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.GameManagement.Application.Commands.GameNight;
+
+/// <summary>
+/// Command for submitting a rule dispute during a live game session.
+/// The handler queries the LLM with a structured arbitration prompt, parses the
+/// verdict, stores the <see cref="RuleDisputeEntry"/> on the session, and
+/// broadcasts a <see cref="DisputeResolvedEvent"/>.
+/// Game Night Improvvisata — E3: Arbitro mode.
+/// </summary>
+public sealed record SubmitRuleDisputeCommand(
+    Guid SessionId,
+    string Description,
+    string RaisedByPlayerName) : IRequest<RuleDisputeResponse>;
+
+/// <summary>
+/// Response returned after the AI arbitro resolves a rule dispute.
+/// </summary>
+public sealed record RuleDisputeResponse(
+    Guid Id,
+    string Verdict,
+    List<string> RuleReferences,
+    string? Note);
+
+/// <summary>
+/// Validates <see cref="SubmitRuleDisputeCommand"/> inputs.
+/// </summary>
+public sealed class SubmitRuleDisputeCommandValidator : AbstractValidator<SubmitRuleDisputeCommand>
+{
+    public SubmitRuleDisputeCommandValidator()
+    {
+        RuleFor(x => x.SessionId)
+            .NotEmpty()
+            .WithMessage("Session ID is required");
+
+        RuleFor(x => x.Description)
+            .NotEmpty()
+            .WithMessage("Dispute description is required")
+            .MaximumLength(1000)
+            .WithMessage("Dispute description cannot exceed 1000 characters");
+
+        RuleFor(x => x.RaisedByPlayerName)
+            .NotEmpty()
+            .WithMessage("Player name is required")
+            .MaximumLength(100)
+            .WithMessage("Player name cannot exceed 100 characters");
+    }
+}
+
+/// <summary>
+/// Handles <see cref="SubmitRuleDisputeCommand"/>.
+/// Orchestrates the Arbitro AI pipeline:
+///   1. Load LiveGameSession from the in-memory repository.
+///   2. Verify session is InProgress.
+///   3. Build an arbitration prompt (Italian, structured output).
+///   4. Call <see cref="ILlmService"/> with the prompt.
+///   5. Parse VERDETTO / REGOLA / NOTA sections from the response.
+///   6. Persist <see cref="RuleDisputeEntry"/> to the session and DB.
+///   7. Publish <see cref="DisputeResolvedEvent"/> for SignalR broadcast.
+/// </summary>
+internal sealed class SubmitRuleDisputeCommandHandler
+    : IRequestHandler<SubmitRuleDisputeCommand, RuleDisputeResponse>
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    private static readonly char[] RuleRefSeparators = { ';', '\n', '|' };
+
+    private readonly ILiveSessionRepository _sessionRepository;
+    private readonly MeepleAiDbContext _dbContext;
+    private readonly ILlmService _llmService;
+    private readonly IPublisher _publisher;
+    private readonly TimeProvider _timeProvider;
+    private readonly ILogger<SubmitRuleDisputeCommandHandler> _logger;
+
+    public SubmitRuleDisputeCommandHandler(
+        ILiveSessionRepository sessionRepository,
+        MeepleAiDbContext dbContext,
+        ILlmService llmService,
+        IPublisher publisher,
+        TimeProvider timeProvider,
+        ILogger<SubmitRuleDisputeCommandHandler> logger)
+    {
+        _sessionRepository = sessionRepository ?? throw new ArgumentNullException(nameof(sessionRepository));
+        _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+        _llmService = llmService ?? throw new ArgumentNullException(nameof(llmService));
+        _publisher = publisher ?? throw new ArgumentNullException(nameof(publisher));
+        _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<RuleDisputeResponse> Handle(
+        SubmitRuleDisputeCommand request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        // 1. Load LiveGameSession — throws NotFoundException if missing
+        var session = await _sessionRepository
+            .GetByIdAsync(request.SessionId, cancellationToken)
+            .ConfigureAwait(false)
+            ?? throw new NotFoundException("LiveGameSession", request.SessionId.ToString());
+
+        // 2. Verify session is InProgress
+        if (session.Status != LiveSessionStatus.InProgress)
+        {
+            throw new ConflictException(
+                $"Cannot submit a rule dispute for session in {session.Status} status. " +
+                "Session must be InProgress.");
+        }
+
+        _logger.LogInformation(
+            "SubmitRuleDisputeCommand: SessionId={SessionId}, Player={Player}, Description={Description}",
+            request.SessionId, request.RaisedByPlayerName, request.Description);
+
+        // 3. Build the arbitration prompt
+        var (systemPrompt, userPrompt) = BuildArbitrationPrompt(session, request);
+
+        // 4. Query the LLM
+        var llmResult = await _llmService
+            .GenerateCompletionAsync(systemPrompt, userPrompt, RequestSource.Manual, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (!llmResult.Success)
+        {
+            _logger.LogError(
+                "LLM arbitration failed for SessionId={SessionId}: {Error}",
+                request.SessionId, llmResult.ErrorMessage);
+
+            throw new InvalidOperationException(
+                $"AI arbitration failed: {llmResult.ErrorMessage}");
+        }
+
+        _logger.LogDebug(
+            "Arbitro LLM response for SessionId={SessionId}: {Response}",
+            request.SessionId, llmResult.Response);
+
+        // 5. Parse the structured response
+        var (verdict, ruleReferences, note) = ParseArbitrationResponse(llmResult.Response);
+
+        // 6. Create and attach the RuleDisputeEntry
+        var now = _timeProvider.GetUtcNow().UtcDateTime;
+        var entry = new RuleDisputeEntry(
+            id: Guid.NewGuid(),
+            description: request.Description,
+            verdict: verdict,
+            ruleReferences: ruleReferences,
+            raisedByPlayerName: request.RaisedByPlayerName,
+            timestamp: now);
+
+        session.AddDispute(entry);
+
+        // 7. Persist disputes JSONB on the DB entity (in-memory repo holds the live state;
+        //    the DB row is updated so sessions can be restored after restart).
+        await PersistDisputesToDbAsync(session, cancellationToken).ConfigureAwait(false);
+
+        // 8. Update the in-memory repository
+        await _sessionRepository.UpdateAsync(session, cancellationToken).ConfigureAwait(false);
+
+        // 9. Publish DisputeResolvedEvent for SignalR broadcast
+        await _publisher
+            .Publish(new DisputeResolvedEvent(session.Id, entry), cancellationToken)
+            .ConfigureAwait(false);
+
+        _logger.LogInformation(
+            "Rule dispute resolved: SessionId={SessionId}, DisputeId={DisputeId}, Verdict={Verdict}",
+            session.Id, entry.Id, verdict);
+
+        return new RuleDisputeResponse(
+            Id: entry.Id,
+            Verdict: entry.Verdict,
+            RuleReferences: entry.RuleReferences,
+            Note: note);
+    }
+
+    // ── Prompt Building ────────────────────────────────────────────────────────
+
+    private static (string SystemPrompt, string UserPrompt) BuildArbitrationPrompt(
+        LiveGameSession session,
+        SubmitRuleDisputeCommand request)
+    {
+        var systemPrompt =
+            "Sei l'ARBITRO ufficiale di una partita da tavolo. " +
+            "Il tuo compito è emettere verdetti chiari, precisi e imparziali sulle dispute di regole. " +
+            "Rispondi SEMPRE in italiano nel formato strutturato richiesto. " +
+            "Basa i tuoi verdetti esclusivamente sul regolamento del gioco.";
+
+        var playerNames = session.Players.Count > 0
+            ? string.Join(", ", session.Players.Where(p => p.IsActive).Select(p => p.DisplayName))
+            : "N/D";
+
+        var previousDisputesSummary = BuildPreviousDisputesSummary(session.Disputes);
+
+        var userPromptBuilder = new StringBuilder();
+        userPromptBuilder.AppendLine("MODALITÀ ARBITRO. Emetti un VERDETTO chiaro su questa disputa.");
+        userPromptBuilder.AppendLine();
+        userPromptBuilder.Append("Disputa: \"").Append(request.Description).AppendLine("\"");
+        userPromptBuilder
+            .Append("Contesto: Sessione \"").Append(session.GameName)
+            .Append("\" con giocatori: ").Append(playerNames)
+            .Append(". Turno: ").Append(session.CurrentTurnIndex).AppendLine(".");
+
+        if (!string.IsNullOrEmpty(previousDisputesSummary))
+        {
+            userPromptBuilder.Append("Verdetti precedenti: ").AppendLine(previousDisputesSummary);
+        }
+
+        userPromptBuilder.AppendLine();
+        userPromptBuilder.AppendLine("Rispondi in formato strutturato:");
+        userPromptBuilder.AppendLine("VERDETTO: [Chi ha ragione e perché — 1-2 frasi]");
+        userPromptBuilder.AppendLine("REGOLA: [Citazione esatta dal regolamento con pagina/sezione]");
+        userPromptBuilder.AppendLine("NOTA: [Se ambigua, spiega perché e suggerisci come gestirla]");
+
+        return (systemPrompt, userPromptBuilder.ToString());
+    }
+
+    private static string BuildPreviousDisputesSummary(IReadOnlyList<RuleDisputeEntry> disputes)
+    {
+        if (disputes.Count == 0)
+            return string.Empty;
+
+        // Only include the last 3 disputes to keep the prompt concise
+        var recent = disputes.TakeLast(3).ToList();
+        var parts = recent.Select((d, i) =>
+            $"{i + 1}. \"{d.Description}\" → {d.Verdict}");
+
+        return string.Join("; ", parts);
+    }
+
+    // ── Response Parsing ───────────────────────────────────────────────────────
+
+    internal static (string Verdict, List<string> RuleReferences, string? Note) ParseArbitrationResponse(
+        string response)
+    {
+        if (string.IsNullOrWhiteSpace(response))
+            return ("Nessun verdetto disponibile.", new List<string>(), null);
+
+        var lines = response
+            .Split('\n', StringSplitOptions.RemoveEmptyEntries)
+            .Select(l => l.Trim())
+            .ToList();
+
+        var verdict = ExtractSection(lines, "VERDETTO:");
+        var regola = ExtractSection(lines, "REGOLA:");
+        var nota = ExtractSection(lines, "NOTA:");
+
+        // If parsing fails entirely, use the full response as the verdict
+        if (string.IsNullOrWhiteSpace(verdict))
+        {
+            verdict = response.Trim();
+        }
+
+        // Parse REGOLA into a list of rule references (split by semicolons or newlines)
+        var ruleReferences = ParseRuleReferences(regola);
+
+        return (verdict, ruleReferences, string.IsNullOrWhiteSpace(nota) ? null : nota);
+    }
+
+    private static string ExtractSection(List<string> lines, string prefix)
+    {
+        var parts = new List<string>();
+        var capturing = false;
+
+        foreach (var line in lines)
+        {
+            if (line.StartsWith(prefix, StringComparison.OrdinalIgnoreCase))
+            {
+                capturing = true;
+                var remainder = line[prefix.Length..].Trim();
+                if (!string.IsNullOrWhiteSpace(remainder))
+                    parts.Add(remainder);
+                continue;
+            }
+
+            if (capturing)
+            {
+                // Stop at the next recognised section header
+                if (line.StartsWith("VERDETTO:", StringComparison.OrdinalIgnoreCase) ||
+                    line.StartsWith("REGOLA:", StringComparison.OrdinalIgnoreCase) ||
+                    line.StartsWith("NOTA:", StringComparison.OrdinalIgnoreCase))
+                {
+                    break;
+                }
+
+                parts.Add(line);
+            }
+        }
+
+        return string.Join(" ", parts).Trim();
+    }
+
+    private static List<string> ParseRuleReferences(string regola)
+    {
+        if (string.IsNullOrWhiteSpace(regola))
+            return new List<string>();
+
+        // Split by common separators to produce multiple references
+        var references = regola
+            .Split(RuleRefSeparators, StringSplitOptions.RemoveEmptyEntries)
+            .Select(r => r.Trim())
+            .Where(r => r.Length > 0)
+            .ToList();
+
+        return references.Count > 0 ? references : new List<string> { regola.Trim() };
+    }
+
+    // ── DB Persistence ─────────────────────────────────────────────────────────
+
+    private async Task PersistDisputesToDbAsync(
+        LiveGameSession session,
+        CancellationToken cancellationToken)
+    {
+        var entity = await _dbContext.LiveGameSessions
+            .FirstOrDefaultAsync(e => e.Id == session.Id, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (entity is null)
+        {
+            _logger.LogWarning(
+                "LiveGameSessionEntity not found in DB for SessionId={SessionId}. " +
+                "DisputesJson will not be persisted to database.",
+                session.Id);
+            return;
+        }
+
+        entity.DisputesJson = JsonSerializer.Serialize(session.Disputes, JsonOptions);
+        await _dbContext.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/EventHandlers/AutoCreateAgentOnPdfReadyHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/EventHandlers/AutoCreateAgentOnPdfReadyHandler.cs
@@ -1,4 +1,5 @@
 using Api.BoundedContexts.KnowledgeBase.Domain.Entities;
+using Api.BoundedContexts.KnowledgeBase.Domain.Events;
 using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
 using Api.BoundedContexts.KnowledgeBase.Domain.ValueObjects;
 using Api.BoundedContexts.UserLibrary.Domain.Repositories;
@@ -32,6 +33,7 @@ internal sealed class AutoCreateAgentOnPdfReadyHandler
     private readonly IAgentDefinitionRepository _agentDefinitionRepository;
     private readonly IUnitOfWork _unitOfWork;
     private readonly ITierEnforcementService _tierEnforcementService;
+    private readonly IPublisher _publisher;
     private readonly ILogger<AutoCreateAgentOnPdfReadyHandler> _logger;
 
     public AutoCreateAgentOnPdfReadyHandler(
@@ -39,12 +41,14 @@ internal sealed class AutoCreateAgentOnPdfReadyHandler
         IAgentDefinitionRepository agentDefinitionRepository,
         IUnitOfWork unitOfWork,
         ITierEnforcementService tierEnforcementService,
+        IPublisher publisher,
         ILogger<AutoCreateAgentOnPdfReadyHandler> logger)
     {
         _privateGameRepository = privateGameRepository ?? throw new ArgumentNullException(nameof(privateGameRepository));
         _agentDefinitionRepository = agentDefinitionRepository ?? throw new ArgumentNullException(nameof(agentDefinitionRepository));
         _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
         _tierEnforcementService = tierEnforcementService ?? throw new ArgumentNullException(nameof(tierEnforcementService));
+        _publisher = publisher ?? throw new ArgumentNullException(nameof(publisher));
         _logger = logger ?? throw new ArgumentNullException(nameof(logger));
     }
 
@@ -161,6 +165,15 @@ internal sealed class AutoCreateAgentOnPdfReadyHandler
         // Step 9: Record tier usage.
         await _tierEnforcementService
             .RecordUsageAsync(userId, TierAction.CreateAgent, ct)
+            .ConfigureAwait(false);
+
+        // Step 10: Publish AgentAutoCreatedEvent so NotifyAgentReadyHandler can send in-app notifications.
+        await _publisher
+            .Publish(new AgentAutoCreatedEvent(
+                agentDefinitionId: agent.Id,
+                privateGameId: privateGame.Id,
+                userId: privateGame.OwnerId,
+                gameName: privateGame.Title), ct)
             .ConfigureAwait(false);
 
         _logger.LogInformation(

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/EventHandlers/DisputeResolvedSignalRHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/EventHandlers/DisputeResolvedSignalRHandler.cs
@@ -1,0 +1,47 @@
+using Api.BoundedContexts.GameManagement.Domain.Events;
+using Api.Hubs;
+using MediatR;
+using Microsoft.AspNetCore.SignalR;
+
+namespace Api.BoundedContexts.GameManagement.Application.EventHandlers;
+
+/// <summary>
+/// Broadcasts the dispute resolution result to all clients in the session
+/// via SignalR when a <see cref="DisputeResolvedEvent"/> is raised.
+/// Issue: Game Night Improvvisata — real-time arbitro verdict push.
+/// </summary>
+internal sealed class DisputeResolvedSignalRHandler : INotificationHandler<DisputeResolvedEvent>
+{
+    private readonly IHubContext<GameStateHub> _hubContext;
+    private readonly ILogger<DisputeResolvedSignalRHandler> _logger;
+
+    public DisputeResolvedSignalRHandler(
+        IHubContext<GameStateHub> hubContext,
+        ILogger<DisputeResolvedSignalRHandler> logger)
+    {
+        _hubContext = hubContext ?? throw new ArgumentNullException(nameof(hubContext));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task Handle(DisputeResolvedEvent notification, CancellationToken cancellationToken)
+    {
+        var group = $"session:{notification.SessionId}";
+
+        await _hubContext.Clients.Group(group)
+            .SendAsync("DisputeResolved", new
+            {
+                notification.Dispute.Id,
+                notification.Dispute.Description,
+                notification.Dispute.Verdict,
+                notification.Dispute.RuleReferences,
+                notification.Dispute.RaisedByPlayerName,
+                notification.Dispute.Timestamp
+            }, cancellationToken)
+            .ConfigureAwait(false);
+
+        _logger.LogInformation(
+            "DisputeResolved SignalR broadcast sent for session {SessionId}, dispute {DisputeId}",
+            notification.SessionId,
+            notification.Dispute.Id);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/EventHandlers/SessionPausedSignalRHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/EventHandlers/SessionPausedSignalRHandler.cs
@@ -1,0 +1,38 @@
+using Api.BoundedContexts.GameManagement.Domain.Events;
+using Api.Hubs;
+using MediatR;
+using Microsoft.AspNetCore.SignalR;
+
+namespace Api.BoundedContexts.GameManagement.Application.EventHandlers;
+
+/// <summary>
+/// Notifies all clients in a session via SignalR that the session has been paused,
+/// triggered by a <see cref="SessionPausedEvent"/> domain event.
+/// Issue: Game Night Improvvisata — real-time pause push to participants.
+/// </summary>
+internal sealed class SessionPausedSignalRHandler : INotificationHandler<SessionPausedEvent>
+{
+    private readonly IHubContext<GameStateHub> _hubContext;
+    private readonly ILogger<SessionPausedSignalRHandler> _logger;
+
+    public SessionPausedSignalRHandler(
+        IHubContext<GameStateHub> hubContext,
+        ILogger<SessionPausedSignalRHandler> logger)
+    {
+        _hubContext = hubContext ?? throw new ArgumentNullException(nameof(hubContext));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task Handle(SessionPausedEvent notification, CancellationToken cancellationToken)
+    {
+        var group = $"session:{notification.SessionId}";
+
+        await _hubContext.Clients.Group(group)
+            .SendAsync("SessionPaused", cancellationToken)
+            .ConfigureAwait(false);
+
+        _logger.LogInformation(
+            "SessionPaused SignalR broadcast sent for session {SessionId}",
+            notification.SessionId);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNight/GetGameDisputeHistoryQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNight/GetGameDisputeHistoryQuery.cs
@@ -1,0 +1,130 @@
+using System.Text.Json;
+using Api.BoundedContexts.GameManagement.Domain.ValueObjects;
+using Api.Infrastructure;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.GameManagement.Application.Queries.GameNight;
+
+/// <summary>
+/// Returns all rule dispute entries across every session played for a given game,
+/// aggregated as a cross-session dispute history for post-game review.
+/// Game Night Improvvisata — E3: Arbitro cross-session history.
+/// </summary>
+/// <param name="GameId">The game whose session history should be queried.</param>
+public sealed record GetGameDisputeHistoryQuery(Guid GameId) : IRequest<GetGameDisputeHistoryResult>;
+
+/// <summary>
+/// Aggregated dispute history for a game, grouped by session.
+/// </summary>
+/// <param name="GameId">The queried game.</param>
+/// <param name="Sessions">Per-session dispute summaries, ordered by session start time descending.</param>
+/// <param name="TotalDisputes">Total number of disputes across all sessions.</param>
+public sealed record GetGameDisputeHistoryResult(
+    Guid GameId,
+    IReadOnlyList<SessionDisputeGroup> Sessions,
+    int TotalDisputes);
+
+/// <summary>
+/// Disputes belonging to a single session.
+/// </summary>
+public sealed record SessionDisputeGroup(
+    Guid SessionId,
+    DateTime? SessionStartedAt,
+    IReadOnlyList<DisputeSummary> Disputes);
+
+/// <summary>
+/// Handles <see cref="GetGameDisputeHistoryQuery"/>.
+/// Reads <c>DisputesJson</c> from the <c>live_game_sessions</c> table (written by
+/// the SubmitRuleDisputeCommand handler) and projects them as a flat history.
+/// Uses <see cref="MeepleAiDbContext"/> directly for a lightweight read-only projection.
+/// </summary>
+internal sealed class GetGameDisputeHistoryQueryHandler
+    : IRequestHandler<GetGameDisputeHistoryQuery, GetGameDisputeHistoryResult>
+{
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    private readonly MeepleAiDbContext _dbContext;
+    private readonly ILogger<GetGameDisputeHistoryQueryHandler> _logger;
+
+    public GetGameDisputeHistoryQueryHandler(
+        MeepleAiDbContext dbContext,
+        ILogger<GetGameDisputeHistoryQueryHandler> logger)
+    {
+        _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<GetGameDisputeHistoryResult> Handle(
+        GetGameDisputeHistoryQuery request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        // Read all sessions for this game that have disputes (DisputesJson is not null/empty)
+        var sessionEntities = await _dbContext.LiveGameSessions
+            .AsNoTracking()
+            .Where(s => s.GameId == request.GameId && s.DisputesJson != null && s.DisputesJson != "[]")
+            .OrderByDescending(s => s.StartedAt)
+            .Select(s => new
+            {
+                s.Id,
+                s.StartedAt,
+                s.DisputesJson
+            })
+            .ToListAsync(cancellationToken)
+            .ConfigureAwait(false);
+
+        var sessionGroups = new List<SessionDisputeGroup>(sessionEntities.Count);
+        var totalDisputes = 0;
+
+        foreach (var entity in sessionEntities)
+        {
+            List<RuleDisputeEntry> disputes;
+            try
+            {
+                disputes = string.IsNullOrWhiteSpace(entity.DisputesJson)
+                    ? new List<RuleDisputeEntry>()
+                    : JsonSerializer.Deserialize<List<RuleDisputeEntry>>(entity.DisputesJson, JsonOptions)
+                      ?? new List<RuleDisputeEntry>();
+            }
+            catch (JsonException ex)
+            {
+                _logger.LogWarning(
+                    ex,
+                    "Failed to deserialise DisputesJson for session {SessionId}. Skipping.",
+                    entity.Id);
+                disputes = new List<RuleDisputeEntry>();
+            }
+
+            if (disputes.Count == 0)
+                continue;
+
+            totalDisputes += disputes.Count;
+
+            var summaries = disputes
+                .OrderBy(d => d.Timestamp)
+                .Select(d => new DisputeSummary(
+                    Id: d.Id,
+                    Description: d.Description,
+                    Verdict: d.Verdict,
+                    RuleReferences: d.RuleReferences,
+                    RaisedByPlayerName: d.RaisedByPlayerName,
+                    Timestamp: d.Timestamp))
+                .ToList();
+
+            sessionGroups.Add(new SessionDisputeGroup(
+                SessionId: entity.Id,
+                SessionStartedAt: entity.StartedAt,
+                Disputes: summaries));
+        }
+
+        return new GetGameDisputeHistoryResult(
+            GameId: request.GameId,
+            Sessions: sessionGroups,
+            TotalDisputes: totalDisputes);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNight/GetSessionDisputesQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Application/Queries/GameNight/GetSessionDisputesQuery.cs
@@ -1,0 +1,73 @@
+using Api.BoundedContexts.GameManagement.Domain.Repositories;
+using Api.BoundedContexts.GameManagement.Domain.ValueObjects;
+using Api.Middleware.Exceptions;
+using MediatR;
+
+namespace Api.BoundedContexts.GameManagement.Application.Queries.GameNight;
+
+/// <summary>
+/// Returns all rule dispute entries for a given live game session.
+/// Game Night Improvvisata — E3: Arbitro history.
+/// </summary>
+/// <param name="SessionId">The live session to retrieve disputes for.</param>
+public sealed record GetSessionDisputesQuery(Guid SessionId) : IRequest<GetSessionDisputesResult>;
+
+/// <summary>
+/// Result carrying the dispute list for a session.
+/// </summary>
+/// <param name="SessionId">The queried session.</param>
+/// <param name="Disputes">All disputes recorded in the session, ordered by timestamp ascending.</param>
+public sealed record GetSessionDisputesResult(
+    Guid SessionId,
+    IReadOnlyList<DisputeSummary> Disputes);
+
+/// <summary>
+/// Lightweight summary of a single rule dispute for client consumption.
+/// </summary>
+public sealed record DisputeSummary(
+    Guid Id,
+    string Description,
+    string Verdict,
+    List<string> RuleReferences,
+    string RaisedByPlayerName,
+    DateTime Timestamp);
+
+/// <summary>
+/// Handles <see cref="GetSessionDisputesQuery"/>.
+/// Loads the live session from the in-memory repository and projects its dispute collection.
+/// </summary>
+internal sealed class GetSessionDisputesQueryHandler
+    : IRequestHandler<GetSessionDisputesQuery, GetSessionDisputesResult>
+{
+    private readonly ILiveSessionRepository _sessionRepository;
+
+    public GetSessionDisputesQueryHandler(ILiveSessionRepository sessionRepository)
+    {
+        _sessionRepository = sessionRepository ?? throw new ArgumentNullException(nameof(sessionRepository));
+    }
+
+    public async Task<GetSessionDisputesResult> Handle(
+        GetSessionDisputesQuery request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var session = await _sessionRepository
+            .GetByIdAsync(request.SessionId, cancellationToken)
+            .ConfigureAwait(false)
+            ?? throw new NotFoundException("LiveGameSession", request.SessionId.ToString());
+
+        var disputes = session.Disputes
+            .OrderBy(d => d.Timestamp)
+            .Select(d => new DisputeSummary(
+                Id: d.Id,
+                Description: d.Description,
+                Verdict: d.Verdict,
+                RuleReferences: d.RuleReferences,
+                RaisedByPlayerName: d.RaisedByPlayerName,
+                Timestamp: d.Timestamp))
+            .ToList();
+
+        return new GetSessionDisputesResult(request.SessionId, disputes);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/LiveGameSession.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/LiveGameSession.cs
@@ -27,6 +27,7 @@ internal sealed class LiveGameSession : AggregateRoot<Guid>
     private readonly List<Guid> _turnOrder = new();
     private readonly List<RoundScore> _roundScores = new();
     private readonly List<TurnRecord> _turnRecords = new();
+    private readonly List<RuleDisputeEntry> _disputes = new();
 
 #pragma warning disable CS8618
     private LiveGameSession() : base()
@@ -69,6 +70,7 @@ internal sealed class LiveGameSession : AggregateRoot<Guid>
     public IReadOnlyList<Guid> TurnOrder => _turnOrder.AsReadOnly();
     public IReadOnlyList<RoundScore> RoundScores => _roundScores.AsReadOnly();
     public IReadOnlyList<TurnRecord> TurnRecords => _turnRecords.AsReadOnly();
+    public IReadOnlyList<RuleDisputeEntry> Disputes => _disputes.AsReadOnly();
 
     // === Computed Properties ===
 
@@ -583,6 +585,18 @@ internal sealed class LiveGameSession : AggregateRoot<Guid>
     /// </summary>
     public string? GetCurrentPhaseName() =>
         PhaseNames.Length > CurrentPhaseIndex ? PhaseNames[CurrentPhaseIndex] : null;
+
+    // === Disputes ===
+
+    /// <summary>
+    /// Adds a rule dispute arbitration entry to the session log.
+    /// Disputes are stored as JSONB and represent AI-resolved rule questions.
+    /// </summary>
+    public void AddDispute(RuleDisputeEntry dispute)
+    {
+        ArgumentNullException.ThrowIfNull(dispute);
+        _disputes.Add(dispute);
+    }
 
     // === State & Notes ===
 

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/PauseSnapshot/PauseSnapshot.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/PauseSnapshot/PauseSnapshot.cs
@@ -1,0 +1,78 @@
+using Api.BoundedContexts.GameManagement.Domain.ValueObjects;
+using Api.SharedKernel.Domain.Entities;
+
+namespace Api.BoundedContexts.GameManagement.Domain.Entities.PauseSnapshot;
+
+/// <summary>
+/// Full-state snapshot captured when a live game session is paused.
+/// Distinct from the delta-based <c>SessionSnapshot</c> (which stores incremental patches).
+/// PauseSnapshot stores a complete picture of session state for reliable save/resume.
+/// </summary>
+#pragma warning disable MA0049
+public sealed class PauseSnapshot : Entity<Guid>
+#pragma warning restore MA0049
+{
+    public Guid LiveGameSessionId { get; private set; }
+    public int CurrentTurn { get; private set; }
+    public string? CurrentPhase { get; private set; }
+    public List<PlayerScoreSnapshot> PlayerScores { get; private set; } = new();
+    public List<Guid> AttachmentIds { get; private set; } = new();
+    public List<RuleDisputeEntry> Disputes { get; private set; } = new();
+    public string? AgentConversationSummary { get; private set; }
+    public string? GameStateJson { get; private set; }
+    public DateTime SavedAt { get; private set; }
+    public Guid SavedByUserId { get; private set; }
+    public bool IsAutoSave { get; private set; }
+
+    // EF Core parameterless constructor
+    private PauseSnapshot() { }
+
+    /// <summary>
+    /// Creates a new PauseSnapshot capturing full session state at the time of pause.
+    /// </summary>
+    public static PauseSnapshot Create(
+        Guid liveGameSessionId,
+        int currentTurn,
+        string? currentPhase,
+        List<PlayerScoreSnapshot> playerScores,
+        Guid savedByUserId,
+        bool isAutoSave,
+        List<Guid>? attachmentIds = null,
+        List<RuleDisputeEntry>? disputes = null,
+        string? gameStateJson = null)
+    {
+        if (liveGameSessionId == Guid.Empty)
+            throw new ArgumentException("LiveGameSessionId cannot be empty.", nameof(liveGameSessionId));
+        if (currentTurn < 0)
+            throw new ArgumentOutOfRangeException(nameof(currentTurn), "CurrentTurn cannot be negative.");
+        if (savedByUserId == Guid.Empty)
+            throw new ArgumentException("SavedByUserId cannot be empty.", nameof(savedByUserId));
+
+        return new PauseSnapshot
+        {
+            Id = Guid.NewGuid(),
+            LiveGameSessionId = liveGameSessionId,
+            CurrentTurn = currentTurn,
+            CurrentPhase = currentPhase,
+            PlayerScores = playerScores ?? new List<PlayerScoreSnapshot>(),
+            AttachmentIds = attachmentIds ?? new List<Guid>(),
+            Disputes = disputes ?? new List<RuleDisputeEntry>(),
+            GameStateJson = gameStateJson,
+            SavedAt = DateTime.UtcNow,
+            SavedByUserId = savedByUserId,
+            IsAutoSave = isAutoSave
+        };
+    }
+
+    /// <summary>
+    /// Sets the agent conversation summary after the AI summarises the session context.
+    /// Called asynchronously once the agent produces a summary post-pause.
+    /// </summary>
+    public void UpdateSummary(string summary)
+    {
+        if (string.IsNullOrWhiteSpace(summary))
+            throw new ArgumentException("Summary cannot be empty.", nameof(summary));
+
+        AgentConversationSummary = summary;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/PauseSnapshot/PlayerScoreSnapshot.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/PauseSnapshot/PlayerScoreSnapshot.cs
@@ -1,0 +1,7 @@
+namespace Api.BoundedContexts.GameManagement.Domain.Entities.PauseSnapshot;
+
+/// <summary>
+/// Value record capturing a single player's score at the moment a session is paused.
+/// Stored as JSONB inside PauseSnapshot.
+/// </summary>
+public sealed record PlayerScoreSnapshot(string PlayerName, decimal Score, int? PlayerId = null);

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/SessionSnapshot/SnapshotTrigger.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/SessionSnapshot/SnapshotTrigger.cs
@@ -27,5 +27,8 @@ internal enum SnapshotTrigger
     SessionPaused = 6,
 
     /// <summary>Automatic snapshot created before restoring a previous snapshot.</summary>
-    PreRestore = 7
+    PreRestore = 7,
+
+    /// <summary>Automatic snapshot triggered by the auto-save background service.</summary>
+    AutoSave = 8
 }

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Events/AppBackgroundedEvent.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Events/AppBackgroundedEvent.cs
@@ -1,0 +1,16 @@
+using Api.SharedKernel.Domain.Events;
+
+namespace Api.BoundedContexts.GameManagement.Domain.Events;
+
+/// <summary>
+/// Domain event raised when the client app is backgrounded (app loses focus or closed).
+/// </summary>
+internal sealed class AppBackgroundedEvent : DomainEventBase
+{
+    public Guid SessionId { get; }
+
+    public AppBackgroundedEvent(Guid sessionId)
+    {
+        SessionId = sessionId;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Events/DisputeResolvedEvent.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Events/DisputeResolvedEvent.cs
@@ -1,0 +1,19 @@
+using Api.BoundedContexts.GameManagement.Domain.ValueObjects;
+using Api.SharedKernel.Domain.Events;
+
+namespace Api.BoundedContexts.GameManagement.Domain.Events;
+
+/// <summary>
+/// Domain event raised when a rule dispute is resolved (arbitro or FAQ applied).
+/// </summary>
+internal sealed class DisputeResolvedEvent : DomainEventBase
+{
+    public Guid SessionId { get; }
+    public RuleDisputeEntry Dispute { get; }
+
+    public DisputeResolvedEvent(Guid sessionId, RuleDisputeEntry dispute)
+    {
+        SessionId = sessionId;
+        Dispute = dispute;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Events/SessionPausedEvent.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Events/SessionPausedEvent.cs
@@ -1,0 +1,16 @@
+using Api.SharedKernel.Domain.Events;
+
+namespace Api.BoundedContexts.GameManagement.Domain.Events;
+
+/// <summary>
+/// Domain event raised when a session is paused (player initiated or timeout).
+/// </summary>
+internal sealed class SessionPausedEvent : DomainEventBase
+{
+    public Guid SessionId { get; }
+
+    public SessionPausedEvent(Guid sessionId)
+    {
+        SessionId = sessionId;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Events/SessionResumedEvent.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Events/SessionResumedEvent.cs
@@ -1,0 +1,18 @@
+using Api.SharedKernel.Domain.Events;
+
+namespace Api.BoundedContexts.GameManagement.Domain.Events;
+
+/// <summary>
+/// Domain event raised when a paused session is resumed.
+/// </summary>
+internal sealed class SessionResumedEvent : DomainEventBase
+{
+    public Guid SessionId { get; }
+    public string? AgentRecap { get; }
+
+    public SessionResumedEvent(Guid sessionId, string? agentRecap)
+    {
+        SessionId = sessionId;
+        AgentRecap = agentRecap;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Events/SessionSaveRequestedEvent.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Events/SessionSaveRequestedEvent.cs
@@ -1,0 +1,26 @@
+using Api.SharedKernel.Domain.Events;
+
+namespace Api.BoundedContexts.GameManagement.Domain.Events;
+
+/// <summary>
+/// Domain event raised when a session save is requested (auto-save, pause snapshot, resume prep).
+/// </summary>
+internal sealed class SessionSaveRequestedEvent : DomainEventBase
+{
+    public Guid PauseSnapshotId { get; }
+    public Guid LiveGameSessionId { get; }
+    public Guid AgentDefinitionId { get; }
+    public List<string> LastMessages { get; }
+
+    public SessionSaveRequestedEvent(
+        Guid pauseSnapshotId,
+        Guid liveGameSessionId,
+        Guid agentDefinitionId,
+        List<string> lastMessages)
+    {
+        PauseSnapshotId = pauseSnapshotId;
+        LiveGameSessionId = liveGameSessionId;
+        AgentDefinitionId = agentDefinitionId;
+        LastMessages = lastMessages;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Repositories/ILiveSessionRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Repositories/ILiveSessionRepository.cs
@@ -12,6 +12,10 @@ internal interface ILiveSessionRepository
     Task<LiveGameSession?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default);
     Task<LiveGameSession?> GetByCodeAsync(string sessionCode, CancellationToken cancellationToken = default);
     Task<IReadOnlyList<LiveGameSession>> GetActiveByUserIdAsync(Guid userId, CancellationToken cancellationToken = default);
+
+    /// <summary>Gets all active (in-progress) sessions across all users. Used by the auto-save background service.</summary>
+    Task<IReadOnlyList<LiveGameSession>> GetAllActiveAsync(CancellationToken cancellationToken = default);
+
     Task AddAsync(LiveGameSession session, CancellationToken cancellationToken = default);
     Task UpdateAsync(LiveGameSession session, CancellationToken cancellationToken = default);
     Task<bool> ExistsAsync(Guid id, CancellationToken cancellationToken = default);

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Repositories/IPauseSnapshotRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Domain/Repositories/IPauseSnapshotRepository.cs
@@ -1,0 +1,34 @@
+using Api.BoundedContexts.GameManagement.Domain.Entities.PauseSnapshot;
+
+namespace Api.BoundedContexts.GameManagement.Domain.Repositories;
+
+/// <summary>
+/// Repository interface for PauseSnapshot persistence.
+/// PauseSnapshot stores full-state snapshots captured at session pause time,
+/// separate from delta-based SessionSnapshot.
+/// </summary>
+public interface IPauseSnapshotRepository
+{
+    Task<PauseSnapshot?> GetByIdAsync(Guid id, CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns the most recent snapshot for a session, ordered by SavedAt descending.
+    /// Returns null if the session has no snapshots.
+    /// </summary>
+    Task<PauseSnapshot?> GetLatestBySessionIdAsync(Guid sessionId, CancellationToken ct = default);
+
+    /// <summary>
+    /// Returns all snapshots for a session ordered by SavedAt ascending.
+    /// </summary>
+    Task<IReadOnlyList<PauseSnapshot>> GetBySessionIdAsync(Guid sessionId, CancellationToken ct = default);
+
+    Task AddAsync(PauseSnapshot snapshot, CancellationToken ct = default);
+
+    Task UpdateAsync(PauseSnapshot snapshot, CancellationToken ct = default);
+
+    /// <summary>
+    /// Deletes all auto-save snapshots for the given session.
+    /// Used on resume to discard stale auto-saves and keep history clean.
+    /// </summary>
+    Task DeleteAutoSavesBySessionIdAsync(Guid sessionId, CancellationToken ct = default);
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Domain/ValueObjects/RuleDisputeEntry.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Domain/ValueObjects/RuleDisputeEntry.cs
@@ -1,0 +1,74 @@
+namespace Api.BoundedContexts.GameManagement.Domain.ValueObjects;
+
+/// <summary>
+/// Value object representing a rule dispute arbitration entry during a live board game session.
+/// Stores the player's question, the AI agent's verdict, and any relevant rule references.
+/// Intended to be stored as JSONB on LiveGameSession and PauseSnapshot entities.
+/// </summary>
+public sealed record RuleDisputeEntry
+{
+    /// <summary>
+    /// Unique identifier for this dispute entry.
+    /// Auto-generated if Guid.Empty is provided.
+    /// </summary>
+    public Guid Id { get; init; }
+
+    /// <summary>
+    /// The question or dispute raised by the player (e.g., "Can I play 2 cards per turn?").
+    /// </summary>
+    public string Description { get; init; }
+
+    /// <summary>
+    /// The AI agent's ruling or verdict on the dispute.
+    /// </summary>
+    public string Verdict { get; init; }
+
+    /// <summary>
+    /// References to specific rulebook pages or sections that support the verdict.
+    /// </summary>
+    public List<string> RuleReferences { get; init; }
+
+    /// <summary>
+    /// Name of the player who raised the dispute.
+    /// </summary>
+    public string RaisedByPlayerName { get; init; }
+
+    /// <summary>
+    /// When the dispute was raised and resolved.
+    /// </summary>
+    public DateTime Timestamp { get; init; }
+
+    /// <summary>
+    /// Creates a new RuleDisputeEntry value object with validation.
+    /// </summary>
+    /// <param name="id">Unique identifier; auto-generated if Guid.Empty.</param>
+    /// <param name="description">The rule question raised by the player. Cannot be empty.</param>
+    /// <param name="verdict">The agent's ruling. Cannot be empty.</param>
+    /// <param name="ruleReferences">Rulebook references supporting the verdict. Defaults to empty list if null.</param>
+    /// <param name="raisedByPlayerName">Name of the player who raised the dispute. Cannot be empty.</param>
+    /// <param name="timestamp">When the dispute occurred.</param>
+    public RuleDisputeEntry(
+        Guid id,
+        string description,
+        string verdict,
+        List<string> ruleReferences,
+        string raisedByPlayerName,
+        DateTime timestamp)
+    {
+        if (string.IsNullOrWhiteSpace(description))
+            throw new ArgumentException("Description is required.", nameof(description));
+
+        if (string.IsNullOrWhiteSpace(verdict))
+            throw new ArgumentException("Verdict is required.", nameof(verdict));
+
+        if (string.IsNullOrWhiteSpace(raisedByPlayerName))
+            throw new ArgumentException("Player name is required.", nameof(raisedByPlayerName));
+
+        Id = id == Guid.Empty ? Guid.NewGuid() : id;
+        Description = description;
+        Verdict = verdict;
+        RuleReferences = ruleReferences ?? new List<string>();
+        RaisedByPlayerName = raisedByPlayerName;
+        Timestamp = timestamp;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/DependencyInjection/GameManagementServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/DependencyInjection/GameManagementServiceExtensions.cs
@@ -36,6 +36,7 @@ internal static class GameManagementServiceExtensions
         services.AddSingleton<ILiveSessionRepository, LiveSessionRepository>(); // Issue #4749: Live session in-memory store
         services.AddScoped<IToolStateRepository, ToolStateRepository>(); // Issue #4754: ToolState persistence
         services.AddScoped<ISessionSnapshotRepository, SessionSnapshotRepository>(); // Issue #4755: SessionSnapshot persistence
+        services.AddScoped<IPauseSnapshotRepository, PauseSnapshotRepository>(); // Game Night: full-state pause snapshots
         services.AddScoped<IGameReviewRepository, GameReviewRepository>();
         services.AddScoped<IGameStrategyRepository, GameStrategyRepository>();
         services.AddScoped<ITurnOrderRepository, TurnOrderRepository>(); // Issue #4970: TurnOrder base toolkit

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Persistence/LiveSessionRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Persistence/LiveSessionRepository.cs
@@ -37,6 +37,16 @@ internal sealed class LiveSessionRepository : ILiveSessionRepository
         return Task.FromResult<IReadOnlyList<LiveGameSession>>(activeSessions);
     }
 
+    public Task<IReadOnlyList<LiveGameSession>> GetAllActiveAsync(CancellationToken cancellationToken = default)
+    {
+        var activeSessions = _sessions.Values
+            .Where(s => s.IsActive)
+            .OrderByDescending(s => s.UpdatedAt)
+            .ToList();
+
+        return Task.FromResult<IReadOnlyList<LiveGameSession>>(activeSessions);
+    }
+
     public Task AddAsync(LiveGameSession session, CancellationToken cancellationToken = default)
     {
         ArgumentNullException.ThrowIfNull(session);

--- a/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Persistence/PauseSnapshotRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Persistence/PauseSnapshotRepository.cs
@@ -1,0 +1,164 @@
+using System.Text.Json;
+using Api.BoundedContexts.GameManagement.Domain.Entities.PauseSnapshot;
+using Api.BoundedContexts.GameManagement.Domain.Repositories;
+using Api.BoundedContexts.GameManagement.Domain.ValueObjects;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.GameManagement;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.GameManagement.Infrastructure.Persistence;
+
+/// <summary>
+/// EF Core implementation of IPauseSnapshotRepository.
+/// Persists full-state pause snapshots to the pause_snapshots table.
+/// JSONB columns (PlayerScoresJson, AttachmentIdsJson, DisputesJson) are
+/// serialised/deserialised via System.Text.Json.
+/// </summary>
+internal sealed class PauseSnapshotRepository : IPauseSnapshotRepository
+{
+    // CA1869: cache options instance for performance
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        PropertyNameCaseInsensitive = true
+    };
+
+    private readonly MeepleAiDbContext _dbContext;
+
+    public PauseSnapshotRepository(MeepleAiDbContext dbContext)
+    {
+        _dbContext = dbContext ?? throw new ArgumentNullException(nameof(dbContext));
+    }
+
+    public async Task<PauseSnapshot?> GetByIdAsync(Guid id, CancellationToken ct = default)
+    {
+        var entity = await _dbContext.PauseSnapshots
+            .AsNoTracking()
+            .FirstOrDefaultAsync(e => e.Id == id, ct)
+            .ConfigureAwait(false);
+
+        return entity == null ? null : MapToDomain(entity);
+    }
+
+    public async Task<PauseSnapshot?> GetLatestBySessionIdAsync(Guid sessionId, CancellationToken ct = default)
+    {
+        var entity = await _dbContext.PauseSnapshots
+            .AsNoTracking()
+            .Where(e => e.LiveGameSessionId == sessionId)
+            .OrderByDescending(e => e.SavedAt)
+            .FirstOrDefaultAsync(ct)
+            .ConfigureAwait(false);
+
+        return entity == null ? null : MapToDomain(entity);
+    }
+
+    public async Task<IReadOnlyList<PauseSnapshot>> GetBySessionIdAsync(Guid sessionId, CancellationToken ct = default)
+    {
+        var entities = await _dbContext.PauseSnapshots
+            .AsNoTracking()
+            .Where(e => e.LiveGameSessionId == sessionId)
+            .OrderBy(e => e.SavedAt)
+            .ToListAsync(ct)
+            .ConfigureAwait(false);
+
+        return entities.Select(MapToDomain).ToList();
+    }
+
+    public async Task AddAsync(PauseSnapshot snapshot, CancellationToken ct = default)
+    {
+        var entity = MapToPersistence(snapshot);
+        await _dbContext.PauseSnapshots.AddAsync(entity, ct).ConfigureAwait(false);
+    }
+
+    public Task UpdateAsync(PauseSnapshot snapshot, CancellationToken ct = default)
+    {
+        var entity = MapToPersistence(snapshot);
+        _dbContext.PauseSnapshots.Update(entity);
+        return Task.CompletedTask;
+    }
+
+    public async Task DeleteAutoSavesBySessionIdAsync(Guid sessionId, CancellationToken ct = default)
+    {
+        var autoSaves = await _dbContext.PauseSnapshots
+            .Where(e => e.LiveGameSessionId == sessionId && e.IsAutoSave)
+            .ToListAsync(ct)
+            .ConfigureAwait(false);
+
+        if (autoSaves.Count > 0)
+            _dbContext.PauseSnapshots.RemoveRange(autoSaves);
+    }
+
+    private PauseSnapshot MapToDomain(PauseSnapshotEntity entity)
+    {
+        var playerScores = JsonSerializer
+            .Deserialize<List<PlayerScoreSnapshot>>(entity.PlayerScoresJson, JsonOptions)
+            ?? new List<PlayerScoreSnapshot>();
+
+        var attachmentIds = JsonSerializer
+            .Deserialize<List<Guid>>(entity.AttachmentIdsJson, JsonOptions)
+            ?? new List<Guid>();
+
+        var disputes = JsonSerializer
+            .Deserialize<List<RuleDisputeEntry>>(entity.DisputesJson, JsonOptions)
+            ?? new List<RuleDisputeEntry>();
+
+        var snapshot = PauseSnapshot.Create(
+            entity.LiveGameSessionId,
+            entity.CurrentTurn,
+            entity.CurrentPhase,
+            playerScores,
+            entity.SavedByUserId,
+            entity.IsAutoSave,
+            attachmentIds,
+            disputes,
+            entity.GameStateJson);
+
+        // Restore identity & timing that EF persisted
+        SetId(snapshot, entity.Id);
+        SetSavedAt(snapshot, entity.SavedAt);
+
+        if (!string.IsNullOrWhiteSpace(entity.AgentConversationSummary))
+            snapshot.UpdateSummary(entity.AgentConversationSummary);
+
+        return snapshot;
+    }
+
+    private PauseSnapshotEntity MapToPersistence(PauseSnapshot snapshot)
+    {
+        return new PauseSnapshotEntity
+        {
+            Id = snapshot.Id,
+            LiveGameSessionId = snapshot.LiveGameSessionId,
+            CurrentTurn = snapshot.CurrentTurn,
+            CurrentPhase = snapshot.CurrentPhase,
+            PlayerScoresJson = JsonSerializer.Serialize(snapshot.PlayerScores, JsonOptions),
+            AttachmentIdsJson = JsonSerializer.Serialize(snapshot.AttachmentIds, JsonOptions),
+            DisputesJson = JsonSerializer.Serialize(snapshot.Disputes, JsonOptions),
+            AgentConversationSummary = snapshot.AgentConversationSummary,
+            GameStateJson = snapshot.GameStateJson,
+            SavedAt = snapshot.SavedAt,
+            SavedByUserId = snapshot.SavedByUserId,
+            IsAutoSave = snapshot.IsAutoSave
+        };
+    }
+
+    /// <summary>
+    /// Restores the persisted ID without going through the factory method (which always generates a new Guid).
+    /// Uses reflection to set the protected <c>Entity&lt;Guid&gt;.Id</c> property.
+    /// </summary>
+    private static void SetId(PauseSnapshot snapshot, Guid id)
+    {
+        var prop = typeof(PauseSnapshot).BaseType?.GetProperty("Id",
+            System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance);
+        prop?.SetValue(snapshot, id);
+    }
+
+    /// <summary>
+    /// Restores the persisted SavedAt timestamp.
+    /// </summary>
+    private static void SetSavedAt(PauseSnapshot snapshot, DateTime savedAt)
+    {
+        var field = typeof(PauseSnapshot).GetProperty("SavedAt",
+            System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance);
+        field?.SetValue(snapshot, savedAt);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/EventHandlers/GenerateAgentSummaryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/EventHandlers/GenerateAgentSummaryHandler.cs
@@ -1,0 +1,147 @@
+using System.Text;
+using Api.BoundedContexts.GameManagement.Domain.Events;
+using Api.BoundedContexts.KnowledgeBase.Domain.Events;
+using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
+using Api.Services;
+using MediatR;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.EventHandlers;
+
+/// <summary>
+/// Handles <see cref="SessionSaveRequestedEvent"/> by generating an AI-powered summary
+/// of the last session messages. The summary is then dispatched via
+/// <see cref="AgentSummaryGeneratedEvent"/> so it can be stored on the PauseSnapshot.
+///
+/// This handler is fire-and-forget: failure is logged but does not crash the flow.
+/// Session save/pause already completed before this runs.
+///
+/// Game Night Improvvisata — E4: Save/Resume — async agent recap.
+/// </summary>
+internal sealed class GenerateAgentSummaryHandler : INotificationHandler<SessionSaveRequestedEvent>
+{
+    private const int MaxMessages = 50;
+
+    private readonly IAgentDefinitionRepository _agentRepo;
+    private readonly ILlmService _llmService;
+    private readonly IPublisher _publisher;
+    private readonly ILogger<GenerateAgentSummaryHandler> _logger;
+
+    public GenerateAgentSummaryHandler(
+        IAgentDefinitionRepository agentRepo,
+        ILlmService llmService,
+        IPublisher publisher,
+        ILogger<GenerateAgentSummaryHandler> logger)
+    {
+        _agentRepo = agentRepo ?? throw new ArgumentNullException(nameof(agentRepo));
+        _llmService = llmService ?? throw new ArgumentNullException(nameof(llmService));
+        _publisher = publisher ?? throw new ArgumentNullException(nameof(publisher));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task Handle(SessionSaveRequestedEvent notification, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(notification);
+
+        try
+        {
+            // 1. Load the agent definition (to get the agent's name/context for the prompt)
+            var agentDefinition = await _agentRepo
+                .GetByIdAsync(notification.AgentDefinitionId, cancellationToken)
+                .ConfigureAwait(false);
+
+            // Use a generic agent name if the definition is not found
+            var agentName = agentDefinition?.Name ?? "AI Assistant";
+
+            // 2. Take last N messages (cap at MaxMessages)
+            var cappedMessages = notification.LastMessages
+                .TakeLast(MaxMessages)
+                .ToList();
+
+            if (cappedMessages.Count == 0)
+            {
+                _logger.LogDebug(
+                    "GenerateAgentSummary: No messages for SessionId={SessionId}. Skipping summary.",
+                    notification.LiveGameSessionId);
+                return;
+            }
+
+            // 3. Build summary prompt
+            var (systemPrompt, userPrompt) = BuildSummaryPrompt(agentName, cappedMessages);
+
+            // 4. Call LLM to generate summary
+            var result = await _llmService
+                .GenerateCompletionAsync(systemPrompt, userPrompt, RequestSource.Manual, cancellationToken)
+                .ConfigureAwait(false);
+
+            if (!result.Success)
+            {
+                _logger.LogError(
+                    "GenerateAgentSummary: LLM call failed for SessionId={SessionId}, SnapshotId={SnapshotId}. Error: {Error}",
+                    notification.LiveGameSessionId, notification.PauseSnapshotId, result.ErrorMessage);
+                return;
+            }
+
+            var summary = result.Response?.Trim();
+            if (string.IsNullOrWhiteSpace(summary))
+            {
+                _logger.LogWarning(
+                    "GenerateAgentSummary: LLM returned empty summary for SessionId={SessionId}.",
+                    notification.LiveGameSessionId);
+                return;
+            }
+
+            _logger.LogInformation(
+                "GenerateAgentSummary: Summary generated for SnapshotId={SnapshotId} ({Length} chars).",
+                notification.PauseSnapshotId, summary.Length);
+
+            // 5. Publish AgentSummaryGeneratedEvent so UpdateSnapshotSummaryHandler can persist it
+            await _publisher
+                .Publish(new AgentSummaryGeneratedEvent(notification.PauseSnapshotId, summary), cancellationToken)
+                .ConfigureAwait(false);
+        }
+#pragma warning disable CA1031
+        catch (Exception ex)
+        {
+            // Summary is optional — log but do NOT re-throw.
+            // The pause/snapshot has already been committed successfully.
+            _logger.LogError(
+                ex,
+                "GenerateAgentSummary: Unexpected failure for SessionId={SessionId}, SnapshotId={SnapshotId}. " +
+                "Session is paused correctly; summary will be unavailable.",
+                notification.LiveGameSessionId,
+                notification.PauseSnapshotId);
+        }
+#pragma warning restore CA1031
+    }
+
+    // ── Prompt Building ──────────────────────────────────────────────────────
+
+    private static (string SystemPrompt, string UserPrompt) BuildSummaryPrompt(
+        string agentName,
+        IReadOnlyList<string> messages)
+    {
+        var systemPrompt =
+            $"Sei {agentName}, l'assistente AI per una sessione di gioco da tavolo. " +
+            "Il tuo compito è creare un breve riassunto di contesto per consentire ai giocatori " +
+            "di riprendere facilmente la sessione dopo una pausa. " +
+            "Rispondi in italiano in 3-5 frasi concise. " +
+            "Includi: a) a che punto era la partita, b) eventuali decisioni importanti, " +
+            "c) l'atmosfera generale della sessione.";
+
+        var userPromptBuilder = new StringBuilder();
+        userPromptBuilder.AppendLine("Ecco gli ultimi messaggi della sessione di gioco:");
+        userPromptBuilder.AppendLine();
+
+        foreach (var message in messages)
+        {
+            userPromptBuilder.AppendLine(message);
+        }
+
+        userPromptBuilder.AppendLine();
+        userPromptBuilder.AppendLine(
+            "Scrivi un breve riassunto (3-5 frasi) che aiuti i giocatori a ricordare " +
+            "dove si erano fermati. Inizia con: \"Quando avete messo in pausa la partita...\"");
+
+        return (systemPrompt, userPromptBuilder.ToString());
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/EventHandlers/UpdateSnapshotSummaryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/EventHandlers/UpdateSnapshotSummaryHandler.cs
@@ -1,0 +1,58 @@
+using Api.BoundedContexts.GameManagement.Domain.Repositories;
+using Api.BoundedContexts.KnowledgeBase.Domain.Events;
+using MediatR;
+
+namespace Api.BoundedContexts.KnowledgeBase.Application.EventHandlers;
+
+/// <summary>
+/// Handles <see cref="AgentSummaryGeneratedEvent"/> by persisting the AI-generated
+/// conversation summary onto the pause snapshot stored via
+/// <see cref="IPauseSnapshotRepository"/>.
+///
+/// This handler runs after <see cref="GenerateAgentSummaryHandler"/> successfully
+/// produces a summary from the LLM. It updates the snapshot so the recap is
+/// available when the session is next resumed.
+///
+/// Game Night Improvvisata — E4: Save/Resume — async agent recap persistence.
+/// </summary>
+internal sealed class UpdateSnapshotSummaryHandler : INotificationHandler<AgentSummaryGeneratedEvent>
+{
+    private readonly IPauseSnapshotRepository _snapshotRepository;
+    private readonly ILogger<UpdateSnapshotSummaryHandler> _logger;
+
+    public UpdateSnapshotSummaryHandler(
+        IPauseSnapshotRepository snapshotRepository,
+        ILogger<UpdateSnapshotSummaryHandler> logger)
+    {
+        _snapshotRepository = snapshotRepository ?? throw new ArgumentNullException(nameof(snapshotRepository));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task Handle(AgentSummaryGeneratedEvent notification, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(notification);
+
+        // 1. Load the PauseSnapshot by ID
+        var snapshot = await _snapshotRepository
+            .GetByIdAsync(notification.PauseSnapshotId, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (snapshot is null)
+        {
+            _logger.LogWarning(
+                "UpdateSnapshotSummary: PauseSnapshot {SnapshotId} not found. Summary will be lost.",
+                notification.PauseSnapshotId);
+            return;
+        }
+
+        // 2. Set the summary on the domain entity
+        snapshot.UpdateSummary(notification.Summary);
+
+        // 3. Persist the updated snapshot
+        await _snapshotRepository.UpdateAsync(snapshot, cancellationToken).ConfigureAwait(false);
+
+        _logger.LogInformation(
+            "UpdateSnapshotSummary: Summary ({Length} chars) persisted to SnapshotId={SnapshotId}.",
+            notification.Summary.Length, notification.PauseSnapshotId);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/SessionContextPromptBuilder.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/SessionContextPromptBuilder.cs
@@ -1,5 +1,7 @@
+using System.Globalization;
 using System.Text;
 using Api.BoundedContexts.GameManagement.Application.DTOs.GameSessionContext;
+using Api.BoundedContexts.GameManagement.Domain.ValueObjects;
 
 namespace Api.BoundedContexts.KnowledgeBase.Application.Services;
 
@@ -7,10 +9,60 @@ namespace Api.BoundedContexts.KnowledgeBase.Application.Services;
 /// Builds system prompt enrichment from a GameSessionContext for session-aware RAG chat.
 /// Prepends game name, expansions, current phase, key mechanics, and missing analysis warnings
 /// to the system prompt so the LLM has full session context.
+/// Also builds live-session prompts that include player names, scores, and dispute history.
 /// Issue #5580: Session-aware RAG chat.
+/// Task 8b: Session context injection for general chat during live game sessions.
 /// </summary>
-internal static class SessionContextPromptBuilder
+internal class SessionContextPromptBuilder
 {
+    /// <summary>
+    /// Builds a live-session system prompt for general chat (not Arbitro mode).
+    /// Includes game name, player roster, current turn/phase, score summary,
+    /// rulebook citation reminder, and any previous dispute verdicts.
+    /// Italian-language output to match the product's target locale.
+    /// Task 8b: Called from <see cref="Commands.AskAgentQuestionCommandHandler"/> when
+    /// <c>AskAgentQuestionCommand.GameSessionId</c> is provided alongside live session metadata.
+    /// </summary>
+    /// <param name="gameName">Name of the active board game.</param>
+    /// <param name="playerNames">Ordered list of player names in the session.</param>
+    /// <param name="currentTurn">Current turn number (1-based).</param>
+    /// <param name="currentPhase">Active game phase, or null if not applicable.</param>
+    /// <param name="scores">Map of player name to their current score.</param>
+    /// <param name="previousDisputes">Rule dispute verdicts issued earlier in this session.</param>
+    /// <returns>Italian system prompt string ready to be prepended to the LLM system prompt.</returns>
+    public string BuildSessionPrompt(
+        string gameName,
+        List<string> playerNames,
+        int currentTurn,
+        string? currentPhase,
+        Dictionary<string, decimal> scores,
+        List<RuleDisputeEntry> previousDisputes)
+    {
+        ArgumentException.ThrowIfNullOrWhiteSpace(gameName);
+        ArgumentNullException.ThrowIfNull(playerNames);
+        ArgumentNullException.ThrowIfNull(scores);
+        ArgumentNullException.ThrowIfNull(previousDisputes);
+
+        var sb = new StringBuilder();
+        sb.Append(CultureInfo.InvariantCulture,
+            $"Sei l'assistente per \"{gameName}\". Sessione attiva con {playerNames.Count} giocatori: {string.Join(", ", playerNames)}.").AppendLine();
+        sb.Append(CultureInfo.InvariantCulture,
+            $"Turno corrente: {currentTurn}. Fase: {currentPhase ?? "N/A"}.").AppendLine();
+        sb.AppendLine($"Punteggi: {string.Join(", ", scores.Select(s => $"{s.Key} {s.Value}"))}.");
+        sb.AppendLine("Quando rispondi su regole, cita SEMPRE la pagina del regolamento.");
+        sb.AppendLine("Se c'è ambiguità nella regola, spiega le possibili interpretazioni.");
+
+        if (previousDisputes.Count > 0)
+        {
+            sb.AppendLine();
+            sb.AppendLine("Verdetti precedenti in questa sessione:");
+            foreach (var d in previousDisputes)
+                sb.AppendLine($"- Disputa: \"{d.Description}\" → Verdetto: \"{d.Verdict}\"");
+        }
+
+        return sb.ToString();
+    }
+
     /// <summary>
     /// Builds a session context preamble to prepend to the system prompt.
     /// Returns empty string if context provides no useful information.

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Events/AgentAutoCreatedEvent.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Events/AgentAutoCreatedEvent.cs
@@ -1,0 +1,26 @@
+using Api.SharedKernel.Domain.Events;
+
+namespace Api.BoundedContexts.KnowledgeBase.Domain.Events;
+
+/// <summary>
+/// Domain event raised when an agent is automatically created from a PDF upload.
+/// </summary>
+internal sealed class AgentAutoCreatedEvent : DomainEventBase
+{
+    public Guid AgentDefinitionId { get; }
+    public Guid PrivateGameId { get; }
+    public Guid UserId { get; }
+    public string GameName { get; }
+
+    public AgentAutoCreatedEvent(
+        Guid agentDefinitionId,
+        Guid privateGameId,
+        Guid userId,
+        string gameName)
+    {
+        AgentDefinitionId = agentDefinitionId;
+        PrivateGameId = privateGameId;
+        UserId = userId;
+        GameName = gameName;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Events/AgentSummaryGeneratedEvent.cs
+++ b/apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Events/AgentSummaryGeneratedEvent.cs
@@ -1,0 +1,18 @@
+using Api.SharedKernel.Domain.Events;
+
+namespace Api.BoundedContexts.KnowledgeBase.Domain.Events;
+
+/// <summary>
+/// Domain event raised when an agent generates a summary of the session (for resume context).
+/// </summary>
+internal sealed class AgentSummaryGeneratedEvent : DomainEventBase
+{
+    public Guid PauseSnapshotId { get; }
+    public string Summary { get; }
+
+    public AgentSummaryGeneratedEvent(Guid pauseSnapshotId, string summary)
+    {
+        PauseSnapshotId = pauseSnapshotId;
+        Summary = summary;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Application/EventHandlers/NotifyAgentReadyHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Application/EventHandlers/NotifyAgentReadyHandler.cs
@@ -1,0 +1,70 @@
+using Api.BoundedContexts.KnowledgeBase.Domain.Events;
+using Api.BoundedContexts.UserNotifications.Application.Services;
+using Api.BoundedContexts.UserNotifications.Domain.ValueObjects;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.UserNotifications.Application.EventHandlers;
+
+/// <summary>
+/// Handles AgentAutoCreatedEvent to notify the user that an AI agent has been
+/// automatically created for their private game after PDF indexing completed.
+///
+/// Game Night Improvvisata: After a user uploads a rulebook PDF and it finishes
+/// indexing, we auto-create an agent and then inform them via in-app notification
+/// so they can start using the AI assistant immediately.
+/// </summary>
+internal sealed class NotifyAgentReadyHandler : INotificationHandler<AgentAutoCreatedEvent>
+{
+    private readonly INotificationDispatcher _dispatcher;
+    private readonly ILogger<NotifyAgentReadyHandler> _logger;
+
+    public NotifyAgentReadyHandler(
+        INotificationDispatcher dispatcher,
+        ILogger<NotifyAgentReadyHandler> logger)
+    {
+        _dispatcher = dispatcher ?? throw new ArgumentNullException(nameof(dispatcher));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task Handle(AgentAutoCreatedEvent notification, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(notification);
+
+        try
+        {
+            var gameName = notification.GameName;
+            var deepLink = $"/library/private/{notification.PrivateGameId}/toolkit";
+
+            await _dispatcher.DispatchAsync(new NotificationMessage
+            {
+                Type = NotificationType.AgentAutoCreated,
+                RecipientUserId = notification.UserId,
+                Payload = new GenericPayload(
+                    $"Agente per {gameName} pronto!",
+                    $"L'agente AI per {gameName} è stato creato automaticamente."),
+                DeepLinkPath = deepLink
+            }, cancellationToken).ConfigureAwait(false);
+
+            _logger.LogInformation(
+                "NotifyAgentReadyHandler: Dispatched AgentAutoCreated notification for UserId={UserId}, " +
+                "AgentId={AgentId}, GameId={GameId}, GameName={GameName}",
+                notification.UserId,
+                notification.AgentDefinitionId,
+                notification.PrivateGameId,
+                gameName);
+        }
+#pragma warning disable CA1031
+        catch (Exception ex)
+        {
+            _logger.LogError(ex,
+                "NotifyAgentReadyHandler: Failed to dispatch notification for UserId={UserId}, " +
+                "AgentId={AgentId}, GameId={GameId}. Notification skipped.",
+                notification.UserId,
+                notification.AgentDefinitionId,
+                notification.PrivateGameId);
+            // Do not rethrow — notification failure must not block the event pipeline.
+        }
+#pragma warning restore CA1031
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/UserNotifications/Domain/ValueObjects/NotificationType.cs
+++ b/apps/api/src/Api/BoundedContexts/UserNotifications/Domain/ValueObjects/NotificationType.cs
@@ -55,6 +55,9 @@ internal sealed class NotificationType : ValueObject
     // ISSUE-5009: Agent linked to shared game notification
     public static readonly NotificationType AgentLinked = new("agent_linked");
 
+    // Game Night Improvvisata: Agent auto-created when PDF rulebook is processed
+    public static readonly NotificationType AgentAutoCreated = new("agent_auto_created");
+
     // ISSUE-5084: OpenRouter RPM threshold alert (admin)
     public static readonly NotificationType AdminOpenRouterRpmAlert = new("admin_openrouter_rpm_alert");
 
@@ -146,6 +149,7 @@ internal sealed class NotificationType : ValueObject
             "processing_job_completed" => ProcessingJobCompleted,
             "processing_job_failed" => ProcessingJobFailed,
             "agent_linked" => AgentLinked,
+            "agent_auto_created" => AgentAutoCreated,
             "admin_openrouter_rpm_alert" => AdminOpenRouterRpmAlert,
             "admin_openrouter_budget_alert" => AdminOpenRouterBudgetAlert,
             "admin_circuit_breaker_state_changed" => AdminCircuitBreakerStateChanged,

--- a/apps/api/src/Api/Hubs/GameStateHub.cs
+++ b/apps/api/src/Api/Hubs/GameStateHub.cs
@@ -1,8 +1,11 @@
 // GameStateHub - SignalR Hub for real-time game state updates
 // Issue #2406: Game State Editor UI - Backend Integration
+// Game Night Improvvisata: Added Improvvisata-specific hub methods (Task 10).
 //
 // Provides real-time bidirectional communication for game state changes.
 
+using Api.BoundedContexts.GameManagement.Domain.Events;
+using MediatR;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.SignalR;
 
@@ -17,10 +20,12 @@ namespace Api.Hubs;
 public class GameStateHub : Hub
 {
     private readonly ILogger<GameStateHub> _logger;
+    private readonly IPublisher _publisher;
 
-    public GameStateHub(ILogger<GameStateHub> logger)
+    public GameStateHub(ILogger<GameStateHub> logger, IPublisher publisher)
     {
         _logger = logger;
+        _publisher = publisher;
     }
 
     /// <summary>
@@ -202,6 +207,78 @@ public class GameStateHub : Hub
             sessionId,
             Context.UserIdentifier
         );
+    }
+
+    // ── Game Night Improvvisata methods (Task 10) ────────────────────────────
+
+    /// <summary>
+    /// Broadcast a dispute verdict to all clients in the session.
+    /// Called by server-side event handlers after AI arbitration.
+    /// </summary>
+    public async Task NotifyDisputeResolved(string sessionId, object verdict)
+    {
+        await Clients.Group(GetSessionGroup(sessionId))
+            .SendAsync("DisputeResolved", verdict).ConfigureAwait(false);
+
+        _logger.LogInformation(
+            "DisputeResolved broadcast for session {SessionId}",
+            sessionId);
+    }
+
+    /// <summary>
+    /// Broadcast session-paused notification to all clients in the session.
+    /// Called by server-side event handlers after pause snapshot creation.
+    /// </summary>
+    public async Task NotifySessionPaused(string sessionId)
+    {
+        await Clients.Group(GetSessionGroup(sessionId))
+            .SendAsync("SessionPaused", new { sessionId, timestamp = DateTime.UtcNow }).ConfigureAwait(false);
+
+        _logger.LogInformation(
+            "SessionPaused broadcast for session {SessionId}",
+            sessionId);
+    }
+
+    /// <summary>
+    /// Broadcast a score update to all clients in the session.
+    /// Used when the host confirms or modifies a score.
+    /// </summary>
+    public async Task NotifyScoreUpdated(string sessionId, object scoreUpdate)
+    {
+        await Clients.Group(GetSessionGroup(sessionId))
+            .SendAsync("ScoreUpdated", scoreUpdate).ConfigureAwait(false);
+
+        _logger.LogDebug(
+            "ScoreUpdated broadcast for session {SessionId}",
+            sessionId);
+    }
+
+    /// <summary>
+    /// Client signals that the app was backgrounded on a mobile device.
+    /// Publishes an <see cref="AppBackgroundedEvent"/> for the auto-save pipeline.
+    /// Silently ignores invalid session IDs.
+    /// </summary>
+    public async Task AppBackgrounded(string sessionId)
+    {
+        if (!Guid.TryParse(sessionId, out var sessionGuid))
+        {
+            _logger.LogDebug("AppBackgrounded: invalid sessionId '{SessionId}' — ignoring", sessionId);
+            return;
+        }
+
+        try
+        {
+            await _publisher.Publish(new AppBackgroundedEvent(sessionGuid)).ConfigureAwait(false);
+            _logger.LogInformation(
+                "AppBackgroundedEvent published for session {SessionId}",
+                sessionGuid);
+        }
+#pragma warning disable CA1031 // Do not catch general exception types
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Failed to publish AppBackgroundedEvent for session {SessionId}", sessionGuid);
+        }
+#pragma warning restore CA1031
     }
 
     /// <summary>

--- a/apps/api/src/Api/Infrastructure/BackgroundServices/SessionAutoSaveBackgroundService.cs
+++ b/apps/api/src/Api/Infrastructure/BackgroundServices/SessionAutoSaveBackgroundService.cs
@@ -1,0 +1,129 @@
+using Api.BoundedContexts.GameManagement.Domain.Entities.PauseSnapshot;
+using Api.BoundedContexts.GameManagement.Domain.Repositories;
+using Api.BoundedContexts.GameManagement.Domain.ValueObjects;
+
+namespace Api.Infrastructure.BackgroundServices;
+
+/// <summary>
+/// Background service that auto-saves all in-progress live game sessions every 10 minutes.
+/// Creates a <see cref="PauseSnapshot"/> with <c>IsAutoSave = true</c> for each active session
+/// so that players can recover session state after an unexpected disconnection or server restart.
+///
+/// Auto-save snapshots are separate from user-initiated saves and are deleted on resume
+/// via <see cref="IPauseSnapshotRepository.DeleteAutoSavesBySessionIdAsync"/>.
+///
+/// Game Night Improvvisata — E4: Session auto-save.
+/// </summary>
+internal sealed class SessionAutoSaveBackgroundService : BackgroundService
+{
+    /// <summary>
+    /// Well-known system user ID used as <c>SavedByUserId</c> for auto-save snapshots.
+    /// This sentinel value allows distinguishing system-generated snapshots from user-initiated ones.
+    /// </summary>
+    internal static readonly Guid SystemUserId = new("00000000-0000-0000-0000-000000000001");
+
+    private static readonly TimeSpan Interval = TimeSpan.FromMinutes(10);
+
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<SessionAutoSaveBackgroundService> _logger;
+
+    public SessionAutoSaveBackgroundService(
+        IServiceScopeFactory scopeFactory,
+        ILogger<SessionAutoSaveBackgroundService> logger)
+    {
+        _scopeFactory = scopeFactory ?? throw new ArgumentNullException(nameof(scopeFactory));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation(
+            "SessionAutoSaveBackgroundService started. Auto-save interval: {Interval} minutes",
+            Interval.TotalMinutes);
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            await Task.Delay(Interval, stoppingToken).ConfigureAwait(false);
+
+#pragma warning disable CA1031 // Do not catch general exception types
+            // BACKGROUND SERVICE: Generic catch prevents service from crashing the host process.
+            // Individual session errors are handled inside AutoSaveActiveSessionsAsync.
+            try
+            {
+                await AutoSaveActiveSessionsAsync(stoppingToken).ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                _logger.LogError(ex, "Unexpected error during auto-save cycle");
+            }
+#pragma warning restore CA1031
+        }
+
+        _logger.LogInformation("SessionAutoSaveBackgroundService stopped");
+    }
+
+    private async Task AutoSaveActiveSessionsAsync(CancellationToken ct)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var sessionRepo = scope.ServiceProvider.GetRequiredService<ILiveSessionRepository>();
+        var snapshotRepo = scope.ServiceProvider.GetRequiredService<IPauseSnapshotRepository>();
+
+        var activeSessions = await sessionRepo
+            .GetAllActiveAsync(ct)
+            .ConfigureAwait(false);
+
+        if (activeSessions.Count == 0)
+        {
+            _logger.LogDebug("Auto-save: no active sessions found");
+            return;
+        }
+
+        _logger.LogInformation(
+            "Auto-save starting for {Count} active session(s)",
+            activeSessions.Count);
+
+        foreach (var session in activeSessions)
+        {
+#pragma warning disable CA1031 // Do not catch general exception types
+            // BACKGROUND SERVICE: Failure for one session must not block auto-save for others.
+            try
+            {
+                var playerScores = session.Players
+                    .Where(p => p.IsActive)
+                    .Select(p => new PlayerScoreSnapshot(
+                        PlayerName: p.DisplayName,
+                        Score: p.TotalScore))
+                    .ToList();
+
+                var snapshot = PauseSnapshot.Create(
+                    liveGameSessionId: session.Id,
+                    currentTurn: session.CurrentTurnIndex,
+                    currentPhase: session.GetCurrentPhaseName(),
+                    playerScores: playerScores,
+                    savedByUserId: SystemUserId,
+                    isAutoSave: true,
+                    gameStateJson: session.GameState?.RootElement.GetRawText());
+
+                await snapshotRepo.AddAsync(snapshot, ct).ConfigureAwait(false);
+
+                // PauseSnapshotRepository.AddAsync stages the entity; call SaveChanges here
+                // because the repo does not own the UoW in background service context.
+                var dbContext = scope.ServiceProvider
+                    .GetRequiredService<Api.Infrastructure.MeepleAiDbContext>();
+                await dbContext.SaveChangesAsync(ct).ConfigureAwait(false);
+
+                _logger.LogInformation(
+                    "Auto-saved session {SessionId} (SnapshotId={SnapshotId}, Turn={Turn})",
+                    session.Id, snapshot.Id, session.CurrentTurnIndex);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(
+                    ex,
+                    "Auto-save failed for session {SessionId}. Continuing with remaining sessions",
+                    session.Id);
+            }
+#pragma warning restore CA1031
+        }
+    }
+}

--- a/apps/api/src/Api/Infrastructure/Configurations/GameManagement/LiveGameSessionEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/Configurations/GameManagement/LiveGameSessionEntityConfiguration.cs
@@ -104,6 +104,10 @@ internal sealed class LiveGameSessionEntityConfiguration : IEntityTypeConfigurat
             .HasColumnName("turn_order_json")
             .HasColumnType("jsonb");
 
+        builder.Property(e => e.DisputesJson)
+            .HasColumnName("disputes_json")
+            .HasColumnType("jsonb");
+
         // --- Concurrency Token ---
 
         builder.Property(e => e.RowVersion)

--- a/apps/api/src/Api/Infrastructure/Configurations/GameManagement/PauseSnapshotEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/Configurations/GameManagement/PauseSnapshotEntityConfiguration.cs
@@ -1,0 +1,81 @@
+using Api.Infrastructure.Entities.GameManagement;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Api.Infrastructure.Configurations.GameManagement;
+
+/// <summary>
+/// EF Core configuration for PauseSnapshotEntity.
+/// Full-state snapshots stored on session pause; distinct from delta-based session_snapshots.
+/// </summary>
+internal sealed class PauseSnapshotEntityConfiguration : IEntityTypeConfiguration<PauseSnapshotEntity>
+{
+    public void Configure(EntityTypeBuilder<PauseSnapshotEntity> builder)
+    {
+        builder.ToTable("pause_snapshots");
+
+        builder.HasKey(e => e.Id);
+
+        builder.Property(e => e.Id)
+            .HasColumnName("id")
+            .IsRequired();
+
+        builder.Property(e => e.LiveGameSessionId)
+            .HasColumnName("live_game_session_id")
+            .IsRequired();
+
+        builder.Property(e => e.CurrentTurn)
+            .HasColumnName("current_turn")
+            .IsRequired();
+
+        builder.Property(e => e.CurrentPhase)
+            .HasColumnName("current_phase")
+            .HasMaxLength(100);
+
+        // JSONB columns
+        builder.Property(e => e.PlayerScoresJson)
+            .HasColumnName("player_scores_json")
+            .HasColumnType("jsonb")
+            .IsRequired();
+
+        builder.Property(e => e.AttachmentIdsJson)
+            .HasColumnName("attachment_ids_json")
+            .HasColumnType("jsonb")
+            .IsRequired();
+
+        builder.Property(e => e.DisputesJson)
+            .HasColumnName("disputes_json")
+            .HasColumnType("jsonb")
+            .IsRequired();
+
+        builder.Property(e => e.AgentConversationSummary)
+            .HasColumnName("agent_conversation_summary")
+            .HasMaxLength(5000);
+
+        builder.Property(e => e.GameStateJson)
+            .HasColumnName("game_state_json")
+            .HasColumnType("jsonb");
+
+        builder.Property(e => e.SavedAt)
+            .HasColumnName("saved_at")
+            .IsRequired();
+
+        builder.Property(e => e.SavedByUserId)
+            .HasColumnName("saved_by_user_id")
+            .IsRequired();
+
+        builder.Property(e => e.IsAutoSave)
+            .HasColumnName("is_auto_save")
+            .IsRequired();
+
+        // Indexes
+        builder.HasIndex(e => e.LiveGameSessionId)
+            .HasDatabaseName("ix_pause_snapshots_live_game_session_id");
+
+        builder.HasIndex(e => new { e.LiveGameSessionId, e.SavedAt })
+            .HasDatabaseName("ix_pause_snapshots_session_saved_at");
+
+        builder.HasIndex(e => new { e.LiveGameSessionId, e.IsAutoSave })
+            .HasDatabaseName("ix_pause_snapshots_session_is_auto_save");
+    }
+}

--- a/apps/api/src/Api/Infrastructure/Entities/GameManagement/LiveGameSessionEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/GameManagement/LiveGameSessionEntity.cs
@@ -44,6 +44,7 @@ public class LiveGameSessionEntity
     public string ScoringConfigJson { get; set; } = default!;
     public string? GameStateJson { get; set; } // Free-form game state
     public string? TurnOrderJson { get; set; } // List<Guid> serialized
+    public string? DisputesJson { get; set; } // List<RuleDisputeEntry> serialized
 
     // Content
     public string? Notes { get; set; }

--- a/apps/api/src/Api/Infrastructure/Entities/GameManagement/PauseSnapshotEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/GameManagement/PauseSnapshotEntity.cs
@@ -1,0 +1,34 @@
+namespace Api.Infrastructure.Entities.GameManagement;
+
+/// <summary>
+/// EF Core persistence entity for PauseSnapshot.
+/// Stores a full-state snapshot when a live game session is paused.
+/// PlayerScores, AttachmentIds and Disputes are persisted as JSONB.
+/// </summary>
+public class PauseSnapshotEntity
+{
+    public Guid Id { get; set; } = Guid.NewGuid();
+    public Guid LiveGameSessionId { get; set; }
+    public int CurrentTurn { get; set; }
+
+    /// <summary>Max 100 characters — phase name within the game (e.g. "Setup", "Round 3").</summary>
+    public string? CurrentPhase { get; set; }
+
+    /// <summary>JSONB: serialised List&lt;PlayerScoreSnapshot&gt;.</summary>
+    public string PlayerScoresJson { get; set; } = "[]";
+
+    /// <summary>JSONB: serialised List&lt;Guid&gt; of session attachment IDs.</summary>
+    public string AttachmentIdsJson { get; set; } = "[]";
+
+    /// <summary>JSONB: serialised List&lt;RuleDisputeEntry&gt;.</summary>
+    public string DisputesJson { get; set; } = "[]";
+
+    public string? AgentConversationSummary { get; set; }
+
+    /// <summary>JSONB: free-form game state blob.</summary>
+    public string? GameStateJson { get; set; }
+
+    public DateTime SavedAt { get; set; }
+    public Guid SavedByUserId { get; set; }
+    public bool IsAutoSave { get; set; }
+}

--- a/apps/api/src/Api/Infrastructure/MeepleAiDbContext.cs
+++ b/apps/api/src/Api/Infrastructure/MeepleAiDbContext.cs
@@ -191,6 +191,7 @@ public class MeepleAiDbContext : DbContext
     // Issue #4754: ToolState for live game sessions
     public DbSet<ToolStateEntity> ToolStates => Set<ToolStateEntity>();
     public DbSet<SessionSnapshotEntity> SessionSnapshots => Set<SessionSnapshotEntity>(); // ISSUE-4755
+    public DbSet<PauseSnapshotEntity> PauseSnapshots => Set<PauseSnapshotEntity>(); // Game Night: full-state pause snapshots
     public DbSet<TurnOrderEntity> TurnOrders => Set<TurnOrderEntity>(); // ISSUE-4970: TurnOrder base toolkit
     public DbSet<WhiteboardStateEntity> WhiteboardStates => Set<WhiteboardStateEntity>(); // ISSUE-4971: Whiteboard base toolkit
     public DbSet<Api.Infrastructure.Entities.SessionTracking.SessionMediaEntity> SessionMedia => Set<Api.Infrastructure.Entities.SessionTracking.SessionMediaEntity>(); // ISSUE-4760

--- a/apps/api/src/Api/Infrastructure/Migrations/20260315140733_AddPauseSnapshotAndDisputesJsonb.Designer.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260315140733_AddPauseSnapshotAndDisputesJsonb.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Api.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Api.Infrastructure.Migrations
 {
     [DbContext(typeof(MeepleAiDbContext))]
-    partial class MeepleAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260315140733_AddPauseSnapshotAndDisputesJsonb")]
+    partial class AddPauseSnapshotAndDisputesJsonb
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/Api/Infrastructure/Migrations/20260315140733_AddPauseSnapshotAndDisputesJsonb.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260315140733_AddPauseSnapshotAndDisputesJsonb.cs
@@ -1,0 +1,90 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddPauseSnapshotAndDisputesJsonb : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "disputes_json",
+                table: "live_game_sessions",
+                type: "jsonb",
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "pause_snapshots",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    live_game_session_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    current_turn = table.Column<int>(type: "integer", nullable: false),
+                    current_phase = table.Column<string>(type: "character varying(100)", maxLength: 100, nullable: true),
+                    player_scores_json = table.Column<string>(type: "jsonb", nullable: false),
+                    attachment_ids_json = table.Column<string>(type: "jsonb", nullable: false),
+                    disputes_json = table.Column<string>(type: "jsonb", nullable: false),
+                    agent_conversation_summary = table.Column<string>(type: "character varying(5000)", maxLength: 5000, nullable: true),
+                    game_state_json = table.Column<string>(type: "jsonb", nullable: true),
+                    saved_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    saved_by_user_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    is_auto_save = table.Column<bool>(type: "boolean", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_pause_snapshots", x => x.id);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_RaptorSummaries_GameId",
+                table: "RaptorSummaries",
+                column: "GameId");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_pause_snapshots_live_game_session_id",
+                table: "pause_snapshots",
+                column: "live_game_session_id");
+
+            migrationBuilder.CreateIndex(
+                name: "ix_pause_snapshots_session_is_auto_save",
+                table: "pause_snapshots",
+                columns: new[] { "live_game_session_id", "is_auto_save" });
+
+            migrationBuilder.CreateIndex(
+                name: "ix_pause_snapshots_session_saved_at",
+                table: "pause_snapshots",
+                columns: new[] { "live_game_session_id", "saved_at" });
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_RaptorSummaries_games_GameId",
+                table: "RaptorSummaries",
+                column: "GameId",
+                principalTable: "games",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.Cascade);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_RaptorSummaries_games_GameId",
+                table: "RaptorSummaries");
+
+            migrationBuilder.DropTable(
+                name: "pause_snapshots");
+
+            migrationBuilder.DropIndex(
+                name: "IX_RaptorSummaries_GameId",
+                table: "RaptorSummaries");
+
+            migrationBuilder.DropColumn(
+                name: "disputes_json",
+                table: "live_game_sessions");
+        }
+    }
+}

--- a/apps/api/src/Api/Routing/GameNightImprovvisataEndpoints.cs
+++ b/apps/api/src/Api/Routing/GameNightImprovvisataEndpoints.cs
@@ -149,10 +149,14 @@ internal static class GameNightImprovvisataEndpoints
         Guid sessionId,
         [FromBody] SubmitRuleDisputeRequest request,
         [FromServices] IMediator mediator,
+        HttpContext httpContext,
         CancellationToken cancellationToken)
     {
+        var userId = httpContext.User.GetUserId();
+
         var command = new SubmitRuleDisputeCommand(
             SessionId: sessionId,
+            CallerUserId: userId,
             Description: request.Description,
             RaisedByPlayerName: request.RaisedByPlayerName);
 

--- a/apps/api/src/Api/Routing/GameNightImprovvisataEndpoints.cs
+++ b/apps/api/src/Api/Routing/GameNightImprovvisataEndpoints.cs
@@ -1,8 +1,10 @@
 using Api.BoundedContexts.GameManagement.Application.Commands;
+using Api.BoundedContexts.GameManagement.Application.Commands.GameNight;
 using Api.BoundedContexts.GameManagement.Application.Queries.GameNight;
 using Api.Extensions;
 using MediatR;
 using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Http;
 
 namespace Api.Routing;
 
@@ -42,6 +44,54 @@ internal static class GameNightImprovvisataEndpoints
             .WithSummary("Import a BGG game as a PrivateGame")
             .WithDescription("Imports a game from BoardGameGeek into the user's private library, subject to tier quotas.");
 
+        // E2-1: Start improvvisata session from a PrivateGame
+        improvvisata.MapPost("/start-session", HandleStartImprovvisataSession)
+            .RequireAuthorization()
+            .Produces<StartImprovvisataSessionResponse>(200)
+            .Produces(400)
+            .Produces(401)
+            .Produces(403)
+            .Produces(404)
+            .WithName("StartImprovvisataSession")
+            .WithSummary("Start a game night session from a PrivateGame")
+            .WithDescription("Creates a LiveGameSession + SessionInvite in one transaction. Host is added automatically. Returns the session ID, invite code (PIN), and shareable join link.");
+
+        // E3: Arbitro mode — submit a rule dispute during an in-progress session
+        improvvisata.MapPost("/sessions/{sessionId:guid}/disputes", HandleSubmitRuleDispute)
+            .RequireAuthorization()
+            .Produces<RuleDisputeResponse>(200)
+            .Produces(400)
+            .Produces(401)
+            .Produces(404)
+            .Produces(409)
+            .WithName("SubmitRuleDispute")
+            .WithSummary("Submit a rule dispute for AI arbitration")
+            .WithDescription("Sends a rule question to the AI arbitro, which returns a structured verdict with rule references. The dispute is stored on the live session for later review.");
+
+        // E4: Save — pause session and create a full-state PauseSnapshot
+        improvvisata.MapPost("/sessions/{sessionId:guid}/save", HandleSaveSession)
+            .RequireAuthorization()
+            .Produces<SaveSessionResponse>(200)
+            .Produces(400)
+            .Produces(401)
+            .Produces(404)
+            .Produces(409)
+            .WithName("SaveSession")
+            .WithSummary("Pause and save a live game session")
+            .WithDescription("Creates a full-state PauseSnapshot and transitions the session to Paused. An async AI summary is generated in the background. Returns the snapshot ID.");
+
+        // E4: Resume — restore a paused session from its latest PauseSnapshot
+        improvvisata.MapPost("/sessions/{sessionId:guid}/resume", HandleResumeSession)
+            .RequireAuthorization()
+            .Produces<ResumeSessionResponse>(200)
+            .Produces(400)
+            .Produces(401)
+            .Produces(404)
+            .Produces(409)
+            .WithName("ResumeSession")
+            .WithSummary("Resume a paused game session")
+            .WithDescription("Resumes a paused session from its latest PauseSnapshot. Issues a fresh invite code and returns an optional agent recap for context.");
+
         return group;
     }
 
@@ -63,6 +113,22 @@ internal static class GameNightImprovvisataEndpoints
 
     #region Command Handlers
 
+    private static async Task<IResult> HandleStartImprovvisataSession(
+        [FromBody] StartImprovvisataSessionRequest request,
+        [FromServices] IMediator mediator,
+        HttpContext httpContext,
+        CancellationToken cancellationToken)
+    {
+        var userId = httpContext.User.GetUserId();
+
+        var command = new StartImprovvisataSessionCommand(
+            UserId: userId,
+            PrivateGameId: request.PrivateGameId);
+
+        var result = await mediator.Send(command, cancellationToken).ConfigureAwait(false);
+        return Results.Ok(result);
+    }
+
     private static async Task<IResult> HandleImportBggGame(
         [FromBody] ImportBggGameRequest request,
         [FromServices] IMediator mediator,
@@ -79,11 +145,68 @@ internal static class GameNightImprovvisataEndpoints
         return Results.Created($"/api/v1/game-night/private-games/{result.PrivateGameId}", result);
     }
 
+    private static async Task<IResult> HandleSubmitRuleDispute(
+        Guid sessionId,
+        [FromBody] SubmitRuleDisputeRequest request,
+        [FromServices] IMediator mediator,
+        CancellationToken cancellationToken)
+    {
+        var command = new SubmitRuleDisputeCommand(
+            SessionId: sessionId,
+            Description: request.Description,
+            RaisedByPlayerName: request.RaisedByPlayerName);
+
+        var result = await mediator.Send(command, cancellationToken).ConfigureAwait(false);
+        return Results.Ok(result);
+    }
+
+    private static async Task<IResult> HandleSaveSession(
+        Guid sessionId,
+        [FromBody] SaveSessionRequest request,
+        [FromServices] IMediator mediator,
+        HttpContext httpContext,
+        CancellationToken cancellationToken)
+    {
+        var userId = httpContext.User.GetUserId();
+
+        var command = new CreatePauseSnapshotCommand(
+            SessionId: sessionId,
+            SavedByUserId: userId,
+            FinalPhotoIds: request.FinalPhotoIds);
+
+        var snapshotId = await mediator.Send(command, cancellationToken).ConfigureAwait(false);
+        return Results.Ok(new SaveSessionResponse(snapshotId));
+    }
+
+    private static async Task<IResult> HandleResumeSession(
+        Guid sessionId,
+        [FromServices] IMediator mediator,
+        HttpContext httpContext,
+        CancellationToken cancellationToken)
+    {
+        var userId = httpContext.User.GetUserId();
+
+        var command = new ResumeSessionFromSnapshotCommand(
+            SessionId: sessionId,
+            ResumedByUserId: userId);
+
+        var result = await mediator.Send(command, cancellationToken).ConfigureAwait(false);
+        return Results.Ok(result);
+    }
+
     #endregion
 
     #region Request Records
 
     private sealed record ImportBggGameRequest(int BggId);
+
+    private sealed record StartImprovvisataSessionRequest(Guid PrivateGameId);
+
+    private sealed record SubmitRuleDisputeRequest(string Description, string RaisedByPlayerName);
+
+    private sealed record SaveSessionRequest(List<Guid>? FinalPhotoIds = null);
+
+    private sealed record SaveSessionResponse(Guid SnapshotId);
 
     #endregion
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/EventHandlers/AutoCreateAgentOnPdfReadyHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/EventHandlers/AutoCreateAgentOnPdfReadyHandlerTests.cs
@@ -9,6 +9,7 @@ using Api.SharedKernel.Infrastructure.Persistence;
 using Api.SharedKernel.Services;
 using Api.Tests.Constants;
 using FluentAssertions;
+using MediatR;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
@@ -28,6 +29,7 @@ public sealed class AutoCreateAgentOnPdfReadyHandlerTests
     private readonly Mock<IAgentDefinitionRepository> _agentDefinitionRepository;
     private readonly Mock<IUnitOfWork> _unitOfWork;
     private readonly Mock<ITierEnforcementService> _tierEnforcementService;
+    private readonly Mock<IPublisher> _publisher;
     private readonly Mock<ILogger<AutoCreateAgentOnPdfReadyHandler>> _logger;
 
     private readonly Guid _userId = Guid.NewGuid();
@@ -41,6 +43,7 @@ public sealed class AutoCreateAgentOnPdfReadyHandlerTests
         _agentDefinitionRepository = new Mock<IAgentDefinitionRepository>();
         _unitOfWork = new Mock<IUnitOfWork>();
         _tierEnforcementService = new Mock<ITierEnforcementService>();
+        _publisher = new Mock<IPublisher>();
         _logger = new Mock<ILogger<AutoCreateAgentOnPdfReadyHandler>>();
 
         // Default: tier quota not exceeded
@@ -52,6 +55,11 @@ public sealed class AutoCreateAgentOnPdfReadyHandlerTests
         _unitOfWork
             .Setup(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()))
             .ReturnsAsync(1);
+
+        // Default: publisher is a no-op
+        _publisher
+            .Setup(p => p.Publish(It.IsAny<object>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
     }
 
     private AutoCreateAgentOnPdfReadyHandler CreateHandler() =>
@@ -60,6 +68,7 @@ public sealed class AutoCreateAgentOnPdfReadyHandlerTests
             _agentDefinitionRepository.Object,
             _unitOfWork.Object,
             _tierEnforcementService.Object,
+            _publisher.Object,
             _logger.Object);
 
     private VectorDocumentReadyIntegrationEvent CreateEvent(
@@ -419,6 +428,7 @@ public sealed class AutoCreateAgentOnPdfReadyHandlerTests
             _agentDefinitionRepository.Object,
             _unitOfWork.Object,
             _tierEnforcementService.Object,
+            _publisher.Object,
             _logger.Object));
     }
 
@@ -430,6 +440,7 @@ public sealed class AutoCreateAgentOnPdfReadyHandlerTests
             null!,
             _unitOfWork.Object,
             _tierEnforcementService.Object,
+            _publisher.Object,
             _logger.Object));
     }
 
@@ -441,6 +452,7 @@ public sealed class AutoCreateAgentOnPdfReadyHandlerTests
             _agentDefinitionRepository.Object,
             null!,
             _tierEnforcementService.Object,
+            _publisher.Object,
             _logger.Object));
     }
 
@@ -451,6 +463,19 @@ public sealed class AutoCreateAgentOnPdfReadyHandlerTests
             _privateGameRepository.Object,
             _agentDefinitionRepository.Object,
             _unitOfWork.Object,
+            null!,
+            _publisher.Object,
+            _logger.Object));
+    }
+
+    [Fact]
+    public void Constructor_NullPublisher_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() => new AutoCreateAgentOnPdfReadyHandler(
+            _privateGameRepository.Object,
+            _agentDefinitionRepository.Object,
+            _unitOfWork.Object,
+            _tierEnforcementService.Object,
             null!,
             _logger.Object));
     }
@@ -463,6 +488,7 @@ public sealed class AutoCreateAgentOnPdfReadyHandlerTests
             _agentDefinitionRepository.Object,
             _unitOfWork.Object,
             _tierEnforcementService.Object,
+            _publisher.Object,
             null!));
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/GameNight/CreatePauseSnapshotCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/GameNight/CreatePauseSnapshotCommandHandlerTests.cs
@@ -1,0 +1,420 @@
+using Api.BoundedContexts.GameManagement.Application.Commands.GameNight;
+using Api.BoundedContexts.GameManagement.Domain.Entities;
+using Api.BoundedContexts.GameManagement.Domain.Entities.PauseSnapshot;
+using Api.BoundedContexts.GameManagement.Domain.Enums;
+using Api.BoundedContexts.GameManagement.Domain.Events;
+using Api.BoundedContexts.GameManagement.Domain.Repositories;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.GameManagement;
+using Api.Middleware.Exceptions;
+using Api.Tests.Constants;
+using Api.Tests.TestHelpers;
+using FluentValidation.TestHelper;
+using MediatR;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameManagement.Application.GameNight;
+
+/// <summary>
+/// Unit tests for <see cref="CreatePauseSnapshotCommandHandler"/>.
+/// Game Night Improvvisata — E4: Save/Resume flow.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "GameManagement")]
+public sealed class CreatePauseSnapshotCommandHandlerTests
+{
+    // ─── Fixtures ─────────────────────────────────────────────────────────────
+
+    private static readonly Guid TestSessionId = Guid.NewGuid();
+    private static readonly Guid TestUserId = Guid.NewGuid();
+
+    private readonly MeepleAiDbContext _dbContext;
+    private readonly Mock<ILiveSessionRepository> _sessionRepoMock;
+    private readonly Mock<IPauseSnapshotRepository> _snapshotRepoMock;
+    private readonly Mock<IPublisher> _publisherMock;
+    private readonly CreatePauseSnapshotCommandHandler _sut;
+
+    public CreatePauseSnapshotCommandHandlerTests()
+    {
+        _dbContext = TestDbContextFactory.CreateInMemoryDbContext();
+        _sessionRepoMock = new Mock<ILiveSessionRepository>();
+        _snapshotRepoMock = new Mock<IPauseSnapshotRepository>();
+        _publisherMock = new Mock<IPublisher>();
+
+        _snapshotRepoMock
+            .Setup(r => r.AddAsync(It.IsAny<PauseSnapshot>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _publisherMock
+            .Setup(p => p.Publish(It.IsAny<INotification>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _sut = new CreatePauseSnapshotCommandHandler(
+            _sessionRepoMock.Object,
+            _snapshotRepoMock.Object,
+            _dbContext,
+            _publisherMock.Object,
+            NullLogger<CreatePauseSnapshotCommandHandler>.Instance);
+    }
+
+    // ─── Helpers ──────────────────────────────────────────────────────────────
+
+    private LiveGameSession CreateInProgressSession(
+        Guid? id = null,
+        bool withDbEntity = false,
+        string gameName = "Wingspan")
+    {
+        var sessionId = id ?? TestSessionId;
+        var session = LiveGameSession.Create(
+            id: sessionId,
+            createdByUserId: TestUserId,
+            gameName: gameName,
+            timeProvider: TimeProvider.System);
+
+        session.AddPlayer(
+            userId: TestUserId,
+            displayName: "Alice",
+            color: PlayerColor.Red,
+            timeProvider: TimeProvider.System,
+            role: PlayerRole.Host);
+
+        session.MoveToSetup(TimeProvider.System);
+        session.Start(TimeProvider.System);
+
+        _sessionRepoMock
+            .Setup(r => r.GetByIdAsync(sessionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(session);
+
+        _sessionRepoMock
+            .Setup(r => r.UpdateAsync(It.IsAny<LiveGameSession>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        if (withDbEntity)
+        {
+            _dbContext.LiveGameSessions.Add(new LiveGameSessionEntity
+            {
+                Id = sessionId,
+                SessionCode = session.SessionCode,
+                GameName = gameName,
+                CreatedByUserId = TestUserId,
+                Status = (int)LiveSessionStatus.InProgress,
+                CurrentTurnIndex = session.CurrentTurnIndex,
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow,
+                AgentMode = (int)AgentSessionMode.None,
+                ScoringConfigJson = "{}",
+                RowVersion = new byte[] { 1 }
+            });
+            _dbContext.SaveChanges();
+        }
+
+        return session;
+    }
+
+    private static CreatePauseSnapshotCommand BuildCommand(
+        Guid? sessionId = null,
+        Guid? userId = null,
+        List<Guid>? photoIds = null)
+        => new(
+            SessionId: sessionId ?? TestSessionId,
+            SavedByUserId: userId ?? TestUserId,
+            FinalPhotoIds: photoIds);
+
+    // ─── Happy path ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Handle_HappyPath_ReturnsSnapshotId()
+    {
+        // Arrange
+        CreateInProgressSession(withDbEntity: true);
+        var command = BuildCommand();
+
+        // Act
+        var snapshotId = await _sut.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.NotEqual(Guid.Empty, snapshotId);
+    }
+
+    [Fact]
+    public async Task Handle_HappyPath_CreatesSnapshotWithCorrectState()
+    {
+        // Arrange
+        CreateInProgressSession(withDbEntity: true);
+        var command = BuildCommand();
+
+        PauseSnapshot? capturedSnapshot = null;
+        _snapshotRepoMock
+            .Setup(r => r.AddAsync(It.IsAny<PauseSnapshot>(), It.IsAny<CancellationToken>()))
+            .Callback<PauseSnapshot, CancellationToken>(
+                (s, _) => capturedSnapshot = s)
+            .Returns(Task.CompletedTask);
+
+        // Act
+        await _sut.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.NotNull(capturedSnapshot);
+        Assert.Equal(TestSessionId, capturedSnapshot!.LiveGameSessionId);
+        Assert.Equal(TestUserId, capturedSnapshot.SavedByUserId);
+        Assert.False(capturedSnapshot.IsAutoSave);
+        Assert.True(capturedSnapshot.CurrentTurn >= 1, "CurrentTurn should be at least 1 after Start()");
+    }
+
+    [Fact]
+    public async Task Handle_HappyPath_PausesSession()
+    {
+        // Arrange
+        var session = CreateInProgressSession(withDbEntity: true);
+        var command = BuildCommand();
+
+        LiveGameSession? capturedSession = null;
+        _sessionRepoMock
+            .Setup(r => r.UpdateAsync(It.IsAny<LiveGameSession>(), It.IsAny<CancellationToken>()))
+            .Callback<LiveGameSession, CancellationToken>((s, _) => capturedSession = s)
+            .Returns(Task.CompletedTask);
+
+        // Act
+        await _sut.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.NotNull(capturedSession);
+        Assert.Equal(LiveSessionStatus.Paused, capturedSession!.Status);
+    }
+
+    [Fact]
+    public async Task Handle_HappyPath_IncludesPlayerScoresInSnapshot()
+    {
+        // Arrange
+        var session = CreateInProgressSession(withDbEntity: true);
+
+        // Session has 1 player (Alice) added in helper
+        var command = BuildCommand();
+
+        PauseSnapshot? capturedSnapshot = null;
+        _snapshotRepoMock
+            .Setup(r => r.AddAsync(It.IsAny<PauseSnapshot>(), It.IsAny<CancellationToken>()))
+            .Callback<PauseSnapshot, CancellationToken>(
+                (s, _) => capturedSnapshot = s)
+            .Returns(Task.CompletedTask);
+
+        // Act
+        await _sut.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.NotNull(capturedSnapshot);
+        Assert.Single(capturedSnapshot!.PlayerScores);
+        Assert.Equal("Alice", capturedSnapshot.PlayerScores[0].PlayerName);
+    }
+
+    [Fact]
+    public async Task Handle_HappyPath_IncludesFinalPhotoIdsInSnapshot()
+    {
+        // Arrange
+        CreateInProgressSession(withDbEntity: true);
+        var photoIds = new List<Guid> { Guid.NewGuid(), Guid.NewGuid() };
+        var command = BuildCommand(photoIds: photoIds);
+
+        PauseSnapshot? capturedSnapshot = null;
+        _snapshotRepoMock
+            .Setup(r => r.AddAsync(It.IsAny<PauseSnapshot>(), It.IsAny<CancellationToken>()))
+            .Callback<PauseSnapshot, CancellationToken>(
+                (s, _) => capturedSnapshot = s)
+            .Returns(Task.CompletedTask);
+
+        // Act
+        await _sut.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.NotNull(capturedSnapshot);
+        Assert.Equal(2, capturedSnapshot!.AttachmentIds.Count);
+        Assert.All(photoIds, id => Assert.Contains(id, capturedSnapshot.AttachmentIds));
+    }
+
+    [Fact]
+    public async Task Handle_HappyPath_PublishesSessionPausedEvent()
+    {
+        // Arrange
+        CreateInProgressSession(withDbEntity: true);
+        var command = BuildCommand();
+
+        // Act
+        await _sut.Handle(command, CancellationToken.None);
+
+        // Assert
+        _publisherMock.Verify(
+            p => p.Publish(
+                It.Is<SessionPausedEvent>(e => e.SessionId == TestSessionId),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_HappyPath_WithAgentMode_PublishesSessionSaveRequestedEvent()
+    {
+        // Arrange — session with an active agent
+        var chatSessionId = Guid.NewGuid();
+        var session = LiveGameSession.Create(
+            id: TestSessionId,
+            createdByUserId: TestUserId,
+            gameName: "Wingspan",
+            timeProvider: TimeProvider.System);
+
+        session.AddPlayer(TestUserId, "Alice", PlayerColor.Red, TimeProvider.System, PlayerRole.Host);
+        session.MoveToSetup(TimeProvider.System);
+        session.Start(TimeProvider.System);
+        session.SetAgentMode(AgentSessionMode.Assistant, chatSessionId, TimeProvider.System);
+
+        _sessionRepoMock
+            .Setup(r => r.GetByIdAsync(TestSessionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(session);
+
+        _sessionRepoMock
+            .Setup(r => r.UpdateAsync(It.IsAny<LiveGameSession>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _dbContext.LiveGameSessions.Add(new LiveGameSessionEntity
+        {
+            Id = TestSessionId,
+            SessionCode = session.SessionCode,
+            GameName = "Wingspan",
+            CreatedByUserId = TestUserId,
+            Status = (int)LiveSessionStatus.InProgress,
+            CurrentTurnIndex = session.CurrentTurnIndex,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow,
+            AgentMode = (int)AgentSessionMode.Assistant,
+            ScoringConfigJson = "{}",
+            RowVersion = new byte[] { 1 }
+        });
+        await _dbContext.SaveChangesAsync();
+
+        var command = BuildCommand();
+
+        // Act
+        await _sut.Handle(command, CancellationToken.None);
+
+        // Assert
+        _publisherMock.Verify(
+            p => p.Publish(
+                It.Is<SessionSaveRequestedEvent>(e =>
+                    e.LiveGameSessionId == TestSessionId),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    // ─── Error cases ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Handle_WhenSessionNotFound_ThrowsNotFoundException()
+    {
+        // Arrange — repository returns null
+        _sessionRepoMock
+            .Setup(r => r.GetByIdAsync(TestSessionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((LiveGameSession?)null);
+
+        var command = BuildCommand();
+
+        // Act & Assert
+        await Assert.ThrowsAsync<NotFoundException>(() =>
+            _sut.Handle(command, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task Handle_WhenSessionIsNotInProgress_ThrowsConflictException()
+    {
+        // Arrange — session in Created status (not started)
+        var session = LiveGameSession.Create(
+            id: TestSessionId,
+            createdByUserId: TestUserId,
+            gameName: "Test Game",
+            timeProvider: TimeProvider.System);
+
+        _sessionRepoMock
+            .Setup(r => r.GetByIdAsync(TestSessionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(session);
+
+        var command = BuildCommand();
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ConflictException>(() =>
+            _sut.Handle(command, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task Handle_WhenSessionIsAlreadyPaused_ThrowsConflictException()
+    {
+        // Arrange
+        var session = LiveGameSession.Create(
+            id: TestSessionId,
+            createdByUserId: TestUserId,
+            gameName: "Test Game",
+            timeProvider: TimeProvider.System);
+
+        session.AddPlayer(TestUserId, "Alice", PlayerColor.Red, TimeProvider.System, PlayerRole.Host);
+        session.MoveToSetup(TimeProvider.System);
+        session.Start(TimeProvider.System);
+        session.Pause(TimeProvider.System); // Already paused
+
+        _sessionRepoMock
+            .Setup(r => r.GetByIdAsync(TestSessionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(session);
+
+        var command = BuildCommand();
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ConflictException>(() =>
+            _sut.Handle(command, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task Handle_WithoutAgent_DoesNotPublishSessionSaveRequestedEvent()
+    {
+        // Arrange — no agent mode set (default = None)
+        CreateInProgressSession(withDbEntity: true);
+        var command = BuildCommand();
+
+        // Act
+        await _sut.Handle(command, CancellationToken.None);
+
+        // Assert — SessionSaveRequestedEvent should NOT be published when no agent
+        _publisherMock.Verify(
+            p => p.Publish(
+                It.IsAny<SessionSaveRequestedEvent>(),
+                It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+}
+
+/// <summary>
+/// Validation tests for <see cref="CreatePauseSnapshotCommandValidator"/>.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "GameManagement")]
+public sealed class CreatePauseSnapshotCommandValidatorTests
+{
+    private readonly CreatePauseSnapshotCommandValidator _validator = new();
+
+    [Fact]
+    public void Validate_WithValidCommand_Passes()
+    {
+        var command = new CreatePauseSnapshotCommand(Guid.NewGuid(), Guid.NewGuid());
+        _validator.TestValidate(command).ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void Validate_WithEmptySessionId_Fails()
+    {
+        var command = new CreatePauseSnapshotCommand(Guid.Empty, Guid.NewGuid());
+        _validator.TestValidate(command).ShouldHaveValidationErrorFor(x => x.SessionId);
+    }
+
+    [Fact]
+    public void Validate_WithEmptyUserId_Fails()
+    {
+        var command = new CreatePauseSnapshotCommand(Guid.NewGuid(), Guid.Empty);
+        _validator.TestValidate(command).ShouldHaveValidationErrorFor(x => x.SavedByUserId);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/GameNight/ResumeSessionFromSnapshotCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/GameNight/ResumeSessionFromSnapshotCommandHandlerTests.cs
@@ -1,0 +1,403 @@
+using Api.BoundedContexts.GameManagement.Application.Commands.GameNight;
+using Api.BoundedContexts.GameManagement.Domain.Entities;
+using Api.BoundedContexts.GameManagement.Domain.Entities.PauseSnapshot;
+using Api.BoundedContexts.GameManagement.Domain.Enums;
+using Api.BoundedContexts.GameManagement.Domain.Events;
+using Api.BoundedContexts.GameManagement.Domain.Repositories;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.GameManagement;
+using Api.Middleware.Exceptions;
+using Api.Tests.Constants;
+using Api.Tests.TestHelpers;
+using FluentValidation.TestHelper;
+using MediatR;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameManagement.Application.GameNight;
+
+/// <summary>
+/// Unit tests for <see cref="ResumeSessionFromSnapshotCommandHandler"/>.
+/// Game Night Improvvisata — E4: Save/Resume flow.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "GameManagement")]
+public sealed class ResumeSessionFromSnapshotCommandHandlerTests
+{
+    // ─── Fixtures ─────────────────────────────────────────────────────────────
+
+    private static readonly Guid TestSessionId = Guid.NewGuid();
+    private static readonly Guid TestUserId = Guid.NewGuid();
+
+    private readonly MeepleAiDbContext _dbContext;
+    private readonly Mock<ILiveSessionRepository> _sessionRepoMock;
+    private readonly Mock<IPauseSnapshotRepository> _snapshotRepoMock;
+    private readonly Mock<IPublisher> _publisherMock;
+    private readonly ResumeSessionFromSnapshotCommandHandler _sut;
+
+    public ResumeSessionFromSnapshotCommandHandlerTests()
+    {
+        _dbContext = TestDbContextFactory.CreateInMemoryDbContext();
+        _sessionRepoMock = new Mock<ILiveSessionRepository>();
+        _snapshotRepoMock = new Mock<IPauseSnapshotRepository>();
+        _publisherMock = new Mock<IPublisher>();
+
+        _snapshotRepoMock
+            .Setup(r => r.DeleteAutoSavesBySessionIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _publisherMock
+            .Setup(p => p.Publish(It.IsAny<INotification>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _sut = new ResumeSessionFromSnapshotCommandHandler(
+            _sessionRepoMock.Object,
+            _snapshotRepoMock.Object,
+            _dbContext,
+            _publisherMock.Object,
+            NullLogger<ResumeSessionFromSnapshotCommandHandler>.Instance);
+    }
+
+    // ─── Helpers ──────────────────────────────────────────────────────────────
+
+    private LiveGameSession CreatePausedSession(
+        Guid? id = null,
+        bool withDbEntity = false,
+        string gameName = "Wingspan")
+    {
+        var sessionId = id ?? TestSessionId;
+        var session = LiveGameSession.Create(
+            id: sessionId,
+            createdByUserId: TestUserId,
+            gameName: gameName,
+            timeProvider: TimeProvider.System);
+
+        session.AddPlayer(
+            userId: TestUserId,
+            displayName: "Alice",
+            color: PlayerColor.Red,
+            timeProvider: TimeProvider.System,
+            role: PlayerRole.Host);
+
+        session.MoveToSetup(TimeProvider.System);
+        session.Start(TimeProvider.System);
+        session.Pause(TimeProvider.System);
+
+        _sessionRepoMock
+            .Setup(r => r.GetByIdAsync(sessionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(session);
+
+        _sessionRepoMock
+            .Setup(r => r.UpdateAsync(It.IsAny<LiveGameSession>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        if (withDbEntity)
+        {
+            _dbContext.LiveGameSessions.Add(new LiveGameSessionEntity
+            {
+                Id = sessionId,
+                SessionCode = session.SessionCode,
+                GameName = gameName,
+                CreatedByUserId = TestUserId,
+                Status = (int)LiveSessionStatus.Paused,
+                CurrentTurnIndex = session.CurrentTurnIndex,
+                PausedAt = session.PausedAt,
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow,
+                AgentMode = (int)AgentSessionMode.None,
+                ScoringConfigJson = "{}",
+                RowVersion = new byte[] { 1 }
+            });
+            _dbContext.SaveChanges();
+        }
+
+        return session;
+    }
+
+    private PauseSnapshot CreateSnapshot(
+        string? agentSummary = null,
+        int currentTurn = 3)
+    {
+        var snapshot = PauseSnapshot.Create(
+            liveGameSessionId: TestSessionId,
+            currentTurn: currentTurn,
+            currentPhase: null,
+            playerScores: new List<PlayerScoreSnapshot>
+            {
+                new("Alice", 42)
+            },
+            savedByUserId: TestUserId,
+            isAutoSave: false);
+
+        if (agentSummary is not null)
+            snapshot.UpdateSummary(agentSummary);
+
+        _snapshotRepoMock
+            .Setup(r => r.GetLatestBySessionIdAsync(TestSessionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(snapshot);
+
+        return snapshot;
+    }
+
+    private static ResumeSessionFromSnapshotCommand BuildCommand(
+        Guid? sessionId = null,
+        Guid? userId = null)
+        => new(
+            SessionId: sessionId ?? TestSessionId,
+            ResumedByUserId: userId ?? TestUserId);
+
+    // ─── Happy path ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Handle_HappyPath_ResumesSessionAndReturnsResponse()
+    {
+        // Arrange
+        CreatePausedSession(withDbEntity: true);
+        CreateSnapshot(agentSummary: "Quando avete messo in pausa, Alice era in vantaggio.");
+        var command = BuildCommand();
+
+        // Act
+        var result = await _sut.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.Equal(TestSessionId, result.SessionId);
+        Assert.NotNull(result.InviteCode);
+        Assert.Equal(6, result.InviteCode.Length);
+        Assert.StartsWith("/join/", result.ShareLink);
+        Assert.NotNull(result.AgentRecap);
+        Assert.Contains("Alice", result.AgentRecap, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Handle_HappyPath_SessionIsResumedToInProgress()
+    {
+        // Arrange
+        var session = CreatePausedSession(withDbEntity: true);
+        CreateSnapshot();
+        var command = BuildCommand();
+
+        LiveGameSession? capturedSession = null;
+        _sessionRepoMock
+            .Setup(r => r.UpdateAsync(It.IsAny<LiveGameSession>(), It.IsAny<CancellationToken>()))
+            .Callback<LiveGameSession, CancellationToken>((s, _) => capturedSession = s)
+            .Returns(Task.CompletedTask);
+
+        // Act
+        await _sut.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.NotNull(capturedSession);
+        Assert.Equal(LiveSessionStatus.InProgress, capturedSession!.Status);
+        Assert.Null(capturedSession.PausedAt);
+    }
+
+    [Fact]
+    public async Task Handle_HappyPath_CreatesNewSessionInvite()
+    {
+        // Arrange
+        CreatePausedSession(withDbEntity: true);
+        CreateSnapshot();
+        var command = BuildCommand();
+
+        // Act
+        await _sut.Handle(command, CancellationToken.None);
+
+        // Assert — a new SessionInvite was persisted to DB
+        var invites = _dbContext.SessionInvites
+            .Where(i => i.SessionId == TestSessionId)
+            .ToList();
+
+        Assert.Single(invites);
+        Assert.Equal(TestUserId, invites[0].CreatedByUserId);
+        Assert.False(invites[0].IsRevoked);
+        Assert.Equal(0, invites[0].CurrentUses);
+    }
+
+    [Fact]
+    public async Task Handle_HappyPath_DeletesAutoSaveSnapshots()
+    {
+        // Arrange
+        CreatePausedSession(withDbEntity: true);
+        CreateSnapshot();
+        var command = BuildCommand();
+
+        // Act
+        await _sut.Handle(command, CancellationToken.None);
+
+        // Assert
+        _snapshotRepoMock.Verify(
+            r => r.DeleteAutoSavesBySessionIdAsync(TestSessionId, It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_HappyPath_PublishesSessionResumedEvent()
+    {
+        // Arrange
+        CreatePausedSession(withDbEntity: true);
+        CreateSnapshot(agentSummary: "Recap testo");
+        var command = BuildCommand();
+
+        // Act
+        await _sut.Handle(command, CancellationToken.None);
+
+        // Assert
+        _publisherMock.Verify(
+            p => p.Publish(
+                It.Is<SessionResumedEvent>(e => e.SessionId == TestSessionId),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_WhenNoAgentSummary_ReturnsFallbackRecap()
+    {
+        // Arrange
+        CreatePausedSession(withDbEntity: true);
+        CreateSnapshot(agentSummary: null, currentTurn: 5);
+        var command = BuildCommand();
+
+        // Act
+        var result = await _sut.Handle(command, CancellationToken.None);
+
+        // Assert — fallback message contains turn number
+        Assert.NotNull(result.AgentRecap);
+        Assert.Contains("5", result.AgentRecap, StringComparison.Ordinal);
+    }
+
+    // ─── Error cases ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Handle_WhenNoSnapshotFound_ThrowsNotFoundException()
+    {
+        // Arrange — no snapshot for this session
+        _snapshotRepoMock
+            .Setup(r => r.GetLatestBySessionIdAsync(TestSessionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((PauseSnapshot?)null);
+
+        _sessionRepoMock
+            .Setup(r => r.GetByIdAsync(TestSessionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreatePausedSession());
+
+        var command = BuildCommand();
+
+        // Act & Assert
+        await Assert.ThrowsAsync<NotFoundException>(() =>
+            _sut.Handle(command, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task Handle_WhenSessionNotFound_ThrowsNotFoundException()
+    {
+        // Arrange
+        CreateSnapshot();
+
+        _sessionRepoMock
+            .Setup(r => r.GetByIdAsync(TestSessionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((LiveGameSession?)null);
+
+        var command = BuildCommand();
+
+        // Act & Assert
+        await Assert.ThrowsAsync<NotFoundException>(() =>
+            _sut.Handle(command, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task Handle_WhenSessionIsInProgress_ThrowsConflictException()
+    {
+        // Arrange — session is InProgress (not Paused)
+        CreateSnapshot();
+
+        var session = LiveGameSession.Create(
+            id: TestSessionId,
+            createdByUserId: TestUserId,
+            gameName: "Test Game",
+            timeProvider: TimeProvider.System);
+
+        session.AddPlayer(TestUserId, "Alice", PlayerColor.Red, TimeProvider.System, PlayerRole.Host);
+        session.MoveToSetup(TimeProvider.System);
+        session.Start(TimeProvider.System); // InProgress, not Paused
+
+        _sessionRepoMock
+            .Setup(r => r.GetByIdAsync(TestSessionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(session);
+
+        var command = BuildCommand();
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ConflictException>(() =>
+            _sut.Handle(command, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task Handle_WhenSessionIsCreated_ThrowsConflictException()
+    {
+        // Arrange — session hasn't started
+        CreateSnapshot();
+
+        var session = LiveGameSession.Create(
+            id: TestSessionId,
+            createdByUserId: TestUserId,
+            gameName: "Test Game",
+            timeProvider: TimeProvider.System);
+
+        _sessionRepoMock
+            .Setup(r => r.GetByIdAsync(TestSessionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(session);
+
+        var command = BuildCommand();
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ConflictException>(() =>
+            _sut.Handle(command, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task Handle_WithAgentSummary_ReturnsRecapFromSnapshot()
+    {
+        // Arrange
+        const string summary = "Quando avete messo in pausa, il turno 7 era appena iniziato con Bob in testa.";
+        CreatePausedSession(withDbEntity: true);
+        CreateSnapshot(agentSummary: summary);
+        var command = BuildCommand();
+
+        // Act
+        var result = await _sut.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.Equal(summary, result.AgentRecap);
+    }
+}
+
+/// <summary>
+/// Validation tests for <see cref="ResumeSessionFromSnapshotCommandValidator"/>.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "GameManagement")]
+public sealed class ResumeSessionFromSnapshotCommandValidatorTests
+{
+    private readonly ResumeSessionFromSnapshotCommandValidator _validator = new();
+
+    [Fact]
+    public void Validate_WithValidCommand_Passes()
+    {
+        var command = new ResumeSessionFromSnapshotCommand(Guid.NewGuid(), Guid.NewGuid());
+        _validator.TestValidate(command).ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void Validate_WithEmptySessionId_Fails()
+    {
+        var command = new ResumeSessionFromSnapshotCommand(Guid.Empty, Guid.NewGuid());
+        _validator.TestValidate(command).ShouldHaveValidationErrorFor(x => x.SessionId);
+    }
+
+    [Fact]
+    public void Validate_WithEmptyUserId_Fails()
+    {
+        var command = new ResumeSessionFromSnapshotCommand(Guid.NewGuid(), Guid.Empty);
+        _validator.TestValidate(command).ShouldHaveValidationErrorFor(x => x.ResumedByUserId);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/GameNight/StartImprovvisataSessionCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/GameNight/StartImprovvisataSessionCommandHandlerTests.cs
@@ -1,0 +1,278 @@
+using Api.BoundedContexts.GameManagement.Application.Commands.GameNight;
+using Api.BoundedContexts.GameManagement.Domain.Entities;
+using Api.BoundedContexts.GameManagement.Domain.Repositories;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.UserLibrary;
+using Api.Middleware.Exceptions;
+using Api.Tests.Constants;
+using Api.Tests.TestHelpers;
+using FluentValidation.TestHelper;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameManagement.Application.GameNight;
+
+/// <summary>
+/// Unit tests for StartImprovvisataSessionCommandHandler.
+/// Game Night Improvvisata - E2-1: Start session from PrivateGame.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "GameManagement")]
+public sealed class StartImprovvisataSessionCommandHandlerTests
+{
+    private readonly MeepleAiDbContext _dbContext;
+    private readonly Mock<ILiveSessionRepository> _sessionRepoMock;
+    private readonly StartImprovvisataSessionCommandHandler _sut;
+
+    private static readonly Guid TestUserId = Guid.NewGuid();
+    private static readonly Guid OtherUserId = Guid.NewGuid();
+    private static readonly Guid TestPrivateGameId = Guid.NewGuid();
+
+    public StartImprovvisataSessionCommandHandlerTests()
+    {
+        _dbContext = TestDbContextFactory.CreateInMemoryDbContext();
+        _sessionRepoMock = new Mock<ILiveSessionRepository>();
+
+        _sut = new StartImprovvisataSessionCommandHandler(
+            _dbContext,
+            _sessionRepoMock.Object,
+            TimeProvider.System,
+            NullLogger<StartImprovvisataSessionCommandHandler>.Instance);
+    }
+
+    private async Task SeedPrivateGame(Guid gameId, Guid ownerId, string title = "Test Game")
+    {
+        _dbContext.PrivateGames.Add(new PrivateGameEntity
+        {
+            Id = gameId,
+            OwnerId = ownerId,
+            Title = title,
+            MinPlayers = 2,
+            MaxPlayers = 4,
+            IsDeleted = false,
+            CreatedAt = DateTime.UtcNow
+        });
+        await _dbContext.SaveChangesAsync();
+    }
+
+    // ─── Happy path ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Handle_HappyPath_ReturnsSessionIdAndInviteCode()
+    {
+        // Arrange
+        await SeedPrivateGame(TestPrivateGameId, TestUserId, "Wingspan");
+        var command = new StartImprovvisataSessionCommand(TestUserId, TestPrivateGameId);
+
+        // Act
+        var result = await _sut.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.NotEqual(Guid.Empty, result.SessionId);
+        Assert.NotNull(result.InviteCode);
+        Assert.Equal(6, result.InviteCode.Length);
+        Assert.StartsWith("/join/", result.ShareLink);
+        Assert.Equal(32, result.ShareLink.Length - "/join/".Length); // UUID without hyphens = 32 chars
+    }
+
+    [Fact]
+    public async Task Handle_HappyPath_PersistsLiveGameSessionToDatabase()
+    {
+        // Arrange
+        await SeedPrivateGame(TestPrivateGameId, TestUserId, "Wingspan");
+        var command = new StartImprovvisataSessionCommand(TestUserId, TestPrivateGameId);
+
+        // Act
+        var result = await _sut.Handle(command, CancellationToken.None);
+
+        // Assert
+        var savedSession = await _dbContext.LiveGameSessions.FindAsync(result.SessionId);
+        Assert.NotNull(savedSession);
+        Assert.Equal("Wingspan", savedSession.GameName);
+        Assert.Equal(TestUserId, savedSession.CreatedByUserId);
+    }
+
+    [Fact]
+    public async Task Handle_HappyPath_PersistsSessionInviteToDatabase()
+    {
+        // Arrange
+        await SeedPrivateGame(TestPrivateGameId, TestUserId);
+        var command = new StartImprovvisataSessionCommand(TestUserId, TestPrivateGameId);
+
+        // Act
+        var result = await _sut.Handle(command, CancellationToken.None);
+
+        // Assert
+        var savedInvite = _dbContext.SessionInvites.FirstOrDefault(i => i.SessionId == result.SessionId);
+        Assert.NotNull(savedInvite);
+        Assert.Equal(result.InviteCode, savedInvite.Pin);
+        Assert.Equal(TestUserId, savedInvite.CreatedByUserId);
+        Assert.False(savedInvite.IsRevoked);
+        Assert.Equal(0, savedInvite.CurrentUses);
+    }
+
+    [Fact]
+    public async Task Handle_HappyPath_InviteHas24HourExpiry()
+    {
+        // Arrange
+        await SeedPrivateGame(TestPrivateGameId, TestUserId);
+        var command = new StartImprovvisataSessionCommand(TestUserId, TestPrivateGameId);
+
+        // Act
+        var result = await _sut.Handle(command, CancellationToken.None);
+
+        // Assert
+        var savedInvite = _dbContext.SessionInvites.FirstOrDefault(i => i.SessionId == result.SessionId);
+        Assert.NotNull(savedInvite);
+        var expectedExpiry = DateTime.UtcNow.AddHours(23); // at least 23h from now
+        Assert.True(savedInvite.ExpiresAt > expectedExpiry,
+            $"Expected ExpiresAt > {expectedExpiry:u} but was {savedInvite.ExpiresAt:u}");
+    }
+
+    [Fact]
+    public async Task Handle_HappyPath_InviteHasMaxTenUses()
+    {
+        // Arrange
+        await SeedPrivateGame(TestPrivateGameId, TestUserId);
+        var command = new StartImprovvisataSessionCommand(TestUserId, TestPrivateGameId);
+
+        // Act
+        var result = await _sut.Handle(command, CancellationToken.None);
+
+        // Assert
+        var savedInvite = _dbContext.SessionInvites.FirstOrDefault(i => i.SessionId == result.SessionId);
+        Assert.NotNull(savedInvite);
+        Assert.Equal(10, savedInvite.MaxUses);
+    }
+
+    [Fact]
+    public async Task Handle_HappyPath_RegistersSessionInLiveSessionRepository()
+    {
+        // Arrange
+        await SeedPrivateGame(TestPrivateGameId, TestUserId);
+        var command = new StartImprovvisataSessionCommand(TestUserId, TestPrivateGameId);
+
+        // Act
+        await _sut.Handle(command, CancellationToken.None);
+
+        // Assert
+        _sessionRepoMock.Verify(
+            r => r.AddAsync(It.Is<LiveGameSession>(s => s.CreatedByUserId == TestUserId), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_HappyPath_UserIsAddedAsHost()
+    {
+        // Arrange
+        await SeedPrivateGame(TestPrivateGameId, TestUserId);
+        var command = new StartImprovvisataSessionCommand(TestUserId, TestPrivateGameId);
+
+        LiveGameSession? capturedSession = null;
+        _sessionRepoMock
+            .Setup(r => r.AddAsync(It.IsAny<LiveGameSession>(), It.IsAny<CancellationToken>()))
+            .Callback<LiveGameSession, CancellationToken>((s, _) => capturedSession = s)
+            .Returns(Task.CompletedTask);
+
+        // Act
+        await _sut.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.NotNull(capturedSession);
+        Assert.NotNull(capturedSession.Host);
+        Assert.Equal(TestUserId, capturedSession.Host!.UserId);
+    }
+
+    // ─── Error cases ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Handle_WhenPrivateGameNotFound_ThrowsNotFoundException()
+    {
+        // Arrange — no game seeded
+        var command = new StartImprovvisataSessionCommand(TestUserId, TestPrivateGameId);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<NotFoundException>(() =>
+            _sut.Handle(command, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task Handle_WhenPrivateGameIsDeleted_ThrowsNotFoundException()
+    {
+        // Arrange — game exists but soft-deleted
+        _dbContext.PrivateGames.Add(new PrivateGameEntity
+        {
+            Id = TestPrivateGameId,
+            OwnerId = TestUserId,
+            Title = "Deleted Game",
+            MinPlayers = 2,
+            MaxPlayers = 4,
+            IsDeleted = true,
+            DeletedAt = DateTime.UtcNow.AddDays(-1),
+            CreatedAt = DateTime.UtcNow.AddDays(-7)
+        });
+        await _dbContext.SaveChangesAsync();
+
+        var command = new StartImprovvisataSessionCommand(TestUserId, TestPrivateGameId);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<NotFoundException>(() =>
+            _sut.Handle(command, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task Handle_WhenUserDoesNotOwnGame_ThrowsForbiddenException()
+    {
+        // Arrange — game owned by a different user
+        await SeedPrivateGame(TestPrivateGameId, OtherUserId, "Someone Else's Game");
+        var command = new StartImprovvisataSessionCommand(TestUserId, TestPrivateGameId);
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ForbiddenException>(() =>
+            _sut.Handle(command, CancellationToken.None));
+    }
+}
+
+/// <summary>
+/// Validation tests for StartImprovvisataSessionValidator.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "GameManagement")]
+public sealed class StartImprovvisataSessionValidatorTests
+{
+    private readonly StartImprovvisataSessionValidator _validator = new();
+
+    [Fact]
+    public void Validate_WithValidCommand_Passes()
+    {
+        var command = new StartImprovvisataSessionCommand(Guid.NewGuid(), Guid.NewGuid());
+        var result = _validator.TestValidate(command);
+        result.ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void Validate_WithEmptyPrivateGameId_Fails()
+    {
+        var command = new StartImprovvisataSessionCommand(Guid.NewGuid(), Guid.Empty);
+        var result = _validator.TestValidate(command);
+        result.ShouldHaveValidationErrorFor(x => x.PrivateGameId);
+    }
+
+    [Fact]
+    public void Validate_WithEmptyUserId_Fails()
+    {
+        var command = new StartImprovvisataSessionCommand(Guid.Empty, Guid.NewGuid());
+        var result = _validator.TestValidate(command);
+        result.ShouldHaveValidationErrorFor(x => x.UserId);
+    }
+
+    [Fact]
+    public void Validate_WithBothEmpty_FailsBothFields()
+    {
+        var command = new StartImprovvisataSessionCommand(Guid.Empty, Guid.Empty);
+        var result = _validator.TestValidate(command);
+        result.ShouldHaveValidationErrorFor(x => x.UserId);
+        result.ShouldHaveValidationErrorFor(x => x.PrivateGameId);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/GameNight/SubmitRuleDisputeCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/GameNight/SubmitRuleDisputeCommandHandlerTests.cs
@@ -1,0 +1,539 @@
+using Api.BoundedContexts.GameManagement.Application.Commands.GameNight;
+using Api.BoundedContexts.GameManagement.Domain.Entities;
+using Api.BoundedContexts.GameManagement.Domain.Enums;
+using Api.BoundedContexts.GameManagement.Domain.Events;
+using Api.BoundedContexts.GameManagement.Domain.Repositories;
+using Api.BoundedContexts.GameManagement.Domain.ValueObjects;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.GameManagement;
+using Api.Middleware.Exceptions;
+using Api.Services;
+using Api.Tests.Constants;
+using Api.Tests.TestHelpers;
+using FluentValidation.TestHelper;
+using MediatR;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameManagement.Application.GameNight;
+
+/// <summary>
+/// Unit tests for <see cref="SubmitRuleDisputeCommandHandler"/>.
+/// Game Night Improvvisata — E3: Arbitro mode.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "GameManagement")]
+public sealed class SubmitRuleDisputeCommandHandlerTests
+{
+    // ─── Fixtures ────────────────────────────────────────────────────────────
+
+    private static readonly Guid TestSessionId = Guid.NewGuid();
+    private static readonly Guid TestUserId = Guid.NewGuid();
+
+    private const string DefaultLlmResponse =
+        "VERDETTO: Il giocatore A ha ragione. Si possono giocare 2 carte per turno.\n" +
+        "REGOLA: Manuale pag. 12, sezione \"Azioni di turno\": ogni giocatore può giocare fino a 2 carte.\n" +
+        "NOTA: Se ci sono dubbi, consultare la FAQ ufficiale.";
+
+    private readonly MeepleAiDbContext _dbContext;
+    private readonly Mock<ILiveSessionRepository> _sessionRepoMock;
+    private readonly Mock<ILlmService> _llmServiceMock;
+    private readonly Mock<IPublisher> _publisherMock;
+    private readonly SubmitRuleDisputeCommandHandler _sut;
+
+    public SubmitRuleDisputeCommandHandlerTests()
+    {
+        _dbContext = TestDbContextFactory.CreateInMemoryDbContext();
+        _sessionRepoMock = new Mock<ILiveSessionRepository>();
+        _llmServiceMock = new Mock<ILlmService>();
+        _publisherMock = new Mock<IPublisher>();
+
+        // Default: LLM always succeeds with structured response
+        _llmServiceMock
+            .Setup(s => s.GenerateCompletionAsync(
+                It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<RequestSource>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(LlmCompletionResult.CreateSuccess(DefaultLlmResponse));
+
+        _sut = new SubmitRuleDisputeCommandHandler(
+            _sessionRepoMock.Object,
+            _dbContext,
+            _llmServiceMock.Object,
+            _publisherMock.Object,
+            TimeProvider.System,
+            NullLogger<SubmitRuleDisputeCommandHandler>.Instance);
+    }
+
+    // ─── Helpers ─────────────────────────────────────────────────────────────
+
+    private LiveGameSession CreateInProgressSession(
+        Guid? id = null,
+        string gameName = "Wingspan",
+        bool withDbEntity = false)
+    {
+        var sessionId = id ?? TestSessionId;
+        var session = LiveGameSession.Create(
+            id: sessionId,
+            createdByUserId: TestUserId,
+            gameName: gameName,
+            timeProvider: TimeProvider.System);
+
+        session.AddPlayer(
+            userId: TestUserId,
+            displayName: "Alice",
+            color: PlayerColor.Red,
+            timeProvider: TimeProvider.System,
+            role: PlayerRole.Host);
+
+        session.MoveToSetup(TimeProvider.System);
+        session.Start(TimeProvider.System);
+
+        _sessionRepoMock
+            .Setup(r => r.GetByIdAsync(sessionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(session);
+
+        _sessionRepoMock
+            .Setup(r => r.UpdateAsync(It.IsAny<LiveGameSession>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        if (withDbEntity)
+        {
+            _dbContext.LiveGameSessions.Add(new LiveGameSessionEntity
+            {
+                Id = sessionId,
+                SessionCode = session.SessionCode,
+                GameName = gameName,
+                CreatedByUserId = TestUserId,
+                Status = (int)LiveSessionStatus.InProgress,
+                CurrentTurnIndex = session.CurrentTurnIndex,
+                CreatedAt = DateTime.UtcNow,
+                UpdatedAt = DateTime.UtcNow,
+                AgentMode = (int)AgentSessionMode.None,
+                ScoringConfigJson = "{}",
+                RowVersion = new byte[] { 1 }
+            });
+            _dbContext.SaveChanges();
+        }
+
+        return session;
+    }
+
+    private static SubmitRuleDisputeCommand BuildCommand(
+        Guid? sessionId = null,
+        string description = "Posso giocare 2 carte per turno?",
+        string player = "Alice")
+        => new(
+            SessionId: sessionId ?? TestSessionId,
+            Description: description,
+            RaisedByPlayerName: player);
+
+    // ─── Happy path ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Handle_HappyPath_ReturnsRuleDisputeResponse()
+    {
+        // Arrange
+        CreateInProgressSession(withDbEntity: true);
+        var command = BuildCommand();
+
+        // Act
+        var result = await _sut.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.NotEqual(Guid.Empty, result.Id);
+        Assert.False(string.IsNullOrWhiteSpace(result.Verdict));
+        Assert.NotNull(result.RuleReferences);
+        Assert.NotEmpty(result.RuleReferences);
+    }
+
+    [Fact]
+    public async Task Handle_HappyPath_AddsDisputeToSession()
+    {
+        // Arrange
+        var session = CreateInProgressSession(withDbEntity: true);
+        var command = BuildCommand(description: "Posso usare un'azione speciale due volte?");
+
+        // Capture the session passed to UpdateAsync
+        LiveGameSession? updatedSession = null;
+        _sessionRepoMock
+            .Setup(r => r.UpdateAsync(It.IsAny<LiveGameSession>(), It.IsAny<CancellationToken>()))
+            .Callback<LiveGameSession, CancellationToken>((s, _) => updatedSession = s)
+            .Returns(Task.CompletedTask);
+
+        // Act
+        await _sut.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.NotNull(updatedSession);
+        Assert.Single(updatedSession!.Disputes);
+        Assert.Equal(command.Description, updatedSession.Disputes[0].Description);
+        Assert.Equal(command.RaisedByPlayerName, updatedSession.Disputes[0].RaisedByPlayerName);
+    }
+
+    [Fact]
+    public async Task Handle_HappyPath_PublishesDisputeResolvedEvent()
+    {
+        // Arrange
+        CreateInProgressSession(withDbEntity: true);
+        var command = BuildCommand();
+
+        // Act
+        await _sut.Handle(command, CancellationToken.None);
+
+        // Assert
+        _publisherMock.Verify(
+            p => p.Publish(
+                It.Is<DisputeResolvedEvent>(e =>
+                    e.SessionId == TestSessionId &&
+                    e.Dispute.RaisedByPlayerName == command.RaisedByPlayerName),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_HappyPath_CallsLlmWithArbitrationPrompt()
+    {
+        // Arrange
+        CreateInProgressSession(withDbEntity: true);
+        var command = BuildCommand(description: "Chi va per primo al turno 3?");
+
+        string? capturedSystemPrompt = null;
+        string? capturedUserPrompt = null;
+
+        _llmServiceMock
+            .Setup(s => s.GenerateCompletionAsync(
+                It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<RequestSource>(), It.IsAny<CancellationToken>()))
+            .Callback<string, string, RequestSource, CancellationToken>(
+                (sys, usr, _, _) =>
+                {
+                    capturedSystemPrompt = sys;
+                    capturedUserPrompt = usr;
+                })
+            .ReturnsAsync(LlmCompletionResult.CreateSuccess(DefaultLlmResponse));
+
+        // Act
+        await _sut.Handle(command, CancellationToken.None);
+
+        // Assert — prompt must contain the arbitration markers
+        Assert.NotNull(capturedSystemPrompt);
+        Assert.Contains("ARBITRO", capturedSystemPrompt, StringComparison.OrdinalIgnoreCase);
+        Assert.NotNull(capturedUserPrompt);
+        Assert.Contains(command.Description, capturedUserPrompt, StringComparison.Ordinal);
+        Assert.Contains("VERDETTO:", capturedUserPrompt, StringComparison.Ordinal);
+        Assert.Contains("REGOLA:", capturedUserPrompt, StringComparison.Ordinal);
+        Assert.Contains("NOTA:", capturedUserPrompt, StringComparison.Ordinal);
+        Assert.Contains("Wingspan", capturedUserPrompt, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Handle_HappyPath_IncludesPreviousDisputesInPrompt()
+    {
+        // Arrange
+        var session = CreateInProgressSession(withDbEntity: true);
+
+        // Pre-populate two disputes on the in-memory session
+        session.AddDispute(new RuleDisputeEntry(
+            Guid.NewGuid(), "Prima disputa?", "Verdetto A", new List<string>(), "Bob", DateTime.UtcNow));
+        session.AddDispute(new RuleDisputeEntry(
+            Guid.NewGuid(), "Seconda disputa?", "Verdetto B", new List<string>(), "Carol", DateTime.UtcNow));
+
+        var command = BuildCommand(description: "Terza domanda?");
+
+        string? capturedUserPrompt = null;
+        _llmServiceMock
+            .Setup(s => s.GenerateCompletionAsync(
+                It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<RequestSource>(), It.IsAny<CancellationToken>()))
+            .Callback<string, string, RequestSource, CancellationToken>(
+                (_, usr, _, _) => capturedUserPrompt = usr)
+            .ReturnsAsync(LlmCompletionResult.CreateSuccess(DefaultLlmResponse));
+
+        // Act
+        await _sut.Handle(command, CancellationToken.None);
+
+        // Assert
+        Assert.NotNull(capturedUserPrompt);
+        Assert.Contains("Prima disputa?", capturedUserPrompt, StringComparison.Ordinal);
+        Assert.Contains("Seconda disputa?", capturedUserPrompt, StringComparison.Ordinal);
+        Assert.Contains("Verdetti precedenti", capturedUserPrompt, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Handle_HappyPath_ParsesVerdictFromLlmResponse()
+    {
+        // Arrange
+        CreateInProgressSession(withDbEntity: true);
+        var command = BuildCommand();
+
+        // Act
+        var result = await _sut.Handle(command, CancellationToken.None);
+
+        // Assert — verdict text extracted from "VERDETTO:" section
+        Assert.Contains("ragione", result.Verdict, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Handle_HappyPath_ParsesRuleReferencesFromLlmResponse()
+    {
+        // Arrange
+        CreateInProgressSession(withDbEntity: true);
+        var command = BuildCommand();
+
+        // Act
+        var result = await _sut.Handle(command, CancellationToken.None);
+
+        // Assert — REGOLA section content ends up in RuleReferences
+        Assert.NotEmpty(result.RuleReferences);
+        Assert.Contains(result.RuleReferences, r => r.Contains("pag.", StringComparison.OrdinalIgnoreCase));
+    }
+
+    [Fact]
+    public async Task Handle_HappyPath_ParsesNoteFromLlmResponse()
+    {
+        // Arrange
+        CreateInProgressSession(withDbEntity: true);
+        var command = BuildCommand();
+
+        // Act
+        var result = await _sut.Handle(command, CancellationToken.None);
+
+        // Assert — NOTA section present in response fixture
+        Assert.NotNull(result.Note);
+        Assert.Contains("FAQ", result.Note, StringComparison.OrdinalIgnoreCase);
+    }
+
+    // ─── Error cases ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Handle_WhenSessionNotFound_ThrowsNotFoundException()
+    {
+        // Arrange — repository returns null
+        _sessionRepoMock
+            .Setup(r => r.GetByIdAsync(TestSessionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((LiveGameSession?)null);
+
+        var command = BuildCommand();
+
+        // Act & Assert
+        await Assert.ThrowsAsync<NotFoundException>(() =>
+            _sut.Handle(command, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task Handle_WhenSessionIsNotInProgress_ThrowsConflictException()
+    {
+        // Arrange — session in Created status (not started)
+        var session = LiveGameSession.Create(
+            id: TestSessionId,
+            createdByUserId: TestUserId,
+            gameName: "Test Game",
+            timeProvider: TimeProvider.System);
+
+        _sessionRepoMock
+            .Setup(r => r.GetByIdAsync(TestSessionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(session);
+
+        var command = BuildCommand();
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ConflictException>(() =>
+            _sut.Handle(command, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task Handle_WhenSessionIsPaused_ThrowsConflictException()
+    {
+        // Arrange — paused session
+        var session = LiveGameSession.Create(
+            id: TestSessionId,
+            createdByUserId: TestUserId,
+            gameName: "Test Game",
+            timeProvider: TimeProvider.System);
+
+        session.AddPlayer(TestUserId, "Host", PlayerColor.Red, TimeProvider.System, PlayerRole.Host);
+        session.MoveToSetup(TimeProvider.System);
+        session.Start(TimeProvider.System);
+        session.Pause(TimeProvider.System);
+
+        _sessionRepoMock
+            .Setup(r => r.GetByIdAsync(TestSessionId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(session);
+
+        var command = BuildCommand();
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ConflictException>(() =>
+            _sut.Handle(command, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task Handle_WhenLlmFails_ThrowsInvalidOperationException()
+    {
+        // Arrange
+        CreateInProgressSession(withDbEntity: true);
+
+        _llmServiceMock
+            .Setup(s => s.GenerateCompletionAsync(
+                It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<RequestSource>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(LlmCompletionResult.CreateFailure("LLM unavailable"));
+
+        var command = BuildCommand();
+
+        // Act & Assert
+        await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            _sut.Handle(command, CancellationToken.None));
+    }
+
+    // ─── Parsing edge cases ───────────────────────────────────────────────────
+
+    [Fact]
+    public void ParseArbitrationResponse_WithWellFormedResponse_ParsesAllSections()
+    {
+        // Arrange
+        const string response =
+            "VERDETTO: Giocatore A ha ragione.\n" +
+            "REGOLA: Pag. 5, sezione Turni.\n" +
+            "NOTA: In caso di dubbio usare la FAQ.";
+
+        // Act
+        var (verdict, refs, note) = SubmitRuleDisputeCommandHandler.ParseArbitrationResponse(response);
+
+        // Assert
+        Assert.Contains("Giocatore A", verdict, StringComparison.Ordinal);
+        Assert.NotEmpty(refs);
+        Assert.Contains("Pag. 5", refs[0], StringComparison.Ordinal);
+        Assert.NotNull(note);
+        Assert.Contains("FAQ", note, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public void ParseArbitrationResponse_WithMalformedResponse_UsesFullResponseAsVerdict()
+    {
+        // Arrange
+        const string response = "Il giocatore A ha torto perché le regole dicono altro.";
+
+        // Act
+        var (verdict, refs, note) = SubmitRuleDisputeCommandHandler.ParseArbitrationResponse(response);
+
+        // Assert — fallback: full response as verdict
+        Assert.Equal(response, verdict);
+        Assert.Empty(refs);
+        Assert.Null(note);
+    }
+
+    [Fact]
+    public void ParseArbitrationResponse_WithEmptyResponse_ReturnsDefaultVerdict()
+    {
+        // Act
+        var (verdict, refs, note) = SubmitRuleDisputeCommandHandler.ParseArbitrationResponse(string.Empty);
+
+        // Assert
+        Assert.False(string.IsNullOrWhiteSpace(verdict));
+        Assert.Empty(refs);
+        Assert.Null(note);
+    }
+
+    [Fact]
+    public void ParseArbitrationResponse_WithMultipleRuleReferencesViaSemicolon_ParsesAllRefs()
+    {
+        // Arrange
+        const string response =
+            "VERDETTO: Ha ragione il difensore.\n" +
+            "REGOLA: Pag. 3 sezione A; Pag. 7 sezione B; Errata 2024.\n" +
+            "NOTA: Consultare la versione aggiornata.";
+
+        // Act
+        var (_, refs, _) = SubmitRuleDisputeCommandHandler.ParseArbitrationResponse(response);
+
+        // Assert
+        Assert.True(refs.Count >= 2, $"Expected at least 2 references, got {refs.Count}");
+    }
+
+    [Fact]
+    public void ParseArbitrationResponse_WithNoNota_ReturnsNullNote()
+    {
+        // Arrange
+        const string response =
+            "VERDETTO: Il giocatore B ha ragione.\n" +
+            "REGOLA: Manuale pag. 8, regola delle azioni.";
+
+        // Act
+        var (verdict, refs, note) = SubmitRuleDisputeCommandHandler.ParseArbitrationResponse(response);
+
+        // Assert
+        Assert.Contains("giocatore B", verdict, StringComparison.OrdinalIgnoreCase);
+        Assert.NotEmpty(refs);
+        Assert.Null(note);
+    }
+}
+
+/// <summary>
+/// Validation tests for <see cref="SubmitRuleDisputeCommandValidator"/>.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "GameManagement")]
+public sealed class SubmitRuleDisputeCommandValidatorTests
+{
+    private readonly SubmitRuleDisputeCommandValidator _validator = new();
+
+    [Fact]
+    public void Validate_WithValidCommand_Passes()
+    {
+        var command = new SubmitRuleDisputeCommand(
+            Guid.NewGuid(), "Posso giocare 2 carte?", "Alice");
+        _validator.TestValidate(command).ShouldNotHaveAnyValidationErrors();
+    }
+
+    [Fact]
+    public void Validate_WithEmptySessionId_Fails()
+    {
+        var command = new SubmitRuleDisputeCommand(
+            Guid.Empty, "Description", "Player");
+        _validator.TestValidate(command).ShouldHaveValidationErrorFor(x => x.SessionId);
+    }
+
+    [Fact]
+    public void Validate_WithEmptyDescription_Fails()
+    {
+        var command = new SubmitRuleDisputeCommand(
+            Guid.NewGuid(), string.Empty, "Player");
+        _validator.TestValidate(command).ShouldHaveValidationErrorFor(x => x.Description);
+    }
+
+    [Fact]
+    public void Validate_WithDescriptionExceeding1000Chars_Fails()
+    {
+        var command = new SubmitRuleDisputeCommand(
+            Guid.NewGuid(), new string('A', 1001), "Player");
+        _validator.TestValidate(command).ShouldHaveValidationErrorFor(x => x.Description);
+    }
+
+    [Fact]
+    public void Validate_WithEmptyPlayerName_Fails()
+    {
+        var command = new SubmitRuleDisputeCommand(
+            Guid.NewGuid(), "Description", string.Empty);
+        _validator.TestValidate(command).ShouldHaveValidationErrorFor(x => x.RaisedByPlayerName);
+    }
+
+    [Fact]
+    public void Validate_WithPlayerNameExceeding100Chars_Fails()
+    {
+        var command = new SubmitRuleDisputeCommand(
+            Guid.NewGuid(), "Description", new string('B', 101));
+        _validator.TestValidate(command).ShouldHaveValidationErrorFor(x => x.RaisedByPlayerName);
+    }
+
+    [Fact]
+    public void Validate_WithAllFieldsEmpty_FailsAllFields()
+    {
+        var command = new SubmitRuleDisputeCommand(Guid.Empty, string.Empty, string.Empty);
+        var result = _validator.TestValidate(command);
+        result.ShouldHaveValidationErrorFor(x => x.SessionId);
+        result.ShouldHaveValidationErrorFor(x => x.Description);
+        result.ShouldHaveValidationErrorFor(x => x.RaisedByPlayerName);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/GameNight/SubmitRuleDisputeCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/GameNight/SubmitRuleDisputeCommandHandlerTests.cs
@@ -121,10 +121,12 @@ public sealed class SubmitRuleDisputeCommandHandlerTests
 
     private static SubmitRuleDisputeCommand BuildCommand(
         Guid? sessionId = null,
+        Guid? callerUserId = null,
         string description = "Posso giocare 2 carte per turno?",
         string player = "Alice")
         => new(
             SessionId: sessionId ?? TestSessionId,
+            CallerUserId: callerUserId ?? TestUserId,
             Description: description,
             RaisedByPlayerName: player);
 
@@ -483,7 +485,7 @@ public sealed class SubmitRuleDisputeCommandValidatorTests
     public void Validate_WithValidCommand_Passes()
     {
         var command = new SubmitRuleDisputeCommand(
-            Guid.NewGuid(), "Posso giocare 2 carte?", "Alice");
+            Guid.NewGuid(), Guid.NewGuid(), "Posso giocare 2 carte?", "Alice");
         _validator.TestValidate(command).ShouldNotHaveAnyValidationErrors();
     }
 
@@ -491,15 +493,23 @@ public sealed class SubmitRuleDisputeCommandValidatorTests
     public void Validate_WithEmptySessionId_Fails()
     {
         var command = new SubmitRuleDisputeCommand(
-            Guid.Empty, "Description", "Player");
+            Guid.Empty, Guid.NewGuid(), "Description", "Player");
         _validator.TestValidate(command).ShouldHaveValidationErrorFor(x => x.SessionId);
+    }
+
+    [Fact]
+    public void Validate_WithEmptyCallerUserId_Fails()
+    {
+        var command = new SubmitRuleDisputeCommand(
+            Guid.NewGuid(), Guid.Empty, "Description", "Player");
+        _validator.TestValidate(command).ShouldHaveValidationErrorFor(x => x.CallerUserId);
     }
 
     [Fact]
     public void Validate_WithEmptyDescription_Fails()
     {
         var command = new SubmitRuleDisputeCommand(
-            Guid.NewGuid(), string.Empty, "Player");
+            Guid.NewGuid(), Guid.NewGuid(), string.Empty, "Player");
         _validator.TestValidate(command).ShouldHaveValidationErrorFor(x => x.Description);
     }
 
@@ -507,7 +517,7 @@ public sealed class SubmitRuleDisputeCommandValidatorTests
     public void Validate_WithDescriptionExceeding1000Chars_Fails()
     {
         var command = new SubmitRuleDisputeCommand(
-            Guid.NewGuid(), new string('A', 1001), "Player");
+            Guid.NewGuid(), Guid.NewGuid(), new string('A', 1001), "Player");
         _validator.TestValidate(command).ShouldHaveValidationErrorFor(x => x.Description);
     }
 
@@ -515,7 +525,7 @@ public sealed class SubmitRuleDisputeCommandValidatorTests
     public void Validate_WithEmptyPlayerName_Fails()
     {
         var command = new SubmitRuleDisputeCommand(
-            Guid.NewGuid(), "Description", string.Empty);
+            Guid.NewGuid(), Guid.NewGuid(), "Description", string.Empty);
         _validator.TestValidate(command).ShouldHaveValidationErrorFor(x => x.RaisedByPlayerName);
     }
 
@@ -523,16 +533,17 @@ public sealed class SubmitRuleDisputeCommandValidatorTests
     public void Validate_WithPlayerNameExceeding100Chars_Fails()
     {
         var command = new SubmitRuleDisputeCommand(
-            Guid.NewGuid(), "Description", new string('B', 101));
+            Guid.NewGuid(), Guid.NewGuid(), "Description", new string('B', 101));
         _validator.TestValidate(command).ShouldHaveValidationErrorFor(x => x.RaisedByPlayerName);
     }
 
     [Fact]
     public void Validate_WithAllFieldsEmpty_FailsAllFields()
     {
-        var command = new SubmitRuleDisputeCommand(Guid.Empty, string.Empty, string.Empty);
+        var command = new SubmitRuleDisputeCommand(Guid.Empty, Guid.Empty, string.Empty, string.Empty);
         var result = _validator.TestValidate(command);
         result.ShouldHaveValidationErrorFor(x => x.SessionId);
+        result.ShouldHaveValidationErrorFor(x => x.CallerUserId);
         result.ShouldHaveValidationErrorFor(x => x.Description);
         result.ShouldHaveValidationErrorFor(x => x.RaisedByPlayerName);
     }

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/Entities/LiveGameSession_DisputesTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/Entities/LiveGameSession_DisputesTests.cs
@@ -1,0 +1,288 @@
+using Api.BoundedContexts.GameManagement.Domain.Entities;
+using Api.BoundedContexts.GameManagement.Domain.Enums;
+using Api.BoundedContexts.GameManagement.Domain.ValueObjects;
+using Api.Middleware.Exceptions;
+using Api.Tests.Constants;
+using Microsoft.Extensions.Time.Testing;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameManagement.Domain.Entities;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "GameManagement")]
+public class LiveGameSession_DisputesTests
+{
+    private readonly FakeTimeProvider _timeProvider;
+    private readonly DateTime _now;
+
+    public LiveGameSession_DisputesTests()
+    {
+        _timeProvider = new FakeTimeProvider(new DateTimeOffset(2026, 3, 15, 10, 0, 0, TimeSpan.Zero));
+        _now = _timeProvider.GetUtcNow().UtcDateTime;
+    }
+
+    /// <summary>
+    /// Creates a session in InProgress state (Created → Start requires players).
+    /// </summary>
+    private LiveGameSession CreateInProgressSession()
+    {
+        var session = LiveGameSession.Create(
+            Guid.NewGuid(),
+            Guid.NewGuid(),
+            "Catan",
+            _timeProvider);
+
+        session.AddPlayer(null, "Alice", PlayerColor.Red, _timeProvider);
+        session.Start(_timeProvider);
+
+        return session;
+    }
+
+    private static RuleDisputeEntry CreateTestDispute(string playerName = "Marco") =>
+        new RuleDisputeEntry(
+            Guid.NewGuid(),
+            "Can I play 2 cards per turn?",
+            "No, rule says 1 card per turn.",
+            new List<string> { "Page 5", "Page 12" },
+            playerName,
+            DateTime.UtcNow);
+
+    #region AddDispute
+
+    [Fact]
+    public void AddDispute_ShouldAddToDisputesList()
+    {
+        // Arrange
+        var session = CreateInProgressSession();
+        var dispute = CreateTestDispute("Marco");
+
+        // Act
+        session.AddDispute(dispute);
+
+        // Assert
+        Assert.Single(session.Disputes);
+        Assert.Equal("Marco", session.Disputes[0].RaisedByPlayerName);
+        Assert.Equal("Can I play 2 cards per turn?", session.Disputes[0].Description);
+        Assert.Equal("No, rule says 1 card per turn.", session.Disputes[0].Verdict);
+    }
+
+    [Fact]
+    public void AddDispute_MultipleDisputes_ShouldAllBePresent()
+    {
+        // Arrange
+        var session = CreateInProgressSession();
+        var dispute1 = CreateTestDispute("Marco");
+        var dispute2 = CreateTestDispute("Luca");
+
+        // Act
+        session.AddDispute(dispute1);
+        session.AddDispute(dispute2);
+
+        // Assert
+        Assert.Equal(2, session.Disputes.Count);
+        Assert.Contains(session.Disputes, d => d.RaisedByPlayerName == "Marco");
+        Assert.Contains(session.Disputes, d => d.RaisedByPlayerName == "Luca");
+    }
+
+    [Fact]
+    public void AddDispute_NullDispute_ShouldThrowArgumentNullException()
+    {
+        // Arrange
+        var session = CreateInProgressSession();
+
+        // Act & Assert
+        Assert.Throws<ArgumentNullException>(() => session.AddDispute(null!));
+    }
+
+    [Fact]
+    public void Disputes_ShouldBeReadOnly()
+    {
+        // Arrange
+        var session = CreateInProgressSession();
+
+        // Act & Assert
+        Assert.IsAssignableFrom<IReadOnlyList<RuleDisputeEntry>>(session.Disputes);
+    }
+
+    [Fact]
+    public void Disputes_InitiallyEmpty()
+    {
+        // Arrange
+        var session = CreateInProgressSession();
+
+        // Assert
+        Assert.Empty(session.Disputes);
+    }
+
+    [Fact]
+    public void AddDispute_PreservesRuleReferences()
+    {
+        // Arrange
+        var session = CreateInProgressSession();
+        var references = new List<string> { "Page 5", "Section 3.2" };
+        var dispute = new RuleDisputeEntry(
+            Guid.NewGuid(),
+            "Is this allowed?",
+            "Yes, per rule 3.2",
+            references,
+            "Player",
+            DateTime.UtcNow);
+
+        // Act
+        session.AddDispute(dispute);
+
+        // Assert
+        Assert.Equal(2, session.Disputes[0].RuleReferences.Count);
+        Assert.Contains("Page 5", session.Disputes[0].RuleReferences);
+        Assert.Contains("Section 3.2", session.Disputes[0].RuleReferences);
+    }
+
+    #endregion
+
+    #region Pause
+
+    [Fact]
+    public void Pause_WhenInProgress_ShouldSetStatusToPaused()
+    {
+        // Arrange
+        var session = CreateInProgressSession();
+
+        // Act
+        session.Pause(_timeProvider);
+
+        // Assert
+        Assert.Equal(LiveSessionStatus.Paused, session.Status);
+    }
+
+    [Fact]
+    public void Pause_WhenInProgress_ShouldSetPausedAt()
+    {
+        // Arrange
+        var session = CreateInProgressSession();
+
+        // Act
+        session.Pause(_timeProvider);
+
+        // Assert
+        Assert.Equal(_now, session.PausedAt);
+    }
+
+    [Fact]
+    public void Pause_WhenNotInProgress_ShouldThrow()
+    {
+        // Arrange
+        var session = CreateInProgressSession();
+        session.Pause(_timeProvider); // now Paused
+
+        // Act & Assert
+        Assert.Throws<ConflictException>(() => session.Pause(_timeProvider));
+    }
+
+    [Fact]
+    public void Pause_WhenCreated_ShouldThrow()
+    {
+        // Arrange
+        var session = LiveGameSession.Create(
+            Guid.NewGuid(), Guid.NewGuid(), "Catan", _timeProvider);
+
+        // Act & Assert
+        Assert.Throws<ConflictException>(() => session.Pause(_timeProvider));
+    }
+
+    [Fact]
+    public void Pause_WhenCompleted_ShouldThrow()
+    {
+        // Arrange
+        var session = CreateInProgressSession();
+        session.Complete(_timeProvider);
+
+        // Act & Assert
+        Assert.Throws<ConflictException>(() => session.Pause(_timeProvider));
+    }
+
+    #endregion
+
+    #region Resume
+
+    [Fact]
+    public void Resume_WhenPaused_ShouldSetStatusToInProgress()
+    {
+        // Arrange
+        var session = CreateInProgressSession();
+        session.Pause(_timeProvider);
+
+        // Act
+        session.Resume(_timeProvider);
+
+        // Assert
+        Assert.Equal(LiveSessionStatus.InProgress, session.Status);
+    }
+
+    [Fact]
+    public void Resume_WhenPaused_ShouldClearPausedAt()
+    {
+        // Arrange
+        var session = CreateInProgressSession();
+        session.Pause(_timeProvider);
+
+        // Act
+        session.Resume(_timeProvider);
+
+        // Assert
+        Assert.Null(session.PausedAt);
+    }
+
+    [Fact]
+    public void Resume_WhenNotPaused_ShouldThrow()
+    {
+        // Arrange
+        var session = CreateInProgressSession(); // InProgress, not Paused
+
+        // Act & Assert
+        Assert.Throws<ConflictException>(() => session.Resume(_timeProvider));
+    }
+
+    [Fact]
+    public void Resume_WhenCreated_ShouldThrow()
+    {
+        // Arrange
+        var session = LiveGameSession.Create(
+            Guid.NewGuid(), Guid.NewGuid(), "Catan", _timeProvider);
+
+        // Act & Assert
+        Assert.Throws<ConflictException>(() => session.Resume(_timeProvider));
+    }
+
+    [Fact]
+    public void Resume_WhenCompleted_ShouldThrow()
+    {
+        // Arrange
+        var session = CreateInProgressSession();
+        session.Complete(_timeProvider);
+
+        // Act & Assert
+        Assert.Throws<ConflictException>(() => session.Resume(_timeProvider));
+    }
+
+    [Fact]
+    public void PauseAndResume_Cycle_ShouldWorkCorrectly()
+    {
+        // Arrange
+        var session = CreateInProgressSession();
+
+        // Act & Assert - full cycle
+        session.Pause(_timeProvider);
+        Assert.Equal(LiveSessionStatus.Paused, session.Status);
+        Assert.NotNull(session.PausedAt);
+
+        session.Resume(_timeProvider);
+        Assert.Equal(LiveSessionStatus.InProgress, session.Status);
+        Assert.Null(session.PausedAt);
+
+        // Can pause again
+        session.Pause(_timeProvider);
+        Assert.Equal(LiveSessionStatus.Paused, session.Status);
+    }
+
+    #endregion
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/PauseSnapshotTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/PauseSnapshotTests.cs
@@ -1,0 +1,330 @@
+using Api.BoundedContexts.GameManagement.Domain.Entities.PauseSnapshot;
+using Api.BoundedContexts.GameManagement.Domain.ValueObjects;
+using Api.Tests.Constants;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameManagement.Domain;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "GameManagement")]
+public class PauseSnapshotTests
+{
+    private static readonly Guid ValidSessionId = Guid.NewGuid();
+    private static readonly Guid ValidUserId = Guid.NewGuid();
+
+    private static List<PlayerScoreSnapshot> SampleScores() =>
+        new()
+        {
+            new PlayerScoreSnapshot("Alice", 42m, 1),
+            new PlayerScoreSnapshot("Bob", 37m, 2),
+        };
+
+    private static List<Guid> SampleAttachmentIds() =>
+        new() { Guid.NewGuid(), Guid.NewGuid() };
+
+    private static RuleDisputeEntry SampleDispute() =>
+        new(
+            Guid.NewGuid(),
+            "Can I play 2 cards per turn?",
+            "No — the rulebook states 1 card per turn.",
+            new List<string> { "Page 5" },
+            "Alice",
+            DateTime.UtcNow);
+
+    // ─── Create with valid data ──────────────────────────────────────────────
+
+    [Fact]
+    public void Create_WithValidData_SetsLiveGameSessionId()
+    {
+        var snapshot = PauseSnapshot.Create(
+            ValidSessionId, 3, "Round 3", SampleScores(), ValidUserId, false);
+
+        Assert.Equal(ValidSessionId, snapshot.LiveGameSessionId);
+    }
+
+    [Fact]
+    public void Create_WithValidData_SetsCurrentTurn()
+    {
+        var snapshot = PauseSnapshot.Create(
+            ValidSessionId, 5, null, SampleScores(), ValidUserId, false);
+
+        Assert.Equal(5, snapshot.CurrentTurn);
+    }
+
+    [Fact]
+    public void Create_WithValidData_SetsCurrentPhase()
+    {
+        var snapshot = PauseSnapshot.Create(
+            ValidSessionId, 1, "Setup", SampleScores(), ValidUserId, false);
+
+        Assert.Equal("Setup", snapshot.CurrentPhase);
+    }
+
+    [Fact]
+    public void Create_WithValidData_SetsPlayerScores()
+    {
+        var scores = SampleScores();
+        var snapshot = PauseSnapshot.Create(
+            ValidSessionId, 1, null, scores, ValidUserId, false);
+
+        Assert.Equal(2, snapshot.PlayerScores.Count);
+        Assert.Contains(snapshot.PlayerScores, s => s.PlayerName == "Alice" && s.Score == 42m);
+        Assert.Contains(snapshot.PlayerScores, s => s.PlayerName == "Bob" && s.Score == 37m);
+    }
+
+    [Fact]
+    public void Create_WithValidData_SetsSavedByUserId()
+    {
+        var snapshot = PauseSnapshot.Create(
+            ValidSessionId, 1, null, SampleScores(), ValidUserId, false);
+
+        Assert.Equal(ValidUserId, snapshot.SavedByUserId);
+    }
+
+    [Fact]
+    public void Create_WithValidData_SetsIsAutoSave_True()
+    {
+        var snapshot = PauseSnapshot.Create(
+            ValidSessionId, 1, null, SampleScores(), ValidUserId, true);
+
+        Assert.True(snapshot.IsAutoSave);
+    }
+
+    [Fact]
+    public void Create_WithValidData_SetsIsAutoSave_False()
+    {
+        var snapshot = PauseSnapshot.Create(
+            ValidSessionId, 1, null, SampleScores(), ValidUserId, false);
+
+        Assert.False(snapshot.IsAutoSave);
+    }
+
+    [Fact]
+    public void Create_WithAttachmentIds_SetsAttachmentIds()
+    {
+        var ids = SampleAttachmentIds();
+        var snapshot = PauseSnapshot.Create(
+            ValidSessionId, 1, null, SampleScores(), ValidUserId, false,
+            attachmentIds: ids);
+
+        Assert.Equal(2, snapshot.AttachmentIds.Count);
+        Assert.Equal(ids[0], snapshot.AttachmentIds[0]);
+        Assert.Equal(ids[1], snapshot.AttachmentIds[1]);
+    }
+
+    [Fact]
+    public void Create_WithDisputes_SetsDisputes()
+    {
+        var dispute = SampleDispute();
+        var snapshot = PauseSnapshot.Create(
+            ValidSessionId, 1, null, SampleScores(), ValidUserId, false,
+            disputes: new List<RuleDisputeEntry> { dispute });
+
+        Assert.Single(snapshot.Disputes);
+        Assert.Equal(dispute.Description, snapshot.Disputes[0].Description);
+    }
+
+    [Fact]
+    public void Create_WithGameStateJson_SetsGameStateJson()
+    {
+        const string json = """{"board":"state"}""";
+        var snapshot = PauseSnapshot.Create(
+            ValidSessionId, 1, null, SampleScores(), ValidUserId, false,
+            gameStateJson: json);
+
+        Assert.Equal(json, snapshot.GameStateJson);
+    }
+
+    [Fact]
+    public void Create_GeneratesNonEmptyId()
+    {
+        var snapshot = PauseSnapshot.Create(
+            ValidSessionId, 1, null, SampleScores(), ValidUserId, false);
+
+        Assert.NotEqual(Guid.Empty, snapshot.Id);
+    }
+
+    // ─── SavedAt ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Create_SetsSavedAt_ApproximatelyNow()
+    {
+        var before = DateTime.UtcNow.AddSeconds(-1);
+        var snapshot = PauseSnapshot.Create(
+            ValidSessionId, 1, null, SampleScores(), ValidUserId, false);
+        var after = DateTime.UtcNow.AddSeconds(1);
+
+        Assert.InRange(snapshot.SavedAt, before, after);
+    }
+
+    // ─── Null optional parameters ─────────────────────────────────────────────
+
+    [Fact]
+    public void Create_WithNullPlayerScores_DefaultsToEmptyList()
+    {
+        var snapshot = PauseSnapshot.Create(
+            ValidSessionId, 1, null, null!, ValidUserId, false);
+
+        Assert.NotNull(snapshot.PlayerScores);
+        Assert.Empty(snapshot.PlayerScores);
+    }
+
+    [Fact]
+    public void Create_WithNullAttachmentIds_DefaultsToEmptyList()
+    {
+        var snapshot = PauseSnapshot.Create(
+            ValidSessionId, 1, null, SampleScores(), ValidUserId, false,
+            attachmentIds: null);
+
+        Assert.NotNull(snapshot.AttachmentIds);
+        Assert.Empty(snapshot.AttachmentIds);
+    }
+
+    [Fact]
+    public void Create_WithNullDisputes_DefaultsToEmptyList()
+    {
+        var snapshot = PauseSnapshot.Create(
+            ValidSessionId, 1, null, SampleScores(), ValidUserId, false,
+            disputes: null);
+
+        Assert.NotNull(snapshot.Disputes);
+        Assert.Empty(snapshot.Disputes);
+    }
+
+    [Fact]
+    public void Create_WithNullCurrentPhase_IsNull()
+    {
+        var snapshot = PauseSnapshot.Create(
+            ValidSessionId, 1, null, SampleScores(), ValidUserId, false);
+
+        Assert.Null(snapshot.CurrentPhase);
+    }
+
+    // ─── AgentConversationSummary initially null ────────────────────────────
+
+    [Fact]
+    public void Create_AgentConversationSummary_IsInitiallyNull()
+    {
+        var snapshot = PauseSnapshot.Create(
+            ValidSessionId, 1, null, SampleScores(), ValidUserId, false);
+
+        Assert.Null(snapshot.AgentConversationSummary);
+    }
+
+    // ─── UpdateSummary ───────────────────────────────────────────────────────
+
+    [Fact]
+    public void UpdateSummary_SetsAgentConversationSummary()
+    {
+        var snapshot = PauseSnapshot.Create(
+            ValidSessionId, 1, null, SampleScores(), ValidUserId, false);
+
+        snapshot.UpdateSummary("Players are winning. Board state: round 3.");
+
+        Assert.Equal("Players are winning. Board state: round 3.", snapshot.AgentConversationSummary);
+    }
+
+    [Fact]
+    public void UpdateSummary_CanOverwritePreviousSummary()
+    {
+        var snapshot = PauseSnapshot.Create(
+            ValidSessionId, 1, null, SampleScores(), ValidUserId, false);
+
+        snapshot.UpdateSummary("First summary.");
+        snapshot.UpdateSummary("Updated summary.");
+
+        Assert.Equal("Updated summary.", snapshot.AgentConversationSummary);
+    }
+
+    [Fact]
+    public void UpdateSummary_WithEmptyString_Throws()
+    {
+        var snapshot = PauseSnapshot.Create(
+            ValidSessionId, 1, null, SampleScores(), ValidUserId, false);
+
+        Assert.Throws<ArgumentException>(() => snapshot.UpdateSummary(string.Empty));
+    }
+
+    [Fact]
+    public void UpdateSummary_WithWhitespace_Throws()
+    {
+        var snapshot = PauseSnapshot.Create(
+            ValidSessionId, 1, null, SampleScores(), ValidUserId, false);
+
+        Assert.Throws<ArgumentException>(() => snapshot.UpdateSummary("   "));
+    }
+
+    // ─── IsAutoSave flag ─────────────────────────────────────────────────────
+
+    [Fact]
+    public void Create_IsAutoSave_PreservedCorrectly_WhenTrue()
+    {
+        var snapshot = PauseSnapshot.Create(
+            ValidSessionId, 1, null, SampleScores(), ValidUserId, isAutoSave: true);
+
+        Assert.True(snapshot.IsAutoSave);
+    }
+
+    [Fact]
+    public void Create_IsAutoSave_PreservedCorrectly_WhenFalse()
+    {
+        var snapshot = PauseSnapshot.Create(
+            ValidSessionId, 1, null, SampleScores(), ValidUserId, isAutoSave: false);
+
+        Assert.False(snapshot.IsAutoSave);
+    }
+
+    // ─── Guard clauses ───────────────────────────────────────────────────────
+
+    [Fact]
+    public void Create_WithEmptySessionId_Throws()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            PauseSnapshot.Create(Guid.Empty, 1, null, SampleScores(), ValidUserId, false));
+    }
+
+    [Fact]
+    public void Create_WithEmptyUserId_Throws()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            PauseSnapshot.Create(ValidSessionId, 1, null, SampleScores(), Guid.Empty, false));
+    }
+
+    [Fact]
+    public void Create_WithNegativeTurn_Throws()
+    {
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            PauseSnapshot.Create(ValidSessionId, -1, null, SampleScores(), ValidUserId, false));
+    }
+
+    [Fact]
+    public void Create_WithZeroTurn_Succeeds()
+    {
+        // Turn 0 is valid (session just started)
+        var snapshot = PauseSnapshot.Create(
+            ValidSessionId, 0, null, SampleScores(), ValidUserId, false);
+
+        Assert.Equal(0, snapshot.CurrentTurn);
+    }
+
+    // ─── PlayerScoreSnapshot record ──────────────────────────────────────────
+
+    [Fact]
+    public void PlayerScoreSnapshot_StoresPlayerNameAndScore()
+    {
+        var record = new PlayerScoreSnapshot("Marco", 99.5m, 42);
+
+        Assert.Equal("Marco", record.PlayerName);
+        Assert.Equal(99.5m, record.Score);
+        Assert.Equal(42, record.PlayerId);
+    }
+
+    [Fact]
+    public void PlayerScoreSnapshot_WithNullPlayerId_IsOptional()
+    {
+        var record = new PlayerScoreSnapshot("Guest", 10m);
+
+        Assert.Equal("Guest", record.PlayerName);
+        Assert.Null(record.PlayerId);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/ValueObjects/RuleDisputeEntryTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/ValueObjects/RuleDisputeEntryTests.cs
@@ -1,0 +1,137 @@
+using Api.BoundedContexts.GameManagement.Domain.ValueObjects;
+using Api.Tests.Constants;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.GameManagement.Domain.ValueObjects;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "GameManagement")]
+public class RuleDisputeEntryTests
+{
+    [Fact]
+    public void Create_WithValidData_ShouldCreateEntry()
+    {
+        var entry = new RuleDisputeEntry(
+            id: Guid.NewGuid(),
+            description: "Can I play 2 cards per turn?",
+            verdict: "No, only one card per turn is allowed.",
+            ruleReferences: new List<string> { "Page 12, Section 3.2" },
+            raisedByPlayerName: "Marco",
+            timestamp: DateTime.UtcNow);
+
+        Assert.Equal("Marco", entry.RaisedByPlayerName);
+        Assert.Single(entry.RuleReferences);
+        Assert.NotEqual(Guid.Empty, entry.Id);
+    }
+
+    [Fact]
+    public void Create_WithEmptyDescription_ShouldThrow()
+    {
+        Assert.Throws<ArgumentException>(() => new RuleDisputeEntry(
+            id: Guid.NewGuid(),
+            description: "",
+            verdict: "verdict",
+            ruleReferences: new List<string>(),
+            raisedByPlayerName: "Marco",
+            timestamp: DateTime.UtcNow));
+    }
+
+    [Fact]
+    public void Create_WithWhitespaceDescription_ShouldThrow()
+    {
+        Assert.Throws<ArgumentException>(() => new RuleDisputeEntry(
+            id: Guid.NewGuid(),
+            description: "   ",
+            verdict: "verdict",
+            ruleReferences: new List<string>(),
+            raisedByPlayerName: "Marco",
+            timestamp: DateTime.UtcNow));
+    }
+
+    [Fact]
+    public void Create_WithEmptyVerdict_ShouldThrow()
+    {
+        Assert.Throws<ArgumentException>(() => new RuleDisputeEntry(
+            id: Guid.NewGuid(),
+            description: "Some dispute",
+            verdict: "",
+            ruleReferences: new List<string>(),
+            raisedByPlayerName: "Marco",
+            timestamp: DateTime.UtcNow));
+    }
+
+    [Fact]
+    public void Create_WithEmptyPlayerName_ShouldThrow()
+    {
+        Assert.Throws<ArgumentException>(() => new RuleDisputeEntry(
+            id: Guid.NewGuid(),
+            description: "Some dispute",
+            verdict: "Some verdict",
+            ruleReferences: new List<string>(),
+            raisedByPlayerName: "",
+            timestamp: DateTime.UtcNow));
+    }
+
+    [Fact]
+    public void Create_WithEmptyGuid_ShouldGenerateNewId()
+    {
+        var entry = new RuleDisputeEntry(
+            id: Guid.Empty,
+            description: "dispute",
+            verdict: "verdict",
+            ruleReferences: new List<string>(),
+            raisedByPlayerName: "Marco",
+            timestamp: DateTime.UtcNow);
+
+        Assert.NotEqual(Guid.Empty, entry.Id);
+    }
+
+    [Fact]
+    public void Create_WithNullRuleReferences_ShouldDefaultToEmptyList()
+    {
+        var entry = new RuleDisputeEntry(
+            id: Guid.NewGuid(),
+            description: "dispute",
+            verdict: "verdict",
+            ruleReferences: null!,
+            raisedByPlayerName: "Marco",
+            timestamp: DateTime.UtcNow);
+
+        Assert.NotNull(entry.RuleReferences);
+        Assert.Empty(entry.RuleReferences);
+    }
+
+    [Fact]
+    public void Create_WithMultipleRuleReferences_ShouldStoreAll()
+    {
+        var references = new List<string> { "Page 5", "Section 2.1", "Appendix A" };
+
+        var entry = new RuleDisputeEntry(
+            id: Guid.NewGuid(),
+            description: "Complex dispute",
+            verdict: "Ruling stands as written",
+            ruleReferences: references,
+            raisedByPlayerName: "Anna",
+            timestamp: DateTime.UtcNow);
+
+        Assert.Equal(3, entry.RuleReferences.Count);
+        Assert.Contains("Page 5", entry.RuleReferences);
+        Assert.Contains("Section 2.1", entry.RuleReferences);
+    }
+
+    [Fact]
+    public void Create_StoresTimestampCorrectly()
+    {
+        var timestamp = new DateTime(2026, 3, 15, 14, 30, 0, DateTimeKind.Utc);
+
+        var entry = new RuleDisputeEntry(
+            id: Guid.NewGuid(),
+            description: "dispute",
+            verdict: "verdict",
+            ruleReferences: new List<string>(),
+            raisedByPlayerName: "Luca",
+            timestamp: timestamp);
+
+        Assert.Equal(timestamp, entry.Timestamp);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/EventHandlers/GenerateAgentSummaryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/EventHandlers/GenerateAgentSummaryHandlerTests.cs
@@ -1,0 +1,272 @@
+using Api.BoundedContexts.GameManagement.Domain.Events;
+using Api.BoundedContexts.KnowledgeBase.Application.EventHandlers;
+using Api.BoundedContexts.KnowledgeBase.Domain.Events;
+using Api.BoundedContexts.KnowledgeBase.Domain.Repositories;
+using Api.Services;
+using Api.Tests.Constants;
+using MediatR;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.KnowledgeBase.Application.EventHandlers;
+
+/// <summary>
+/// Unit tests for <see cref="GenerateAgentSummaryHandler"/>.
+/// Game Night Improvvisata — E4: async session recap generation.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "KnowledgeBase")]
+public sealed class GenerateAgentSummaryHandlerTests
+{
+    // ─── Fixtures ─────────────────────────────────────────────────────────────
+
+    private static readonly Guid TestSnapshotId = Guid.NewGuid();
+    private static readonly Guid TestSessionId = Guid.NewGuid();
+    private static readonly Guid TestAgentId = Guid.NewGuid();
+
+    private const string DefaultSummary =
+        "Quando avete messo in pausa la partita, il turno 5 era appena iniziato.";
+
+    private readonly Mock<IAgentDefinitionRepository> _agentRepoMock;
+    private readonly Mock<ILlmService> _llmServiceMock;
+    private readonly Mock<IPublisher> _publisherMock;
+    private readonly GenerateAgentSummaryHandler _sut;
+
+    public GenerateAgentSummaryHandlerTests()
+    {
+        _agentRepoMock = new Mock<IAgentDefinitionRepository>();
+        _llmServiceMock = new Mock<ILlmService>();
+        _publisherMock = new Mock<IPublisher>();
+
+        // Default: agent definition returns null (not found is gracefully handled)
+        _agentRepoMock
+            .Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Api.BoundedContexts.KnowledgeBase.Domain.Entities.AgentDefinition?)null);
+
+        // Default: LLM returns a summary
+        _llmServiceMock
+            .Setup(s => s.GenerateCompletionAsync(
+                It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<RequestSource>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(LlmCompletionResult.CreateSuccess(DefaultSummary));
+
+        _publisherMock
+            .Setup(p => p.Publish(It.IsAny<INotification>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _sut = new GenerateAgentSummaryHandler(
+            _agentRepoMock.Object,
+            _llmServiceMock.Object,
+            _publisherMock.Object,
+            NullLogger<GenerateAgentSummaryHandler>.Instance);
+    }
+
+    // ─── Helpers ──────────────────────────────────────────────────────────────
+
+    private static SessionSaveRequestedEvent BuildEvent(
+        List<string>? messages = null,
+        Guid? snapshotId = null,
+        Guid? agentId = null)
+        => new SessionSaveRequestedEvent(
+            pauseSnapshotId: snapshotId ?? TestSnapshotId,
+            liveGameSessionId: TestSessionId,
+            agentDefinitionId: agentId ?? TestAgentId,
+            lastMessages: messages ?? new List<string>
+            {
+                "[user] Chi vince se abbiamo lo stesso punteggio?",
+                "[assistant] Secondo le regole, in caso di parità vince il giocatore che ha giocato meno turni in totale.",
+                "[user] Grazie! Facciamo pausa."
+            });
+
+    // ─── Happy path ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Handle_HappyPath_PublishesAgentSummaryGeneratedEvent()
+    {
+        // Arrange
+        var notification = BuildEvent();
+
+        // Act
+        await _sut.Handle(notification, CancellationToken.None);
+
+        // Assert
+        _publisherMock.Verify(
+            p => p.Publish(
+                It.Is<AgentSummaryGeneratedEvent>(e =>
+                    e.PauseSnapshotId == TestSnapshotId &&
+                    e.Summary == DefaultSummary),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_HappyPath_CallsLlmWithSummaryPrompt()
+    {
+        // Arrange
+        var notification = BuildEvent();
+
+        string? capturedSystemPrompt = null;
+        string? capturedUserPrompt = null;
+
+        _llmServiceMock
+            .Setup(s => s.GenerateCompletionAsync(
+                It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<RequestSource>(), It.IsAny<CancellationToken>()))
+            .Callback<string, string, RequestSource, CancellationToken>(
+                (sys, usr, _, _) =>
+                {
+                    capturedSystemPrompt = sys;
+                    capturedUserPrompt = usr;
+                })
+            .ReturnsAsync(LlmCompletionResult.CreateSuccess(DefaultSummary));
+
+        // Act
+        await _sut.Handle(notification, CancellationToken.None);
+
+        // Assert
+        Assert.NotNull(capturedSystemPrompt);
+        Assert.Contains("riassunto", capturedSystemPrompt, StringComparison.OrdinalIgnoreCase);
+        Assert.NotNull(capturedUserPrompt);
+        // User prompt should include actual message content
+        Assert.Contains("[user]", capturedUserPrompt, StringComparison.Ordinal);
+        Assert.Contains("[assistant]", capturedUserPrompt, StringComparison.Ordinal);
+    }
+
+    [Fact]
+    public async Task Handle_HappyPath_CapsAtLast50Messages()
+    {
+        // Arrange — provide 75 messages
+        var messages = Enumerable
+            .Range(1, 75)
+            .Select(i => $"[user] Messaggio {i}")
+            .ToList();
+
+        var notification = BuildEvent(messages: messages);
+
+        string? capturedUserPrompt = null;
+        _llmServiceMock
+            .Setup(s => s.GenerateCompletionAsync(
+                It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<RequestSource>(), It.IsAny<CancellationToken>()))
+            .Callback<string, string, RequestSource, CancellationToken>(
+                (_, usr, _, _) => capturedUserPrompt = usr)
+            .ReturnsAsync(LlmCompletionResult.CreateSuccess(DefaultSummary));
+
+        // Act
+        await _sut.Handle(notification, CancellationToken.None);
+
+        // Assert — only last 50 messages (26..75) should be in the prompt
+        Assert.NotNull(capturedUserPrompt);
+        Assert.Contains("Messaggio 75", capturedUserPrompt, StringComparison.Ordinal);
+        Assert.Contains("Messaggio 26", capturedUserPrompt, StringComparison.Ordinal);
+        Assert.DoesNotContain("Messaggio 25", capturedUserPrompt, StringComparison.Ordinal);
+        Assert.DoesNotContain("Messaggio 1", capturedUserPrompt, StringComparison.Ordinal);
+    }
+
+    // ─── Failure cases ────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Handle_WhenNoMessages_DoesNotCallLlmOrPublish()
+    {
+        // Arrange
+        var notification = BuildEvent(messages: new List<string>());
+
+        // Act — should not throw
+        await _sut.Handle(notification, CancellationToken.None);
+
+        // Assert
+        _llmServiceMock.Verify(
+            s => s.GenerateCompletionAsync(
+                It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<RequestSource>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+
+        _publisherMock.Verify(
+            p => p.Publish(It.IsAny<AgentSummaryGeneratedEvent>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_WhenLlmFails_DoesNotPublishAndDoesNotThrow()
+    {
+        // Arrange
+        _llmServiceMock
+            .Setup(s => s.GenerateCompletionAsync(
+                It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<RequestSource>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(LlmCompletionResult.CreateFailure("OpenRouter unavailable"));
+
+        var notification = BuildEvent();
+
+        // Act — should NOT throw; summary is optional
+        await _sut.Handle(notification, CancellationToken.None);
+
+        // Assert
+        _publisherMock.Verify(
+            p => p.Publish(It.IsAny<AgentSummaryGeneratedEvent>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_WhenLlmThrows_DoesNotPropagateException()
+    {
+        // Arrange
+        _llmServiceMock
+            .Setup(s => s.GenerateCompletionAsync(
+                It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<RequestSource>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new HttpRequestException("Network error"));
+
+        var notification = BuildEvent();
+
+        // Act — must not throw; fire-and-forget handler
+        var exception = await Record.ExceptionAsync(
+            () => _sut.Handle(notification, CancellationToken.None));
+
+        // Assert
+        Assert.Null(exception);
+    }
+
+    [Fact]
+    public async Task Handle_WhenLlmReturnsEmptySummary_DoesNotPublish()
+    {
+        // Arrange
+        _llmServiceMock
+            .Setup(s => s.GenerateCompletionAsync(
+                It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<RequestSource>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(LlmCompletionResult.CreateSuccess(string.Empty));
+
+        var notification = BuildEvent();
+
+        // Act
+        await _sut.Handle(notification, CancellationToken.None);
+
+        // Assert
+        _publisherMock.Verify(
+            p => p.Publish(It.IsAny<AgentSummaryGeneratedEvent>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_WhenAgentDefinitionNotFound_StillGeneratesSummary()
+    {
+        // Arrange — agent definition returns null (uses generic name)
+        _agentRepoMock
+            .Setup(r => r.GetByIdAsync(TestAgentId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((Api.BoundedContexts.KnowledgeBase.Domain.Entities.AgentDefinition?)null);
+
+        var notification = BuildEvent();
+
+        // Act
+        await _sut.Handle(notification, CancellationToken.None);
+
+        // Assert — should still call LLM and publish
+        _publisherMock.Verify(
+            p => p.Publish(
+                It.IsAny<AgentSummaryGeneratedEvent>(),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/EventHandlers/UpdateSnapshotSummaryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/EventHandlers/UpdateSnapshotSummaryHandlerTests.cs
@@ -1,0 +1,140 @@
+using Api.BoundedContexts.GameManagement.Domain.Entities.PauseSnapshot;
+using Api.BoundedContexts.GameManagement.Domain.Repositories;
+using Api.BoundedContexts.KnowledgeBase.Application.EventHandlers;
+using Api.BoundedContexts.KnowledgeBase.Domain.Events;
+using Api.Tests.Constants;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.KnowledgeBase.Application.EventHandlers;
+
+/// <summary>
+/// Unit tests for <see cref="UpdateSnapshotSummaryHandler"/>.
+/// Game Night Improvvisata — E4: persisting AI summary to PauseSnapshot.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "KnowledgeBase")]
+public sealed class UpdateSnapshotSummaryHandlerTests
+{
+    // ─── Fixtures ─────────────────────────────────────────────────────────────
+
+    private static readonly Guid TestSnapshotId = Guid.NewGuid();
+    private static readonly Guid TestSessionId = Guid.NewGuid();
+    private static readonly Guid TestUserId = Guid.NewGuid();
+
+    private const string TestSummary = "Quando avete messo in pausa, turno 4 era in corso.";
+
+    private readonly Mock<IPauseSnapshotRepository> _snapshotRepoMock;
+    private readonly UpdateSnapshotSummaryHandler _sut;
+
+    public UpdateSnapshotSummaryHandlerTests()
+    {
+        _snapshotRepoMock = new Mock<IPauseSnapshotRepository>();
+
+        _snapshotRepoMock
+            .Setup(r => r.UpdateAsync(It.IsAny<PauseSnapshot>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _sut = new UpdateSnapshotSummaryHandler(
+            _snapshotRepoMock.Object,
+            NullLogger<UpdateSnapshotSummaryHandler>.Instance);
+    }
+
+    // ─── Helpers ──────────────────────────────────────────────────────────────
+
+    private PauseSnapshot CreateSnapshot(Guid? id = null)
+    {
+        var snapshot = PauseSnapshot.Create(
+            liveGameSessionId: TestSessionId,
+            currentTurn: 4,
+            currentPhase: null,
+            playerScores: new List<PlayerScoreSnapshot>(),
+            savedByUserId: TestUserId,
+            isAutoSave: false);
+
+        var snapshotId = id ?? TestSnapshotId;
+
+        // Restore ID via reflection (same pattern used by repository)
+        var prop = typeof(PauseSnapshot).BaseType?.GetProperty("Id",
+            System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance);
+        prop?.SetValue(snapshot, snapshotId);
+
+        _snapshotRepoMock
+            .Setup(r => r.GetByIdAsync(snapshotId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(snapshot);
+
+        return snapshot;
+    }
+
+    private static AgentSummaryGeneratedEvent BuildEvent(
+        Guid? snapshotId = null,
+        string? summary = null)
+        => new AgentSummaryGeneratedEvent(
+            pauseSnapshotId: snapshotId ?? TestSnapshotId,
+            summary: summary ?? TestSummary);
+
+    // ─── Happy path ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Handle_HappyPath_UpdatesSnapshotWithSummary()
+    {
+        // Arrange
+        var snapshot = CreateSnapshot();
+        var notification = BuildEvent();
+
+        PauseSnapshot? capturedSnapshot = null;
+        _snapshotRepoMock
+            .Setup(r => r.UpdateAsync(It.IsAny<PauseSnapshot>(), It.IsAny<CancellationToken>()))
+            .Callback<PauseSnapshot, CancellationToken>((s, _) => capturedSnapshot = s)
+            .Returns(Task.CompletedTask);
+
+        // Act
+        await _sut.Handle(notification, CancellationToken.None);
+
+        // Assert
+        Assert.NotNull(capturedSnapshot);
+        Assert.Equal(TestSummary, capturedSnapshot!.AgentConversationSummary);
+    }
+
+    [Fact]
+    public async Task Handle_HappyPath_CallsRepositoryUpdate()
+    {
+        // Arrange
+        CreateSnapshot();
+        var notification = BuildEvent();
+
+        // Act
+        await _sut.Handle(notification, CancellationToken.None);
+
+        // Assert
+        _snapshotRepoMock.Verify(
+            r => r.UpdateAsync(It.IsAny<PauseSnapshot>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    // ─── Edge cases ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Handle_WhenSnapshotNotFound_DoesNotThrowAndSkipsUpdate()
+    {
+        // Arrange — repository returns null
+        _snapshotRepoMock
+            .Setup(r => r.GetByIdAsync(TestSnapshotId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((PauseSnapshot?)null);
+
+        var notification = BuildEvent();
+
+        // Act — should not throw
+        var exception = await Record.ExceptionAsync(
+            () => _sut.Handle(notification, CancellationToken.None));
+
+        // Assert
+        Assert.Null(exception);
+
+        // UpdateAsync should NOT be called when snapshot was not found
+        _snapshotRepoMock.Verify(
+            r => r.UpdateAsync(It.IsAny<PauseSnapshot>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/UserNotifications/Application/EventHandlers/NotifyAgentReadyHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/UserNotifications/Application/EventHandlers/NotifyAgentReadyHandlerTests.cs
@@ -1,0 +1,216 @@
+using Api.BoundedContexts.KnowledgeBase.Domain.Events;
+using Api.BoundedContexts.UserNotifications.Application.EventHandlers;
+using Api.BoundedContexts.UserNotifications.Application.Services;
+using Api.BoundedContexts.UserNotifications.Domain.ValueObjects;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.UserNotifications.Application.EventHandlers;
+
+/// <summary>
+/// Unit tests for NotifyAgentReadyHandler.
+/// Verifies that when AgentAutoCreatedEvent is raised, the user receives
+/// an in-app notification directing them to the game's toolkit page.
+///
+/// Test scenarios:
+/// - Happy path: dispatches notification with correct Italian message, type, and deep link
+/// - Dispatcher failure: exception is caught and does not propagate
+/// - Constructor null guards: each dependency throws ArgumentNullException
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "UserNotifications")]
+public sealed class NotifyAgentReadyHandlerTests
+{
+    private readonly Mock<INotificationDispatcher> _dispatcher;
+    private readonly Mock<ILogger<NotifyAgentReadyHandler>> _logger;
+
+    private readonly Guid _userId = Guid.NewGuid();
+    private readonly Guid _agentId = Guid.NewGuid();
+    private readonly Guid _privateGameId = Guid.NewGuid();
+    private const string GameName = "Twilight Imperium";
+
+    public NotifyAgentReadyHandlerTests()
+    {
+        _dispatcher = new Mock<INotificationDispatcher>();
+        _logger = new Mock<ILogger<NotifyAgentReadyHandler>>();
+    }
+
+    private NotifyAgentReadyHandler CreateHandler() =>
+        new(_dispatcher.Object, _logger.Object);
+
+    private AgentAutoCreatedEvent CreateEvent(
+        string? gameName = null,
+        Guid? userId = null,
+        Guid? agentId = null,
+        Guid? privateGameId = null) =>
+        new(
+            agentDefinitionId: agentId ?? _agentId,
+            privateGameId: privateGameId ?? _privateGameId,
+            userId: userId ?? _userId,
+            gameName: gameName ?? GameName);
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Happy path: notification dispatched with correct properties
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Handle_DispatchesNotificationWithCorrectType()
+    {
+        // Arrange
+        var handler = CreateHandler();
+        var evt = CreateEvent();
+
+        // Act
+        await handler.Handle(evt, CancellationToken.None);
+
+        // Assert
+        _dispatcher.Verify(d => d.DispatchAsync(
+            It.Is<NotificationMessage>(m =>
+                m.Type == NotificationType.AgentAutoCreated),
+            It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_DispatchesNotificationToCorrectUser()
+    {
+        // Arrange
+        var handler = CreateHandler();
+        var evt = CreateEvent();
+
+        // Act
+        await handler.Handle(evt, CancellationToken.None);
+
+        // Assert
+        _dispatcher.Verify(d => d.DispatchAsync(
+            It.Is<NotificationMessage>(m =>
+                m.RecipientUserId == _userId),
+            It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_DispatchesNotificationWithCorrectDeepLink()
+    {
+        // Arrange
+        var handler = CreateHandler();
+        var evt = CreateEvent();
+        var expectedLink = $"/library/private/{_privateGameId}/toolkit";
+
+        // Act
+        await handler.Handle(evt, CancellationToken.None);
+
+        // Assert
+        _dispatcher.Verify(d => d.DispatchAsync(
+            It.Is<NotificationMessage>(m =>
+                m.DeepLinkPath == expectedLink),
+            It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_DispatchesNotificationWithItalianGameNameInPayload()
+    {
+        // Arrange
+        var handler = CreateHandler();
+        var evt = CreateEvent(gameName: GameName);
+
+        NotificationMessage? capturedMessage = null;
+        _dispatcher
+            .Setup(d => d.DispatchAsync(It.IsAny<NotificationMessage>(), It.IsAny<CancellationToken>()))
+            .Callback<NotificationMessage, CancellationToken>((msg, _) => capturedMessage = msg)
+            .Returns(Task.CompletedTask);
+
+        // Act
+        await handler.Handle(evt, CancellationToken.None);
+
+        // Assert — Italian message contains the game name
+        capturedMessage.Should().NotBeNull();
+        var payload = capturedMessage!.Payload.Should().BeOfType<GenericPayload>().Subject;
+        payload.Title.Should().Contain(GameName);
+        payload.Body.Should().Contain(GameName);
+        payload.Body.Should().Contain("creato automaticamente");
+    }
+
+    [Fact]
+    public async Task Handle_DispatchesExactlyOneNotification()
+    {
+        // Arrange
+        var handler = CreateHandler();
+        var evt = CreateEvent();
+
+        // Act
+        await handler.Handle(evt, CancellationToken.None);
+
+        // Assert
+        _dispatcher.Verify(
+            d => d.DispatchAsync(It.IsAny<NotificationMessage>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Resilience: dispatcher failure must not propagate
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Handle_DispatcherThrows_ExceptionIsCaughtAndDoesNotPropagate()
+    {
+        // Arrange
+        _dispatcher
+            .Setup(d => d.DispatchAsync(It.IsAny<NotificationMessage>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("Dispatcher unavailable"));
+
+        var handler = CreateHandler();
+        var evt = CreateEvent();
+
+        // Act — must not throw; notification failure is non-critical
+        var act = async () => await handler.Handle(evt, CancellationToken.None);
+        await act.Should().NotThrowAsync();
+    }
+
+    [Fact]
+    public async Task Handle_DispatcherThrows_ErrorIsLogged()
+    {
+        // Arrange
+        _dispatcher
+            .Setup(d => d.DispatchAsync(It.IsAny<NotificationMessage>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new Exception("Connection lost"));
+
+        var handler = CreateHandler();
+        var evt = CreateEvent();
+
+        // Act
+        await handler.Handle(evt, CancellationToken.None);
+
+        // Assert — error was logged with enough context
+        _logger.Verify(
+            x => x.Log(
+                LogLevel.Error,
+                It.IsAny<EventId>(),
+                It.Is<It.IsAnyType>((v, _) => v.ToString()!.Contains("NotifyAgentReadyHandler")),
+                It.IsAny<Exception?>(),
+                It.IsAny<Func<It.IsAnyType, Exception?, string>>()),
+            Times.Once);
+    }
+
+    // ─────────────────────────────────────────────────────────────────────────
+    // Constructor null guards
+    // ─────────────────────────────────────────────────────────────────────────
+
+    [Fact]
+    public void Constructor_NullDispatcher_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            new NotifyAgentReadyHandler(null!, _logger.Object));
+    }
+
+    [Fact]
+    public void Constructor_NullLogger_ThrowsArgumentNullException()
+    {
+        Assert.Throws<ArgumentNullException>(() =>
+            new NotifyAgentReadyHandler(_dispatcher.Object, null!));
+    }
+}

--- a/apps/api/tests/Api.Tests/Hubs/GameStateHubTests.cs
+++ b/apps/api/tests/Api.Tests/Hubs/GameStateHubTests.cs
@@ -1,6 +1,7 @@
 using Api.Hubs;
 using Api.Tests.Constants;
 using FluentAssertions;
+using MediatR;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Logging;
 using Moq;
@@ -34,7 +35,8 @@ public class GameStateHubTests
         _mockContext.Setup(c => c.UserIdentifier).Returns("test-user");
 
         var logger = new Mock<ILogger<GameStateHub>>();
-        _hub = new GameStateHub(logger.Object)
+        var publisher = new Mock<IPublisher>();
+        _hub = new GameStateHub(logger.Object, publisher.Object)
         {
             Clients = _mockClients.Object,
             Groups = _mockGroups.Object,

--- a/apps/api/tests/Api.Tests/Hubs/GameStateHub_ImprovvisataTests.cs
+++ b/apps/api/tests/Api.Tests/Hubs/GameStateHub_ImprovvisataTests.cs
@@ -1,0 +1,374 @@
+using Api.BoundedContexts.GameManagement.Application.EventHandlers;
+using Api.BoundedContexts.GameManagement.Domain.Events;
+using Api.BoundedContexts.GameManagement.Domain.ValueObjects;
+using Api.Hubs;
+using Api.Tests.Constants;
+using FluentAssertions;
+using MediatR;
+using Microsoft.AspNetCore.SignalR;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.Hubs;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "GameManagement")]
+public class GameStateHub_ImprovvisataTests
+{
+    private readonly Mock<IHubCallerClients> _mockClients;
+    private readonly Mock<IGroupManager> _mockGroups;
+    private readonly Mock<HubCallerContext> _mockContext;
+    private readonly Mock<IClientProxy> _mockClientProxy;
+    private readonly Mock<IPublisher> _mockPublisher;
+    private readonly GameStateHub _hub;
+
+    private const string TestSessionId = "session-abc";
+    private const string TestSessionGroup = $"session:{TestSessionId}";
+    private const string TestConnectionId = "conn-xyz";
+
+    public GameStateHub_ImprovvisataTests()
+    {
+        _mockClients = new Mock<IHubCallerClients>();
+        _mockGroups = new Mock<IGroupManager>();
+        _mockContext = new Mock<HubCallerContext>();
+        _mockClientProxy = new Mock<IClientProxy>();
+        _mockPublisher = new Mock<IPublisher>();
+
+        _mockContext.Setup(c => c.ConnectionId).Returns(TestConnectionId);
+        _mockContext.Setup(c => c.UserIdentifier).Returns("test-user");
+
+        var logger = new Mock<ILogger<GameStateHub>>();
+        _hub = new GameStateHub(logger.Object, _mockPublisher.Object)
+        {
+            Clients = _mockClients.Object,
+            Groups = _mockGroups.Object,
+            Context = _mockContext.Object
+        };
+    }
+
+    // ── NotifyDisputeResolved ──
+
+    [Fact]
+    public async Task NotifyDisputeResolved_SendsToCorrectSessionGroup()
+    {
+        // Arrange
+        var verdict = new { Id = Guid.NewGuid(), Description = "Can I play 2 cards?", Verdict = "No." };
+        _mockClients
+            .Setup(c => c.Group(TestSessionGroup))
+            .Returns(_mockClientProxy.Object);
+        _mockClientProxy
+            .Setup(p => p.SendCoreAsync("DisputeResolved", It.IsAny<object?[]>(), default))
+            .Returns(Task.CompletedTask);
+
+        // Act
+        await _hub.NotifyDisputeResolved(TestSessionId, verdict);
+
+        // Assert
+        _mockClients.Verify(c => c.Group(TestSessionGroup), Times.Once);
+        _mockClientProxy.Verify(
+            p => p.SendCoreAsync("DisputeResolved", It.Is<object?[]>(args => args[0] == (object)verdict), default),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task NotifyDisputeResolved_DoesNotSendToOtherGroups()
+    {
+        // Arrange
+        var verdict = new { Id = Guid.NewGuid(), Verdict = "Yes." };
+        _mockClients
+            .Setup(c => c.Group(TestSessionGroup))
+            .Returns(_mockClientProxy.Object);
+        _mockClientProxy
+            .Setup(p => p.SendCoreAsync(It.IsAny<string>(), It.IsAny<object?[]>(), default))
+            .Returns(Task.CompletedTask);
+
+        // Act
+        await _hub.NotifyDisputeResolved(TestSessionId, verdict);
+
+        // Assert — should only send to the specific session group
+        _mockClients.Verify(c => c.Group(It.Is<string>(g => g != TestSessionGroup)), Times.Never);
+    }
+
+    // ── NotifySessionPaused ──
+
+    [Fact]
+    public async Task NotifySessionPaused_SendsToCorrectSessionGroup()
+    {
+        // Arrange
+        _mockClients
+            .Setup(c => c.Group(TestSessionGroup))
+            .Returns(_mockClientProxy.Object);
+        _mockClientProxy
+            .Setup(p => p.SendCoreAsync("SessionPaused", It.IsAny<object?[]>(), default))
+            .Returns(Task.CompletedTask);
+
+        // Act
+        await _hub.NotifySessionPaused(TestSessionId);
+
+        // Assert
+        _mockClients.Verify(c => c.Group(TestSessionGroup), Times.Once);
+        _mockClientProxy.Verify(
+            p => p.SendCoreAsync("SessionPaused", It.IsAny<object?[]>(), default),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task NotifySessionPaused_DoesNotSendToHostSubgroup()
+    {
+        // Arrange
+        _mockClients
+            .Setup(c => c.Group(TestSessionGroup))
+            .Returns(_mockClientProxy.Object);
+        _mockClientProxy
+            .Setup(p => p.SendCoreAsync(It.IsAny<string>(), It.IsAny<object?[]>(), default))
+            .Returns(Task.CompletedTask);
+
+        // Act
+        await _hub.NotifySessionPaused(TestSessionId);
+
+        // Assert — not restricted to host sub-group
+        _mockClients.Verify(c => c.Group($"{TestSessionGroup}:host"), Times.Never);
+    }
+
+    // ── NotifyScoreUpdated ──
+
+    [Fact]
+    public async Task NotifyScoreUpdated_SendsToCorrectSessionGroup()
+    {
+        // Arrange
+        var scoreUpdate = new { PlayerId = "player-1", Score = 42 };
+        _mockClients
+            .Setup(c => c.Group(TestSessionGroup))
+            .Returns(_mockClientProxy.Object);
+        _mockClientProxy
+            .Setup(p => p.SendCoreAsync("ScoreUpdated", It.IsAny<object?[]>(), default))
+            .Returns(Task.CompletedTask);
+
+        // Act
+        await _hub.NotifyScoreUpdated(TestSessionId, scoreUpdate);
+
+        // Assert
+        _mockClients.Verify(c => c.Group(TestSessionGroup), Times.Once);
+        _mockClientProxy.Verify(
+            p => p.SendCoreAsync("ScoreUpdated", It.Is<object?[]>(args => args[0] == (object)scoreUpdate), default),
+            Times.Once);
+    }
+
+    // ── AppBackgrounded ──
+
+    [Fact]
+    public async Task AppBackgrounded_PublishesAppBackgroundedEvent()
+    {
+        // Arrange
+        var sessionGuid = Guid.NewGuid();
+        _mockPublisher
+            .Setup(p => p.Publish(It.IsAny<AppBackgroundedEvent>(), default))
+            .Returns(Task.CompletedTask);
+
+        // Act
+        await _hub.AppBackgrounded(sessionGuid.ToString());
+
+        // Assert
+        _mockPublisher.Verify(
+            p => p.Publish(
+                It.Is<AppBackgroundedEvent>(e => e.SessionId == sessionGuid),
+                default),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task AppBackgrounded_WithInvalidSessionId_DoesNotPublishEvent()
+    {
+        // Arrange — invalid GUID string
+        // Act
+        await _hub.AppBackgrounded("not-a-guid");
+
+        // Assert
+        _mockPublisher.Verify(
+            p => p.Publish(It.IsAny<AppBackgroundedEvent>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task AppBackgrounded_WhenPublisherThrows_DoesNotPropagateException()
+    {
+        // Arrange
+        var sessionGuid = Guid.NewGuid();
+        _mockPublisher
+            .Setup(p => p.Publish(It.IsAny<AppBackgroundedEvent>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("Save failed"));
+
+        // Act — must not throw
+        var act = async () => await _hub.AppBackgrounded(sessionGuid.ToString());
+
+        // Assert
+        await act.Should().NotThrowAsync();
+    }
+}
+
+// ── SignalR Event Handler Tests ──
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "GameManagement")]
+public class DisputeResolvedSignalRHandlerTests
+{
+    private readonly Mock<IHubContext<GameStateHub>> _mockHubContext;
+    private readonly Mock<IHubClients> _mockHubClients;
+    private readonly Mock<IClientProxy> _mockClientProxy;
+    private readonly DisputeResolvedSignalRHandler _handler;
+
+    public DisputeResolvedSignalRHandlerTests()
+    {
+        _mockHubContext = new Mock<IHubContext<GameStateHub>>();
+        _mockHubClients = new Mock<IHubClients>();
+        _mockClientProxy = new Mock<IClientProxy>();
+
+        _mockHubContext.Setup(h => h.Clients).Returns(_mockHubClients.Object);
+
+        var logger = new Mock<ILogger<DisputeResolvedSignalRHandler>>();
+        _handler = new DisputeResolvedSignalRHandler(_mockHubContext.Object, logger.Object);
+    }
+
+    [Fact]
+    public async Task Handle_BroadcastsToCorrectSessionGroup()
+    {
+        // Arrange
+        var sessionId = Guid.NewGuid();
+        var dispute = new RuleDisputeEntry(
+            Guid.NewGuid(),
+            "Can I place 2 workers?",
+            "No, one per turn.",
+            new List<string> { "Rulebook p.12" },
+            "Alice",
+            DateTime.UtcNow);
+        var @event = new DisputeResolvedEvent(sessionId, dispute);
+        var expectedGroup = $"session:{sessionId}";
+
+        _mockHubClients
+            .Setup(c => c.Group(expectedGroup))
+            .Returns(_mockClientProxy.Object);
+        _mockClientProxy
+            .Setup(p => p.SendCoreAsync("DisputeResolved", It.IsAny<object?[]>(), default))
+            .Returns(Task.CompletedTask);
+
+        // Act
+        await _handler.Handle(@event, CancellationToken.None);
+
+        // Assert
+        _mockHubClients.Verify(c => c.Group(expectedGroup), Times.Once);
+        _mockClientProxy.Verify(
+            p => p.SendCoreAsync("DisputeResolved", It.IsAny<object?[]>(), default),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_SendsDisputePayloadWithCorrectFields()
+    {
+        // Arrange
+        var sessionId = Guid.NewGuid();
+        var disputeId = Guid.NewGuid();
+        var dispute = new RuleDisputeEntry(
+            disputeId,
+            "Move question",
+            "Allowed.",
+            new List<string> { "p.5", "p.8" },
+            "Bob",
+            new DateTime(2026, 3, 15, 12, 0, 0, DateTimeKind.Utc));
+        var @event = new DisputeResolvedEvent(sessionId, dispute);
+
+        _mockHubClients
+            .Setup(c => c.Group(It.IsAny<string>()))
+            .Returns(_mockClientProxy.Object);
+
+        object?[]? capturedArgs = null;
+        _mockClientProxy
+            .Setup(p => p.SendCoreAsync("DisputeResolved", It.IsAny<object?[]>(), default))
+            .Callback<string, object?[], CancellationToken>((_, args, _) => capturedArgs = args)
+            .Returns(Task.CompletedTask);
+
+        // Act
+        await _handler.Handle(@event, CancellationToken.None);
+
+        // Assert — payload is an anonymous object; verify via dynamic reflection
+        capturedArgs.Should().NotBeNull();
+        capturedArgs!.Should().HaveCount(1);
+        var payload = capturedArgs[0]!;
+        var payloadType = payload.GetType();
+        payloadType.GetProperty("Id")!.GetValue(payload).Should().Be(disputeId);
+        payloadType.GetProperty("Description")!.GetValue(payload).Should().Be("Move question");
+        payloadType.GetProperty("Verdict")!.GetValue(payload).Should().Be("Allowed.");
+        payloadType.GetProperty("RaisedByPlayerName")!.GetValue(payload).Should().Be("Bob");
+    }
+}
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "GameManagement")]
+public class SessionPausedSignalRHandlerTests
+{
+    private readonly Mock<IHubContext<GameStateHub>> _mockHubContext;
+    private readonly Mock<IHubClients> _mockHubClients;
+    private readonly Mock<IClientProxy> _mockClientProxy;
+    private readonly SessionPausedSignalRHandler _handler;
+
+    public SessionPausedSignalRHandlerTests()
+    {
+        _mockHubContext = new Mock<IHubContext<GameStateHub>>();
+        _mockHubClients = new Mock<IHubClients>();
+        _mockClientProxy = new Mock<IClientProxy>();
+
+        _mockHubContext.Setup(h => h.Clients).Returns(_mockHubClients.Object);
+
+        var logger = new Mock<ILogger<SessionPausedSignalRHandler>>();
+        _handler = new SessionPausedSignalRHandler(_mockHubContext.Object, logger.Object);
+    }
+
+    [Fact]
+    public async Task Handle_BroadcastsToCorrectSessionGroup()
+    {
+        // Arrange
+        var sessionId = Guid.NewGuid();
+        var @event = new SessionPausedEvent(sessionId);
+        var expectedGroup = $"session:{sessionId}";
+
+        _mockHubClients
+            .Setup(c => c.Group(expectedGroup))
+            .Returns(_mockClientProxy.Object);
+        _mockClientProxy
+            .Setup(p => p.SendCoreAsync("SessionPaused", It.IsAny<object?[]>(), default))
+            .Returns(Task.CompletedTask);
+
+        // Act
+        await _handler.Handle(@event, CancellationToken.None);
+
+        // Assert
+        _mockHubClients.Verify(c => c.Group(expectedGroup), Times.Once);
+        _mockClientProxy.Verify(
+            p => p.SendCoreAsync("SessionPaused", It.IsAny<object?[]>(), default),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_DoesNotSendToOtherGroups()
+    {
+        // Arrange
+        var sessionId = Guid.NewGuid();
+        var @event = new SessionPausedEvent(sessionId);
+        var expectedGroup = $"session:{sessionId}";
+
+        _mockHubClients
+            .Setup(c => c.Group(expectedGroup))
+            .Returns(_mockClientProxy.Object);
+        _mockClientProxy
+            .Setup(p => p.SendCoreAsync(It.IsAny<string>(), It.IsAny<object?[]>(), default))
+            .Returns(Task.CompletedTask);
+
+        // Act
+        await _handler.Handle(@event, CancellationToken.None);
+
+        // Assert — only the specific group is targeted
+        _mockHubClients.Verify(
+            c => c.Group(It.Is<string>(g => g != expectedGroup)),
+            Times.Never);
+    }
+}

--- a/apps/api/tests/Api.Tests/Infrastructure/SessionAutoSaveBackgroundServiceTests.cs
+++ b/apps/api/tests/Api.Tests/Infrastructure/SessionAutoSaveBackgroundServiceTests.cs
@@ -1,0 +1,223 @@
+using System.Reflection;
+using Api.BoundedContexts.GameManagement.Domain.Entities;
+using Api.BoundedContexts.GameManagement.Domain.Entities.PauseSnapshot;
+using Api.BoundedContexts.GameManagement.Domain.Enums;
+using Api.BoundedContexts.GameManagement.Domain.Repositories;
+using Api.Infrastructure;
+using Api.Infrastructure.BackgroundServices;
+using Api.Tests.Constants;
+using Api.Tests.TestHelpers;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.Infrastructure;
+
+/// <summary>
+/// Unit tests for <see cref="SessionAutoSaveBackgroundService"/>.
+/// Game Night Improvvisata — E4: Session auto-save background job.
+///
+/// Tests:
+/// - No active sessions → no snapshots created
+/// - Active InProgress sessions → PauseSnapshot created with IsAutoSave=true
+/// - Failure for one session does not stop others
+/// - SaveChanges is called once per snapshot
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "GameManagement")]
+public sealed class SessionAutoSaveBackgroundServiceTests : IDisposable
+{
+    private readonly Mock<IServiceScopeFactory> _scopeFactoryMock;
+    private readonly Mock<IServiceScope> _scopeMock;
+    private readonly Mock<IServiceProvider> _serviceProviderMock;
+    private readonly Mock<ILiveSessionRepository> _sessionRepoMock;
+    private readonly Mock<IPauseSnapshotRepository> _snapshotRepoMock;
+    private readonly MeepleAiDbContext _dbContext;
+    private readonly SessionAutoSaveBackgroundService _sut;
+
+    private static readonly Guid UserId = Guid.NewGuid();
+
+    public SessionAutoSaveBackgroundServiceTests()
+    {
+        _scopeFactoryMock = new Mock<IServiceScopeFactory>();
+        _scopeMock = new Mock<IServiceScope>();
+        _serviceProviderMock = new Mock<IServiceProvider>();
+        _sessionRepoMock = new Mock<ILiveSessionRepository>();
+        _snapshotRepoMock = new Mock<IPauseSnapshotRepository>();
+        _dbContext = TestDbContextFactory.CreateInMemoryDbContext();
+
+        // Wire scope chain
+        _scopeMock.Setup(s => s.ServiceProvider).Returns(_serviceProviderMock.Object);
+        _scopeFactoryMock.Setup(f => f.CreateScope()).Returns(_scopeMock.Object);
+
+        _serviceProviderMock
+            .Setup(sp => sp.GetService(typeof(ILiveSessionRepository)))
+            .Returns(_sessionRepoMock.Object);
+        _serviceProviderMock
+            .Setup(sp => sp.GetService(typeof(IPauseSnapshotRepository)))
+            .Returns(_snapshotRepoMock.Object);
+        _serviceProviderMock
+            .Setup(sp => sp.GetService(typeof(MeepleAiDbContext)))
+            .Returns(_dbContext);
+
+        _snapshotRepoMock
+            .Setup(r => r.AddAsync(It.IsAny<PauseSnapshot>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _sut = new SessionAutoSaveBackgroundService(
+            _scopeFactoryMock.Object,
+            NullLogger<SessionAutoSaveBackgroundService>.Instance);
+    }
+
+    public void Dispose() => _dbContext.Dispose();
+
+    // ── Helpers ───────────────────────────────────────────────────────────────
+
+    /// <summary>
+    /// Invokes the private AutoSaveActiveSessionsAsync method directly to bypass the 10-min delay.
+    /// </summary>
+    private async Task InvokeAutoSaveAsync()
+    {
+        var method = typeof(SessionAutoSaveBackgroundService).GetMethod(
+            "AutoSaveActiveSessionsAsync",
+            BindingFlags.NonPublic | BindingFlags.Instance);
+
+        await (Task)method!.Invoke(_sut, [CancellationToken.None])!;
+    }
+
+    private static LiveGameSession CreateInProgressSession(Guid? id = null)
+    {
+        var session = LiveGameSession.Create(
+            id: id ?? Guid.NewGuid(),
+            createdByUserId: UserId,
+            gameName: "Test Game",
+            timeProvider: TimeProvider.System);
+
+        session.AddPlayer(
+            userId: UserId,
+            displayName: "Alice",
+            color: PlayerColor.Red,
+            timeProvider: TimeProvider.System,
+            role: PlayerRole.Host);
+
+        session.MoveToSetup(TimeProvider.System);
+        session.Start(TimeProvider.System);
+
+        return session;
+    }
+
+    // ── No active sessions ────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task AutoSave_WhenNoActiveSessions_DoesNotAddAnySnapshot()
+    {
+        // Arrange
+        _sessionRepoMock
+            .Setup(r => r.GetAllActiveAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<LiveGameSession>());
+
+        // Act
+        await InvokeAutoSaveAsync();
+
+        // Assert
+        _snapshotRepoMock.Verify(
+            r => r.AddAsync(It.IsAny<PauseSnapshot>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    // ── Single active session ─────────────────────────────────────────────────
+
+    [Fact]
+    public async Task AutoSave_WithOneActiveSession_CreatesAutoSaveSnapshot()
+    {
+        // Arrange
+        var session = CreateInProgressSession();
+
+        _sessionRepoMock
+            .Setup(r => r.GetAllActiveAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<LiveGameSession> { session });
+
+        PauseSnapshot? capturedSnapshot = null;
+        _snapshotRepoMock
+            .Setup(r => r.AddAsync(It.IsAny<PauseSnapshot>(), It.IsAny<CancellationToken>()))
+            .Callback<PauseSnapshot, CancellationToken>((s, _) => capturedSnapshot = s)
+            .Returns(Task.CompletedTask);
+
+        // Act
+        await InvokeAutoSaveAsync();
+
+        // Assert — exactly one snapshot
+        _snapshotRepoMock.Verify(
+            r => r.AddAsync(It.IsAny<PauseSnapshot>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        Assert.NotNull(capturedSnapshot);
+        Assert.True(capturedSnapshot!.IsAutoSave);
+        Assert.Equal(session.Id, capturedSnapshot.LiveGameSessionId);
+        Assert.Equal(SessionAutoSaveBackgroundService.SystemUserId, capturedSnapshot.SavedByUserId);
+    }
+
+    // ── Multiple active sessions ───────────────────────────────────────────────
+
+    [Fact]
+    public async Task AutoSave_WithMultipleActiveSessions_CreatesSnapshotForEach()
+    {
+        // Arrange
+        var session1 = CreateInProgressSession();
+        var session2 = CreateInProgressSession();
+        var session3 = CreateInProgressSession();
+
+        _sessionRepoMock
+            .Setup(r => r.GetAllActiveAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<LiveGameSession> { session1, session2, session3 });
+
+        // Act
+        await InvokeAutoSaveAsync();
+
+        // Assert — three snapshots created
+        _snapshotRepoMock.Verify(
+            r => r.AddAsync(It.IsAny<PauseSnapshot>(), It.IsAny<CancellationToken>()),
+            Times.Exactly(3));
+    }
+
+    // ── Error isolation ───────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task AutoSave_WhenOneSessionFails_ContinuesWithRemainingSessions()
+    {
+        // Arrange
+        var goodSession = CreateInProgressSession();
+        var badSession = CreateInProgressSession();
+
+        _sessionRepoMock
+            .Setup(r => r.GetAllActiveAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new List<LiveGameSession> { badSession, goodSession });
+
+        var callCount = 0;
+        _snapshotRepoMock
+            .Setup(r => r.AddAsync(It.IsAny<PauseSnapshot>(), It.IsAny<CancellationToken>()))
+            .Returns<PauseSnapshot, CancellationToken>((snapshot, _) =>
+            {
+                callCount++;
+                // First call (badSession) throws; second call (goodSession) succeeds
+                if (snapshot.LiveGameSessionId == badSession.Id)
+                    throw new InvalidOperationException("Simulated save failure");
+                return Task.CompletedTask;
+            });
+
+        // Act — must not throw
+        await InvokeAutoSaveAsync();
+
+        // Assert — both sessions were attempted; good one succeeded
+        Assert.Equal(2, callCount);
+    }
+
+    // ── SystemUserId is not Guid.Empty ─────────────────────────────────────────
+
+    [Fact]
+    public void SystemUserId_IsNotEmpty()
+    {
+        Assert.NotEqual(Guid.Empty, SessionAutoSaveBackgroundService.SystemUserId);
+    }
+}

--- a/apps/web/src/app/(authenticated)/sessions/live/[sessionId]/agent/page.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/live/[sessionId]/agent/page.tsx
@@ -1,0 +1,269 @@
+/**
+ * Agent Chat Child Card — /sessions/live/[sessionId]/agent
+ *
+ * Game Night Improvvisata — Task 22
+ *
+ * Provides an in-session chat interface for querying the game Arbitro
+ * agent. Includes ArbitroModal (for formal disputes) and DisputeHistory.
+ *
+ * Note: The existing ChatThreadView is deeply coupled to the toolkit
+ * session system. This page implements a simplified inline chat that
+ * works directly with the live session context.
+ */
+
+'use client';
+
+import { use, useState, useRef } from 'react';
+
+import { Bot, Loader2, Send } from 'lucide-react';
+
+import { ArbitroModal } from '@/components/sessions/live/ArbitroModal';
+import { DisputeHistory } from '@/components/sessions/live/DisputeHistory';
+import { Button } from '@/components/ui/button';
+import { Textarea } from '@/components/ui/primitives/textarea';
+import { useLiveSessionStore } from '@/lib/stores/live-session-store';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface ChatMessage {
+  id: string;
+  role: 'user' | 'assistant';
+  content: string;
+  timestamp: number;
+}
+
+// ─── Sub-components ───────────────────────────────────────────────────────────
+
+interface MessageBubbleProps {
+  message: ChatMessage;
+}
+
+function MessageBubble({ message }: MessageBubbleProps) {
+  const isUser = message.role === 'user';
+
+  return (
+    <div className={`flex ${isUser ? 'justify-end' : 'justify-start'} gap-2`}>
+      {!isUser && (
+        <div className="h-7 w-7 rounded-full bg-amber-100 border border-amber-200 flex items-center justify-center shrink-0 mt-1">
+          <Bot className="h-4 w-4 text-amber-600" />
+        </div>
+      )}
+      <div
+        className={[
+          'max-w-[80%] rounded-2xl px-4 py-2.5 text-sm font-nunito',
+          isUser
+            ? 'bg-amber-500 text-white rounded-tr-sm'
+            : 'bg-white/80 backdrop-blur-sm border border-white/60 text-gray-800 rounded-tl-sm shadow-sm',
+        ].join(' ')}
+      >
+        <p className="whitespace-pre-wrap leading-relaxed">{message.content}</p>
+      </div>
+    </div>
+  );
+}
+
+// ─── Main Component ────────────────────────────────────────────────────────────
+
+interface AgentPageProps {
+  params: Promise<{ sessionId: string }>;
+}
+
+export default function AgentPage({ params }: AgentPageProps) {
+  const { sessionId } = use(params);
+
+  const players = useLiveSessionStore(s => s.players);
+  const gameName = useLiveSessionStore(s => s.gameName);
+
+  const [messages, setMessages] = useState<ChatMessage[]>([
+    {
+      id: 'welcome',
+      role: 'assistant',
+      content: `Ciao! Sono l'Arbitro per ${gameName || 'la vostra partita'}. Chiedimi qualsiasi cosa sulle regole del gioco, oppure usa "⚖️ Arbitro" per una contestazione formale.`,
+      timestamp: Date.now(),
+    },
+  ]);
+  const [input, setInput] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+
+  function scrollToBottom() {
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }
+
+  async function handleSend(e: React.FormEvent) {
+    e.preventDefault();
+    const trimmed = input.trim();
+    if (!trimmed || isLoading) return;
+
+    const userMessage: ChatMessage = {
+      id: `user-${Date.now()}`,
+      role: 'user',
+      content: trimmed,
+      timestamp: Date.now(),
+    };
+
+    setMessages(prev => [...prev, userMessage]);
+    setInput('');
+    setIsLoading(true);
+    scrollToBottom();
+
+    try {
+      // POST to the agent chat endpoint with session context for RAG injection
+      const res = await fetch('/api/v1/agent/chat', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          message: trimmed,
+          sessionContext: { sessionId, gameName },
+        }),
+      });
+
+      if (!res.ok) throw new Error('Agent unavailable');
+
+      const assistantId = `assistant-${Date.now()}`;
+      let assistantContent = '';
+
+      // Add placeholder message that we'll fill from the stream
+      setMessages(prev => [
+        ...prev,
+        { id: assistantId, role: 'assistant', content: '...', timestamp: Date.now() },
+      ]);
+
+      const reader = res.body?.getReader();
+      const decoder = new TextDecoder();
+
+      if (reader) {
+        while (true) {
+          const { done, value } = await reader.read();
+          if (done) break;
+
+          const chunk = decoder.decode(value, { stream: true });
+          for (const line of chunk.split('\n')) {
+            if (!line.startsWith('data: ')) continue;
+            const data = line.slice(6);
+            if (data === '[DONE]') break;
+            try {
+              const parsed = JSON.parse(data) as { content?: string };
+              if (parsed.content) {
+                assistantContent += parsed.content;
+                setMessages(prev =>
+                  prev.map(m => (m.id === assistantId ? { ...m, content: assistantContent } : m))
+                );
+                scrollToBottom();
+              }
+            } catch {
+              // Non-JSON SSE chunk — ignore
+            }
+          }
+        }
+      }
+
+      // If stream produced nothing, fallback to full JSON response
+      if (!assistantContent) {
+        const fallback = (await res.json().catch(() => null)) as { content?: string } | null;
+        setMessages(prev =>
+          prev.map(m =>
+            m.id === assistantId
+              ? { ...m, content: fallback?.content ?? 'Risposta non disponibile.' }
+              : m
+          )
+        );
+      }
+    } catch {
+      setMessages(prev => [
+        ...prev,
+        {
+          id: `error-${Date.now()}`,
+          role: 'assistant',
+          content:
+            "Non riesco a rispondere al momento. Usa '⚖️ Arbitro' per una contestazione formale.",
+          timestamp: Date.now(),
+        },
+      ]);
+    } finally {
+      setIsLoading(false);
+      scrollToBottom();
+    }
+  }
+
+  function handleKeyDown(e: React.KeyboardEvent) {
+    if (e.key === 'Enter' && !e.shiftKey) {
+      e.preventDefault();
+      handleSend(e as unknown as React.FormEvent);
+    }
+  }
+
+  return (
+    <div className="flex flex-col" style={{ minHeight: 'calc(100vh - 12rem)' }}>
+      {/* Header */}
+      <div className="flex items-center justify-between p-4 pb-2 shrink-0">
+        <div className="flex items-center gap-2">
+          <div className="h-8 w-8 rounded-full bg-amber-100 border border-amber-200 flex items-center justify-center">
+            <Bot className="h-4 w-4 text-amber-600" />
+          </div>
+          <div>
+            <h2 className="text-base font-quicksand font-bold text-gray-900 leading-none">
+              Arbitro AI
+            </h2>
+            <p className="text-xs text-gray-500 font-nunito">{gameName || 'Sessione live'}</p>
+          </div>
+        </div>
+
+        {/* ArbitroModal renders its own trigger button */}
+        <ArbitroModal sessionId={sessionId} players={players.map(p => ({ name: p.name }))} />
+      </div>
+
+      {/* Messages */}
+      <div className="flex-1 overflow-y-auto px-4 py-2 space-y-3">
+        {messages.map(msg => (
+          <MessageBubble key={msg.id} message={msg} />
+        ))}
+
+        {isLoading && (
+          <div className="flex justify-start gap-2">
+            <div className="h-7 w-7 rounded-full bg-amber-100 border border-amber-200 flex items-center justify-center shrink-0">
+              <Loader2 className="h-4 w-4 text-amber-600 animate-spin" />
+            </div>
+            <div className="rounded-2xl rounded-tl-sm bg-white/80 border border-white/60 px-4 py-3 shadow-sm">
+              <div className="flex gap-1 items-center">
+                <span className="h-1.5 w-1.5 rounded-full bg-gray-400 animate-bounce [animation-delay:0ms]" />
+                <span className="h-1.5 w-1.5 rounded-full bg-gray-400 animate-bounce [animation-delay:150ms]" />
+                <span className="h-1.5 w-1.5 rounded-full bg-gray-400 animate-bounce [animation-delay:300ms]" />
+              </div>
+            </div>
+          </div>
+        )}
+
+        <div ref={messagesEndRef} />
+      </div>
+
+      {/* Input */}
+      <form onSubmit={handleSend} className="shrink-0 px-4 pb-4 pt-2 flex gap-2 items-end">
+        <Textarea
+          value={input}
+          onChange={e => setInput(e.target.value)}
+          onKeyDown={handleKeyDown}
+          placeholder="Chiedi una regola... (Invio per inviare)"
+          className="flex-1 resize-none min-h-[42px] max-h-[120px] font-nunito text-sm"
+          rows={1}
+          disabled={isLoading}
+          aria-label="Messaggio per l'arbitro"
+        />
+        <Button
+          type="submit"
+          size="icon"
+          disabled={isLoading || !input.trim()}
+          className="h-[42px] w-[42px] bg-amber-500 hover:bg-amber-600 shrink-0"
+          aria-label="Invia messaggio"
+        >
+          <Send className="h-4 w-4 text-white" />
+        </Button>
+      </form>
+
+      {/* Dispute History collapsible */}
+      <div className="shrink-0 px-4 pb-4">
+        <DisputeHistory sessionId={sessionId} />
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/app/(authenticated)/sessions/live/[sessionId]/layout.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/live/[sessionId]/layout.tsx
@@ -1,0 +1,30 @@
+/**
+ * Live Session Layout — /sessions/live/[sessionId]
+ *
+ * Game Night Improvvisata — Task 15
+ *
+ * Wraps live session pages with session-specific MiniNav tabs:
+ * Partita · Chat AI · Punteggi · Foto · Giocatori
+ */
+
+'use client';
+
+import { type ReactNode, use } from 'react';
+
+import { SessionNavConfig } from '@/components/sessions/live/SessionNavConfig';
+
+interface LiveSessionLayoutProps {
+  children: ReactNode;
+  params: Promise<{ sessionId: string }>;
+}
+
+export default function LiveSessionLayout({ children, params }: LiveSessionLayoutProps) {
+  const { sessionId } = use(params);
+
+  return (
+    <>
+      <SessionNavConfig sessionId={sessionId} />
+      {children}
+    </>
+  );
+}

--- a/apps/web/src/app/(authenticated)/sessions/live/[sessionId]/page.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/live/[sessionId]/page.tsx
@@ -1,0 +1,22 @@
+/**
+ * Live Session Main Page — /sessions/live/[sessionId]
+ *
+ * Game Night Improvvisata — Task 15
+ *
+ * Renders the SessionCardParent component as the primary session overview.
+ */
+
+'use client';
+
+import { use } from 'react';
+
+import { SessionCardParent } from '@/components/sessions/live/SessionCardParent';
+
+interface LiveSessionPageProps {
+  params: Promise<{ sessionId: string }>;
+}
+
+export default function LiveSessionPage({ params }: LiveSessionPageProps) {
+  const { sessionId } = use(params);
+  return <SessionCardParent sessionId={sessionId} />;
+}

--- a/apps/web/src/app/(authenticated)/sessions/live/[sessionId]/photos/page.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/live/[sessionId]/photos/page.tsx
@@ -1,0 +1,199 @@
+/**
+ * Photos Child Card — /sessions/live/[sessionId]/photos
+ *
+ * Game Night Improvvisata — Task 21
+ *
+ * Camera capture for board-state photos. Grid of captured photos with
+ * timestamps. Photos are held locally in component state; if the
+ * session attachment endpoint exists they can be uploaded there.
+ */
+
+'use client';
+
+import { use, useRef, useState, useCallback } from 'react';
+
+import { Camera, Image as ImageIcon, Trash2, Upload } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface CapturedPhoto {
+  id: string;
+  dataUrl: string;
+  timestamp: number;
+  filename: string;
+}
+
+// ─── Sub-components ───────────────────────────────────────────────────────────
+
+interface PhotoCardProps {
+  photo: CapturedPhoto;
+  onDelete: (id: string) => void;
+}
+
+function PhotoCard({ photo, onDelete }: PhotoCardProps) {
+  const date = new Date(photo.timestamp);
+  const timeLabel = date.toLocaleTimeString('it-IT', {
+    hour: '2-digit',
+    minute: '2-digit',
+  });
+
+  return (
+    <div className="group relative rounded-xl overflow-hidden bg-gray-100 aspect-square shadow-sm border border-white/60">
+      {/* eslint-disable-next-line @next/next/no-img-element */}
+      <img
+        src={photo.dataUrl}
+        alt={`Foto partita ${timeLabel}`}
+        className="w-full h-full object-cover"
+      />
+      {/* Overlay */}
+      <div className="absolute inset-0 bg-black/0 group-hover:bg-black/30 transition-colors" />
+      {/* Timestamp */}
+      <div className="absolute bottom-0 inset-x-0 bg-gradient-to-t from-black/60 to-transparent p-2">
+        <p className="text-white text-xs font-mono">{timeLabel}</p>
+      </div>
+      {/* Delete button */}
+      <button
+        className="absolute top-1.5 right-1.5 h-7 w-7 rounded-full bg-black/40 hover:bg-red-500/80 flex items-center justify-center opacity-0 group-hover:opacity-100 transition-all"
+        onClick={() => onDelete(photo.id)}
+        aria-label={`Elimina foto ${timeLabel}`}
+      >
+        <Trash2 className="h-3.5 w-3.5 text-white" />
+      </button>
+    </div>
+  );
+}
+
+// ─── Main Component ────────────────────────────────────────────────────────────
+
+interface PhotosPageProps {
+  params: Promise<{ sessionId: string }>;
+}
+
+export default function PhotosPage({ params }: PhotosPageProps) {
+  const { sessionId: _sessionId } = use(params);
+
+  const fileInputRef = useRef<HTMLInputElement>(null);
+  const [photos, setPhotos] = useState<CapturedPhoto[]>([]);
+  const [isUploading, setIsUploading] = useState(false);
+
+  const handleCapture = useCallback((e: React.ChangeEvent<HTMLInputElement>) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    // Reset input so same file can be re-selected
+    e.target.value = '';
+
+    const reader = new FileReader();
+    reader.onload = ev => {
+      const dataUrl = ev.target?.result as string;
+      if (!dataUrl) return;
+      setPhotos(prev => [
+        ...prev,
+        {
+          id: `photo-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`,
+          dataUrl,
+          timestamp: Date.now(),
+          filename: file.name,
+        },
+      ]);
+    };
+    reader.readAsDataURL(file);
+  }, []);
+
+  function handleDelete(id: string) {
+    setPhotos(prev => prev.filter(p => p.id !== id));
+  }
+
+  async function handleUploadAll() {
+    if (photos.length === 0) return;
+    setIsUploading(true);
+    try {
+      // Placeholder: session attachment upload endpoint
+      // await api.sessions.uploadAttachment(sessionId, photoBlob)
+      // For now: simulate upload delay
+      await new Promise(r => setTimeout(r, 1000));
+    } finally {
+      setIsUploading(false);
+    }
+  }
+
+  return (
+    <div className="space-y-4 p-4">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-xl font-quicksand font-bold text-gray-900">Foto partita</h2>
+          <p className="text-xs text-gray-500 font-nunito mt-0.5">
+            {photos.length === 0 ? 'Nessuna foto ancora' : `${photos.length} foto`}
+          </p>
+        </div>
+
+        <div className="flex gap-2">
+          {photos.length > 0 && (
+            <Button
+              size="sm"
+              variant="outline"
+              className="gap-1 font-nunito text-xs"
+              onClick={handleUploadAll}
+              disabled={isUploading}
+              data-testid="upload-button"
+            >
+              <Upload className="h-3.5 w-3.5" />
+              {isUploading ? 'Caricamento...' : 'Carica'}
+            </Button>
+          )}
+
+          <Button
+            size="sm"
+            className="gap-2 bg-amber-500 hover:bg-amber-600 text-white font-nunito"
+            onClick={() => fileInputRef.current?.click()}
+            data-testid="capture-button"
+          >
+            <Camera className="h-4 w-4" />
+            Scatta
+          </Button>
+        </div>
+      </div>
+
+      {/* Hidden file input (camera capture on mobile) */}
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/*"
+        capture="environment"
+        className="hidden"
+        onChange={handleCapture}
+        data-testid="photo-input"
+      />
+
+      {/* Empty state */}
+      {photos.length === 0 && (
+        <div className="flex flex-col items-center gap-3 py-12 text-gray-400">
+          <ImageIcon className="h-12 w-12 opacity-30" />
+          <p className="text-sm font-nunito text-center">
+            Scatta foto per documentare lo stato della partita
+          </p>
+          <Button
+            variant="outline"
+            className="gap-2 font-nunito"
+            onClick={() => fileInputRef.current?.click()}
+          >
+            <Camera className="h-4 w-4" />
+            Prima foto
+          </Button>
+        </div>
+      )}
+
+      {/* Photo grid */}
+      {photos.length > 0 && (
+        <div className="grid grid-cols-2 gap-3 sm:grid-cols-3">
+          {photos.map(photo => (
+            <PhotoCard key={photo.id} photo={photo} onDelete={handleDelete} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/app/(authenticated)/sessions/live/[sessionId]/players/page.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/live/[sessionId]/players/page.tsx
@@ -1,0 +1,48 @@
+/**
+ * Players Child Card — /sessions/live/[sessionId]/players
+ *
+ * Game Night Improvvisata — Task 21
+ *
+ * Shows the session player list with online indicators, host crown,
+ * and invite modal.
+ */
+
+'use client';
+
+import { use } from 'react';
+
+import { PlayerList } from '@/components/sessions/live/PlayerList';
+import { useLiveSessionStore } from '@/lib/stores/live-session-store';
+
+interface PlayersPageProps {
+  params: Promise<{ sessionId: string }>;
+}
+
+export default function PlayersPage({ params }: PlayersPageProps) {
+  const { sessionId } = use(params);
+
+  // Read invite info from store (set when session starts via startImprovvisata)
+  // The store doesn't hold inviteCode/shareLink directly; we derive the share link
+  // from the current URL pattern. The inviteCode is read from sessionInfo if available.
+  const gameName = useLiveSessionStore(s => s.gameName);
+
+  // Build a fallback share link from the current session ID
+  const shareLink =
+    typeof window !== 'undefined'
+      ? `${window.location.origin}/join/${sessionId}`
+      : `/join/${sessionId}`;
+
+  return (
+    <PlayerList
+      sessionId={sessionId}
+      inviteCode={sessionId.slice(0, 6).toUpperCase()}
+      shareLink={shareLink}
+    />
+  );
+}
+
+// Export metadata for the tab label
+export const metadata = {
+  title: 'Giocatori',
+  description: `Gestisci i giocatori della sessione`,
+};

--- a/apps/web/src/app/(authenticated)/sessions/live/[sessionId]/players/page.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/live/[sessionId]/players/page.tsx
@@ -40,9 +40,3 @@ export default function PlayersPage({ params }: PlayersPageProps) {
     />
   );
 }
-
-// Export metadata for the tab label
-export const metadata = {
-  title: 'Giocatori',
-  description: `Gestisci i giocatori della sessione`,
-};

--- a/apps/web/src/app/(authenticated)/sessions/live/[sessionId]/scores/page.tsx
+++ b/apps/web/src/app/(authenticated)/sessions/live/[sessionId]/scores/page.tsx
@@ -1,0 +1,24 @@
+/**
+ * Live Session Scores Page — /sessions/live/[sessionId]/scores
+ *
+ * Game Night Improvvisata — Task 16
+ */
+
+'use client';
+
+import { use } from 'react';
+
+import { ScoreBoard } from '@/components/sessions/live/ScoreBoard';
+import { useLiveSessionStore } from '@/lib/stores/live-session-store';
+
+interface LiveSessionScoresPageProps {
+  params: Promise<{ sessionId: string }>;
+}
+
+export default function LiveSessionScoresPage({ params }: LiveSessionScoresPageProps) {
+  const { sessionId } = use(params);
+  const players = useLiveSessionStore(s => s.players);
+  const isHost = players.find(p => p.isHost)?.isHost ?? false;
+
+  return <ScoreBoard sessionId={sessionId} isHost={isHost} />;
+}

--- a/apps/web/src/app/join/[inviteToken]/GuestJoinView.tsx
+++ b/apps/web/src/app/join/[inviteToken]/GuestJoinView.tsx
@@ -1,0 +1,371 @@
+/**
+ * GuestJoinView — Interactive guest session view
+ *
+ * Game Night Improvvisata — Task 18
+ *
+ * Testable inner component that receives a plain `inviteToken` string.
+ * All interactive logic lives here; the parent page.tsx only unwraps params.
+ */
+
+'use client';
+
+import { useEffect, useState, useCallback } from 'react';
+
+import { Loader2, Users } from 'lucide-react';
+
+import { GuestScoreProposal } from '@/components/sessions/live/GuestScoreProposal';
+import { ScoreBoard } from '@/components/sessions/live/ScoreBoard';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { useLiveSessionStore } from '@/lib/stores/live-session-store';
+
+// ─── Constants ────────────────────────────────────────────────────────────────
+
+const STORAGE_KEY = 'improvvisata_participant_token';
+const STORAGE_NAME_KEY = 'improvvisata_guest_name';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+type JoinState = 'loading' | 'name-entry' | 'joined' | 'error';
+
+interface SessionInfo {
+  sessionId: string;
+  gameName: string;
+  hostName: string;
+  inviteCode: string;
+}
+
+// ─── Storage helpers ──────────────────────────────────────────────────────────
+
+function getSavedToken(): string | null {
+  try {
+    return localStorage.getItem(STORAGE_KEY);
+  } catch {
+    return null;
+  }
+}
+
+function getSavedName(): string | null {
+  try {
+    return localStorage.getItem(STORAGE_NAME_KEY);
+  } catch {
+    return null;
+  }
+}
+
+function saveParticipantData(token: string, name: string) {
+  try {
+    localStorage.setItem(STORAGE_KEY, token);
+    localStorage.setItem(STORAGE_NAME_KEY, name);
+  } catch {
+    // Storage unavailable — continue without persistence
+  }
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export interface GuestJoinViewProps {
+  inviteToken: string;
+}
+
+export function GuestJoinView({ inviteToken }: GuestJoinViewProps) {
+  const [joinState, setJoinState] = useState<JoinState>('loading');
+  const [sessionInfo, setSessionInfo] = useState<SessionInfo | null>(null);
+  const [guestName, setGuestName] = useState('');
+  const [inputName, setInputName] = useState('');
+  const [nameError, setNameError] = useState<string | null>(null);
+  const [isJoining, setIsJoining] = useState(false);
+  const [errorMessage, setErrorMessage] = useState<string | null>(null);
+
+  const setSession = useLiveSessionStore(s => s.setSession);
+  const addProposal = useLiveSessionStore(s => s.addProposal);
+
+  // ── Load session ─────────────────────────────────────────────────────────────
+
+  const loadSession = useCallback(async () => {
+    setJoinState('loading');
+    try {
+      const res = await fetch(`/api/v1/live-sessions/code/${encodeURIComponent(inviteToken)}`);
+      if (!res.ok) {
+        setErrorMessage('Link non valido o sessione non trovata.');
+        setJoinState('error');
+        return;
+      }
+
+      const data = (await res.json()) as {
+        id: string;
+        gameName: string;
+        inviteCode: string;
+        players?: Array<{ displayName: string; isHost?: boolean; isOnline?: boolean; id: string }>;
+        scores?: Record<string, number>;
+        status?: string;
+        currentTurn?: number;
+      };
+
+      const info: SessionInfo = {
+        sessionId: data.id,
+        gameName: data.gameName ?? 'Partita',
+        hostName: data.players?.find(p => p.isHost)?.displayName ?? 'Host',
+        inviteCode: data.inviteCode,
+      };
+      setSessionInfo(info);
+
+      setSession({
+        sessionId: data.id,
+        gameName: data.gameName ?? '',
+        status: (data.status as 'InProgress' | 'Paused' | 'Completed') ?? 'InProgress',
+        currentTurn: data.currentTurn ?? 1,
+        players:
+          data.players?.map(p => ({
+            id: p.id,
+            name: p.displayName,
+            isHost: p.isHost ?? false,
+            isOnline: p.isOnline ?? false,
+          })) ?? [],
+        scores: data.scores ?? {},
+      });
+
+      // Auto-rejoin if valid saved token
+      const savedToken = getSavedToken();
+      const savedName = getSavedName();
+
+      if (savedToken && savedName) {
+        const tokenRes = await fetch(
+          `/api/v1/live-sessions/${encodeURIComponent(data.id)}/guest/validate`,
+          {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ participantToken: savedToken }),
+          }
+        );
+        if (tokenRes.ok) {
+          setGuestName(savedName);
+          setJoinState('joined');
+          return;
+        }
+        try {
+          localStorage.removeItem(STORAGE_KEY);
+          localStorage.removeItem(STORAGE_NAME_KEY);
+        } catch {
+          // ignore
+        }
+      }
+
+      setJoinState('name-entry');
+    } catch {
+      setErrorMessage('Errore di connessione. Riprova tra qualche secondo.');
+      setJoinState('error');
+    }
+  }, [inviteToken, setSession]);
+
+  useEffect(() => {
+    loadSession();
+  }, [loadSession]);
+
+  // ── Join ──────────────────────────────────────────────────────────────────────
+
+  async function handleJoin(e: React.FormEvent) {
+    e.preventDefault();
+    const trimmed = inputName.trim();
+    if (!trimmed) {
+      setNameError('Inserisci il tuo nome');
+      return;
+    }
+    if (trimmed.length < 2) {
+      setNameError('Il nome deve avere almeno 2 caratteri');
+      return;
+    }
+    if (!sessionInfo) return;
+
+    setNameError(null);
+    setIsJoining(true);
+
+    try {
+      const res = await fetch(
+        `/api/v1/live-sessions/${encodeURIComponent(sessionInfo.sessionId)}/guest/join`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ displayName: trimmed }),
+        }
+      );
+
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as { message?: string };
+        setNameError(body.message ?? 'Impossibile unirsi alla sessione');
+        return;
+      }
+
+      const joinData = (await res.json()) as { participantToken?: string };
+      if (joinData.participantToken) {
+        saveParticipantData(joinData.participantToken, trimmed);
+      }
+
+      setGuestName(trimmed);
+      setJoinState('joined');
+    } catch {
+      setNameError('Errore di connessione. Riprova.');
+    } finally {
+      setIsJoining(false);
+    }
+  }
+
+  // ── Score proposal ────────────────────────────────────────────────────────────
+
+  async function handlePropose(delta: number) {
+    if (!sessionInfo) return;
+
+    const res = await fetch(
+      `/api/v1/live-sessions/${encodeURIComponent(sessionInfo.sessionId)}/scores/propose`,
+      {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ playerName: guestName, delta }),
+      }
+    );
+
+    if (!res.ok) throw new Error('Proposta rifiutata dal server');
+
+    const data = (await res.json()) as { proposalId?: string };
+    addProposal({
+      id: data.proposalId ?? `proposal-${Date.now()}`,
+      playerName: guestName,
+      delta,
+      timestamp: Date.now(),
+    });
+  }
+
+  // ── Loading ───────────────────────────────────────────────────────────────────
+
+  if (joinState === 'loading') {
+    return (
+      <main className="min-h-screen bg-gradient-to-br from-amber-50 to-orange-50 flex items-center justify-center p-4">
+        <div className="flex flex-col items-center gap-3 text-gray-600">
+          <Loader2 className="h-8 w-8 animate-spin text-amber-500" />
+          <p className="font-nunito" data-testid="loading-text">
+            Caricamento sessione...
+          </p>
+        </div>
+      </main>
+    );
+  }
+
+  // ── Error ─────────────────────────────────────────────────────────────────────
+
+  if (joinState === 'error') {
+    return (
+      <main className="min-h-screen bg-gradient-to-br from-amber-50 to-orange-50 flex items-center justify-center p-4">
+        <div className="max-w-sm w-full text-center space-y-4">
+          <div className="h-16 w-16 mx-auto rounded-2xl bg-red-100 flex items-center justify-center">
+            <Users className="h-8 w-8 text-red-500" />
+          </div>
+          <h1 className="text-xl font-quicksand font-bold text-gray-900">Sessione non trovata</h1>
+          <p className="text-sm font-nunito text-gray-600">
+            {errorMessage ?? 'Il link potrebbe essere scaduto o non valido.'}
+          </p>
+          <Button onClick={() => loadSession()} variant="outline" className="w-full">
+            Riprova
+          </Button>
+        </div>
+      </main>
+    );
+  }
+
+  // ── Name Entry ────────────────────────────────────────────────────────────────
+
+  if (joinState === 'name-entry' && sessionInfo) {
+    return (
+      <main className="min-h-screen bg-gradient-to-br from-amber-50 to-orange-50 flex items-center justify-center p-4">
+        <div className="max-w-sm w-full space-y-6">
+          <div className="text-center space-y-2">
+            <div className="h-16 w-16 mx-auto rounded-2xl bg-amber-100 flex items-center justify-center">
+              <Users className="h-8 w-8 text-amber-600" />
+            </div>
+            <h1 className="text-2xl font-quicksand font-bold text-gray-900">
+              Unisciti alla partita
+            </h1>
+            <p className="text-sm font-nunito text-gray-600">
+              <span className="font-semibold text-gray-900">{sessionInfo.gameName}</span> ospitata
+              da <span className="font-semibold text-gray-900">{sessionInfo.hostName}</span>
+            </p>
+            <Badge variant="outline" className="font-mono text-lg px-4 py-1">
+              {sessionInfo.inviteCode}
+            </Badge>
+          </div>
+
+          <form onSubmit={handleJoin} className="space-y-3">
+            <div className="space-y-1.5">
+              <label htmlFor="guest-name" className="text-sm font-nunito font-medium text-gray-700">
+                Il tuo nome
+              </label>
+              <Input
+                id="guest-name"
+                type="text"
+                value={inputName}
+                onChange={e => {
+                  setInputName(e.target.value);
+                  setNameError(null);
+                }}
+                placeholder="Come ti chiami?"
+                autoFocus
+                autoComplete="name"
+                maxLength={40}
+                disabled={isJoining}
+                className="text-center text-lg"
+                aria-describedby={nameError ? 'name-error' : undefined}
+              />
+              {nameError && (
+                <p id="name-error" className="text-xs text-red-600 font-nunito" role="alert">
+                  {nameError}
+                </p>
+              )}
+            </div>
+
+            <Button
+              type="submit"
+              className="w-full bg-amber-500 hover:bg-amber-600 text-white font-quicksand font-semibold"
+              disabled={isJoining || !inputName.trim()}
+            >
+              {isJoining ? (
+                <>
+                  <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                  Connessione...
+                </>
+              ) : (
+                'Entra nella partita'
+              )}
+            </Button>
+          </form>
+        </div>
+      </main>
+    );
+  }
+
+  // ── Joined ────────────────────────────────────────────────────────────────────
+
+  if (joinState === 'joined' && sessionInfo) {
+    return (
+      <main className="min-h-screen bg-gradient-to-br from-amber-50 to-orange-50 p-4">
+        <div className="max-w-sm mx-auto space-y-4">
+          <div className="text-center pt-4 pb-2">
+            <h1 className="text-xl font-quicksand font-bold text-gray-900">
+              {sessionInfo.gameName}
+            </h1>
+            <p className="text-sm font-nunito text-gray-500">
+              Giochi come <span className="font-semibold text-amber-700">{guestName}</span>
+            </p>
+          </div>
+
+          <div className="rounded-2xl bg-white/70 backdrop-blur-md border border-white/40 shadow-sm overflow-hidden">
+            <ScoreBoard sessionId={sessionInfo.sessionId} isHost={false} />
+          </div>
+
+          <GuestScoreProposal guestName={guestName} onPropose={handlePropose} />
+        </div>
+      </main>
+    );
+  }
+
+  return null;
+}

--- a/apps/web/src/app/join/[inviteToken]/page.tsx
+++ b/apps/web/src/app/join/[inviteToken]/page.tsx
@@ -1,0 +1,41 @@
+/**
+ * Guest Landing Page — /join/[inviteToken]
+ *
+ * Game Night Improvvisata — Task 18
+ *
+ * PUBLIC page (no auth required). Allows guests to join a live session
+ * by entering their name. After joining, shows a read-only scoreboard
+ * and score proposal form.
+ *
+ * Middleware note: /join/* is whitelisted in PUBLIC_PREFIXES in middleware.ts.
+ */
+
+import { use, Suspense } from 'react';
+
+import { GuestJoinView } from './GuestJoinView';
+
+interface GuestJoinPageProps {
+  params: Promise<{ inviteToken: string }>;
+}
+
+/**
+ * Server-compatible wrapper that unwraps the async `params` with `use()`.
+ * The inner GuestJoinView is a 'use client' component containing all the
+ * interactive logic. This split makes the inner component independently
+ * testable with a plain string prop.
+ */
+export default function GuestJoinPage({ params }: GuestJoinPageProps) {
+  const { inviteToken } = use(params);
+
+  return (
+    <Suspense
+      fallback={
+        <main className="min-h-screen bg-gradient-to-br from-amber-50 to-orange-50 flex items-center justify-center">
+          <p className="font-nunito text-gray-600">Caricamento sessione...</p>
+        </main>
+      }
+    >
+      <GuestJoinView inviteToken={inviteToken} />
+    </Suspense>
+  );
+}

--- a/apps/web/src/app/join/__tests__/guest-join.test.tsx
+++ b/apps/web/src/app/join/__tests__/guest-join.test.tsx
@@ -1,0 +1,227 @@
+/**
+ * Guest Join Tests
+ *
+ * Game Night Improvvisata — Task 18
+ *
+ * Tests GuestJoinView (the testable inner component) directly,
+ * avoiding the async-params wrapper of page.tsx.
+ */
+
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+// ─── Mocks ────────────────────────────────────────────────────────────────────
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+// Mutable store state — allows per-test customization
+const mockStoreState = {
+  pendingProposals: [] as Array<{
+    id: string;
+    playerName: string;
+    delta: number;
+    timestamp: number;
+  }>,
+  players: [] as Array<{ id: string; name: string; isHost: boolean; isOnline: boolean }>,
+  scores: {} as Record<string, number>,
+  setSession: vi.fn(),
+  addProposal: vi.fn(),
+};
+
+vi.mock('@/lib/stores/live-session-store', () => ({
+  useLiveSessionStore: (selector: (s: typeof mockStoreState) => unknown) =>
+    selector(mockStoreState),
+}));
+
+vi.mock('@/components/sessions/live/ScoreBoard', () => ({
+  ScoreBoard: ({ sessionId }: { sessionId: string }) => (
+    <div data-testid="scoreboard" data-session-id={sessionId}>
+      Scoreboard
+    </div>
+  ),
+}));
+
+import { GuestJoinView } from '../[inviteToken]/GuestJoinView';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const SESSION_RESPONSE = {
+  id: 'session-uuid-123',
+  gameName: 'Catan',
+  inviteCode: 'ABC123',
+  status: 'InProgress',
+  currentTurn: 1,
+  players: [{ id: 'host-1', displayName: 'Mario', isHost: true, isOnline: true }],
+  scores: { Mario: 10 },
+};
+
+function setupFetch(opts: { sessionOk?: boolean; tokenValid?: boolean; joinOk?: boolean } = {}) {
+  const { sessionOk = true, tokenValid = false, joinOk = true } = opts;
+
+  mockFetch.mockImplementation((url: string) => {
+    if (url.includes('/code/')) {
+      return Promise.resolve({
+        ok: sessionOk,
+        json: () => Promise.resolve(SESSION_RESPONSE),
+      });
+    }
+    if (url.includes('/guest/validate')) {
+      return Promise.resolve({ ok: tokenValid });
+    }
+    if (url.includes('/guest/join')) {
+      return Promise.resolve({
+        ok: joinOk,
+        json: () => Promise.resolve({ participantToken: 'pt-abc123' }),
+      });
+    }
+    if (url.includes('/scores/propose')) {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ proposalId: 'prop-1' }),
+      });
+    }
+    return Promise.resolve({ ok: false, json: () => Promise.resolve({}) });
+  });
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('GuestJoinView', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockStoreState.pendingProposals = [];
+    mockStoreState.players = [];
+    mockStoreState.scores = {};
+    localStorage.clear();
+  });
+
+  it('shows loading state initially', () => {
+    setupFetch();
+    render(<GuestJoinView inviteToken="ABC123" />);
+    expect(screen.getByTestId('loading-text')).toBeInTheDocument();
+  });
+
+  it('renders name input after session loads', async () => {
+    setupFetch();
+    render(<GuestJoinView inviteToken="ABC123" />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/il tuo nome/i)).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Catan')).toBeInTheDocument();
+    expect(screen.getByText('ABC123')).toBeInTheDocument();
+  });
+
+  it('disables submit button when name is empty', async () => {
+    setupFetch();
+    render(<GuestJoinView inviteToken="ABC123" />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/il tuo nome/i)).toBeInTheDocument();
+    });
+
+    // Button should be disabled when input is empty
+    const button = screen.getByRole('button', { name: /entra/i });
+    expect(button).toBeDisabled();
+  });
+
+  it('shows validation error for whitespace-only name via aria-label', async () => {
+    setupFetch();
+    const user = userEvent.setup();
+    render(<GuestJoinView inviteToken="ABC123" />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/il tuo nome/i)).toBeInTheDocument();
+    });
+
+    // Enable the button by typing something valid, then clear to simulate whitespace
+    const nameInput = screen.getByLabelText(/il tuo nome/i);
+    // Type valid name so button enables
+    await user.type(nameInput, 'x');
+    // Clear and type whitespace
+    await user.clear(nameInput);
+    await user.type(nameInput, '   ');
+    // button is still disabled because ' '.trim() === ''
+    expect(screen.getByRole('button', { name: /entra/i })).toBeDisabled();
+  });
+
+  it('joins session and shows scoreboard after submitting valid name', async () => {
+    setupFetch();
+    const user = userEvent.setup();
+    render(<GuestJoinView inviteToken="ABC123" />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/il tuo nome/i)).toBeInTheDocument();
+    });
+
+    await user.type(screen.getByLabelText(/il tuo nome/i), 'Luigi');
+    await user.click(screen.getByRole('button', { name: /entra/i }));
+
+    await waitFor(() => {
+      expect(screen.getByTestId('scoreboard')).toBeInTheDocument();
+    });
+
+    expect(screen.getAllByText(/Luigi/).length).toBeGreaterThan(0);
+    expect(screen.getByText(/proponi punteggio/i)).toBeInTheDocument();
+  });
+
+  it('shows error state when session fetch fails', async () => {
+    setupFetch({ sessionOk: false });
+    render(<GuestJoinView inviteToken="INVALID" />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('heading', { name: /sessione non trovata/i })).toBeInTheDocument();
+    });
+  });
+
+  it('auto-rejoins when valid saved token exists', async () => {
+    localStorage.setItem('improvvisata_participant_token', 'valid-token');
+    localStorage.setItem('improvvisata_guest_name', 'SavedUser');
+    setupFetch({ tokenValid: true });
+
+    render(<GuestJoinView inviteToken="ABC123" />);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('scoreboard')).toBeInTheDocument();
+    });
+
+    expect(screen.getAllByText(/SavedUser/).length).toBeGreaterThan(0);
+  });
+});
+
+describe('GuestScoreProposal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockStoreState.pendingProposals = [
+      { id: '1', playerName: 'Luigi', delta: 5, timestamp: 1 },
+      { id: '2', playerName: 'Luigi', delta: 3, timestamp: 2 },
+      { id: '3', playerName: 'Luigi', delta: -2, timestamp: 3 },
+    ];
+  });
+
+  it('enforces max 3 pending proposals limit', async () => {
+    const { GuestScoreProposal } = await import('@/components/sessions/live/GuestScoreProposal');
+
+    render(<GuestScoreProposal guestName="Luigi" onPropose={vi.fn()} />);
+
+    expect(screen.getByText(/hai raggiunto il limite/i)).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /proponi/i })).not.toBeInTheDocument();
+  });
+
+  it('shows proposal form when under limit', async () => {
+    mockStoreState.pendingProposals = []; // no pending
+    const { GuestScoreProposal } = await import('@/components/sessions/live/GuestScoreProposal');
+
+    render(<GuestScoreProposal guestName="Luigi" onPropose={vi.fn()} />);
+
+    expect(screen.getByRole('button', { name: /proponi/i })).toBeInTheDocument();
+    expect(screen.getByLabelText(/delta punteggio/i)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/library/add-game-sheet/steps/SuccessState.tsx
+++ b/apps/web/src/components/library/add-game-sheet/steps/SuccessState.tsx
@@ -4,14 +4,112 @@
  * SuccessState - Post-save success view with navigation links.
  * Issue #4821: Step 3 Info & Save
  * Epic #4817: User Collection Wizard
+ *
+ * Task 23 (Game Night Improvvisata): Added PdfProcessingBanner with
+ * 4 animated stages shown when a PDF rulebook was uploaded.
  */
 
-import { useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 
-import { CheckCircle2, Library, ExternalLink, PlusCircle } from 'lucide-react';
+import { CheckCircle2, Library, ExternalLink, PlusCircle, Loader2 } from 'lucide-react';
 import Link from 'next/link';
 
 import { Button } from '@/components/ui/button';
+
+// ─── PDF Processing Banner ────────────────────────────────────────────────────
+
+const PDF_STAGES = [
+  { id: 'chunking', label: 'Suddivisione in sezioni' },
+  { id: 'embedding', label: 'Generazione embedding' },
+  { id: 'indexing', label: 'Indicizzazione' },
+  { id: 'ready', label: 'Pronto' },
+] as const;
+
+const STAGE_DURATION_MS = 3000;
+
+function PdfProcessingBanner() {
+  const [stageIndex, setStageIndex] = useState(0);
+  const isDone = stageIndex >= PDF_STAGES.length - 1;
+
+  useEffect(() => {
+    if (isDone) return;
+    const id = setInterval(() => {
+      setStageIndex(prev => {
+        if (prev >= PDF_STAGES.length - 1) {
+          clearInterval(id);
+          return prev;
+        }
+        return prev + 1;
+      });
+    }, STAGE_DURATION_MS);
+    return () => clearInterval(id);
+  }, [isDone]);
+
+  const progress = ((stageIndex + 1) / PDF_STAGES.length) * 100;
+
+  return (
+    <div
+      className="mt-6 w-full max-w-xs rounded-xl border border-amber-500/20 bg-amber-500/10 p-4 text-left"
+      role="status"
+      aria-label="Stato elaborazione PDF"
+      data-testid="pdf-processing-banner"
+    >
+      <div className="flex items-center gap-2 mb-3">
+        {isDone ? (
+          <CheckCircle2 className="h-4 w-4 text-teal-400 shrink-0" />
+        ) : (
+          <Loader2 className="h-4 w-4 text-amber-400 animate-spin shrink-0" />
+        )}
+        <p className="text-xs font-medium text-amber-200">
+          {isDone ? 'Regolamento indicizzato!' : 'Elaborazione regolamento PDF...'}
+        </p>
+      </div>
+
+      {/* Stage list */}
+      <ol className="space-y-1 mb-3" aria-label="Fasi di elaborazione">
+        {PDF_STAGES.map((stage, i) => (
+          <li
+            key={stage.id}
+            className={`flex items-center gap-2 text-xs ${
+              i < stageIndex
+                ? 'text-teal-400'
+                : i === stageIndex
+                  ? 'text-amber-200 font-medium'
+                  : 'text-slate-500'
+            }`}
+          >
+            {i < stageIndex ? (
+              <CheckCircle2 className="h-3 w-3 shrink-0" />
+            ) : i === stageIndex && !isDone ? (
+              <Loader2 className="h-3 w-3 animate-spin shrink-0" />
+            ) : i === stageIndex && isDone ? (
+              <CheckCircle2 className="h-3 w-3 text-teal-400 shrink-0" />
+            ) : (
+              <span className="h-3 w-3 shrink-0 rounded-full border border-slate-600 inline-block" />
+            )}
+            {stage.label}
+          </li>
+        ))}
+      </ol>
+
+      {/* Progress bar */}
+      <div
+        className="w-full h-1 rounded-full bg-amber-900/40 overflow-hidden"
+        role="progressbar"
+        aria-valuenow={Math.round(progress)}
+        aria-valuemin={0}
+        aria-valuemax={100}
+      >
+        <div
+          className="h-full rounded-full bg-amber-400 transition-all duration-700 ease-in-out"
+          style={{ width: `${progress}%` }}
+        />
+      </div>
+    </div>
+  );
+}
+
+// ─── SuccessState ─────────────────────────────────────────────────────────────
 
 export interface SuccessStateProps {
   /** The saved game title */
@@ -26,6 +124,11 @@ export interface SuccessStateProps {
   onAutoClose: () => void;
   /** Auto-close delay in ms (default: 5000) */
   autoCloseDelay?: number;
+  /**
+   * Whether a PDF rulebook was uploaded. When true, shows the
+   * PdfProcessingBanner with animated pipeline stages (Task 23).
+   */
+  hasPdf?: boolean;
 }
 
 export function SuccessState({
@@ -35,6 +138,7 @@ export function SuccessState({
   onAddAnother,
   onAutoClose,
   autoCloseDelay = 5000,
+  hasPdf = false,
 }: SuccessStateProps) {
   const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined);
 
@@ -61,8 +165,11 @@ export function SuccessState({
         <span className="font-medium text-slate-300">{gameTitle}</span> è ora nella tua libreria.
       </p>
 
+      {/* PDF processing indicator */}
+      {hasPdf && <PdfProcessingBanner />}
+
       {/* Navigation links */}
-      <div className="flex flex-col gap-2.5 w-full max-w-xs">
+      <div className={`flex flex-col gap-2.5 w-full max-w-xs ${hasPdf ? 'mt-6' : ''}`}>
         <Button variant="default" className="w-full gap-2 bg-teal-600 hover:bg-teal-700" asChild>
           <Link href="/library">
             <Library className="h-4 w-4" />

--- a/apps/web/src/components/sessions/live/ArbitroModal.tsx
+++ b/apps/web/src/components/sessions/live/ArbitroModal.tsx
@@ -1,0 +1,197 @@
+/**
+ * ArbitroModal
+ *
+ * Game Night Improvvisata — Task 17
+ *
+ * Dialog that lets a player submit a rule dispute and shows the AI verdict.
+ * Triggers POST /api/v1/game-night/sessions/{sessionId}/disputes
+ */
+
+'use client';
+
+import { useState } from 'react';
+
+import { Loader2 } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '@/components/ui/overlays/dialog';
+import { api } from '@/lib/api';
+import type { RuleDisputeResponse } from '@/lib/api/schemas/improvvisata.schemas';
+import { useLiveSessionStore } from '@/lib/stores/live-session-store';
+
+import { ArbitroVerdictCard } from './ArbitroVerdictCard';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface ArbitroModalProps {
+  sessionId: string;
+  players: Array<{ name: string }>;
+  onVerdictReceived?: (verdict: RuleDisputeResponse) => void;
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function ArbitroModal({ sessionId, players, onVerdictReceived }: ArbitroModalProps) {
+  const [open, setOpen] = useState(false);
+  const [description, setDescription] = useState('');
+  const [raisedBy, setRaisedBy] = useState('');
+  const [isLoading, setIsLoading] = useState(false);
+  const [verdict, setVerdict] = useState<RuleDisputeResponse | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const addDispute = useLiveSessionStore(s => s.addDispute);
+
+  function handleOpenChange(next: boolean) {
+    setOpen(next);
+    if (!next) {
+      // Reset form on close
+      setDescription('');
+      setRaisedBy('');
+      setVerdict(null);
+      setError(null);
+    }
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    if (!description.trim() || !raisedBy) return;
+
+    setIsLoading(true);
+    setError(null);
+
+    try {
+      const result = await api.liveSessions.submitDispute(sessionId, description.trim(), raisedBy);
+      setVerdict(result);
+      onVerdictReceived?.(result);
+
+      // Persist to store so DisputeHistory picks it up
+      addDispute({
+        id: result.id,
+        description: description.trim(),
+        verdict: result.verdict,
+        ruleReferences: result.ruleReferences,
+        raisedByPlayerName: raisedBy,
+        timestamp: new Date().toISOString(),
+      });
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : 'Errore durante la richiesta.';
+      setError(message);
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  return (
+    <Dialog open={open} onOpenChange={handleOpenChange}>
+      <DialogTrigger asChild>
+        <Button variant="outline" size="sm">
+          ⚖️ Arbitro
+        </Button>
+      </DialogTrigger>
+
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle className="font-quicksand flex items-center gap-2">
+            <span>⚖️</span>
+            <span>Chiedi all&apos;Arbitro</span>
+          </DialogTitle>
+        </DialogHeader>
+
+        {/* Loading */}
+        {isLoading && (
+          <div className="flex flex-col items-center justify-center py-10 gap-3">
+            <Loader2 className="h-8 w-8 animate-spin text-amber-500" />
+            <p className="text-sm text-gray-500 font-nunito">
+              L&apos;arbitro sta analizzando il regolamento...
+            </p>
+          </div>
+        )}
+
+        {/* Verdict */}
+        {!isLoading && verdict && (
+          <div className="space-y-4">
+            <ArbitroVerdictCard verdict={verdict} />
+            <Button
+              variant="outline"
+              className="w-full font-nunito"
+              onClick={() => {
+                setVerdict(null);
+                setDescription('');
+                setRaisedBy('');
+              }}
+            >
+              Nuova disputa
+            </Button>
+          </div>
+        )}
+
+        {/* Form */}
+        {!isLoading && !verdict && (
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <div className="space-y-1.5">
+              <label
+                htmlFor="arbitro-description"
+                className="text-sm font-nunito font-medium text-gray-700"
+              >
+                Descrivi la disputa
+              </label>
+              <textarea
+                id="arbitro-description"
+                className="w-full min-h-[100px] rounded-lg border border-gray-300 px-3 py-2 text-sm font-nunito text-gray-900 placeholder-gray-400 focus:outline-none focus:ring-2 focus:ring-amber-400 focus:border-transparent resize-none"
+                placeholder="Es: È possibile giocare questa carta durante il turno dell'avversario?"
+                value={description}
+                onChange={e => setDescription(e.target.value)}
+                required
+              />
+            </div>
+
+            <div className="space-y-1.5">
+              <label
+                htmlFor="arbitro-raised-by"
+                className="text-sm font-nunito font-medium text-gray-700"
+              >
+                Sollevata da
+              </label>
+              <select
+                id="arbitro-raised-by"
+                className="w-full rounded-lg border border-gray-300 px-3 py-2 text-sm font-nunito text-gray-900 focus:outline-none focus:ring-2 focus:ring-amber-400 focus:border-transparent bg-white"
+                value={raisedBy}
+                onChange={e => setRaisedBy(e.target.value)}
+                required
+              >
+                <option value="" disabled>
+                  Seleziona il giocatore…
+                </option>
+                {players.map(p => (
+                  <option key={p.name} value={p.name}>
+                    {p.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+
+            {error && (
+              <p className="text-sm text-red-600 font-nunito" role="alert">
+                {error}
+              </p>
+            )}
+
+            <Button
+              type="submit"
+              className="w-full bg-amber-500 hover:bg-amber-600 text-white font-nunito"
+              disabled={!description.trim() || !raisedBy}
+            >
+              Chiedi all&apos;Arbitro
+            </Button>
+          </form>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/sessions/live/ArbitroVerdictCard.tsx
+++ b/apps/web/src/components/sessions/live/ArbitroVerdictCard.tsx
@@ -1,0 +1,50 @@
+/**
+ * ArbitroVerdictCard
+ *
+ * Game Night Improvvisata — Task 17
+ *
+ * Displays an AI rule-dispute verdict with amber border styling,
+ * rule references, and optional note.
+ */
+
+'use client';
+
+import type { RuleDisputeResponse } from '@/lib/api/schemas/improvvisata.schemas';
+
+interface ArbitroVerdictCardProps {
+  verdict: RuleDisputeResponse;
+}
+
+export function ArbitroVerdictCard({ verdict }: ArbitroVerdictCardProps) {
+  return (
+    <div className="border-2 border-amber-400 bg-amber-50 rounded-xl p-4 space-y-3">
+      {/* Header */}
+      <div className="flex items-center gap-2">
+        <span className="text-2xl" aria-hidden="true">
+          ⚖️
+        </span>
+        <h3 className="font-quicksand font-bold text-amber-900 text-base">Verdetto</h3>
+      </div>
+
+      {/* Verdict text */}
+      <p className="text-sm text-amber-900 font-nunito leading-relaxed">{verdict.verdict}</p>
+
+      {/* Rule references */}
+      {verdict.ruleReferences.length > 0 && (
+        <div className="flex items-start gap-1.5">
+          <span className="text-sm" aria-hidden="true">
+            📖
+          </span>
+          <p className="text-xs text-amber-700 font-nunito">{verdict.ruleReferences.join(' | ')}</p>
+        </div>
+      )}
+
+      {/* Optional note */}
+      {verdict.note && (
+        <p className="text-xs text-gray-500 font-nunito italic border-t border-amber-200 pt-2">
+          {verdict.note}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/sessions/live/DisputeHistory.tsx
+++ b/apps/web/src/components/sessions/live/DisputeHistory.tsx
@@ -1,0 +1,81 @@
+/**
+ * DisputeHistory
+ *
+ * Game Night Improvvisata — Task 17
+ *
+ * Collapsible section listing all rule dispute verdicts for the current session.
+ * When `gameId` is provided, it could fetch cross-session history (future extension);
+ * for now it reads from the live-session-store.
+ */
+
+'use client';
+
+import { useState } from 'react';
+
+import { ChevronDown, ChevronUp } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { useLiveSessionStore } from '@/lib/stores/live-session-store';
+
+import { ArbitroVerdictCard } from './ArbitroVerdictCard';
+
+interface DisputeHistoryProps {
+  sessionId: string;
+  /** Reserved for future cross-session history retrieval */
+
+  gameId?: string;
+}
+
+export function DisputeHistory({ sessionId: _sessionId }: DisputeHistoryProps) {
+  const disputes = useLiveSessionStore(s => s.disputes);
+  const [isOpen, setIsOpen] = useState(false);
+
+  if (disputes.length === 0) {
+    return null;
+  }
+
+  return (
+    <div className="space-y-2">
+      {/* Toggle button */}
+      <Button
+        variant="ghost"
+        size="sm"
+        className="w-full justify-between font-nunito text-gray-600 hover:text-gray-800"
+        onClick={() => setIsOpen(prev => !prev)}
+        aria-expanded={isOpen}
+      >
+        <span className="flex items-center gap-2">
+          <span>⚖️</span>
+          <span>Verdetti precedenti ({disputes.length})</span>
+        </span>
+        {isOpen ? <ChevronUp className="h-4 w-4" /> : <ChevronDown className="h-4 w-4" />}
+      </Button>
+
+      {/* Collapsible content */}
+      {isOpen && (
+        <div className="space-y-3 pt-1">
+          {disputes.map(dispute => (
+            <div key={dispute.id} className="space-y-1.5">
+              {/* Dispute description */}
+              <p className="text-xs text-gray-500 font-nunito px-1">
+                <span className="font-medium text-gray-700">{dispute.raisedByPlayerName}</span>
+                {' — '}
+                {dispute.description}
+              </p>
+
+              {/* Verdict card */}
+              <ArbitroVerdictCard
+                verdict={{
+                  id: dispute.id,
+                  verdict: dispute.verdict,
+                  ruleReferences: dispute.ruleReferences,
+                  note: null,
+                }}
+              />
+            </div>
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/sessions/live/GuestScoreProposal.tsx
+++ b/apps/web/src/components/sessions/live/GuestScoreProposal.tsx
@@ -1,0 +1,138 @@
+/**
+ * GuestScoreProposal
+ *
+ * Game Night Improvvisata — Task 18
+ *
+ * Form for a guest player to propose a score delta for themselves.
+ * Business rules:
+ *   - Self-only: guest can only propose for themselves
+ *   - Delta range: -100 to +100
+ *   - Max 3 pending proposals per guest
+ */
+
+'use client';
+
+import { useState } from 'react';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { useLiveSessionStore, type ScoreProposal } from '@/lib/stores/live-session-store';
+
+const MAX_PENDING = 3;
+const MIN_DELTA = -100;
+const MAX_DELTA = 100;
+
+interface GuestScoreProposalProps {
+  guestName: string;
+  onPropose: (delta: number) => Promise<void>;
+}
+
+export function GuestScoreProposal({ guestName, onPropose }: GuestScoreProposalProps) {
+  const [delta, setDelta] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [lastSubmitted, setLastSubmitted] = useState<number | null>(null);
+
+  const pendingProposals = useLiveSessionStore(s => s.pendingProposals);
+  const myPendingCount = pendingProposals.filter(
+    (p: ScoreProposal) => p.playerName === guestName
+  ).length;
+
+  const atLimit = myPendingCount >= MAX_PENDING;
+
+  function validate(value: string): string | null {
+    const num = parseInt(value, 10);
+    if (isNaN(num)) return 'Inserisci un numero valido';
+    if (num < MIN_DELTA || num > MAX_DELTA) return `Valore tra ${MIN_DELTA} e +${MAX_DELTA}`;
+    return null;
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    const validationError = validate(delta);
+    if (validationError) {
+      setError(validationError);
+      return;
+    }
+    if (atLimit) {
+      setError(`Hai già ${MAX_PENDING} proposte in attesa`);
+      return;
+    }
+
+    setError(null);
+    setIsSubmitting(true);
+    try {
+      const num = parseInt(delta, 10);
+      await onPropose(num);
+      setLastSubmitted(num);
+      setDelta('');
+    } catch {
+      setError("Errore durante l'invio. Riprova.");
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  return (
+    <div className="rounded-xl bg-white/70 backdrop-blur-md border border-white/40 shadow-sm p-4 space-y-3">
+      <div className="flex items-center justify-between">
+        <h3 className="font-quicksand font-semibold text-gray-900 text-sm">Proponi punteggio</h3>
+        {myPendingCount > 0 && (
+          <Badge variant="outline" className="text-xs">
+            {myPendingCount}/{MAX_PENDING} in attesa
+          </Badge>
+        )}
+      </div>
+
+      {atLimit ? (
+        <p className="text-sm text-amber-700 font-nunito bg-amber-50 rounded-lg p-3 border border-amber-200">
+          Hai raggiunto il limite di {MAX_PENDING} proposte in attesa. Attendi che l&apos;host le
+          approvi.
+        </p>
+      ) : (
+        <form onSubmit={handleSubmit} className="space-y-2">
+          <div className="flex gap-2">
+            <Input
+              type="number"
+              min={MIN_DELTA}
+              max={MAX_DELTA}
+              value={delta}
+              onChange={e => {
+                setDelta(e.target.value);
+                setError(null);
+              }}
+              placeholder="es. +5 o -3"
+              className="flex-1 font-mono text-center"
+              aria-label="Delta punteggio"
+              disabled={isSubmitting}
+            />
+            <Button
+              type="submit"
+              size="sm"
+              disabled={isSubmitting || !delta}
+              className="bg-amber-500 hover:bg-amber-600 text-white"
+            >
+              {isSubmitting ? 'Invio...' : 'Proponi'}
+            </Button>
+          </div>
+          {error && (
+            <p className="text-xs text-red-600 font-nunito" role="alert">
+              {error}
+            </p>
+          )}
+          <p className="text-xs text-gray-500 font-nunito">
+            Proposta per: <span className="font-semibold">{guestName}</span>
+          </p>
+        </form>
+      )}
+
+      {lastSubmitted !== null && !atLimit && (
+        <p className="text-xs text-green-700 font-nunito" role="status">
+          Proposta di {lastSubmitted >= 0 ? `+${lastSubmitted}` : lastSubmitted} inviata. Attendi
+          approvazione.
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/src/components/sessions/live/InviteModal.tsx
+++ b/apps/web/src/components/sessions/live/InviteModal.tsx
@@ -1,0 +1,122 @@
+/**
+ * InviteModal
+ *
+ * Game Night Improvvisata — Task 19
+ *
+ * Dialog showing a QR code and invite code so the host can invite guests.
+ * Uses qrcode.react (already installed as a project dependency).
+ */
+
+'use client';
+
+import { useState } from 'react';
+
+import { Check, Copy } from 'lucide-react';
+import { QRCodeSVG } from 'qrcode.react';
+
+import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/overlays/dialog';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface InviteModalProps {
+  /** The short invite code (e.g. "ABC123") */
+  inviteCode: string;
+  /** Full share URL shown as QR code (e.g. "https://app.meepleai.it/join/ABC123") */
+  shareLink: string;
+  /** Controls dialog visibility */
+  isOpen: boolean;
+  /** Called when dialog should close */
+  onClose: () => void;
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function InviteModal({ inviteCode, shareLink, isOpen, onClose }: InviteModalProps) {
+  const [copied, setCopied] = useState(false);
+
+  async function handleCopy() {
+    try {
+      await navigator.clipboard.writeText(shareLink);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Fallback: select the text via execCommand (older browsers)
+      const input = document.createElement('input');
+      input.value = shareLink;
+      document.body.appendChild(input);
+      input.select();
+      document.execCommand('copy');
+      document.body.removeChild(input);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    }
+  }
+
+  return (
+    <Dialog open={isOpen} onOpenChange={open => !open && onClose()}>
+      <DialogContent className="max-w-xs text-center sm:max-w-sm">
+        <DialogHeader>
+          <DialogTitle className="font-quicksand text-xl font-bold text-center">
+            Invita giocatori
+          </DialogTitle>
+        </DialogHeader>
+
+        {/* QR Code */}
+        <div className="flex justify-center my-2">
+          <div
+            className="rounded-2xl bg-white p-4 shadow-md border border-gray-100"
+            data-testid="qr-container"
+          >
+            <QRCodeSVG
+              value={shareLink}
+              size={180}
+              bgColor="#ffffff"
+              fgColor="#1c1917"
+              level="M"
+              aria-label={`QR code per il link ${shareLink}`}
+            />
+          </div>
+        </div>
+
+        {/* Session code */}
+        <div className="space-y-1 mt-1">
+          <p className="text-xs text-gray-500 font-nunito uppercase tracking-wider">
+            Codice sessione
+          </p>
+          <p
+            className="text-3xl font-mono font-bold text-gray-900 tracking-widest"
+            data-testid="invite-code"
+          >
+            {inviteCode}
+          </p>
+        </div>
+
+        {/* Share link (truncated display) */}
+        <p className="text-xs text-gray-400 font-nunito truncate px-2" title={shareLink}>
+          {shareLink}
+        </p>
+
+        {/* Copy button */}
+        <Button
+          onClick={handleCopy}
+          variant="outline"
+          className="w-full font-nunito gap-2 mt-2"
+          data-testid="copy-link-button"
+        >
+          {copied ? (
+            <>
+              <Check className="h-4 w-4 text-green-600" />
+              <span className="text-green-600">Link copiato!</span>
+            </>
+          ) : (
+            <>
+              <Copy className="h-4 w-4" />
+              Copia link
+            </>
+          )}
+        </Button>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/sessions/live/PlayerList.tsx
+++ b/apps/web/src/components/sessions/live/PlayerList.tsx
@@ -1,0 +1,130 @@
+/**
+ * PlayerList
+ *
+ * Game Night Improvvisata — Task 21
+ *
+ * Renders session players with online/offline indicator and host crown.
+ * Provides an "Invita" button that opens the InviteModal.
+ */
+
+'use client';
+
+import { useState } from 'react';
+
+import { Crown, UserPlus } from 'lucide-react';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { useLiveSessionStore, type PlayerInfo } from '@/lib/stores/live-session-store';
+
+import { InviteModal } from './InviteModal';
+
+// ─── Sub-components ───────────────────────────────────────────────────────────
+
+interface OnlineDotProps {
+  isOnline: boolean;
+}
+
+function OnlineDot({ isOnline }: OnlineDotProps) {
+  return (
+    <span
+      className={[
+        'h-2.5 w-2.5 rounded-full shrink-0',
+        isOnline ? 'bg-green-400 shadow-sm shadow-green-200' : 'bg-gray-300',
+      ].join(' ')}
+      aria-label={isOnline ? 'Online' : 'Offline'}
+    />
+  );
+}
+
+interface PlayerRowProps {
+  player: PlayerInfo;
+}
+
+function PlayerRow({ player }: PlayerRowProps) {
+  return (
+    <div className="flex items-center gap-3 rounded-xl bg-white/70 backdrop-blur-md border border-white/40 shadow-sm px-4 py-3">
+      <OnlineDot isOnline={player.isOnline} />
+
+      <span className="flex-1 font-nunito text-sm font-medium text-gray-900 truncate">
+        {player.name}
+      </span>
+
+      {player.isHost && (
+        <Badge
+          variant="outline"
+          className="bg-amber-50 border-amber-200 text-amber-700 gap-1 text-xs font-nunito"
+        >
+          <Crown className="h-3 w-3" />
+          Host
+        </Badge>
+      )}
+
+      {!player.isHost && (
+        <span className="text-xs text-gray-400 font-nunito">
+          {player.isOnline ? 'Online' : 'Offline'}
+        </span>
+      )}
+    </div>
+  );
+}
+
+// ─── Main Component ────────────────────────────────────────────────────────────
+
+interface PlayerListProps {
+  sessionId: string;
+  inviteCode: string;
+  shareLink: string;
+}
+
+export function PlayerList({ sessionId: _sessionId, inviteCode, shareLink }: PlayerListProps) {
+  const players = useLiveSessionStore(s => s.players);
+  const [showInvite, setShowInvite] = useState(false);
+
+  const onlineCount = players.filter((p: PlayerInfo) => p.isOnline).length;
+
+  return (
+    <div className="space-y-4 p-4">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h2 className="text-xl font-quicksand font-bold text-gray-900">Giocatori</h2>
+          <p className="text-xs text-gray-500 font-nunito mt-0.5">
+            {onlineCount}/{players.length} online
+          </p>
+        </div>
+        <Button
+          size="sm"
+          variant="outline"
+          className="gap-2 font-nunito"
+          onClick={() => setShowInvite(true)}
+          data-testid="invite-button"
+        >
+          <UserPlus className="h-4 w-4" />
+          Invita
+        </Button>
+      </div>
+
+      {/* Player list */}
+      {players.length === 0 ? (
+        <p className="text-sm text-gray-500 font-nunito text-center py-8">
+          Nessun giocatore registrato.
+        </p>
+      ) : (
+        <div className="space-y-2">
+          {players.map((player: PlayerInfo) => (
+            <PlayerRow key={player.id} player={player} />
+          ))}
+        </div>
+      )}
+
+      {/* Invite Modal */}
+      <InviteModal
+        inviteCode={inviteCode}
+        shareLink={shareLink}
+        isOpen={showInvite}
+        onClose={() => setShowInvite(false)}
+      />
+    </div>
+  );
+}

--- a/apps/web/src/components/sessions/live/SaveSessionModal.tsx
+++ b/apps/web/src/components/sessions/live/SaveSessionModal.tsx
@@ -1,0 +1,133 @@
+/**
+ * SaveSessionModal
+ *
+ * Game Night Improvvisata — Task 20
+ *
+ * Confirmation dialog for "Salva & Esci":
+ *   1. Asks the user to confirm saving
+ *   2. Calls createPauseSnapshot()
+ *   3. On success → redirect to library
+ */
+
+'use client';
+
+import { useState } from 'react';
+
+import { Camera, Loader2, Save } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+
+import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/overlays/dialog';
+import { api } from '@/lib/api';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+export interface SaveSessionModalProps {
+  sessionId: string;
+  gameName: string;
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export function SaveSessionModal({ sessionId, gameName, isOpen, onClose }: SaveSessionModalProps) {
+  const router = useRouter();
+  const [isSaving, setIsSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [savedOk, setSavedOk] = useState(false);
+
+  async function handleSave() {
+    setError(null);
+    setIsSaving(true);
+    try {
+      await api.liveSessions.createPauseSnapshot(sessionId);
+      setSavedOk(true);
+      // Brief success flash before redirect
+      setTimeout(() => {
+        router.push('/library');
+      }, 800);
+    } catch {
+      setError('Impossibile salvare la partita. Riprova.');
+    } finally {
+      setIsSaving(false);
+    }
+  }
+
+  return (
+    <Dialog open={isOpen} onOpenChange={open => !open && !isSaving && onClose()}>
+      <DialogContent className="max-w-sm">
+        <DialogHeader>
+          <DialogTitle className="font-quicksand text-xl font-bold flex items-center gap-2">
+            <Save className="h-5 w-5 text-amber-500" />
+            Salva &amp; Esci
+          </DialogTitle>
+        </DialogHeader>
+
+        <div className="space-y-4 py-2">
+          {/* Confirmation message */}
+          <p className="text-sm font-nunito text-gray-600">
+            Vuoi salvare lo stato della partita{' '}
+            <span className="font-semibold text-gray-900">{gameName}</span>?
+          </p>
+          <p className="text-xs font-nunito text-gray-500">
+            Potrai riprendere da dove hai lasciato in qualsiasi momento.
+          </p>
+
+          {/* Optional photo prompt */}
+          <div className="flex items-center gap-2 rounded-lg bg-amber-50 border border-amber-200 p-3 text-sm text-amber-800 font-nunito">
+            <Camera className="h-4 w-4 shrink-0 text-amber-600" />
+            <span>
+              Consiglio: scatta una foto del tabellone prima di uscire per ricordare la situazione.
+            </span>
+          </div>
+
+          {/* Error */}
+          {error && (
+            <p className="text-xs text-red-600 font-nunito" role="alert">
+              {error}
+            </p>
+          )}
+
+          {/* Success flash */}
+          {savedOk && (
+            <p
+              className="text-sm text-green-700 font-nunito text-center font-semibold"
+              role="status"
+            >
+              Partita salvata! Ritorno alla libreria...
+            </p>
+          )}
+        </div>
+
+        {/* Actions */}
+        <div className="flex gap-2 pt-2">
+          <Button
+            variant="outline"
+            className="flex-1 font-nunito"
+            onClick={onClose}
+            disabled={isSaving || savedOk}
+            data-testid="cancel-save"
+          >
+            Annulla
+          </Button>
+          <Button
+            className="flex-1 bg-amber-500 hover:bg-amber-600 text-white font-nunito font-semibold"
+            onClick={handleSave}
+            disabled={isSaving || savedOk}
+            data-testid="confirm-save"
+          >
+            {isSaving ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Salvataggio...
+              </>
+            ) : (
+              'Salva partita'
+            )}
+          </Button>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/sessions/live/ScoreBoard.tsx
+++ b/apps/web/src/components/sessions/live/ScoreBoard.tsx
@@ -1,0 +1,238 @@
+/**
+ * ScoreBoard
+ *
+ * Game Night Improvvisata — Task 16
+ *
+ * Displays per-player scores from the live-session-store.
+ * Host sees +/− buttons to adjust scores and approve/reject pending proposals.
+ */
+
+'use client';
+
+import { CheckCircle, Crown, Minus, Plus, XCircle } from 'lucide-react';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { useSessionScores } from '@/lib/hooks/use-session-scores';
+import { useSignalRSession } from '@/lib/hooks/use-signalr-session';
+import {
+  useLiveSessionStore,
+  type PlayerInfo,
+  type ScoreProposal,
+} from '@/lib/stores/live-session-store';
+
+// ─── PlayerScoreCard ──────────────────────────────────────────────────────────
+
+interface PlayerScoreCardProps {
+  player: PlayerInfo;
+  score: number;
+  isLeader: boolean;
+  isHost: boolean;
+  onIncrement: () => void;
+  onDecrement: () => void;
+}
+
+function PlayerScoreCard({
+  player,
+  score,
+  isLeader,
+  isHost,
+  onIncrement,
+  onDecrement,
+}: PlayerScoreCardProps) {
+  return (
+    <div
+      className={[
+        'rounded-xl border p-3 space-y-2 transition-shadow',
+        isLeader
+          ? 'bg-amber-50 border-amber-300 shadow-md shadow-amber-100'
+          : 'bg-white/70 backdrop-blur-md border-white/40 shadow-sm',
+        player.isOnline ? '' : 'opacity-60',
+      ]
+        .filter(Boolean)
+        .join(' ')}
+    >
+      {/* Player name + leader badge */}
+      <div className="flex items-center justify-between gap-1">
+        <span className="font-quicksand font-semibold text-sm truncate text-gray-900">
+          {player.name}
+        </span>
+        {isLeader && <Crown className="h-4 w-4 shrink-0 text-amber-500" aria-label="Leader" />}
+      </div>
+
+      {/* Score */}
+      <p className="text-2xl font-quicksand font-bold text-gray-900">{score}</p>
+
+      {/* Online indicator */}
+      <div className="flex items-center gap-1">
+        <span
+          className={[
+            'h-2 w-2 rounded-full',
+            player.isOnline ? 'bg-green-400' : 'bg-gray-300',
+          ].join(' ')}
+        />
+        <span className="text-xs text-gray-500 font-nunito">
+          {player.isOnline ? 'Online' : 'Offline'}
+        </span>
+      </div>
+
+      {/* Host controls */}
+      {isHost && (
+        <div className="flex gap-1 pt-1">
+          <Button
+            variant="outline"
+            size="sm"
+            className="flex-1 h-8 px-2"
+            onClick={onDecrement}
+            aria-label={`Decrementa punteggio di ${player.name}`}
+          >
+            <Minus className="h-3 w-3" />
+          </Button>
+          <Button
+            variant="outline"
+            size="sm"
+            className="flex-1 h-8 px-2"
+            onClick={onIncrement}
+            aria-label={`Incrementa punteggio di ${player.name}`}
+          >
+            <Plus className="h-3 w-3" />
+          </Button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── ProposalCard ─────────────────────────────────────────────────────────────
+
+interface ProposalCardProps {
+  proposal: ScoreProposal;
+  onApprove: () => void;
+  onReject: () => void;
+}
+
+function ProposalCard({ proposal, onApprove, onReject }: ProposalCardProps) {
+  const deltaLabel = proposal.delta >= 0 ? `+${proposal.delta}` : String(proposal.delta);
+
+  return (
+    <div className="flex items-center justify-between gap-3 rounded-lg bg-white border border-gray-200 px-3 py-2 shadow-sm">
+      <div className="flex items-center gap-2 min-w-0">
+        <Badge variant="outline" className="shrink-0 font-mono text-xs">
+          {deltaLabel}
+        </Badge>
+        <span className="text-sm font-nunito text-gray-700 truncate">{proposal.playerName}</span>
+      </div>
+
+      <div className="flex gap-1 shrink-0">
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-7 w-7 p-0 text-green-600 hover:text-green-700 hover:bg-green-50"
+          onClick={onApprove}
+          aria-label="Approva proposta"
+        >
+          <CheckCircle className="h-4 w-4" />
+        </Button>
+        <Button
+          variant="ghost"
+          size="sm"
+          className="h-7 w-7 p-0 text-red-500 hover:text-red-600 hover:bg-red-50"
+          onClick={onReject}
+          aria-label="Rifiuta proposta"
+        >
+          <XCircle className="h-4 w-4" />
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+// ─── ScoreBoard ────────────────────────────────────────────────────────────────
+
+interface ScoreBoardProps {
+  sessionId: string;
+  isHost?: boolean;
+}
+
+export function ScoreBoard({ sessionId, isHost = false }: ScoreBoardProps) {
+  const { scores, players, pendingProposals, leader } = useSessionScores(sessionId);
+  const resolveProposal = useLiveSessionStore(s => s.resolveProposal);
+  const updateScore = useLiveSessionStore(s => s.updateScore);
+
+  const { sendScore } = useSignalRSession(sessionId);
+
+  function handleScoreChange(playerName: string, delta: number) {
+    const current = scores[playerName] ?? 0;
+    const next = Math.max(0, current + delta);
+    updateScore(playerName, next);
+    sendScore(playerName, next).catch((err: unknown) => {
+      console.error('[ScoreBoard] sendScore failed:', err);
+    });
+  }
+
+  function handleApprove(proposal: ScoreProposal) {
+    resolveProposal(proposal.id, true);
+    const next = (scores[proposal.playerName] ?? 0) + proposal.delta;
+    sendScore(proposal.playerName, next).catch((err: unknown) => {
+      console.error('[ScoreBoard] sendScore (approve) failed:', err);
+    });
+  }
+
+  function handleReject(proposalId: string) {
+    resolveProposal(proposalId, false);
+  }
+
+  return (
+    <div className="space-y-6 p-4">
+      <h2 className="text-xl font-quicksand font-bold text-gray-900">Punteggi</h2>
+
+      {/* Empty state */}
+      {players.length === 0 && (
+        <p className="text-sm text-gray-500 font-nunito text-center py-8">
+          Nessun giocatore ancora registrato.
+        </p>
+      )}
+
+      {/* Player score cards */}
+      {players.length > 0 && (
+        <div className="grid grid-cols-2 gap-3">
+          {players.map(player => (
+            <PlayerScoreCard
+              key={player.id}
+              player={player}
+              score={scores[player.name] ?? 0}
+              isLeader={player.name === leader}
+              isHost={isHost}
+              onIncrement={() => handleScoreChange(player.name, 1)}
+              onDecrement={() => handleScoreChange(player.name, -1)}
+            />
+          ))}
+        </div>
+      )}
+
+      {/* Pending proposals — host only */}
+      {isHost && pendingProposals.length > 0 && (
+        <div className="space-y-2">
+          <h3 className="text-sm font-semibold text-gray-500 font-nunito uppercase tracking-wide">
+            Proposte in attesa
+          </h3>
+          <div className="space-y-2">
+            {pendingProposals.map(p => (
+              <ProposalCard
+                key={p.id}
+                proposal={p}
+                onApprove={() => handleApprove(p)}
+                onReject={() => handleReject(p.id)}
+              />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {/* New round button */}
+      <Button variant="outline" className="w-full font-nunito">
+        Nuovo Round
+      </Button>
+    </div>
+  );
+}

--- a/apps/web/src/components/sessions/live/SessionCardParent.tsx
+++ b/apps/web/src/components/sessions/live/SessionCardParent.tsx
@@ -1,0 +1,147 @@
+/**
+ * SessionCardParent
+ *
+ * Game Night Improvvisata — Task 15
+ *
+ * Main session overview card showing game name, status badge, player count,
+ * connection state, pending proposals, and quick action buttons.
+ */
+
+'use client';
+
+import { Loader2, Pause, UserPlus } from 'lucide-react';
+import Link from 'next/link';
+
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { useSignalRSession } from '@/lib/hooks/use-signalr-session';
+import { useLiveSessionStore, type SessionStatus } from '@/lib/stores/live-session-store';
+
+// ─── Sub-components ───────────────────────────────────────────────────────────
+
+interface StatusBadgeProps {
+  status: SessionStatus;
+}
+
+function StatusBadge({ status }: StatusBadgeProps) {
+  const map: Record<SessionStatus, { label: string; className: string }> = {
+    InProgress: {
+      label: 'In corso',
+      className: 'bg-green-100 text-green-800 border-green-200',
+    },
+    Paused: {
+      label: 'In pausa',
+      className: 'bg-amber-100 text-amber-800 border-amber-200',
+    },
+    Completed: {
+      label: 'Completata',
+      className: 'bg-gray-100 text-gray-700 border-gray-200',
+    },
+  };
+
+  const { label, className } = map[status];
+
+  return (
+    <Badge variant="outline" className={className}>
+      {label}
+    </Badge>
+  );
+}
+
+interface InfoCardProps {
+  label: string;
+  value: string;
+}
+
+function InfoCard({ label, value }: InfoCardProps) {
+  return (
+    <div className="rounded-xl bg-white/70 backdrop-blur-md border border-white/40 p-3 text-center shadow-sm">
+      <p className="text-xs text-gray-500 font-nunito mb-1">{label}</p>
+      <p className="text-lg font-quicksand font-bold text-gray-900">{value}</p>
+    </div>
+  );
+}
+
+// ─── Main Component ────────────────────────────────────────────────────────────
+
+interface SessionCardParentProps {
+  sessionId: string;
+}
+
+export function SessionCardParent({ sessionId }: SessionCardParentProps) {
+  const gameName = useLiveSessionStore(s => s.gameName);
+  const status = useLiveSessionStore(s => s.status);
+  const players = useLiveSessionStore(s => s.players);
+  const currentTurn = useLiveSessionStore(s => s.currentTurn);
+  const pendingProposals = useLiveSessionStore(s => s.pendingProposals);
+  const isOffline = useLiveSessionStore(s => s.isOffline);
+
+  const { isConnected } = useSignalRSession(sessionId);
+
+  const onlinePlayers = players.filter(p => p.isOnline).length;
+
+  return (
+    <div className="space-y-6 p-4">
+      {/* Offline banner */}
+      {isOffline && (
+        <div className="flex items-center gap-2 rounded-lg bg-red-50 border border-red-200 p-3 text-red-800 text-sm font-nunito">
+          <Loader2 className="h-4 w-4 animate-spin shrink-0" />
+          <span>Connessione persa — tentativo di riconnessione...</span>
+        </div>
+      )}
+
+      {/* Header */}
+      <div className="flex items-center justify-between gap-3">
+        <h1 className="text-2xl font-quicksand font-bold text-gray-900 truncate">
+          {gameName || 'Sessione'}
+        </h1>
+        <StatusBadge status={status} />
+      </div>
+
+      {/* Info grid */}
+      <div className="grid grid-cols-3 gap-3">
+        <InfoCard label="Turno" value={String(currentTurn)} />
+        <InfoCard
+          label="Giocatori"
+          value={players.length > 0 ? `${onlinePlayers}/${players.length}` : '—'}
+        />
+        <InfoCard label="Rete" value={isConnected ? 'Online' : 'Offline'} />
+      </div>
+
+      {/* Pending proposals alert */}
+      {pendingProposals.length > 0 && (
+        <Link href={`/sessions/live/${sessionId}/scores`}>
+          <div className="cursor-pointer rounded-xl bg-amber-50 border border-amber-200 p-4 text-amber-900 text-sm font-nunito hover:bg-amber-100 transition-colors">
+            <span className="font-semibold">{pendingProposals.length}</span>{' '}
+            {pendingProposals.length === 1
+              ? 'proposta di punteggio in attesa'
+              : 'proposte di punteggio in attesa'}
+            {' — '}
+            <span className="underline underline-offset-2">Vai ai punteggi</span>
+          </div>
+        </Link>
+      )}
+
+      {/* Quick actions */}
+      <div className="flex flex-wrap gap-2">
+        <Button variant="outline" size="sm" asChild>
+          <Link href={`/sessions/live/${sessionId}/players`}>
+            <UserPlus className="mr-2 h-4 w-4" />
+            Invita
+          </Link>
+        </Button>
+
+        <Button variant="outline" size="sm" asChild>
+          <Link href={`/sessions/live/${sessionId}/save`}>
+            <Pause className="mr-2 h-4 w-4" />
+            Pausa
+          </Link>
+        </Button>
+
+        <Button variant="destructive" size="sm" asChild>
+          <Link href={`/sessions/live/${sessionId}/save`}>Salva &amp; Esci</Link>
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/sessions/live/SessionNavConfig.tsx
+++ b/apps/web/src/components/sessions/live/SessionNavConfig.tsx
@@ -1,0 +1,65 @@
+/**
+ * SessionNavConfig
+ *
+ * Game Night Improvvisata — Task 15
+ *
+ * Registers MiniNav tabs for the live session section.
+ * Renders null — purely declarative navigation config.
+ *
+ * Tabs: Partita · Chat AI · Punteggi · Foto · Giocatori
+ */
+
+'use client';
+
+import { useEffect } from 'react';
+
+import { Bot, Camera, LayoutDashboard, Trophy, Users } from 'lucide-react';
+
+import { useSetNavConfig } from '@/context/NavigationContext';
+
+interface SessionNavConfigProps {
+  sessionId: string;
+}
+
+export function SessionNavConfig({ sessionId }: SessionNavConfigProps) {
+  const setNavConfig = useSetNavConfig();
+
+  useEffect(() => {
+    setNavConfig({
+      miniNav: [
+        {
+          id: 'partita',
+          label: 'Partita',
+          href: `/sessions/live/${sessionId}`,
+          icon: LayoutDashboard,
+        },
+        {
+          id: 'agent',
+          label: 'Chat AI',
+          href: `/sessions/live/${sessionId}/agent`,
+          icon: Bot,
+        },
+        {
+          id: 'scores',
+          label: 'Punteggi',
+          href: `/sessions/live/${sessionId}/scores`,
+          icon: Trophy,
+        },
+        {
+          id: 'photos',
+          label: 'Foto',
+          href: `/sessions/live/${sessionId}/photos`,
+          icon: Camera,
+        },
+        {
+          id: 'players',
+          label: 'Giocatori',
+          href: `/sessions/live/${sessionId}/players`,
+          icon: Users,
+        },
+      ],
+    });
+  }, [sessionId, setNavConfig]);
+
+  return null;
+}

--- a/apps/web/src/components/sessions/live/__tests__/ArbitroModal.test.tsx
+++ b/apps/web/src/components/sessions/live/__tests__/ArbitroModal.test.tsx
@@ -1,0 +1,205 @@
+/**
+ * ArbitroModal Tests
+ *
+ * Game Night Improvvisata — Task 17
+ */
+
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { ArbitroModal } from '../ArbitroModal';
+
+// ─── Mock API ─────────────────────────────────────────────────────────────────
+
+const mockSubmitDispute = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    liveSessions: {
+      submitDispute: mockSubmitDispute,
+    },
+  },
+}));
+
+// ─── Mock store ───────────────────────────────────────────────────────────────
+
+const mockAddDispute = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/stores/live-session-store', () => ({
+  useLiveSessionStore: (selector: (s: Record<string, unknown>) => unknown) => {
+    const state = { addDispute: mockAddDispute };
+    return selector(state);
+  },
+}));
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const mockPlayers = [{ name: 'Alice' }, { name: 'Bob' }];
+
+const mockVerdict = {
+  id: 'verdict-uuid',
+  verdict: 'Sì, la carta può essere giocata.',
+  ruleReferences: ['Regola 4.2', 'Regola 7.1'],
+  note: null,
+};
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('ArbitroModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders the trigger button', () => {
+    render(<ArbitroModal sessionId="sess-1" players={mockPlayers} />);
+    expect(screen.getByRole('button', { name: /arbitro/i })).toBeInTheDocument();
+  });
+
+  it('opens the dialog on trigger click', async () => {
+    render(<ArbitroModal sessionId="sess-1" players={mockPlayers} />);
+    const trigger = screen.getByRole('button', { name: /arbitro/i });
+    await userEvent.click(trigger);
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+  });
+
+  it('shows textarea and player select inside the dialog', async () => {
+    render(<ArbitroModal sessionId="sess-1" players={mockPlayers} />);
+    await userEvent.click(screen.getByRole('button', { name: /arbitro/i }));
+
+    expect(screen.getByLabelText('Descrivi la disputa')).toBeInTheDocument();
+    expect(screen.getByLabelText('Sollevata da')).toBeInTheDocument();
+  });
+
+  it('shows player options in the select', async () => {
+    render(<ArbitroModal sessionId="sess-1" players={mockPlayers} />);
+    await userEvent.click(screen.getByRole('button', { name: /arbitro/i }));
+
+    expect(screen.getByRole('option', { name: 'Alice' })).toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Bob' })).toBeInTheDocument();
+  });
+
+  it('submit button is disabled when form is empty', async () => {
+    render(<ArbitroModal sessionId="sess-1" players={mockPlayers} />);
+    await userEvent.click(screen.getByRole('button', { name: /arbitro/i }));
+
+    const submitBtn = screen.getByRole('button', { name: /chiedi all'arbitro/i });
+    expect(submitBtn).toBeDisabled();
+  });
+
+  it('submit calls api with correct params', async () => {
+    mockSubmitDispute.mockResolvedValue(mockVerdict);
+
+    render(<ArbitroModal sessionId="sess-1" players={mockPlayers} />);
+    await userEvent.click(screen.getByRole('button', { name: /arbitro/i }));
+
+    await userEvent.type(
+      screen.getByLabelText('Descrivi la disputa'),
+      'Posso giocare questa carta?'
+    );
+
+    fireEvent.change(screen.getByLabelText('Sollevata da'), {
+      target: { value: 'Alice' },
+    });
+
+    const submitBtn = screen.getByRole('button', { name: /chiedi all'arbitro/i });
+    await userEvent.click(submitBtn);
+
+    expect(mockSubmitDispute).toHaveBeenCalledWith(
+      'sess-1',
+      'Posso giocare questa carta?',
+      'Alice'
+    );
+  });
+
+  it('shows loading state while API call is in progress', async () => {
+    // Never resolves to keep loading state
+    mockSubmitDispute.mockReturnValue(new Promise(() => {}));
+
+    render(<ArbitroModal sessionId="sess-1" players={mockPlayers} />);
+    await userEvent.click(screen.getByRole('button', { name: /arbitro/i }));
+
+    await userEvent.type(screen.getByLabelText('Descrivi la disputa'), 'Test dispute');
+    fireEvent.change(screen.getByLabelText('Sollevata da'), { target: { value: 'Bob' } });
+
+    await userEvent.click(screen.getByRole('button', { name: /chiedi all'arbitro/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/analizzando il regolamento/i)).toBeInTheDocument();
+    });
+  });
+
+  it('displays the verdict card on successful API response', async () => {
+    mockSubmitDispute.mockResolvedValue(mockVerdict);
+
+    render(<ArbitroModal sessionId="sess-1" players={mockPlayers} />);
+    await userEvent.click(screen.getByRole('button', { name: /arbitro/i }));
+
+    await userEvent.type(screen.getByLabelText('Descrivi la disputa'), 'Test');
+    fireEvent.change(screen.getByLabelText('Sollevata da'), { target: { value: 'Alice' } });
+    await userEvent.click(screen.getByRole('button', { name: /chiedi all'arbitro/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText('Verdetto')).toBeInTheDocument();
+      expect(screen.getByText('Sì, la carta può essere giocata.')).toBeInTheDocument();
+    });
+  });
+
+  it('calls onVerdictReceived callback with verdict', async () => {
+    mockSubmitDispute.mockResolvedValue(mockVerdict);
+    const onVerdictReceived = vi.fn();
+
+    render(
+      <ArbitroModal
+        sessionId="sess-1"
+        players={mockPlayers}
+        onVerdictReceived={onVerdictReceived}
+      />
+    );
+    await userEvent.click(screen.getByRole('button', { name: /arbitro/i }));
+
+    await userEvent.type(screen.getByLabelText('Descrivi la disputa'), 'Test');
+    fireEvent.change(screen.getByLabelText('Sollevata da'), { target: { value: 'Alice' } });
+    await userEvent.click(screen.getByRole('button', { name: /chiedi all'arbitro/i }));
+
+    await waitFor(() => {
+      expect(onVerdictReceived).toHaveBeenCalledWith(mockVerdict);
+    });
+  });
+
+  it('shows error message on API failure', async () => {
+    mockSubmitDispute.mockRejectedValue(new Error('Network error'));
+
+    render(<ArbitroModal sessionId="sess-1" players={mockPlayers} />);
+    await userEvent.click(screen.getByRole('button', { name: /arbitro/i }));
+
+    await userEvent.type(screen.getByLabelText('Descrivi la disputa'), 'Test');
+    fireEvent.change(screen.getByLabelText('Sollevata da'), { target: { value: 'Bob' } });
+    await userEvent.click(screen.getByRole('button', { name: /chiedi all'arbitro/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toHaveTextContent('Network error');
+    });
+  });
+
+  it('adds the dispute to the store after successful API call', async () => {
+    mockSubmitDispute.mockResolvedValue(mockVerdict);
+
+    render(<ArbitroModal sessionId="sess-1" players={mockPlayers} />);
+    await userEvent.click(screen.getByRole('button', { name: /arbitro/i }));
+
+    await userEvent.type(screen.getByLabelText('Descrivi la disputa'), 'Test dispute');
+    fireEvent.change(screen.getByLabelText('Sollevata da'), { target: { value: 'Alice' } });
+    await userEvent.click(screen.getByRole('button', { name: /chiedi all'arbitro/i }));
+
+    await waitFor(() => {
+      expect(mockAddDispute).toHaveBeenCalledWith(
+        expect.objectContaining({
+          id: mockVerdict.id,
+          verdict: mockVerdict.verdict,
+          raisedByPlayerName: 'Alice',
+        })
+      );
+    });
+  });
+});

--- a/apps/web/src/components/sessions/live/__tests__/InviteModal.test.tsx
+++ b/apps/web/src/components/sessions/live/__tests__/InviteModal.test.tsx
@@ -1,0 +1,110 @@
+/**
+ * InviteModal — Tests
+ *
+ * Game Night Improvvisata — Task 19
+ */
+
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+// Mock qrcode.react to avoid SVG rendering complexity in tests
+vi.mock('qrcode.react', () => ({
+  QRCodeSVG: ({ value, 'aria-label': ariaLabel }: { value: string; 'aria-label'?: string }) => (
+    <svg data-testid="qr-code" aria-label={ariaLabel} data-value={value} />
+  ),
+}));
+
+import { InviteModal } from '../InviteModal';
+
+const DEFAULT_PROPS = {
+  inviteCode: 'ABC123',
+  shareLink: 'https://app.meepleai.it/join/ABC123',
+  isOpen: true,
+  onClose: vi.fn(),
+};
+
+describe('InviteModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders dialog when isOpen is true', () => {
+    render(<InviteModal {...DEFAULT_PROPS} />);
+    expect(screen.getByRole('dialog')).toBeInTheDocument();
+    expect(screen.getByText('Invita giocatori')).toBeInTheDocument();
+  });
+
+  it('does not render dialog when isOpen is false', () => {
+    render(<InviteModal {...DEFAULT_PROPS} isOpen={false} />);
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+
+  it('displays the QR code SVG', () => {
+    render(<InviteModal {...DEFAULT_PROPS} />);
+    const qr = screen.getByTestId('qr-code');
+    expect(qr).toBeInTheDocument();
+    expect(qr).toHaveAttribute('data-value', DEFAULT_PROPS.shareLink);
+  });
+
+  it('displays the session invite code', () => {
+    render(<InviteModal {...DEFAULT_PROPS} />);
+    expect(screen.getByTestId('invite-code')).toHaveTextContent('ABC123');
+  });
+
+  it('shows the copy link button', () => {
+    render(<InviteModal {...DEFAULT_PROPS} />);
+    expect(screen.getByTestId('copy-link-button')).toBeInTheDocument();
+    expect(screen.getByText(/copia link/i)).toBeInTheDocument();
+  });
+
+  it('copy link button is visible and interactive', async () => {
+    // jsdom doesn't implement Clipboard API — we test the button is present and clickable
+    const user = userEvent.setup();
+    render(<InviteModal {...DEFAULT_PROPS} />);
+
+    const copyBtn = screen.getByTestId('copy-link-button');
+    expect(copyBtn).toBeInTheDocument();
+    expect(copyBtn).not.toBeDisabled();
+
+    // Verify it can be clicked without throwing
+    await user.click(copyBtn);
+  });
+
+  it('shows confirmation text after clipboard copy', async () => {
+    const mockWriteText = vi.fn().mockResolvedValue(undefined);
+    // Use defineProperty with writable:true to avoid "only a getter" error in jsdom
+    const clipboardDesc = Object.getOwnPropertyDescriptor(navigator, 'clipboard');
+    if (!clipboardDesc) {
+      // jsdom: clipboard not defined — define it
+      Object.defineProperty(navigator, 'clipboard', {
+        value: { writeText: mockWriteText },
+        configurable: true,
+        writable: true,
+      });
+    } else {
+      // Already defined — spy on it
+      vi.spyOn(navigator.clipboard, 'writeText').mockResolvedValue(undefined);
+    }
+
+    const user = userEvent.setup();
+    render(<InviteModal {...DEFAULT_PROPS} />);
+
+    await user.click(screen.getByTestId('copy-link-button'));
+
+    await waitFor(() => {
+      expect(screen.getByText(/link copiato/i)).toBeInTheDocument();
+    });
+  });
+
+  it('calls onClose when dialog is closed', async () => {
+    const onClose = vi.fn();
+    const user = userEvent.setup();
+    render(<InviteModal {...DEFAULT_PROPS} onClose={onClose} />);
+
+    // Close via Escape key
+    await user.keyboard('{Escape}');
+
+    expect(onClose).toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/sessions/live/__tests__/PausedSessionCard.test.tsx
+++ b/apps/web/src/components/sessions/live/__tests__/PausedSessionCard.test.tsx
@@ -1,0 +1,76 @@
+/**
+ * PausedSessionCard (live/private-game-detail) — Tests
+ *
+ * Game Night Improvvisata — Task 20
+ *
+ * Tests the PausedSessionCard already located in
+ * components/library/private-game-detail/PausedSessionCard.tsx
+ * to verify the resume navigation works correctly.
+ */
+
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi } from 'vitest';
+
+import {
+  PausedSessionCard,
+  type PausedSession,
+} from '@/components/library/private-game-detail/PausedSessionCard';
+
+const MOCK_SESSION: PausedSession = {
+  id: 'session-abc',
+  sessionDate: new Date().toISOString(),
+  participants: [
+    { displayName: 'Mario', score: 42 },
+    { displayName: 'Luigi', score: 18 },
+  ],
+  hasPhotos: false,
+  hasNotes: false,
+  hasAgentSummary: false,
+};
+
+describe('PausedSessionCard', () => {
+  it('renders participant names and scores', () => {
+    render(<PausedSessionCard session={MOCK_SESSION} onResume={vi.fn()} onAbandon={vi.fn()} />);
+
+    expect(screen.getByText(/Mario: 42/)).toBeInTheDocument();
+    expect(screen.getByText(/Luigi: 18/)).toBeInTheDocument();
+  });
+
+  it('shows resume button', () => {
+    render(<PausedSessionCard session={MOCK_SESSION} onResume={vi.fn()} onAbandon={vi.fn()} />);
+
+    expect(screen.getByRole('button', { name: /riprendi/i })).toBeInTheDocument();
+  });
+
+  it('calls onResume with session id when resume clicked', async () => {
+    const onResume = vi.fn();
+    const user = userEvent.setup();
+
+    render(<PausedSessionCard session={MOCK_SESSION} onResume={onResume} onAbandon={vi.fn()} />);
+
+    await user.click(screen.getByRole('button', { name: /riprendi/i }));
+    expect(onResume).toHaveBeenCalledWith('session-abc');
+  });
+
+  it('calls onAbandon when abandon button clicked', async () => {
+    const onAbandon = vi.fn();
+    const user = userEvent.setup();
+
+    render(<PausedSessionCard session={MOCK_SESSION} onResume={vi.fn()} onAbandon={onAbandon} />);
+
+    await user.click(screen.getByRole('button', { name: /abbandona/i }));
+    expect(onAbandon).toHaveBeenCalledWith('session-abc');
+  });
+
+  it('marks old sessions with a visual indicator', () => {
+    const oldSession: PausedSession = {
+      ...MOCK_SESSION,
+      sessionDate: new Date(Date.now() - 31 * 24 * 60 * 60 * 1000).toISOString(),
+    };
+
+    render(<PausedSessionCard session={oldSession} onResume={vi.fn()} onAbandon={vi.fn()} />);
+
+    expect(screen.getByText(/vecchia/i)).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/sessions/live/__tests__/SaveSessionModal.test.tsx
+++ b/apps/web/src/components/sessions/live/__tests__/SaveSessionModal.test.tsx
@@ -1,0 +1,116 @@
+/**
+ * SaveSessionModal — Tests
+ *
+ * Game Night Improvvisata — Task 20
+ */
+
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
+
+const mockPush = vi.fn();
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+const mockCreatePauseSnapshot = vi.fn();
+vi.mock('@/lib/api', () => ({
+  api: {
+    liveSessions: {
+      createPauseSnapshot: (...args: unknown[]) => mockCreatePauseSnapshot(...args),
+    },
+  },
+}));
+
+import { SaveSessionModal } from '../SaveSessionModal';
+
+const DEFAULT_PROPS = {
+  sessionId: 'session-123',
+  gameName: 'Catan',
+  isOpen: true,
+  onClose: vi.fn(),
+};
+
+describe('SaveSessionModal', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders dialog with confirmation message', () => {
+    render(<SaveSessionModal {...DEFAULT_PROPS} />);
+    expect(screen.getByText(/vuoi salvare/i)).toBeInTheDocument();
+    expect(screen.getByText('Catan')).toBeInTheDocument();
+  });
+
+  it('shows cancel and confirm buttons', () => {
+    render(<SaveSessionModal {...DEFAULT_PROPS} />);
+    expect(screen.getByTestId('cancel-save')).toBeInTheDocument();
+    expect(screen.getByTestId('confirm-save')).toBeInTheDocument();
+  });
+
+  it('calls onClose when cancel is clicked', async () => {
+    const onClose = vi.fn();
+    const user = userEvent.setup();
+    render(<SaveSessionModal {...DEFAULT_PROPS} onClose={onClose} />);
+
+    await user.click(screen.getByTestId('cancel-save'));
+    expect(onClose).toHaveBeenCalled();
+  });
+
+  it('calls createPauseSnapshot and redirects on confirm', async () => {
+    mockCreatePauseSnapshot.mockResolvedValueOnce({ snapshotId: 'snap-1' });
+    const user = userEvent.setup();
+
+    render(<SaveSessionModal {...DEFAULT_PROPS} />);
+
+    await user.click(screen.getByTestId('confirm-save'));
+
+    await waitFor(() => {
+      expect(mockCreatePauseSnapshot).toHaveBeenCalledWith('session-123');
+    });
+
+    await waitFor(
+      () => {
+        expect(mockPush).toHaveBeenCalledWith('/library');
+      },
+      { timeout: 1500 }
+    );
+  });
+
+  it('shows saving state while request is pending', async () => {
+    let resolve: (value: unknown) => void = () => {};
+    mockCreatePauseSnapshot.mockReturnValueOnce(
+      new Promise(r => {
+        resolve = r;
+      })
+    );
+
+    const user = userEvent.setup();
+    render(<SaveSessionModal {...DEFAULT_PROPS} />);
+
+    await user.click(screen.getByTestId('confirm-save'));
+
+    await waitFor(() => {
+      expect(screen.getByText(/salvataggio/i)).toBeInTheDocument();
+    });
+
+    resolve({});
+  });
+
+  it('shows error message when save fails', async () => {
+    mockCreatePauseSnapshot.mockRejectedValueOnce(new Error('Network error'));
+    const user = userEvent.setup();
+    render(<SaveSessionModal {...DEFAULT_PROPS} />);
+
+    await user.click(screen.getByTestId('confirm-save'));
+
+    await waitFor(() => {
+      expect(screen.getByRole('alert')).toBeInTheDocument();
+    });
+  });
+
+  it('is not rendered when isOpen is false', () => {
+    render(<SaveSessionModal {...DEFAULT_PROPS} isOpen={false} />);
+    expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/components/sessions/live/__tests__/ScoreBoard.test.tsx
+++ b/apps/web/src/components/sessions/live/__tests__/ScoreBoard.test.tsx
@@ -1,0 +1,133 @@
+/**
+ * ScoreBoard Tests
+ *
+ * Game Night Improvvisata — Task 16
+ */
+
+import { render, screen, fireEvent } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { ScoreBoard } from '../ScoreBoard';
+
+// ─── Mock Zustand store ───────────────────────────────────────────────────────
+
+const mockScores: Record<string, number> = { Alice: 10, Bob: 7 };
+const mockPlayers = [
+  { id: 'p1', name: 'Alice', isHost: true, isOnline: true },
+  { id: 'p2', name: 'Bob', isHost: false, isOnline: true },
+];
+const mockPendingProposals = [{ id: 'prop-1', playerName: 'Bob', delta: 3, timestamp: Date.now() }];
+
+const mockResolveProposal = vi.hoisted(() => vi.fn());
+const mockUpdateScore = vi.hoisted(() => vi.fn());
+
+vi.mock('@/lib/stores/live-session-store', () => ({
+  useLiveSessionStore: (selector: (s: Record<string, unknown>) => unknown) => {
+    const state = {
+      scores: mockScores,
+      players: mockPlayers,
+      pendingProposals: mockPendingProposals,
+      disputes: [],
+      resolveProposal: mockResolveProposal,
+      updateScore: mockUpdateScore,
+    };
+    return selector(state);
+  },
+}));
+
+// ─── Mock useSessionScores ─────────────────────────────────────────────────────
+
+vi.mock('@/lib/hooks/use-session-scores', () => ({
+  useSessionScores: () => ({
+    scores: mockScores,
+    players: mockPlayers,
+    pendingProposals: mockPendingProposals,
+    leader: 'Alice',
+  }),
+}));
+
+// ─── Mock useSignalRSession ───────────────────────────────────────────────────
+
+vi.mock('@/lib/hooks/use-signalr-session', () => ({
+  useSignalRSession: () => ({
+    connection: null,
+    isConnected: true,
+    sendScore: vi.fn().mockResolvedValue(undefined),
+    proposeScore: vi.fn().mockResolvedValue(undefined),
+    appBackgrounded: vi.fn().mockResolvedValue(undefined),
+  }),
+}));
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('ScoreBoard', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders player names', () => {
+    render(<ScoreBoard sessionId="sess-1" />);
+    expect(screen.getByText('Alice')).toBeInTheDocument();
+    expect(screen.getByText('Bob')).toBeInTheDocument();
+  });
+
+  it('renders player scores', () => {
+    render(<ScoreBoard sessionId="sess-1" />);
+    expect(screen.getByText('10')).toBeInTheDocument();
+    expect(screen.getByText('7')).toBeInTheDocument();
+  });
+
+  it('renders crown icon on leader (Alice)', () => {
+    render(<ScoreBoard sessionId="sess-1" />);
+    const crown = document.querySelector('[aria-label="Leader"]');
+    expect(crown).toBeInTheDocument();
+  });
+
+  it('does not show +/- buttons for guests (isHost=false)', () => {
+    render(<ScoreBoard sessionId="sess-1" isHost={false} />);
+    const incrementBtns = screen.queryAllByLabelText(/Incrementa punteggio/i);
+    expect(incrementBtns).toHaveLength(0);
+  });
+
+  it('shows +/- buttons for the host', () => {
+    render(<ScoreBoard sessionId="sess-1" isHost />);
+    const incrementBtns = screen.getAllByLabelText(/Incrementa punteggio/i);
+    const decrementBtns = screen.getAllByLabelText(/Decrementa punteggio/i);
+    expect(incrementBtns.length).toBeGreaterThan(0);
+    expect(decrementBtns.length).toBeGreaterThan(0);
+  });
+
+  it('calls updateScore when host clicks + button', () => {
+    render(<ScoreBoard sessionId="sess-1" isHost />);
+    const aliceIncrement = screen.getByLabelText('Incrementa punteggio di Alice');
+    fireEvent.click(aliceIncrement);
+    expect(mockUpdateScore).toHaveBeenCalledWith('Alice', 11);
+  });
+
+  it('shows pending proposals for host', () => {
+    render(<ScoreBoard sessionId="sess-1" isHost />);
+    expect(screen.getByText('Proposte in attesa')).toBeInTheDocument();
+    // Bob appears in both the player card and the proposal card — use getAllByText
+    expect(screen.getAllByText('Bob').length).toBeGreaterThan(0);
+    expect(screen.getByText('+3')).toBeInTheDocument();
+  });
+
+  it('does not show pending proposals section for non-host', () => {
+    render(<ScoreBoard sessionId="sess-1" isHost={false} />);
+    expect(screen.queryByText('Proposte in attesa')).not.toBeInTheDocument();
+  });
+
+  it('calls resolveProposal(id, true) on approve', () => {
+    render(<ScoreBoard sessionId="sess-1" isHost />);
+    const approveBtn = screen.getByLabelText('Approva proposta');
+    fireEvent.click(approveBtn);
+    expect(mockResolveProposal).toHaveBeenCalledWith('prop-1', true);
+  });
+
+  it('calls resolveProposal(id, false) on reject', () => {
+    render(<ScoreBoard sessionId="sess-1" isHost />);
+    const rejectBtn = screen.getByLabelText('Rifiuta proposta');
+    fireEvent.click(rejectBtn);
+    expect(mockResolveProposal).toHaveBeenCalledWith('prop-1', false);
+  });
+});

--- a/apps/web/src/lib/api/clients/liveSessionsClient.ts
+++ b/apps/web/src/lib/api/clients/liveSessionsClient.ts
@@ -10,6 +10,12 @@
 import { z } from 'zod';
 
 import {
+  RuleDisputeResponseSchema,
+  CreatePauseSnapshotResponseSchema,
+  type RuleDisputeResponse,
+  type CreatePauseSnapshotResponse,
+} from '../schemas/improvvisata.schemas';
+import {
   LiveSessionDtoSchema,
   LiveSessionSummaryDtoSchema,
   LiveSessionPlayerDtoSchema,
@@ -49,6 +55,7 @@ import {
 import type { HttpClient } from '../core/httpClient';
 
 const BASE = '/api/v1/live-sessions';
+const GAME_NIGHT_BASE = '/api/v1/game-night';
 
 export interface LiveSessionsClient {
   // ========== Queries ==========
@@ -160,6 +167,24 @@ export interface LiveSessionsClient {
 
   /** Get session resume context with recap, scores, and photos */
   getResumeContext(sessionId: string): Promise<SessionResumeContext>;
+
+  // ========== Game Night Improvvisata ==========
+
+  /**
+   * Submit a rule dispute and get an AI verdict.
+   * POST /api/v1/game-night/sessions/{sessionId}/disputes
+   */
+  submitDispute(
+    sessionId: string,
+    description: string,
+    raisedByPlayerName: string
+  ): Promise<RuleDisputeResponse>;
+
+  /**
+   * Create a pause snapshot for the session.
+   * POST /api/v1/game-night/sessions/{sessionId}/pause-snapshot
+   */
+  createPauseSnapshot(sessionId: string): Promise<CreatePauseSnapshotResponse>;
 }
 
 export function createLiveSessionsClient({
@@ -357,6 +382,26 @@ export function createLiveSessionsClient({
       );
       if (!response) throw new Error('Resume context not found');
       return SessionResumeContextSchema.parse(response);
+    },
+
+    // ========== Game Night Improvvisata ==========
+
+    async submitDispute(sessionId, description, raisedByPlayerName) {
+      const response = await httpClient.post<RuleDisputeResponse>(
+        `${GAME_NIGHT_BASE}/sessions/${encodeURIComponent(sessionId)}/disputes`,
+        { description, raisedByPlayerName }
+      );
+      if (!response) throw new Error('Dispute submission failed');
+      return RuleDisputeResponseSchema.parse(response);
+    },
+
+    async createPauseSnapshot(sessionId) {
+      const response = await httpClient.post<CreatePauseSnapshotResponse>(
+        `${GAME_NIGHT_BASE}/sessions/${encodeURIComponent(sessionId)}/pause-snapshot`,
+        {}
+      );
+      if (!response) throw new Error('Pause snapshot creation failed');
+      return CreatePauseSnapshotResponseSchema.parse(response);
     },
   };
 }

--- a/apps/web/src/lib/api/clients/liveSessionsClient.ts
+++ b/apps/web/src/lib/api/clients/liveSessionsClient.ts
@@ -397,7 +397,7 @@ export function createLiveSessionsClient({
 
     async createPauseSnapshot(sessionId) {
       const response = await httpClient.post<CreatePauseSnapshotResponse>(
-        `${GAME_NIGHT_BASE}/sessions/${encodeURIComponent(sessionId)}/pause-snapshot`,
+        `${GAME_NIGHT_BASE}/sessions/${encodeURIComponent(sessionId)}/save`,
         {}
       );
       if (!response) throw new Error('Pause snapshot creation failed');

--- a/apps/web/src/lib/api/schemas/improvvisata.schemas.ts
+++ b/apps/web/src/lib/api/schemas/improvvisata.schemas.ts
@@ -1,0 +1,78 @@
+/**
+ * Improvvisata API Schemas
+ *
+ * Game Night Improvvisata — Task 14
+ *
+ * Zod schemas for the /api/v1/game-night/* endpoints:
+ *   - Start improvvisata session
+ *   - Rule dispute submission and retrieval
+ *   - Pause snapshot and resume
+ */
+
+import { z } from 'zod';
+
+// ──────────────────────────────────────────────
+// Start Improvvisata Session
+// ──────────────────────────────────────────────
+
+export const StartImprovvisataResponseSchema = z.object({
+  sessionId: z.string().uuid(),
+  inviteCode: z.string(),
+  shareLink: z.string(),
+});
+
+export type StartImprovvisataResponse = z.infer<typeof StartImprovvisataResponseSchema>;
+
+// ──────────────────────────────────────────────
+// Rule Dispute
+// ──────────────────────────────────────────────
+
+export const RuleDisputeResponseSchema = z.object({
+  id: z.string().uuid(),
+  verdict: z.string(),
+  ruleReferences: z.array(z.string()),
+  note: z.string().nullable(),
+});
+
+export type RuleDisputeResponse = z.infer<typeof RuleDisputeResponseSchema>;
+
+export const RuleDisputeDtoSchema = z.object({
+  id: z.string().uuid(),
+  description: z.string(),
+  verdict: z.string(),
+  ruleReferences: z.array(z.string()),
+  raisedByPlayerName: z.string(),
+  timestamp: z.string(),
+});
+
+export type RuleDisputeDto = z.infer<typeof RuleDisputeDtoSchema>;
+
+export const GameDisputeHistoryItemSchema = z.object({
+  sessionId: z.string().uuid(),
+  disputes: z.array(RuleDisputeDtoSchema),
+});
+
+export type GameDisputeHistoryItem = z.infer<typeof GameDisputeHistoryItemSchema>;
+
+// ──────────────────────────────────────────────
+// Pause Snapshot
+// ──────────────────────────────────────────────
+
+export const CreatePauseSnapshotResponseSchema = z.object({
+  snapshotId: z.string().uuid(),
+});
+
+export type CreatePauseSnapshotResponse = z.infer<typeof CreatePauseSnapshotResponseSchema>;
+
+// ──────────────────────────────────────────────
+// Resume Session
+// ──────────────────────────────────────────────
+
+export const ResumeSessionResponseSchema = z.object({
+  sessionId: z.string().uuid(),
+  inviteCode: z.string(),
+  shareLink: z.string(),
+  agentRecap: z.string().nullable(),
+});
+
+export type ResumeSessionResponse = z.infer<typeof ResumeSessionResponseSchema>;

--- a/apps/web/src/lib/hooks/__tests__/use-signalr-session.test.ts
+++ b/apps/web/src/lib/hooks/__tests__/use-signalr-session.test.ts
@@ -1,0 +1,191 @@
+/**
+ * use-signalr-session Tests
+ *
+ * Game Night Improvvisata — Task 13
+ *
+ * Unit tests for the Zustand live-session-store and the useSignalRSession hook.
+ * Full SignalR integration is validated in E2E tests.
+ */
+
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { renderHook, act } from '@testing-library/react';
+
+// ──────────────────────────────────────────────────────────
+// Mock @microsoft/signalr before importing the hook
+// ──────────────────────────────────────────────────────────
+
+const mockOn = vi.fn();
+const mockStart = vi.fn().mockResolvedValue(undefined);
+const mockStop = vi.fn().mockResolvedValue(undefined);
+const mockInvoke = vi.fn().mockResolvedValue(undefined);
+const mockOnreconnected = vi.fn();
+const mockOnreconnecting = vi.fn();
+const mockOnclose = vi.fn();
+
+const mockConnection = {
+  on: mockOn,
+  start: mockStart,
+  stop: mockStop,
+  invoke: mockInvoke,
+  onreconnected: mockOnreconnected,
+  onreconnecting: mockOnreconnecting,
+  onclose: mockOnclose,
+  state: 'Connected',
+};
+
+const mockWithUrl = vi.fn().mockReturnThis();
+const mockWithAutomaticReconnect = vi.fn().mockReturnThis();
+const mockConfigureLogging = vi.fn().mockReturnThis();
+const mockBuild = vi.fn().mockReturnValue(mockConnection);
+
+vi.mock('@microsoft/signalr', () => ({
+  HubConnectionBuilder: vi.fn().mockImplementation(() => ({
+    withUrl: mockWithUrl,
+    withAutomaticReconnect: mockWithAutomaticReconnect,
+    configureLogging: mockConfigureLogging,
+    build: mockBuild,
+  })),
+  HubConnectionState: {
+    Connected: 'Connected',
+    Connecting: 'Connecting',
+    Disconnected: 'Disconnected',
+    Disconnecting: 'Disconnecting',
+    Reconnecting: 'Reconnecting',
+  },
+  LogLevel: {
+    Warning: 1,
+  },
+}));
+
+// ──────────────────────────────────────────────────────────
+// Imports (after mock setup)
+// ──────────────────────────────────────────────────────────
+
+import { useLiveSessionStore } from '@/lib/stores/live-session-store';
+import { useSignalRSession } from '../use-signalr-session';
+
+// ──────────────────────────────────────────────────────────
+// Store tests
+// ──────────────────────────────────────────────────────────
+
+describe('useLiveSessionStore', () => {
+  beforeEach(() => {
+    useLiveSessionStore.getState().reset();
+    vi.clearAllMocks();
+  });
+
+  it('setSession updates state fields', () => {
+    useLiveSessionStore.getState().setSession({
+      sessionId: 'sess-1',
+      gameName: 'Catan',
+      status: 'InProgress',
+    });
+
+    const state = useLiveSessionStore.getState();
+    expect(state.sessionId).toBe('sess-1');
+    expect(state.gameName).toBe('Catan');
+    expect(state.status).toBe('InProgress');
+  });
+
+  it('updateScore updates score for the given player', () => {
+    useLiveSessionStore.getState().updateScore('Alice', 42);
+    useLiveSessionStore.getState().updateScore('Bob', 18);
+
+    const { scores } = useLiveSessionStore.getState();
+    expect(scores['Alice']).toBe(42);
+    expect(scores['Bob']).toBe(18);
+  });
+
+  it('addDispute appends to the disputes array', () => {
+    const dispute = {
+      id: 'd-1',
+      description: 'Can Robber be placed on desert?',
+      verdict: 'No — desert is exempt.',
+      ruleReferences: ['Catan 4.2'],
+      raisedByPlayerName: 'Alice',
+      timestamp: '2026-03-15T10:00:00Z',
+    };
+
+    useLiveSessionStore.getState().addDispute(dispute);
+    const { disputes } = useLiveSessionStore.getState();
+    expect(disputes).toHaveLength(1);
+    expect(disputes[0]).toEqual(dispute);
+  });
+
+  it('reset clears all state to initial values', () => {
+    // Dirty the store
+    useLiveSessionStore.getState().setSession({ sessionId: 'sess-1', gameName: 'Test' });
+    useLiveSessionStore.getState().updateScore('Alice', 100);
+    useLiveSessionStore.getState().addProposal({
+      id: 'p-1',
+      playerName: 'Alice',
+      delta: 5,
+      timestamp: Date.now(),
+    });
+    useLiveSessionStore.getState().setConnected(true);
+
+    useLiveSessionStore.getState().reset();
+
+    const state = useLiveSessionStore.getState();
+    expect(state.sessionId).toBeNull();
+    expect(state.gameName).toBe('');
+    expect(state.scores).toEqual({});
+    expect(state.pendingProposals).toEqual([]);
+    expect(state.disputes).toEqual([]);
+    expect(state.isConnected).toBe(false);
+  });
+});
+
+// ──────────────────────────────────────────────────────────
+// Hook tests
+// ──────────────────────────────────────────────────────────
+
+describe('useSignalRSession', () => {
+  const sessionId = 'test-session-123';
+
+  beforeEach(() => {
+    useLiveSessionStore.getState().reset();
+    vi.clearAllMocks();
+    // Reset start mock to succeed by default
+    mockStart.mockResolvedValue(undefined);
+    mockStop.mockResolvedValue(undefined);
+    mockInvoke.mockResolvedValue(undefined);
+    mockConnection.state = 'Connected';
+  });
+
+  it('connects to SignalR hub on mount', async () => {
+    const { unmount } = renderHook(() => useSignalRSession(sessionId));
+
+    // Allow async start() to settle
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 0));
+    });
+
+    expect(mockBuild).toHaveBeenCalled();
+    expect(mockStart).toHaveBeenCalled();
+    expect(mockInvoke).toHaveBeenCalledWith('JoinSession', sessionId);
+
+    unmount();
+  });
+
+  it('does not connect when sessionId is null', () => {
+    renderHook(() => useSignalRSession(null));
+    expect(mockBuild).not.toHaveBeenCalled();
+  });
+
+  it('cleans up (stops) on unmount', async () => {
+    const { unmount } = renderHook(() => useSignalRSession(sessionId));
+
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 0));
+    });
+
+    unmount();
+
+    await act(async () => {
+      await new Promise(r => setTimeout(r, 0));
+    });
+
+    expect(mockStop).toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/lib/hooks/use-session-scores.ts
+++ b/apps/web/src/lib/hooks/use-session-scores.ts
@@ -1,0 +1,46 @@
+/**
+ * useSessionScores Hook
+ *
+ * Game Night Improvvisata — Task 13
+ *
+ * Derives score-related data from the live-session-store.
+ * Memoises the leader calculation to avoid unnecessary re-renders.
+ */
+
+import { useMemo } from 'react';
+
+import { useLiveSessionStore } from '@/lib/stores/live-session-store';
+import type { PlayerInfo, ScoreProposal } from '@/lib/stores/live-session-store';
+
+export interface UseSessionScoresReturn {
+  /** Current cumulative scores, keyed by player name */
+  scores: Record<string, number>;
+  /** Player info array (order, host flag, online status) */
+  players: PlayerInfo[];
+  /** Score proposals awaiting host confirmation */
+  pendingProposals: ScoreProposal[];
+  /** Player name currently leading (null when no scores exist) */
+  leader: string | null;
+}
+
+/**
+ * useSessionScores
+ *
+ * Reads scores, players and pending proposals from the live-session-store.
+ * Computes the current leader via a memoised selector.
+ *
+ * @param _sessionId - Reserved for future per-session store isolation; unused today.
+ */
+export function useSessionScores(_sessionId?: string): UseSessionScoresReturn {
+  const scores = useLiveSessionStore(s => s.scores);
+  const players = useLiveSessionStore(s => s.players);
+  const pendingProposals = useLiveSessionStore(s => s.pendingProposals);
+
+  const leader = useMemo<string | null>(() => {
+    const entries = Object.entries(scores);
+    if (!entries.length) return null;
+    return entries.reduce((best, current) => (current[1] > best[1] ? current : best))[0];
+  }, [scores]);
+
+  return { scores, players, pendingProposals, leader };
+}

--- a/apps/web/src/lib/hooks/use-signalr-session.ts
+++ b/apps/web/src/lib/hooks/use-signalr-session.ts
@@ -1,0 +1,209 @@
+/**
+ * useSignalRSession Hook
+ *
+ * Game Night Improvvisata — Task 13
+ *
+ * Manages a SignalR connection to GameStateHub for real-time session events.
+ * Populates the live-session-store on incoming events.
+ * Exposes methods to send score proposals and session signals.
+ *
+ * Hub: /hubs/game-state
+ * Requires: @microsoft/signalr
+ */
+
+import { useState, useEffect, useRef } from 'react';
+
+import {
+  HubConnectionBuilder,
+  HubConnection,
+  HubConnectionState,
+  LogLevel,
+} from '@microsoft/signalr';
+
+import {
+  useLiveSessionStore,
+  type RuleDispute,
+  type ScoreProposal,
+} from '@/lib/stores/live-session-store';
+
+// -------- Hub event payload shapes --------
+
+interface ScoreUpdatedPayload {
+  playerName: string;
+  score: number;
+}
+
+interface DisputeResolvedPayload {
+  id: string;
+  description: string;
+  verdict: string;
+  ruleReferences: string[];
+  raisedByPlayerName: string;
+  timestamp: string;
+}
+
+interface ProposeScorePayload {
+  id: string;
+  playerName: string;
+  delta: number;
+  timestamp: number;
+}
+
+// -------- Hook return type --------
+
+export interface UseSignalRSessionReturn {
+  /** Current SignalR HubConnection instance (null before first connect) */
+  connection: HubConnection | null;
+  /** Whether the hub is currently connected */
+  isConnected: boolean;
+  /** Notify all clients that a player's total score changed */
+  sendScore: (playerName: string, score: number) => Promise<void>;
+  /** Propose a score delta that the host must confirm */
+  proposeScore: (playerName: string, delta: number) => Promise<void>;
+  /** Signal that this client went to the background (mobile PWA pause) */
+  appBackgrounded: () => Promise<void>;
+}
+
+/**
+ * useSignalRSession
+ *
+ * Connects to /hubs/game-state when sessionId is non-null.
+ * Tears down the connection on unmount or when sessionId changes.
+ *
+ * @param sessionId - The live session GUID, or null to skip connection.
+ */
+export function useSignalRSession(sessionId: string | null): UseSignalRSessionReturn {
+  const [connection, setConnection] = useState<HubConnection | null>(null);
+  const [isConnected, setIsConnected] = useState(false);
+
+  // Keep stable references to store actions so the effect closure stays current
+  const store = useLiveSessionStore;
+  const connectionRef = useRef<HubConnection | null>(null);
+
+  useEffect(() => {
+    if (!sessionId) return;
+
+    const conn = new HubConnectionBuilder()
+      .withUrl('/hubs/game-state')
+      .withAutomaticReconnect()
+      .configureLogging(LogLevel.Warning)
+      .build();
+
+    // ---- Register incoming event handlers ----
+
+    conn.on('ScoreUpdated', (data: ScoreUpdatedPayload) => {
+      store.getState().updateScore(data.playerName, data.score);
+    });
+
+    conn.on('DisputeResolved', (data: DisputeResolvedPayload) => {
+      const dispute: RuleDispute = {
+        id: data.id,
+        description: data.description,
+        verdict: data.verdict,
+        ruleReferences: data.ruleReferences ?? [],
+        raisedByPlayerName: data.raisedByPlayerName,
+        timestamp: data.timestamp,
+      };
+      store.getState().addDispute(dispute);
+    });
+
+    conn.on('SessionPaused', () => {
+      store.getState().setSession({ status: 'Paused' });
+    });
+
+    conn.on('SessionResumed', () => {
+      store.getState().setSession({ status: 'InProgress' });
+    });
+
+    conn.on('SessionCompleted', () => {
+      store.getState().setSession({ status: 'Completed' });
+    });
+
+    conn.on('ProposeScore', (data: ProposeScorePayload) => {
+      const proposal: ScoreProposal = {
+        id: data.id,
+        playerName: data.playerName,
+        delta: data.delta,
+        timestamp: data.timestamp,
+      };
+      store.getState().addProposal(proposal);
+    });
+
+    // ---- Connection lifecycle ----
+
+    conn
+      .start()
+      .then(() => {
+        return conn.invoke('JoinSession', sessionId);
+      })
+      .then(() => {
+        setIsConnected(true);
+        store.getState().setConnected(true);
+        store.getState().setOffline(false);
+      })
+      .catch((err: unknown) => {
+        console.error('[useSignalRSession] Connection failed:', err);
+        store.getState().setConnected(false);
+      });
+
+    conn.onreconnected(() => {
+      conn.invoke('JoinSession', sessionId).catch((err: unknown) => {
+        console.error('[useSignalRSession] Re-join failed:', err);
+      });
+      setIsConnected(true);
+      store.getState().setConnected(true);
+      store.getState().setOffline(false);
+    });
+
+    conn.onreconnecting(() => {
+      setIsConnected(false);
+      store.getState().setConnected(false);
+      store.getState().setOffline(true);
+    });
+
+    conn.onclose(() => {
+      setIsConnected(false);
+      store.getState().setConnected(false);
+    });
+
+    connectionRef.current = conn;
+    setConnection(conn);
+
+    return () => {
+      conn.stop().catch((err: unknown) => {
+        console.error('[useSignalRSession] Stop failed:', err);
+      });
+      connectionRef.current = null;
+      setConnection(null);
+      setIsConnected(false);
+    };
+  }, [sessionId]); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // ---- Outbound methods ----
+
+  const sendScore = async (playerName: string, score: number): Promise<void> => {
+    const conn = connectionRef.current;
+    if (!conn || conn.state !== HubConnectionState.Connected) return;
+    await conn.invoke('NotifyScoreUpdated', sessionId, { playerName, score });
+  };
+
+  const proposeScore = async (playerName: string, delta: number): Promise<void> => {
+    const conn = connectionRef.current;
+    if (!conn || conn.state !== HubConnectionState.Connected) return;
+    await conn.invoke('ProposeScore', sessionId, { playerName, delta });
+  };
+
+  const appBackgrounded = async (): Promise<void> => {
+    const conn = connectionRef.current;
+    if (!conn || conn.state !== HubConnectionState.Connected) return;
+    await conn.invoke('AppBackgrounded', sessionId);
+  };
+
+  return {
+    connection,
+    isConnected,
+    sendScore,
+    proposeScore,
+    appBackgrounded,
+  };
+}

--- a/apps/web/src/lib/stores/live-session-store.ts
+++ b/apps/web/src/lib/stores/live-session-store.ts
@@ -1,0 +1,144 @@
+/**
+ * Live Session Store
+ *
+ * Game Night Improvvisata — Tasks 13/14
+ *
+ * Zustand store for real-time session state management.
+ * Driven by SignalR events from GameStateHub.
+ */
+
+import { create } from 'zustand';
+import { devtools } from 'zustand/middleware';
+
+export interface PlayerInfo {
+  id: string;
+  name: string;
+  isHost: boolean;
+  isOnline: boolean;
+}
+
+export interface ScoreProposal {
+  id: string;
+  playerName: string;
+  delta: number;
+  timestamp: number;
+}
+
+export interface RuleDispute {
+  id: string;
+  description: string;
+  verdict: string;
+  ruleReferences: string[];
+  raisedByPlayerName: string;
+  timestamp: string;
+}
+
+export type SessionStatus = 'InProgress' | 'Paused' | 'Completed';
+
+interface LiveSessionState {
+  sessionId: string | null;
+  gameName: string;
+  status: SessionStatus;
+  currentTurn: number;
+  currentPhase: string | null;
+  players: PlayerInfo[];
+  scores: Record<string, number>;
+  pendingProposals: ScoreProposal[];
+  disputes: RuleDispute[];
+  isConnected: boolean;
+  isOffline: boolean;
+  elapsedSeconds: number;
+
+  // Actions
+  setSession: (data: Partial<LiveSessionState>) => void;
+  updateScore: (playerName: string, score: number) => void;
+  addProposal: (proposal: ScoreProposal) => void;
+  resolveProposal: (proposalId: string, accepted: boolean) => void;
+  addDispute: (dispute: RuleDispute) => void;
+  setConnected: (connected: boolean) => void;
+  setOffline: (offline: boolean) => void;
+  reset: () => void;
+}
+
+const initialState = {
+  sessionId: null as string | null,
+  gameName: '',
+  status: 'InProgress' as SessionStatus,
+  currentTurn: 1,
+  currentPhase: null as string | null,
+  players: [] as PlayerInfo[],
+  scores: {} as Record<string, number>,
+  pendingProposals: [] as ScoreProposal[],
+  disputes: [] as RuleDispute[],
+  isConnected: false,
+  isOffline: false,
+  elapsedSeconds: 0,
+};
+
+export const useLiveSessionStore = create<LiveSessionState>()(
+  devtools(
+    (set, get) => ({
+      ...initialState,
+
+      setSession: data => set(data as Partial<LiveSessionState>, false, 'setSession'),
+
+      updateScore: (playerName, score) =>
+        set(
+          state => ({
+            scores: { ...state.scores, [playerName]: score },
+          }),
+          false,
+          'updateScore'
+        ),
+
+      addProposal: proposal =>
+        set(
+          state => ({
+            pendingProposals: [...state.pendingProposals, proposal],
+          }),
+          false,
+          'addProposal'
+        ),
+
+      resolveProposal: (proposalId, accepted) => {
+        const proposal = get().pendingProposals.find(p => p.id === proposalId);
+        if (!proposal) return;
+
+        set(
+          state => {
+            const pendingProposals = state.pendingProposals.filter(p => p.id !== proposalId);
+            if (!accepted) {
+              return { pendingProposals };
+            }
+            const currentScore = state.scores[proposal.playerName] ?? 0;
+            return {
+              pendingProposals,
+              scores: {
+                ...state.scores,
+                [proposal.playerName]: currentScore + proposal.delta,
+              },
+            };
+          },
+          false,
+          'resolveProposal'
+        );
+      },
+
+      addDispute: dispute =>
+        set(
+          state => ({
+            disputes: [...state.disputes, dispute],
+          }),
+          false,
+          'addDispute'
+        ),
+
+      setConnected: connected => set({ isConnected: connected }, false, 'setConnected'),
+
+      setOffline: offline => set({ isOffline: offline }, false, 'setOffline'),
+
+      reset: () => set(initialState, false, 'reset'),
+    }),
+    { name: 'live-session-store' }
+  )
+);

--- a/apps/web/src/middleware.ts
+++ b/apps/web/src/middleware.ts
@@ -35,11 +35,22 @@ const EXCLUDED_PREFIXES = [
   '/twitter-card',
 ];
 
+/**
+ * Public path prefixes — allow without auth or onboarding check.
+ * /join/* is the guest landing page for live sessions (Task 18).
+ */
+const PUBLIC_PREFIXES = ['/join/'];
+
 export function middleware(request: NextRequest) {
   const { pathname } = request.nextUrl;
 
   // Skip excluded prefixes
   if (EXCLUDED_PREFIXES.some(prefix => pathname.startsWith(prefix))) {
+    return NextResponse.next();
+  }
+
+  // Skip public path prefixes (e.g. /join/*)
+  if (PUBLIC_PREFIXES.some(prefix => pathname.startsWith(prefix))) {
     return NextResponse.next();
   }
 

--- a/docs/superpowers/plans/2026-03-15-game-night-improvvisata-plan.md
+++ b/docs/superpowers/plans/2026-03-15-game-night-improvvisata-plan.md
@@ -1,0 +1,1825 @@
+# Game Night Improvvisata — Vertical Slice Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build a complete end-to-end game night experience: BGG search → PDF upload → auto-agent → live session with CardStack → score tracking → rule arbitration → save/resume.
+
+**Architecture:** Vertical slice through GameManagement, KnowledgeBase, UserLibrary, UserNotifications, and DocumentProcessing bounded contexts. Backend is CQRS with MediatR, DDD entities, EF Core + PostgreSQL. Frontend is Next.js App Router with CardStack navigation pattern. Real-time via SignalR `GameStateHub`.
+
+**Tech Stack:** .NET 9 (MediatR, EF Core, SignalR, FluentValidation) | Next.js 16 (React 19, Zustand, React Query, Tailwind 4, shadcn/ui) | PostgreSQL 16 (JSONB) | Redis (quotas)
+
+**Spec:** `docs/superpowers/specs/2026-03-15-game-night-improvvisata-vertical-slice-design.md`
+
+---
+
+## File Map
+
+### Backend — New Files
+
+| File | Responsibility |
+|------|---------------|
+| `apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/PauseSnapshot/PauseSnapshot.cs` | Full-state snapshot for save/resume |
+| `apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/PauseSnapshot/PlayerScoreSnapshot.cs` | Score snapshot VO |
+| `apps/api/src/Api/BoundedContexts/GameManagement/Domain/ValueObjects/RuleDisputeEntry.cs` | Arbitro verdict VO |
+| `apps/api/src/Api/BoundedContexts/GameManagement/Domain/Repositories/IPauseSnapshotRepository.cs` | Repository interface |
+| `apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Persistence/PauseSnapshotRepository.cs` | EF implementation |
+| `apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/StartImprovvisataSessionCommand.cs` | Session creation shortcut |
+| `apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/CreatePauseSnapshotCommand.cs` | Save session state |
+| `apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/ResumeSessionCommand.cs` | Resume paused session |
+| `apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/SubmitRuleDisputeCommand.cs` | Arbitro verdict |
+| `apps/api/src/Api/BoundedContexts/GameManagement/Domain/Events/SessionSaveRequestedEvent.cs` | Cross-context event for summary |
+| `apps/api/src/Api/BoundedContexts/GameManagement/Domain/Events/DisputeResolvedEvent.cs` | SignalR broadcast trigger |
+| `apps/api/src/Api/BoundedContexts/GameManagement/Domain/Events/SessionPausedEvent.cs` | Graceful disconnect trigger |
+| `apps/api/src/Api/BoundedContexts/GameManagement/Domain/Events/SessionResumedEvent.cs` | Recap trigger |
+| `apps/api/src/Api/BoundedContexts/GameManagement/Domain/Events/AppBackgroundedEvent.cs` | Auto-save trigger |
+| `apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/EventHandlers/UpdateSnapshotSummaryHandler.cs` | Updates PauseSnapshot with summary |
+| `apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/SessionContextPromptBuilder.cs` | Builds session-aware agent prompt |
+| `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/RetryPdfProcessingCommand.cs` | Retry failed PDF processing |
+| `apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/EventHandlers/AutoCreateAgentOnPdfReadyHandler.cs` | Auto-create agent when PDF done |
+| `apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/EventHandlers/GenerateAgentSummaryHandler.cs` | Async summary generation |
+| `apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Events/AgentAutoCreatedEvent.cs` | Notification trigger |
+| `apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Events/AgentSummaryGeneratedEvent.cs` | Summary complete event |
+| `apps/api/src/Api/BoundedContexts/UserNotifications/Application/EventHandlers/NotifyAgentReadyHandler.cs` | In-app notification |
+| `apps/api/src/Api/Infrastructure/BackgroundServices/SessionAutoSaveBackgroundService.cs` | 10-min auto-save |
+| `apps/api/src/Api/Infrastructure/Configurations/GameManagement/PauseSnapshotEntityConfiguration.cs` | EF config |
+| `apps/api/src/Api/Infrastructure/Entities/GameManagement/PauseSnapshotEntity.cs` | EF entity model |
+
+### Backend — Modified Files
+
+| File | Change |
+|------|--------|
+| `apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/LiveGameSession.cs` | Add `Disputes` (JSONB), `AddDispute()`, `Pause()`, `Resume()` methods |
+| `apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/SessionSnapshot/SnapshotTrigger.cs` | Add `AutoSave = 8` value |
+| `apps/api/src/Api/BoundedContexts/GameManagement/Domain/Repositories/ILiveSessionRepository.cs` | Add `GetPausedByGameIdAsync()`, `GetDisputesByGameIdAsync()` |
+| `apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Persistence/LiveSessionRepository.cs` | Implement new methods |
+| `apps/api/src/Api/Infrastructure/Configurations/GameManagement/LiveGameSessionEntityConfiguration.cs` | JSONB column for Disputes |
+| `apps/api/src/Api/Hubs/GameStateHub.cs` | Add `DisputeResolved`, `SessionPaused`, `ScoreUpdated`, `AppBackgrounded` methods |
+| `apps/api/src/Api/Routing/GameNightImprovvisataEndpoints.cs` | Add session, dispute, snapshot endpoints |
+| `apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/DependencyInjection/GameManagementServiceExtensions.cs` | Register new repos, handlers |
+| `apps/api/src/Api/BoundedContexts/KnowledgeBase/Infrastructure/DependencyInjection/KnowledgeBaseServiceExtensions.cs` | Register auto-create handler |
+
+### Frontend — New Files
+
+| File | Responsibility |
+|------|---------------|
+| `apps/web/src/app/(authenticated)/sessions/live/[sessionId]/page.tsx` | Session card parent page |
+| `apps/web/src/app/(authenticated)/sessions/live/[sessionId]/agent/page.tsx` | Agent chat child card |
+| `apps/web/src/app/(authenticated)/sessions/live/[sessionId]/scores/page.tsx` | Scoreboard child card |
+| `apps/web/src/app/(authenticated)/sessions/live/[sessionId]/photos/page.tsx` | Photo gallery child card |
+| `apps/web/src/app/(authenticated)/sessions/live/[sessionId]/players/page.tsx` | Players + invite child card |
+| `apps/web/src/app/(authenticated)/sessions/live/[sessionId]/layout.tsx` | Session layout with NavigationProvider |
+| `apps/web/src/app/join/[inviteToken]/page.tsx` | Guest landing page (no auth) |
+| `apps/web/src/components/sessions/live/SessionCardParent.tsx` | Session overview component |
+| `apps/web/src/components/sessions/live/ScoreBoard.tsx` | Real-time scoreboard |
+| `apps/web/src/components/sessions/live/PlayerList.tsx` | Player list with status |
+| `apps/web/src/components/sessions/live/InviteModal.tsx` | QR code + share link modal |
+| `apps/web/src/components/sessions/live/ArbitroModal.tsx` | Dispute submission modal |
+| `apps/web/src/components/sessions/live/ArbitroVerdictCard.tsx` | Styled verdict display |
+| `apps/web/src/components/sessions/live/DisputeHistory.tsx` | Past verdicts collapsible |
+| `apps/web/src/components/sessions/live/SaveSessionModal.tsx` | Save & exit confirmation |
+| `apps/web/src/components/sessions/live/PausedSessionCard.tsx` | Resume card in library |
+| `apps/web/src/components/sessions/live/GuestScoreProposal.tsx` | Guest score proposal form |
+| `apps/web/src/components/sessions/live/SessionNavConfig.tsx` | MiniNav config for session |
+| `apps/web/src/lib/hooks/use-signalr-session.ts` | SignalR connection hook |
+| `apps/web/src/lib/hooks/use-session-scores.ts` | Real-time score state |
+| `apps/web/src/lib/stores/live-session-store.ts` | Zustand store for session |
+
+### Frontend — Modified Files
+
+| File | Change |
+|------|--------|
+| `apps/web/src/lib/api/clients/liveSessionsClient.ts` | Add `startImprovvisata()`, `createPauseSnapshot()`, `resumeSession()`, `submitDispute()`, `getDisputeHistory()` |
+| `apps/web/src/components/library/add-game-sheet/steps/SuccessState.tsx` | Add processing progress indicator |
+| `apps/web/src/app/(authenticated)/library/private/[privateGameId]/page.tsx` | Add "Sessioni in pausa" section |
+
+### Test Files
+
+| File | Tests |
+|------|-------|
+| `apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/PauseSnapshotTests.cs` | Entity creation, validation |
+| `apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/RuleDisputeEntryTests.cs` | VO immutability |
+| `apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/LiveGameSession_DisputesTests.cs` | AddDispute, JSONB serialization |
+| `apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/StartImprovvisataSessionCommandHandlerTests.cs` | Session creation flow |
+| `apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/CreatePauseSnapshotCommandHandlerTests.cs` | Save flow |
+| `apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/ResumeSessionCommandHandlerTests.cs` | Resume flow |
+| `apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/SubmitRuleDisputeCommandHandlerTests.cs` | Arbitro flow |
+| `apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/AutoCreateAgentOnPdfReadyHandlerTests.cs` | Auto-create flow |
+| `apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/GenerateAgentSummaryHandlerTests.cs` | Summary generation |
+| `apps/api/tests/Api.Tests/Hubs/GameStateHub_ImprovvisataTests.cs` | New SignalR methods |
+| `apps/api/tests/Api.Tests/Infrastructure/SessionAutoSaveBackgroundServiceTests.cs` | Auto-save logic |
+| `apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/SessionContextPromptBuilderTests.cs` | Prompt building |
+| `apps/web/src/components/sessions/live/__tests__/ScoreBoard.test.tsx` | Score display + interaction |
+| `apps/web/src/components/sessions/live/__tests__/ArbitroModal.test.tsx` | Dispute submission |
+| `apps/web/src/components/sessions/live/__tests__/SaveSessionModal.test.tsx` | Save confirmation |
+| `apps/web/src/components/sessions/live/__tests__/InviteModal.test.tsx` | QR + link display |
+| `apps/web/src/components/sessions/live/__tests__/PausedSessionCard.test.tsx` | Resume UI |
+| `apps/web/src/lib/hooks/__tests__/use-signalr-session.test.ts` | Hook connection lifecycle |
+| `apps/web/src/app/join/__tests__/guest-join.test.tsx` | Guest landing page |
+
+---
+
+## Chunk 1: Backend Domain Model + Infrastructure
+
+### Task 1: RuleDisputeEntry Value Object
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/GameManagement/Domain/ValueObjects/RuleDisputeEntry.cs`
+- Test: `apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/RuleDisputeEntryTests.cs`
+
+- [ ] **Step 1: Write failing test for RuleDisputeEntry creation**
+
+```csharp
+// RuleDisputeEntryTests.cs
+public class RuleDisputeEntryTests
+{
+    [Fact]
+    public void Create_WithValidData_ShouldCreateEntry()
+    {
+        var entry = new RuleDisputeEntry(
+            id: Guid.NewGuid(),
+            description: "Can I play 2 cards per turn?",
+            verdict: "No, only one card per turn is allowed.",
+            ruleReferences: new List<string> { "Page 12, Section 3.2" },
+            raisedByPlayerName: "Marco",
+            timestamp: DateTime.UtcNow);
+
+        Assert.Equal("Marco", entry.RaisedByPlayerName);
+        Assert.Single(entry.RuleReferences);
+        Assert.NotEqual(Guid.Empty, entry.Id);
+    }
+
+    [Fact]
+    public void Create_WithEmptyDescription_ShouldThrow()
+    {
+        Assert.Throws<ArgumentException>(() => new RuleDisputeEntry(
+            id: Guid.NewGuid(),
+            description: "",
+            verdict: "verdict",
+            ruleReferences: new List<string>(),
+            raisedByPlayerName: "Marco",
+            timestamp: DateTime.UtcNow));
+    }
+}
+```
+
+- [ ] **Step 2: Run test — expect FAIL** (class doesn't exist)
+
+Run: `cd apps/api && dotnet test --filter "FullyQualifiedName~RuleDisputeEntryTests" --no-build 2>&1 | head -20`
+
+- [ ] **Step 3: Implement RuleDisputeEntry**
+
+```csharp
+// RuleDisputeEntry.cs
+namespace Api.BoundedContexts.GameManagement.Domain.ValueObjects;
+
+public sealed record RuleDisputeEntry
+{
+    public Guid Id { get; init; }
+    public string Description { get; init; }
+    public string Verdict { get; init; }
+    public List<string> RuleReferences { get; init; }
+    public string RaisedByPlayerName { get; init; }
+    public DateTime Timestamp { get; init; }
+
+    public RuleDisputeEntry(
+        Guid id, string description, string verdict,
+        List<string> ruleReferences, string raisedByPlayerName,
+        DateTime timestamp)
+    {
+        if (string.IsNullOrWhiteSpace(description))
+            throw new ArgumentException("Description is required.", nameof(description));
+        if (string.IsNullOrWhiteSpace(verdict))
+            throw new ArgumentException("Verdict is required.", nameof(verdict));
+        if (string.IsNullOrWhiteSpace(raisedByPlayerName))
+            throw new ArgumentException("Player name is required.", nameof(raisedByPlayerName));
+
+        Id = id == Guid.Empty ? Guid.NewGuid() : id;
+        Description = description;
+        Verdict = verdict;
+        RuleReferences = ruleReferences ?? new List<string>();
+        RaisedByPlayerName = raisedByPlayerName;
+        Timestamp = timestamp;
+    }
+}
+```
+
+- [ ] **Step 4: Run test — expect PASS**
+
+Run: `cd apps/api && dotnet test --filter "FullyQualifiedName~RuleDisputeEntryTests"`
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/GameManagement/Domain/ValueObjects/RuleDisputeEntry.cs \
+       apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/RuleDisputeEntryTests.cs
+git commit -m "feat(game-night): add RuleDisputeEntry value object for arbitro verdicts"
+```
+
+---
+
+### Task 2: Add Disputes JSONB to LiveGameSession
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/LiveGameSession.cs`
+- Modify: `apps/api/src/Api/Infrastructure/Configurations/GameManagement/LiveGameSessionEntityConfiguration.cs`
+- Test: `apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/LiveGameSession_DisputesTests.cs`
+
+- [ ] **Step 1: Write failing test for AddDispute on LiveGameSession**
+
+```csharp
+// LiveGameSession_DisputesTests.cs
+public class LiveGameSession_DisputesTests
+{
+    [Fact]
+    public void AddDispute_ShouldAddToDisputesList()
+    {
+        var session = CreateTestSession();
+        var dispute = new RuleDisputeEntry(
+            Guid.NewGuid(), "Can I do X?", "No, rule says Y.",
+            new List<string> { "Page 5" }, "Marco", DateTime.UtcNow);
+
+        session.AddDispute(dispute);
+
+        Assert.Single(session.Disputes);
+        Assert.Equal("Marco", session.Disputes[0].RaisedByPlayerName);
+    }
+
+    [Fact]
+    public void Disputes_ShouldBeReadOnly()
+    {
+        var session = CreateTestSession();
+        Assert.IsAssignableFrom<IReadOnlyList<RuleDisputeEntry>>(session.Disputes);
+    }
+
+    private LiveGameSession CreateTestSession()
+    {
+        // Use existing factory method — check LiveGameSession.Create() signature
+        return LiveGameSession.Create(Guid.NewGuid(), Guid.NewGuid(), "Test Game");
+    }
+}
+```
+
+- [ ] **Step 2: Run test — expect FAIL** (AddDispute method doesn't exist)
+
+- [ ] **Step 3: Add Disputes collection and AddDispute method to LiveGameSession**
+
+Add to `LiveGameSession.cs`:
+```csharp
+private readonly List<RuleDisputeEntry> _disputes = new();
+public IReadOnlyList<RuleDisputeEntry> Disputes => _disputes.AsReadOnly();
+
+public void AddDispute(RuleDisputeEntry dispute)
+{
+    ArgumentNullException.ThrowIfNull(dispute);
+    _disputes.Add(dispute);
+}
+```
+
+- [ ] **Step 4: Add Pause() and Resume() domain methods to LiveGameSession**
+
+```csharp
+// Add to LiveGameSession.cs
+public void Pause()
+{
+    if (Status != LiveSessionStatus.InProgress)
+        throw new InvalidOperationException("Can only pause an in-progress session.");
+    Status = LiveSessionStatus.Paused;
+    PausedAt = DateTime.UtcNow;
+}
+
+public void Resume()
+{
+    if (Status != LiveSessionStatus.Paused)
+        throw new InvalidOperationException("Can only resume a paused session.");
+    Status = LiveSessionStatus.InProgress;
+    PausedAt = null;
+}
+```
+
+Add tests:
+```csharp
+[Fact]
+public void Pause_WhenInProgress_ShouldSetStatusToPaused()
+{
+    var session = CreateTestSession(); // Status = InProgress
+    session.Pause();
+    Assert.Equal(LiveSessionStatus.Paused, session.Status);
+    Assert.NotNull(session.PausedAt);
+}
+
+[Fact]
+public void Resume_WhenPaused_ShouldSetStatusToInProgress()
+{
+    var session = CreateTestSession();
+    session.Pause();
+    session.Resume();
+    Assert.Equal(LiveSessionStatus.InProgress, session.Status);
+    Assert.Null(session.PausedAt);
+}
+```
+
+- [ ] **Step 5: Configure JSONB column in EF configuration**
+
+Add to `LiveGameSessionEntityConfiguration.cs`:
+```csharp
+builder.Property(e => e.Disputes)
+    .HasColumnType("jsonb")
+    .HasConversion(
+        v => JsonSerializer.Serialize(v, JsonSerializerOptions.Default),
+        v => JsonSerializer.Deserialize<List<RuleDisputeEntry>>(v, JsonSerializerOptions.Default)
+            ?? new List<RuleDisputeEntry>());
+```
+
+Note: Check existing JSONB patterns in codebase (e.g., `AgentDefinition.KbCardIds` uses a backing field pattern). Follow the same approach.
+
+- [ ] **Step 5: Run test — expect PASS**
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/LiveGameSession.cs \
+       apps/api/src/Api/Infrastructure/Configurations/GameManagement/LiveGameSessionEntityConfiguration.cs \
+       apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/LiveGameSession_DisputesTests.cs
+git commit -m "feat(game-night): add Disputes JSONB collection to LiveGameSession"
+```
+
+---
+
+### Task 3: PauseSnapshot Entity + Repository
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/PauseSnapshot/PauseSnapshot.cs`
+- Create: `apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/PauseSnapshot/PlayerScoreSnapshot.cs`
+- Create: `apps/api/src/Api/BoundedContexts/GameManagement/Domain/Repositories/IPauseSnapshotRepository.cs`
+- Create: `apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Persistence/PauseSnapshotRepository.cs`
+- Create: `apps/api/src/Api/Infrastructure/Configurations/GameManagement/PauseSnapshotEntityConfiguration.cs`
+- Create: `apps/api/src/Api/Infrastructure/Entities/GameManagement/PauseSnapshotEntity.cs`
+- Test: `apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/PauseSnapshotTests.cs`
+
+- [ ] **Step 1: Write failing tests for PauseSnapshot creation**
+
+```csharp
+// PauseSnapshotTests.cs
+public class PauseSnapshotTests
+{
+    [Fact]
+    public void Create_WithValidData_ShouldCreateSnapshot()
+    {
+        var snapshot = PauseSnapshot.Create(
+            liveGameSessionId: Guid.NewGuid(),
+            currentTurn: 5,
+            currentPhase: "Trading",
+            playerScores: new List<PlayerScoreSnapshot>
+            {
+                new("Marco", 42),
+                new("Giulia", 45)
+            },
+            savedByUserId: Guid.NewGuid(),
+            isAutoSave: false);
+
+        Assert.Equal(5, snapshot.CurrentTurn);
+        Assert.Equal("Trading", snapshot.CurrentPhase);
+        Assert.Equal(2, snapshot.PlayerScores.Count);
+        Assert.False(snapshot.IsAutoSave);
+        Assert.Null(snapshot.AgentConversationSummary);
+    }
+
+    [Fact]
+    public void UpdateSummary_ShouldSetAgentConversationSummary()
+    {
+        var snapshot = PauseSnapshot.Create(
+            Guid.NewGuid(), 1, null, new(), Guid.NewGuid(), false);
+
+        snapshot.UpdateSummary("{\"game_state\": \"round 5\"}");
+
+        Assert.NotNull(snapshot.AgentConversationSummary);
+    }
+}
+```
+
+- [ ] **Step 2: Run test — expect FAIL**
+
+- [ ] **Step 3: Implement PlayerScoreSnapshot record**
+
+```csharp
+// PlayerScoreSnapshot.cs
+namespace Api.BoundedContexts.GameManagement.Domain.Entities.PauseSnapshot;
+
+public sealed record PlayerScoreSnapshot(string PlayerName, decimal Score, int? PlayerId = null);
+```
+
+- [ ] **Step 4: Implement PauseSnapshot entity**
+
+```csharp
+// PauseSnapshot.cs
+namespace Api.BoundedContexts.GameManagement.Domain.Entities.PauseSnapshot;
+
+public sealed class PauseSnapshot : Entity
+{
+    public Guid LiveGameSessionId { get; private set; }
+    public int CurrentTurn { get; private set; }
+    public string? CurrentPhase { get; private set; }
+    public List<PlayerScoreSnapshot> PlayerScores { get; private set; } = new();
+    public List<Guid> AttachmentIds { get; private set; } = new();
+    public List<RuleDisputeEntry> Disputes { get; private set; } = new();
+    public string? AgentConversationSummary { get; private set; }
+    public string? GameStateJson { get; private set; }
+    public DateTime SavedAt { get; private set; }
+    public Guid SavedByUserId { get; private set; }
+    public bool IsAutoSave { get; private set; }
+
+    private PauseSnapshot() { } // EF
+
+    public static PauseSnapshot Create(
+        Guid liveGameSessionId, int currentTurn, string? currentPhase,
+        List<PlayerScoreSnapshot> playerScores, Guid savedByUserId,
+        bool isAutoSave, List<Guid>? attachmentIds = null,
+        List<RuleDisputeEntry>? disputes = null, string? gameStateJson = null)
+    {
+        return new PauseSnapshot
+        {
+            Id = Guid.NewGuid(),
+            LiveGameSessionId = liveGameSessionId,
+            CurrentTurn = currentTurn,
+            CurrentPhase = currentPhase,
+            PlayerScores = playerScores ?? new(),
+            AttachmentIds = attachmentIds ?? new(),
+            Disputes = disputes ?? new(),
+            GameStateJson = gameStateJson,
+            SavedAt = DateTime.UtcNow,
+            SavedByUserId = savedByUserId,
+            IsAutoSave = isAutoSave
+        };
+    }
+
+    public void UpdateSummary(string summary)
+    {
+        AgentConversationSummary = summary;
+    }
+}
+```
+
+- [ ] **Step 5: Implement repository interface**
+
+```csharp
+// IPauseSnapshotRepository.cs
+namespace Api.BoundedContexts.GameManagement.Domain.Repositories;
+
+public interface IPauseSnapshotRepository
+{
+    Task<PauseSnapshot?> GetByIdAsync(Guid id, CancellationToken ct = default);
+    Task<PauseSnapshot?> GetLatestBySessionIdAsync(Guid sessionId, CancellationToken ct = default);
+    Task<IReadOnlyList<PauseSnapshot>> GetBySessionIdAsync(Guid sessionId, CancellationToken ct = default);
+    Task AddAsync(PauseSnapshot snapshot, CancellationToken ct = default);
+    Task UpdateAsync(PauseSnapshot snapshot, CancellationToken ct = default);
+    Task DeleteAutoSavesBySessionIdAsync(Guid sessionId, CancellationToken ct = default);
+}
+```
+
+- [ ] **Step 6: Implement EF entity model, configuration, and repository**
+
+Follow existing patterns from `SessionSnapshotEntity.cs` and `SessionSnapshotEntityConfiguration.cs`. JSONB columns for `PlayerScores`, `AttachmentIds`, `Disputes`. FK to `LiveGameSessions`.
+
+- [ ] **Step 7: Run tests — expect PASS**
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/PauseSnapshot/ \
+       apps/api/src/Api/BoundedContexts/GameManagement/Domain/Repositories/IPauseSnapshotRepository.cs \
+       apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/Persistence/PauseSnapshotRepository.cs \
+       apps/api/src/Api/Infrastructure/Configurations/GameManagement/PauseSnapshotEntityConfiguration.cs \
+       apps/api/src/Api/Infrastructure/Entities/GameManagement/PauseSnapshotEntity.cs \
+       apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Domain/PauseSnapshotTests.cs
+git commit -m "feat(game-night): add PauseSnapshot entity for session save/resume"
+```
+
+---
+
+### Task 4: EF Migration + SnapshotTrigger Update
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/SessionSnapshot/SnapshotTrigger.cs`
+- Create: New migration in `apps/api/src/Api/Infrastructure/Migrations/`
+
+- [ ] **Step 1: Add AutoSave value to SnapshotTrigger enum**
+
+```csharp
+// Add to SnapshotTrigger.cs
+AutoSave = 8
+```
+
+- [ ] **Step 2: Register PauseSnapshotRepository in DI**
+
+Add to `GameManagementServiceExtensions.cs`:
+```csharp
+services.AddScoped<IPauseSnapshotRepository, PauseSnapshotRepository>();
+```
+
+- [ ] **Step 3: Generate EF migration**
+
+```bash
+cd apps/api/src/Api
+dotnet ef migrations add AddPauseSnapshotAndDisputesJsonb
+```
+
+- [ ] **Step 4: Review generated migration SQL**
+
+Verify it creates:
+- `PauseSnapshots` table with FK to `LiveGameSessions`
+- JSONB columns for `PlayerScores`, `AttachmentIds`, `Disputes` on `PauseSnapshots`
+- JSONB column for `Disputes` on `LiveGameSessions`
+
+- [ ] **Step 5: Apply migration locally**
+
+```bash
+cd apps/api/src/Api
+dotnet ef database update
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/GameManagement/Domain/Entities/SessionSnapshot/SnapshotTrigger.cs \
+       apps/api/src/Api/BoundedContexts/GameManagement/Infrastructure/DependencyInjection/GameManagementServiceExtensions.cs \
+       apps/api/src/Api/Infrastructure/Migrations/
+git commit -m "feat(game-night): add EF migration for PauseSnapshot table and Disputes JSONB"
+```
+
+---
+
+## Chunk 2: Backend Commands + Handlers
+
+### Task 5: Domain Events
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/GameManagement/Domain/Events/SessionSaveRequestedEvent.cs`
+- Create: `apps/api/src/Api/BoundedContexts/GameManagement/Domain/Events/DisputeResolvedEvent.cs`
+- Create: `apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Events/AgentAutoCreatedEvent.cs`
+- Create: `apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Events/AgentSummaryGeneratedEvent.cs`
+
+- [ ] **Step 1: Create all 7 domain events**
+
+```csharp
+// SessionSaveRequestedEvent.cs
+public sealed record SessionSaveRequestedEvent(
+    Guid PauseSnapshotId,
+    Guid LiveGameSessionId,
+    Guid AgentDefinitionId,
+    List<string> LastMessages) : INotification;
+
+// DisputeResolvedEvent.cs
+public sealed record DisputeResolvedEvent(
+    Guid SessionId,
+    RuleDisputeEntry Dispute) : INotification;
+
+// AgentAutoCreatedEvent.cs
+public sealed record AgentAutoCreatedEvent(
+    Guid AgentDefinitionId,
+    Guid PrivateGameId,
+    Guid UserId,
+    string GameName) : INotification;
+
+// AgentSummaryGeneratedEvent.cs
+public sealed record AgentSummaryGeneratedEvent(
+    Guid PauseSnapshotId,
+    string Summary) : INotification;
+
+// SessionPausedEvent.cs
+public sealed record SessionPausedEvent(
+    Guid SessionId) : INotification;
+
+// SessionResumedEvent.cs
+public sealed record SessionResumedEvent(
+    Guid SessionId,
+    string? AgentRecap) : INotification;
+
+// AppBackgroundedEvent.cs
+public sealed record AppBackgroundedEvent(
+    Guid SessionId) : INotification;
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/GameManagement/Domain/Events/ \
+       apps/api/src/Api/BoundedContexts/KnowledgeBase/Domain/Events/
+git commit -m "feat(game-night): add domain events for session save, disputes, agent creation"
+```
+
+---
+
+### Task 6: AutoCreateAgentOnPdfReadyHandler
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/EventHandlers/AutoCreateAgentOnPdfReadyHandler.cs`
+- Create: `apps/api/src/Api/BoundedContexts/UserNotifications/Application/EventHandlers/NotifyAgentReadyHandler.cs`
+- Test: `apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/AutoCreateAgentOnPdfReadyHandlerTests.cs`
+
+- [ ] **Step 1: Find the PDF processing completion event**
+
+Search for the domain event that fires when PDF processing (embedding/indexing) completes. Check `DocumentProcessing` bounded context for events. If none exists, check what the existing cross-context test stubs reference.
+
+```bash
+cd apps/api && grep -r "PdfProcessing\|DocumentIndexed\|EmbeddingCompleted\|VectorDocument.*Created" \
+  src/Api/BoundedContexts/DocumentProcessing/Domain/Events/ \
+  src/Api/BoundedContexts/KnowledgeBase/Domain/Events/ 2>/dev/null | head -20
+```
+
+- [ ] **Step 2: Write failing test for AutoCreateAgentOnPdfReadyHandler**
+
+```csharp
+// AutoCreateAgentOnPdfReadyHandlerTests.cs
+public class AutoCreateAgentOnPdfReadyHandlerTests
+{
+    [Fact]
+    public async Task Handle_WhenPdfLinkedToPrivateGame_ShouldCreateAgent()
+    {
+        // Arrange: mock IMediator, IPrivateGameRepository
+        // The handler receives the PDF completion event
+        // It checks if the PDF is linked to a PrivateGame
+        // If yes: creates AgentDefinition with default prompt, publishes AgentAutoCreatedEvent
+
+        // Assert: mediator.Send(CreateAgentDefinitionCommand) was called
+        // Assert: mediator.Publish(AgentAutoCreatedEvent) was called
+    }
+
+    [Fact]
+    public async Task Handle_WhenPdfNotLinkedToPrivateGame_ShouldDoNothing()
+    {
+        // No agent created for unlinked PDFs
+    }
+
+    [Fact]
+    public async Task Handle_WhenAgentCreationFails_ShouldPublishFailureNotification()
+    {
+        // Agent creation throws → notification sent instead
+    }
+}
+```
+
+- [ ] **Step 3: Implement AutoCreateAgentOnPdfReadyHandler**
+
+Key logic:
+1. Receive PDF completion event
+2. Query PrivateGame by PdfDocumentId (check if this FK exists; if not, use the document's GameId or SharedGameId)
+3. If linked to PrivateGame → create AgentDefinition via MediatR `Send(CreateAgentDefinitionCommand)`
+4. Use default Italian prompt template with `{GameName}` interpolation
+5. Publish `AgentAutoCreatedEvent` on success
+6. On failure: catch, log, publish notification with manual creation link
+
+- [ ] **Step 4: Implement NotifyAgentReadyHandler**
+
+```csharp
+// NotifyAgentReadyHandler.cs — handles AgentAutoCreatedEvent
+public class NotifyAgentReadyHandler : INotificationHandler<AgentAutoCreatedEvent>
+{
+    public async Task Handle(AgentAutoCreatedEvent notification, CancellationToken ct)
+    {
+        var notif = new Notification(
+            Guid.NewGuid(),
+            notification.UserId,
+            NotificationType.FromString("AgentReady"),
+            NotificationSeverity.Info,
+            $"Agente per {notification.GameName} pronto!",
+            $"L'agente AI per {notification.GameName} è stato creato automaticamente.",
+            link: $"/library/private/{notification.PrivateGameId}/toolkit");
+
+        await _notificationRepository.AddAsync(notif, ct);
+    }
+}
+```
+
+- [ ] **Step 5: Implement RetryPdfProcessingCommand**
+
+Create `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/RetryPdfProcessingCommand.cs`:
+- Re-queues a failed PDF document for processing
+- Max 3 retries (track retry count on PdfDocument entity or metadata)
+- On max retries exceeded: notification with "Contatta il supporto"
+- Endpoint: `POST /api/v1/game-night/pdf/{pdfId}/retry`
+
+- [ ] **Step 6: Register handlers in DI**
+
+Add to `KnowledgeBaseServiceExtensions.cs` — MediatR auto-discovers `INotificationHandler` implementations, but verify the assembly scanning includes the handler's namespace.
+
+- [ ] **Step 7: Run tests — expect PASS**
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/EventHandlers/AutoCreateAgentOnPdfReadyHandler.cs \
+       apps/api/src/Api/BoundedContexts/UserNotifications/Application/EventHandlers/NotifyAgentReadyHandler.cs \
+       apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/RetryPdfProcessingCommand.cs \
+       apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/AutoCreateAgentOnPdfReadyHandlerTests.cs
+git commit -m "feat(game-night): auto-create agent when PDF processing completes + retry support"
+```
+
+---
+
+### Task 7: StartImprovvisataSessionCommand
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/StartImprovvisataSessionCommand.cs`
+- Test: `apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/StartImprovvisataSessionCommandHandlerTests.cs`
+
+- [ ] **Step 1: Write failing tests**
+
+Test cases:
+1. Creates `LiveGameSession` with correct game name, status InProgress
+2. Creates `SessionInvite` with 24h expiry, max 10 uses
+3. Sets current user as host player
+4. Links toolkit if PrivateGame has one
+5. Returns sessionId, inviteCode, shareLink
+6. Fails if PrivateGame not found → NotFoundException
+7. Tier quota check (if applicable)
+
+- [ ] **Step 2: Implement command + handler**
+
+```csharp
+// StartImprovvisataSessionCommand.cs
+public sealed record StartImprovvisataSessionCommand(
+    Guid PrivateGameId) : IRequest<StartImprovvisataSessionResponse>;
+
+public sealed record StartImprovvisataSessionResponse(
+    Guid SessionId,
+    string InviteCode,
+    string ShareLink);
+```
+
+Handler logic:
+1. Get PrivateGame by ID (throw NotFoundException if missing)
+2. Create LiveGameSession via factory method
+3. Add host as first player
+4. Create SessionInvite (6-char code + UUID token, 24h expiry, max 10 uses)
+5. Save all via repository
+6. Return response with session code and share link
+
+- [ ] **Step 3: Add FluentValidation validator**
+
+```csharp
+public class StartImprovvisataSessionValidator : AbstractValidator<StartImprovvisataSessionCommand>
+{
+    public StartImprovvisataSessionValidator()
+    {
+        RuleFor(x => x.PrivateGameId).NotEmpty();
+    }
+}
+```
+
+- [ ] **Step 4: Run tests — expect PASS**
+
+- [ ] **Step 5: Add endpoint to GameNightImprovvisataEndpoints.cs**
+
+```csharp
+group.MapPost("/start-session", async (StartImprovvisataSessionCommand cmd, IMediator mediator) =>
+    Results.Ok(await mediator.Send(cmd)))
+    .RequireAuthorization();
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/StartImprovvisataSessionCommand.cs \
+       apps/api/src/Api/Routing/GameNightImprovvisataEndpoints.cs \
+       apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/StartImprovvisataSessionCommandHandlerTests.cs
+git commit -m "feat(game-night): add StartImprovvisataSession command for quick session creation"
+```
+
+---
+
+### Task 8: SubmitRuleDisputeCommand (Arbitro)
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/SubmitRuleDisputeCommand.cs`
+- Test: `apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/SubmitRuleDisputeCommandHandlerTests.cs`
+
+- [ ] **Step 1: Write failing tests**
+
+Test cases:
+1. Creates RuleDisputeEntry with verdict from agent
+2. Adds dispute to LiveGameSession.Disputes
+3. Publishes DisputeResolvedEvent for SignalR broadcast
+4. Returns the verdict DTO
+5. Fails if session not found
+6. Fails if session not InProgress
+
+- [ ] **Step 2: Implement command + handler**
+
+```csharp
+public sealed record SubmitRuleDisputeCommand(
+    Guid SessionId,
+    string Description,
+    string RaisedByPlayerName) : IRequest<RuleDisputeResponse>;
+
+public sealed record RuleDisputeResponse(
+    Guid Id, string Verdict, List<string> RuleReferences, string? Note);
+```
+
+Handler logic:
+1. Load LiveGameSession
+2. Load AgentDefinition via session's ToolkitId
+3. Build arbitration prompt (spec Section 3B) with session context + previous disputes
+4. Query the RAG agent (use existing chat/query service)
+5. Parse structured response (VERDETTO/REGOLA/NOTA sections)
+6. Create RuleDisputeEntry, call `session.AddDispute(entry)`
+7. Publish `DisputeResolvedEvent`
+8. Save session
+
+**Important:** Check how existing agent querying works — look at `ChatSessionsClient` or the existing RAG query pipeline in KnowledgeBase. The handler needs to call the same LLM query path but with the arbitro system prompt.
+
+- [ ] **Step 3: Add endpoint**
+
+```csharp
+group.MapPost("/sessions/{sessionId:guid}/disputes", async (
+    Guid sessionId, SubmitRuleDisputeRequest request, IMediator mediator) =>
+    Results.Ok(await mediator.Send(new SubmitRuleDisputeCommand(
+        sessionId, request.Description, request.RaisedByPlayerName))))
+    .RequireAuthorization();
+```
+
+- [ ] **Step 4: Run tests — expect PASS**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/SubmitRuleDisputeCommand.cs \
+       apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/SubmitRuleDisputeCommandHandlerTests.cs
+git commit -m "feat(game-night): add SubmitRuleDispute command for arbitro mode"
+```
+
+---
+
+### Task 8b: Session Context Injection into Agent Prompt
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/SessionContextPromptBuilder.cs`
+
+This is **Must-Have #8** from the spec. When a chat query includes a `sessionId`, the agent's system prompt must be augmented with session context.
+
+- [ ] **Step 1: Write failing test**
+
+Test that `SessionContextPromptBuilder.BuildSessionPrompt()` returns a prompt containing:
+- Game name, player names, current turn/phase, scores
+- Previous dispute verdicts (for consistency)
+
+- [ ] **Step 2: Implement SessionContextPromptBuilder**
+
+```csharp
+public class SessionContextPromptBuilder
+{
+    public string BuildSessionPrompt(
+        string gameName, List<string> playerNames, int currentTurn,
+        string? currentPhase, Dictionary<string, decimal> scores,
+        List<RuleDisputeEntry> previousDisputes)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine($"Sei l'assistente per \"{gameName}\". Sessione attiva con {playerNames.Count} giocatori: {string.Join(", ", playerNames)}.");
+        sb.AppendLine($"Turno corrente: {currentTurn}. Fase: {currentPhase ?? "N/A"}.");
+        sb.AppendLine($"Punteggi: {string.Join(", ", scores.Select(s => $"{s.Key} {s.Value}"))}.");
+        sb.AppendLine("Quando rispondi su regole, cita SEMPRE la pagina del regolamento.");
+        sb.AppendLine("Se c'è ambiguità nella regola, spiega le possibili interpretazioni.");
+
+        if (previousDisputes.Any())
+        {
+            sb.AppendLine();
+            sb.AppendLine("Verdetti precedenti in questa sessione:");
+            foreach (var d in previousDisputes)
+                sb.AppendLine($"- Disputa: \"{d.Description}\" → Verdetto: \"{d.Verdict}\"");
+        }
+
+        return sb.ToString();
+    }
+}
+```
+
+- [ ] **Step 3: Integrate into existing chat/query pipeline**
+
+Find where the agent system prompt is assembled (likely in the RAG query handler or chat session handler in KnowledgeBase). When `sessionId` is provided in the query:
+1. Load `LiveGameSession` by ID
+2. Call `SessionContextPromptBuilder.BuildSessionPrompt()`
+3. Prepend to the agent's system prompt
+
+- [ ] **Step 4: Run tests — expect PASS**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/Services/SessionContextPromptBuilder.cs
+git commit -m "feat(game-night): inject session context into agent prompt for live sessions"
+```
+
+---
+
+### Task 9: CreatePauseSnapshot + ResumeSession Commands
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/CreatePauseSnapshotCommand.cs`
+- Create: `apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/ResumeSessionFromSnapshotCommand.cs`
+- Create: `apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/EventHandlers/GenerateAgentSummaryHandler.cs`
+- Test: `apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/CreatePauseSnapshotCommandHandlerTests.cs`
+- Test: `apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/ResumeSessionCommandHandlerTests.cs`
+- Test: `apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/GenerateAgentSummaryHandlerTests.cs`
+
+- [ ] **Step 1: Write failing tests for CreatePauseSnapshotCommand**
+
+Test cases:
+1. Creates PauseSnapshot with current session state
+2. Sets session status to Paused
+3. Publishes SessionSaveRequestedEvent for async summary
+4. Returns snapshot ID
+5. Waits for pending score proposals (max 5s)
+
+- [ ] **Step 2: Implement CreatePauseSnapshotCommand + handler**
+
+```csharp
+public sealed record CreatePauseSnapshotCommand(
+    Guid SessionId,
+    List<Guid>? FinalPhotoIds = null) : IRequest<Guid>;
+```
+
+Handler logic:
+1. Load LiveGameSession with all related data
+2. Wait for pending score proposals (configurable timeout, default 5s)
+3. Capture: CurrentTurn, CurrentPhase, PlayerScores, Disputes, AttachmentIds
+4. Create PauseSnapshot via factory (IsAutoSave = false)
+5. Set session Status = Paused, PausedAt = UtcNow
+6. Save snapshot via IPauseSnapshotRepository
+7. Publish SessionSaveRequestedEvent (for async summary in KnowledgeBase)
+8. Return snapshot ID
+
+- [ ] **Step 3: Write failing tests for ResumeSessionFromSnapshotCommand**
+
+Test cases:
+1. Loads PauseSnapshot and restores session state
+2. Sets status to InProgress, clears PausedAt
+3. Creates new SessionInvite
+4. Publishes SessionResumedEvent
+5. Returns session ID + new invite code
+6. Fails if session not Paused
+7. Works without AgentConversationSummary (fallback)
+
+- [ ] **Step 4: Implement ResumeSessionFromSnapshotCommand + handler**
+
+```csharp
+public sealed record ResumeSessionFromSnapshotCommand(
+    Guid SessionId) : IRequest<ResumeSessionResponse>;
+
+public sealed record ResumeSessionResponse(
+    Guid SessionId, string InviteCode, string ShareLink,
+    string? AgentRecap);
+```
+
+Handler logic:
+1. Load latest PauseSnapshot for session
+2. Restore session state (turn, phase)
+3. Set Status = InProgress, PausedAt = null
+4. Create new SessionInvite (old may be expired)
+5. Delete auto-save snapshots for this session
+6. If AgentConversationSummary exists → use for recap; else → fallback to raw messages
+7. Return response
+
+- [ ] **Step 5: Implement GenerateAgentSummaryHandler**
+
+```csharp
+// Handles SessionSaveRequestedEvent — generates summary asynchronously
+public class GenerateAgentSummaryHandler : INotificationHandler<SessionSaveRequestedEvent>
+{
+    public async Task Handle(SessionSaveRequestedEvent notification, CancellationToken ct)
+    {
+        // 1. Get agent for the session
+        // 2. Build summary prompt (spec Section 3C) with last 50 messages
+        // 3. Query LLM for structured JSON summary
+        // 4. Publish AgentSummaryGeneratedEvent with result
+        // Timeout: if generation takes >60s, abandon (PauseSnapshot stays with null summary)
+    }
+}
+```
+
+Also need: handler for `AgentSummaryGeneratedEvent` that updates PauseSnapshot:
+```csharp
+public class UpdateSnapshotSummaryHandler : INotificationHandler<AgentSummaryGeneratedEvent>
+{
+    public async Task Handle(AgentSummaryGeneratedEvent notification, CancellationToken ct)
+    {
+        var snapshot = await _repo.GetByIdAsync(notification.PauseSnapshotId, ct);
+        snapshot?.UpdateSummary(notification.Summary);
+        if (snapshot != null) await _repo.UpdateAsync(snapshot, ct);
+    }
+}
+```
+
+- [ ] **Step 6: Run all tests — expect PASS**
+
+- [ ] **Step 7: Add endpoints**
+
+```csharp
+// In GameNightImprovvisataEndpoints.cs
+group.MapPost("/sessions/{sessionId:guid}/save", async (Guid sessionId, IMediator m) =>
+    Results.Ok(await m.Send(new CreatePauseSnapshotCommand(sessionId))))
+    .RequireAuthorization();
+
+group.MapPost("/sessions/{sessionId:guid}/resume", async (Guid sessionId, IMediator m) =>
+    Results.Ok(await m.Send(new ResumeSessionFromSnapshotCommand(sessionId))))
+    .RequireAuthorization();
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/CreatePauseSnapshotCommand.cs \
+       apps/api/src/Api/BoundedContexts/GameManagement/Application/Commands/ResumeSessionFromSnapshotCommand.cs \
+       apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/EventHandlers/GenerateAgentSummaryHandler.cs \
+       apps/api/src/Api/BoundedContexts/KnowledgeBase/Application/EventHandlers/UpdateSnapshotSummaryHandler.cs \
+       apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/CreatePauseSnapshotCommandHandlerTests.cs \
+       apps/api/tests/Api.Tests/BoundedContexts/GameManagement/Application/ResumeSessionCommandHandlerTests.cs \
+       apps/api/tests/Api.Tests/BoundedContexts/KnowledgeBase/Application/GenerateAgentSummaryHandlerTests.cs
+git commit -m "feat(game-night): add save/resume commands with async agent summary"
+```
+
+---
+
+## Chunk 3: Backend SignalR + Background Services
+
+### Task 10: Extend GameStateHub
+
+**Files:**
+- Modify: `apps/api/src/Api/Hubs/GameStateHub.cs`
+- Test: `apps/api/tests/Api.Tests/Hubs/GameStateHub_ImprovvisataTests.cs`
+
+- [ ] **Step 1: Write failing tests for new SignalR methods**
+
+Test cases:
+1. `DisputeResolved` broadcasts verdict to session group
+2. `SessionPaused` notifies all participants, triggers graceful disconnect
+3. `ScoreUpdated` broadcasts score change to session group
+4. `AppBackgrounded` triggers auto-save (fire and forget)
+
+- [ ] **Step 2: Add new methods to GameStateHub**
+
+```csharp
+// Add to GameStateHub.cs
+public async Task NotifyDisputeResolved(string sessionId, RuleDisputeResponse verdict)
+{
+    await Clients.Group($"session:{sessionId}").SendAsync("DisputeResolved", verdict);
+}
+
+public async Task NotifySessionPaused(string sessionId)
+{
+    await Clients.Group($"session:{sessionId}").SendAsync("SessionPaused");
+}
+
+public async Task NotifyScoreUpdated(string sessionId, object scoreUpdate)
+{
+    await Clients.Group($"session:{sessionId}").SendAsync("ScoreUpdated", scoreUpdate);
+}
+
+public async Task AppBackgrounded(string sessionId)
+{
+    // Best-effort auto-save trigger
+    await _mediator.Publish(new AppBackgroundedEvent(Guid.Parse(sessionId)));
+}
+```
+
+- [ ] **Step 3: Create DisputeResolvedEvent SignalR handler**
+
+This handler listens for `DisputeResolvedEvent` (MediatR notification) and calls `NotifyDisputeResolved` on the hub.
+
+- [ ] **Step 4: Run tests — expect PASS**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/api/src/Api/Hubs/GameStateHub.cs \
+       apps/api/tests/Api.Tests/Hubs/GameStateHub_ImprovvisataTests.cs
+git commit -m "feat(game-night): extend GameStateHub with dispute, pause, score SignalR methods"
+```
+
+---
+
+### Task 11: SessionAutoSaveBackgroundService
+
+**Files:**
+- Create: `apps/api/src/Api/Infrastructure/BackgroundServices/SessionAutoSaveBackgroundService.cs`
+- Test: `apps/api/tests/Api.Tests/Infrastructure/SessionAutoSaveBackgroundServiceTests.cs`
+- Modify: `apps/api/src/Api/Program.cs` or service registration file
+
+- [ ] **Step 1: Write failing test**
+
+Test cases:
+1. Service creates PauseSnapshot(IsAutoSave=true) for active sessions
+2. Service skips sessions with Status != InProgress
+3. Cleanup: deletes auto-saves when manual save occurs
+
+- [ ] **Step 2: Implement background service**
+
+```csharp
+public class SessionAutoSaveBackgroundService : BackgroundService
+{
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<SessionAutoSaveBackgroundService> _logger;
+    private static readonly TimeSpan Interval = TimeSpan.FromMinutes(10);
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            await Task.Delay(Interval, stoppingToken);
+            await AutoSaveActiveSessions(stoppingToken);
+        }
+    }
+
+    private async Task AutoSaveActiveSessions(CancellationToken ct)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var sessionRepo = scope.ServiceProvider.GetRequiredService<ILiveSessionRepository>();
+        var snapshotRepo = scope.ServiceProvider.GetRequiredService<IPauseSnapshotRepository>();
+
+        // Find all sessions with Status = InProgress
+        // For each: create PauseSnapshot(IsAutoSave = true)
+        // Log count of auto-saved sessions
+    }
+}
+```
+
+- [ ] **Step 2: Register in DI**
+
+```csharp
+services.AddHostedService<SessionAutoSaveBackgroundService>();
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/api/src/Api/Infrastructure/BackgroundServices/SessionAutoSaveBackgroundService.cs
+git commit -m "feat(game-night): add auto-save background service (10-min interval)"
+```
+
+---
+
+### Task 12: Add All New Endpoints to Routing
+
+**Files:**
+- Modify: `apps/api/src/Api/Routing/GameNightImprovvisataEndpoints.cs`
+
+- [ ] **Step 1: Add all remaining endpoints**
+
+Verify all endpoints are registered:
+```csharp
+// Existing:
+// GET  /api/v1/game-night/bgg/search
+// POST /api/v1/game-night/import-bgg
+
+// New:
+// POST /api/v1/game-night/start-session
+// POST /api/v1/game-night/sessions/{id}/save
+// POST /api/v1/game-night/sessions/{id}/resume
+// POST /api/v1/game-night/sessions/{id}/disputes
+// GET  /api/v1/game-night/sessions/{id}/disputes
+// GET  /api/v1/game-night/games/{gameId}/disputes  (cross-session history)
+```
+
+- [ ] **Step 2: Run all backend tests**
+
+```bash
+cd apps/api && dotnet test --filter "Category=Unit"
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/api/src/Api/Routing/GameNightImprovvisataEndpoints.cs
+git commit -m "feat(game-night): complete endpoint routing for improvvisata API"
+```
+
+---
+
+## Chunk 4: Frontend — Session UI Components
+
+### Task 13: Live Session Zustand Store + SignalR Hook
+
+**Files:**
+- Create: `apps/web/src/lib/stores/live-session-store.ts`
+- Create: `apps/web/src/lib/hooks/use-signalr-session.ts`
+- Create: `apps/web/src/lib/hooks/use-session-scores.ts`
+- Test: `apps/web/src/lib/hooks/__tests__/use-signalr-session.test.ts`
+
+- [ ] **Step 1: Implement Zustand store**
+
+```typescript
+// live-session-store.ts
+interface LiveSessionState {
+  sessionId: string | null;
+  gameName: string;
+  status: 'InProgress' | 'Paused' | 'Completed';
+  currentTurn: number;
+  currentPhase: string | null;
+  players: PlayerInfo[];
+  scores: Record<string, number>;
+  pendingProposals: ScoreProposal[];
+  disputes: RuleDispute[];
+  isConnected: boolean;
+  isOffline: boolean;
+
+  // Actions
+  setSession: (session: LiveSessionData) => void;
+  updateScore: (playerId: string, score: number) => void;
+  addProposal: (proposal: ScoreProposal) => void;
+  resolveProposal: (proposalId: string, accepted: boolean) => void;
+  addDispute: (dispute: RuleDispute) => void;
+  setConnected: (connected: boolean) => void;
+  setOffline: (offline: boolean) => void;
+}
+```
+
+- [ ] **Step 2: Implement SignalR hook**
+
+```typescript
+// use-signalr-session.ts
+export function useSignalRSession(sessionId: string | null) {
+  // 1. Create HubConnection to /hubs/game-state
+  // 2. Join session group on connect
+  // 3. Listen for: ScoreUpdated, DisputeResolved, SessionPaused, ProposeScore, ConfirmScore
+  // 4. Update Zustand store on each event
+  // 5. Handle reconnection (auto-rejoin group)
+  // 6. Cleanup on unmount
+  // Return: { connection, isConnected, sendScore, proposeScore, appBackgrounded }
+}
+```
+
+- [ ] **Step 3: Write tests for hook lifecycle**
+
+Test: connection established, events update store, cleanup on unmount, reconnection.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/src/lib/stores/live-session-store.ts \
+       apps/web/src/lib/hooks/use-signalr-session.ts \
+       apps/web/src/lib/hooks/use-session-scores.ts \
+       apps/web/src/lib/hooks/__tests__/use-signalr-session.test.ts
+git commit -m "feat(game-night): add live session Zustand store and SignalR hook"
+```
+
+---
+
+### Task 14: API Client Extensions
+
+**Files:**
+- Modify: `apps/web/src/lib/api/clients/liveSessionsClient.ts`
+
+- [ ] **Step 1: Add new API methods**
+
+```typescript
+// Add to liveSessionsClient.ts
+startImprovvisata: (privateGameId: string) =>
+  httpClient.post<StartImprovvisataResponse>('/game-night/start-session', { privateGameId }),
+
+submitDispute: (sessionId: string, description: string, raisedBy: string) =>
+  httpClient.post<RuleDisputeResponse>(`/game-night/sessions/${sessionId}/disputes`, {
+    description, raisedByPlayerName: raisedBy
+  }),
+
+getDisputeHistory: (sessionId: string) =>
+  httpClient.get<RuleDispute[]>(`/game-night/sessions/${sessionId}/disputes`),
+
+getGameDisputeHistory: (gameId: string) =>
+  httpClient.get<RuleDispute[]>(`/game-night/games/${gameId}/disputes`),
+
+createPauseSnapshot: (sessionId: string, photoIds?: string[]) =>
+  httpClient.post<{ snapshotId: string }>(`/game-night/sessions/${sessionId}/save`, { finalPhotoIds: photoIds }),
+
+resumeFromSnapshot: (sessionId: string) =>
+  httpClient.post<ResumeSessionResponse>(`/game-night/sessions/${sessionId}/resume`),
+```
+
+- [ ] **Step 2: Add TypeScript types**
+
+```typescript
+interface StartImprovvisataResponse {
+  sessionId: string;
+  inviteCode: string;
+  shareLink: string;
+}
+interface RuleDisputeResponse {
+  id: string;
+  verdict: string;
+  ruleReferences: string[];
+  note: string | null;
+}
+interface ResumeSessionResponse {
+  sessionId: string;
+  inviteCode: string;
+  shareLink: string;
+  agentRecap: string | null;
+}
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/src/lib/api/clients/liveSessionsClient.ts
+git commit -m "feat(game-night): extend liveSessionsClient with improvvisata API methods"
+```
+
+---
+
+### Task 15: Session Layout + Card Parent
+
+**Files:**
+- Create: `apps/web/src/app/(authenticated)/sessions/live/[sessionId]/layout.tsx`
+- Create: `apps/web/src/app/(authenticated)/sessions/live/[sessionId]/page.tsx`
+- Create: `apps/web/src/components/sessions/live/SessionCardParent.tsx`
+- Create: `apps/web/src/components/sessions/live/SessionNavConfig.tsx`
+
+- [ ] **Step 1: Create session layout with NavigationProvider**
+
+Follow the pattern from Epic #5033 — `NavigationProvider` + `MiniNav` + `NavActionBar`.
+
+```tsx
+// layout.tsx
+export default function LiveSessionLayout({ children, params }: { children: React.ReactNode; params: Promise<{ sessionId: string }> }) {
+  const { sessionId } = use(params);
+  return (
+    <NavigationProvider>
+      <SessionNavConfig sessionId={sessionId} />
+      {children}
+    </NavigationProvider>
+  );
+}
+```
+
+- [ ] **Step 2: Create SessionNavConfig**
+
+Registers MiniNav tabs: Partita, Chat AI, Punteggi, Foto, Giocatori.
+
+```tsx
+// SessionNavConfig.tsx — renders null, calls useSetNavConfig()
+export function SessionNavConfig({ sessionId }: { sessionId: string }) {
+  const setNavConfig = useSetNavConfig();
+  useEffect(() => {
+    setNavConfig({
+      miniNav: {
+        tabs: [
+          { label: 'Partita', href: `/sessions/live/${sessionId}` },
+          { label: 'Chat AI', href: `/sessions/live/${sessionId}/agent` },
+          { label: 'Punteggi', href: `/sessions/live/${sessionId}/scores` },
+          { label: 'Foto', href: `/sessions/live/${sessionId}/photos` },
+          { label: 'Giocatori', href: `/sessions/live/${sessionId}/players` },
+        ]
+      }
+    });
+  }, [sessionId, setNavConfig]);
+  return null;
+}
+```
+
+- [ ] **Step 3: Create SessionCardParent page**
+
+Shows: game name, status badge, timer, player count, quick actions (Invita, Pausa, Salva & Esci).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/src/app/\(authenticated\)/sessions/live/ \
+       apps/web/src/components/sessions/live/SessionCardParent.tsx \
+       apps/web/src/components/sessions/live/SessionNavConfig.tsx
+git commit -m "feat(game-night): add session layout with CardStack navigation"
+```
+
+---
+
+### Task 16: Scoreboard Child Card
+
+**Files:**
+- Create: `apps/web/src/app/(authenticated)/sessions/live/[sessionId]/scores/page.tsx`
+- Create: `apps/web/src/components/sessions/live/ScoreBoard.tsx`
+- Test: `apps/web/src/components/sessions/live/__tests__/ScoreBoard.test.tsx`
+
+- [ ] **Step 1: Write tests for ScoreBoard component**
+
+Test cases:
+1. Renders player names and scores
+2. Host sees +/- buttons, exact input field
+3. Leader is highlighted
+4. Pending proposals show approve/reject buttons
+5. "Nuovo Round" button saves current scores
+
+- [ ] **Step 2: Implement ScoreBoard component**
+
+Uses `useSessionScores` hook (from Task 13) for real-time updates. Host actions call SignalR `sendScore`. Visual: colored player cards, leader indicator.
+
+- [ ] **Step 3: Create page wrapper**
+
+```tsx
+// scores/page.tsx
+export default function ScoresPage({ params }: { params: Promise<{ sessionId: string }> }) {
+  const { sessionId } = use(params);
+  return <ScoreBoard sessionId={sessionId} />;
+}
+```
+
+- [ ] **Step 4: Run tests — expect PASS**
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/app/\(authenticated\)/sessions/live/\[sessionId\]/scores/ \
+       apps/web/src/components/sessions/live/ScoreBoard.tsx \
+       apps/web/src/components/sessions/live/__tests__/ScoreBoard.test.tsx
+git commit -m "feat(game-night): add real-time scoreboard child card"
+```
+
+---
+
+### Task 17: Arbitro UI Components
+
+**Files:**
+- Create: `apps/web/src/components/sessions/live/ArbitroModal.tsx`
+- Create: `apps/web/src/components/sessions/live/ArbitroVerdictCard.tsx`
+- Create: `apps/web/src/components/sessions/live/DisputeHistory.tsx`
+- Test: `apps/web/src/components/sessions/live/__tests__/ArbitroModal.test.tsx`
+
+- [ ] **Step 1: Write tests for ArbitroModal**
+
+Test cases:
+1. Modal opens on button click
+2. Form has description field + player dropdown
+3. Submit calls `liveSessionsClient.submitDispute()`
+4. Loading state shown during API call
+5. Verdict card displayed on success
+
+- [ ] **Step 2: Implement ArbitroModal**
+
+```tsx
+// ArbitroModal.tsx
+export function ArbitroModal({ sessionId, players, onVerdictReceived }: ArbitroModalProps) {
+  // shadcn Dialog with form
+  // Description textarea + player select
+  // Submit → loading "L'arbitro sta analizzando..." → verdict display
+}
+```
+
+- [ ] **Step 3: Implement ArbitroVerdictCard**
+
+Distinct styling: amber border, ⚖️ icon, structured layout (Verdict, Rule citation, Notes).
+
+- [ ] **Step 4: Implement DisputeHistory**
+
+Collapsible section showing past verdicts. Queries `getGameDisputeHistory` for cross-session history.
+
+- [ ] **Step 5: Run tests — expect PASS**
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/components/sessions/live/ArbitroModal.tsx \
+       apps/web/src/components/sessions/live/ArbitroVerdictCard.tsx \
+       apps/web/src/components/sessions/live/DisputeHistory.tsx \
+       apps/web/src/components/sessions/live/__tests__/ArbitroModal.test.tsx
+git commit -m "feat(game-night): add arbitro modal and verdict display components"
+```
+
+---
+
+## Chunk 5: Frontend — Guest, Save/Resume, Integration
+
+### Task 18: Guest Landing Page
+
+**Files:**
+- Create: `apps/web/src/app/join/[inviteToken]/page.tsx`
+- Create: `apps/web/src/components/sessions/live/GuestScoreProposal.tsx`
+- Test: `apps/web/src/app/join/__tests__/guest-join.test.tsx`
+
+- [ ] **Step 1: Create guest page (public, no auth)**
+
+```tsx
+// join/[inviteToken]/page.tsx — NO (authenticated) route group
+// This page is public (no session required)
+export default function GuestJoinPage({ params }: { params: Promise<{ inviteToken: string }> }) {
+  // 1. Check localStorage for participantToken → auto-rejoin
+  // 2. Otherwise: show game name, host name, "Il tuo nome" input
+  // 3. On submit: POST join session → get participantToken → save to localStorage
+  // 4. After join: show minimal view with:
+  //    - Current turn + phase
+  //    - Live scoreboard (SignalR read-only)
+  //    - "Proponi punteggio" button (self-only, max 3 pending)
+}
+```
+
+- [ ] **Step 2: Implement GuestScoreProposal**
+
+Simple form: score delta input, submit button. Business rules: self-only, -100 to +100, max 3 pending.
+
+- [ ] **Step 3: Write tests for guest page**
+
+Test cases:
+1. Shows game name and name input when no participantToken in localStorage
+2. Auto-rejoins when valid participantToken exists
+3. After join: shows scoreboard (read-only) and propose button
+4. Score proposal enforces self-only, delta limits, max 3 pending
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/src/app/join/ \
+       apps/web/src/components/sessions/live/GuestScoreProposal.tsx
+git commit -m "feat(game-night): add guest landing page with score proposals"
+```
+
+---
+
+### Task 19: Invite Modal + QR Code
+
+**Files:**
+- Create: `apps/web/src/components/sessions/live/InviteModal.tsx`
+- Test: `apps/web/src/components/sessions/live/__tests__/InviteModal.test.tsx`
+
+- [ ] **Step 1: Install qrcode.react**
+
+```bash
+cd apps/web && pnpm add qrcode.react
+```
+
+- [ ] **Step 2: Implement InviteModal**
+
+```tsx
+// InviteModal.tsx
+import { QRCodeSVG } from 'qrcode.react';
+
+export function InviteModal({ inviteCode, shareLink, onClose }: InviteModalProps) {
+  return (
+    <Dialog>
+      <QRCodeSVG value={shareLink} size={200} />
+      <div>Codice sessione: <strong>{inviteCode}</strong></div>
+      <Button onClick={() => navigator.clipboard.writeText(shareLink)}>
+        Copia link
+      </Button>
+    </Dialog>
+  );
+}
+```
+
+- [ ] **Step 3: Write tests**
+
+Test: QR rendered, session code displayed, copy button works.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/src/components/sessions/live/InviteModal.tsx \
+       apps/web/src/components/sessions/live/__tests__/InviteModal.test.tsx \
+       apps/web/pnpm-lock.yaml apps/web/package.json
+git commit -m "feat(game-night): add invite modal with QR code and share link"
+```
+
+---
+
+### Task 20: Save & Resume UI
+
+**Files:**
+- Create: `apps/web/src/components/sessions/live/SaveSessionModal.tsx`
+- Create: `apps/web/src/components/sessions/live/PausedSessionCard.tsx`
+- Modify: `apps/web/src/app/(authenticated)/library/private/[privateGameId]/page.tsx`
+- Test: `apps/web/src/components/sessions/live/__tests__/SaveSessionModal.test.tsx`
+- Test: `apps/web/src/components/sessions/live/__tests__/PausedSessionCard.test.tsx`
+
+- [ ] **Step 1: Write tests for SaveSessionModal**
+
+Test cases:
+1. Confirmation modal shown on "Salva & Esci"
+2. Optional photo capture prompt
+3. Calls `createPauseSnapshot()` on confirm
+4. Shows success message with redirect to library
+
+- [ ] **Step 2: Implement SaveSessionModal**
+
+```tsx
+export function SaveSessionModal({ sessionId, onSaved }: SaveSessionModalProps) {
+  // Confirmation dialog
+  // Optional: "Scatta foto finale?" with camera capture
+  // Submit → loading → "Sessione salvata!" → redirect
+}
+```
+
+- [ ] **Step 3: Write tests for PausedSessionCard**
+
+Test cases:
+1. Shows game name, date saved, score preview
+2. Photo thumbnail if available
+3. "Riprendi" button calls `resumeFromSnapshot()`
+4. On resume success → navigates to live session page
+
+- [ ] **Step 4: Implement PausedSessionCard**
+
+```tsx
+export function PausedSessionCard({ session, snapshot }: PausedSessionCardProps) {
+  // Card showing: game name, saved date, scores, photo preview
+  // "▶️ Riprendi" button → resume API call → navigate to /sessions/live/{id}
+}
+```
+
+- [ ] **Step 5: Add "Sessioni in pausa" section to PrivateGame detail page**
+
+Modify `apps/web/src/app/(authenticated)/library/private/[privateGameId]/page.tsx`:
+- Query paused sessions for this game
+- Render `PausedSessionCard` for each
+- "Avvia nuova sessione" button → `startImprovvisata()` API call
+
+- [ ] **Step 6: Run tests — expect PASS**
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/web/src/components/sessions/live/SaveSessionModal.tsx \
+       apps/web/src/components/sessions/live/PausedSessionCard.tsx \
+       apps/web/src/components/sessions/live/__tests__/SaveSessionModal.test.tsx \
+       apps/web/src/components/sessions/live/__tests__/PausedSessionCard.test.tsx \
+       apps/web/src/app/\(authenticated\)/library/private/\[privateGameId\]/page.tsx
+git commit -m "feat(game-night): add save/resume UI with paused session cards"
+```
+
+---
+
+### Task 21: Players + Photos Child Cards
+
+**Files:**
+- Create: `apps/web/src/app/(authenticated)/sessions/live/[sessionId]/players/page.tsx`
+- Create: `apps/web/src/app/(authenticated)/sessions/live/[sessionId]/photos/page.tsx`
+- Create: `apps/web/src/components/sessions/live/PlayerList.tsx`
+
+- [ ] **Step 1: Implement PlayerList component**
+
+Shows: player name, online/offline indicator, invite button. Uses SignalR presence.
+
+- [ ] **Step 2: Create players page**
+
+```tsx
+export default function PlayersPage({ params }: { params: Promise<{ sessionId: string }> }) {
+  const { sessionId } = use(params);
+  return (
+    <div>
+      <PlayerList sessionId={sessionId} />
+      <InviteModal /> {/* Triggered by button */}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 3: Create photos page**
+
+Camera capture via `<input type="file" accept="image/*" capture="environment">`. Grid display with timestamps. Upload to `SessionAttachment` endpoint.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/src/app/\(authenticated\)/sessions/live/\[sessionId\]/players/ \
+       apps/web/src/app/\(authenticated\)/sessions/live/\[sessionId\]/photos/ \
+       apps/web/src/components/sessions/live/PlayerList.tsx
+git commit -m "feat(game-night): add players and photos child card pages"
+```
+
+---
+
+### Task 22: Agent Chat Child Card + Session Context
+
+**Files:**
+- Create: `apps/web/src/app/(authenticated)/sessions/live/[sessionId]/agent/page.tsx`
+
+- [ ] **Step 1: Create agent chat page**
+
+Reuse existing toolkit chat experience. Pass `sessionId` as context parameter so the backend injects session context (players, turn, scores, previous disputes) into the agent's system prompt.
+
+```tsx
+// agent/page.tsx
+export default function AgentPage({ params }: { params: Promise<{ sessionId: string }> }) {
+  const { sessionId } = use(params);
+  // Reuse existing chat component from toolkit
+  // Add ArbitroModal button in action bar
+  // Add DisputeHistory collapsible section
+  // On resumed session: show recap as first message
+}
+```
+
+- [ ] **Step 2: Verify agent prompt injection works**
+
+The backend needs to inject session context into the agent system prompt when `sessionId` is provided in chat queries. Check how existing toolkit chat sends the session context — it may already pass `toolkitSessionId`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/src/app/\(authenticated\)/sessions/live/\[sessionId\]/agent/
+git commit -m "feat(game-night): add agent chat child card with arbitro button"
+```
+
+---
+
+### Task 23: Enhanced SuccessState + Processing Progress
+
+**Files:**
+- Modify: `apps/web/src/components/library/add-game-sheet/steps/SuccessState.tsx`
+- Test: `apps/web/src/components/library/add-game-sheet/steps/__tests__/SuccessState.test.tsx` (extend existing)
+
+- [ ] **Step 1: Write tests for new SuccessState behavior**
+
+Test cases:
+1. Shows progress indicator when PDF is processing
+2. Shows toast on AgentAutoCreatedEvent
+3. Shows error toast on PdfProcessingFailed with retry button
+
+- [ ] **Step 2: Add processing progress indicator**
+
+After "Game added + PDF uploaded", show:
+- Progress stages: Chunking → Embedding → Indexing → Ready
+- Animated progress bar
+- Message: "Stiamo analizzando il regolamento... Ti avviseremo quando l'agente è pronto"
+- On `AgentAutoCreatedEvent` via SSE: toast with "Apri" action
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add apps/web/src/components/library/add-game-sheet/steps/SuccessState.tsx
+git commit -m "feat(game-night): add PDF processing progress indicator to SuccessState"
+```
+
+---
+
+### Task 24: Final Integration Test + Cleanup
+
+- [ ] **Step 1: Run full backend test suite**
+
+```bash
+cd apps/api && dotnet test
+```
+
+- [ ] **Step 2: Run frontend tests**
+
+```bash
+cd apps/web && pnpm test
+```
+
+- [ ] **Step 3: Run frontend type check**
+
+```bash
+cd apps/web && pnpm typecheck
+```
+
+- [ ] **Step 4: Run frontend lint**
+
+```bash
+cd apps/web && pnpm lint
+```
+
+- [ ] **Step 5: Manual smoke test**
+
+Start API + web locally. Walk through the complete flow:
+1. Library → Add Game → BGG Search → Select Catan → Upload PDF → Accept disclaimer
+2. Wait for notification "Agent ready"
+3. Open PrivateGame → "Avvia Sessione"
+4. Share invite link → open in incognito (guest)
+5. Add scores, try Arbitro, take photo
+6. Save & Exit → verify paused session in library
+7. Resume → verify recap message
+
+- [ ] **Step 6: Final commit**
+
+```bash
+git commit -m "feat(game-night): complete vertical slice integration"
+```
+
+---
+
+## Dependencies Between Tasks
+
+```
+Task 1 (RuleDisputeEntry VO)
+  └→ Task 2 (Disputes on LiveGameSession)
+      └→ Task 4 (Migration)
+Task 3 (PauseSnapshot entity)
+  └→ Task 4 (Migration)
+Task 5 (Domain events) → Task 6, 8, 8b, 9
+Task 7 (StartSession) — independent after Task 4
+Task 8 (Arbitro) — needs Task 2, 5
+Task 8b (Session context) — needs Task 2, 5 (agent prompt injection)
+Task 9 (Save/Resume) — needs Task 3, 5
+Task 10 (SignalR) — needs Task 5
+Task 11 (AutoSave) — needs Task 3, 9
+Task 12 (Routing) — needs Task 7, 8, 9
+Task 13 (Store + hooks) — independent (frontend)
+Task 14 (API client) — independent (frontend)
+Task 15 (Layout) — needs Task 13
+Task 16 (Scoreboard) — needs Task 13, 14
+Task 17 (Arbitro UI) — needs Task 14
+Task 18 (Guest) — needs Task 14
+Task 19 (Invite) — independent
+Task 20 (Save/Resume UI) — needs Task 14
+Task 21 (Players/Photos) — needs Task 13
+Task 22 (Agent chat) — needs Task 17
+Task 23 (SuccessState) — independent
+Task 24 (Integration) — needs all
+```
+
+**Parallelization opportunities:**
+- Tasks 1-3 can run in parallel (domain model)
+- Tasks 13-14 can run in parallel with backend tasks
+- Tasks 16-19 can run in parallel (independent UI components)
+- Tasks 21-23 can run in parallel (independent pages)

--- a/docs/superpowers/specs/2026-03-15-game-night-improvvisata-vertical-slice-design.md
+++ b/docs/superpowers/specs/2026-03-15-game-night-improvvisata-vertical-slice-design.md
@@ -1,0 +1,637 @@
+# Game Night Improvvisata — Vertical Slice Design
+
+**Date**: 2026-03-15
+**Approach**: Vertical Slice — one complete game night, end-to-end
+**Effort**: ~12-15 days
+**Status**: Design approved
+
+## Overview
+
+A complete user journey from "friends arrive unexpectedly" to "save unfinished game for later". The user finds a game via BGG, adds it to their private library, uploads the rulebook PDF, gets an AI agent auto-created, and uses it during the game night for setup help, score tracking, rule arbitration, and session save/resume.
+
+### Design Decisions (from brainstorming)
+
+| Decision | Choice | Rationale |
+|----------|--------|-----------|
+| Entry point | Library → Add Game wizard | Reuses existing AddGameSheet multi-step wizard |
+| Agent creation | Auto-create with personalization optional | New AutoCreateAgentOnPdfReadyHandler + good defaults |
+| Session UI | CardStack with child cards | One Card = One Function, consistent with "Carte in Mano" |
+| Guest access | Lightweight via link/QR (or email invite) | No login required, PIN + UUID token via SessionInvite |
+| Rule disputes | Chat libre + official "Arbitro" mode | Casual questions + structured verdicts with citations |
+| Session save | Structured state + agent memory + recap | AgentConversationSummary enables auto-recap on resume |
+| Agent access | Host only | Guests see scores and propose, but don't query the agent |
+
+---
+
+## Section 1: Onboarding Flow — BGG → PrivateGame → PDF → Agent
+
+### Existing Infrastructure
+- `AddGameSheet` wizard: GameSourceStep → GameSearchResults → PdfUploadZone → KnowledgeBaseStep → SuccessState
+- `ImportBggGameCommand` creates `PrivateGame` with tier enforcement
+- `AcceptCopyrightDisclaimerCommand` for PDF copyright acceptance
+- `AutoCreateAgentOnPdfReadyHandler` — referenced in cross-context integration tests but **not yet wired in production code**; needs to be created as a full handler
+
+### Changes Required
+
+#### Backend
+
+**1. Create `AutoCreateAgentOnPdfReadyHandler`** *(Note: handler exists only in test stubs, must be fully implemented)*
+- Subscribes to `PdfProcessingCompletedEvent` (or equivalent domain event from DocumentProcessing)
+- Trigger for user PDFs associated with a PrivateGame
+- Default agent prompt:
+  ```
+  Sei un assistente esperto per il gioco {GameName}. Aiuti i giocatori con setup,
+  regole e punteggi. Cita sempre la pagina del regolamento quando rispondi su regole.
+  Se una regola è ambigua, spiega le possibili interpretazioni.
+  ```
+- Links auto-created agent to PrivateGame's Toolkit
+
+**2. `AgentAutoCreatedEvent` → Notification**
+- New domain event `AgentAutoCreatedEvent(AgentDefinitionId, PrivateGameId, GameName)`
+- Handler creates in-app `Notification` with deep link to `/library/private/{id}/toolkit`
+- SSE push to connected user
+
+**3. PDF Processing Failure Path** *(spec-panel fix: Wiegers #1)*
+- Add `ProcessingStatus` enum: `Queued → Processing → Ready → Failed`
+- On failure: create `Notification` with message "PDF processing failed for {GameName}. You can retry or upload a different file."
+- Retry action: `RetryPdfProcessingCommand` re-queues the document
+- Max 3 retries, then permanent failure with support contact suggestion
+
+**4. `PdfProcessingProgressEvent`**
+- SSE events during processing: `{ stage: "chunking" | "embedding" | "indexing" | "ready" | "failed", progress: 0-100 }`
+- Frontend can show real-time progress without polling
+
+#### Frontend
+
+**1. Enhanced SuccessState**
+- After "game added + PDF uploaded", show processing progress indicator
+- Message: "Stiamo analizzando il regolamento... Ti avviseremo quando l'agente è pronto"
+- Progress stages visualized: Chunking → Embedding → Indexing → Ready
+
+**2. Notification Toast**
+- On `AgentAutoCreatedEvent` via SSE: toast "🤖 Agente per {GameName} pronto!" with "Apri" action
+- Click → navigates to PrivateGame card in CardStack with agent selectable
+
+**3. Failure Recovery**
+- On `PdfProcessingFailed`: toast "⚠️ Errore nel processing del PDF. Riprova?" with retry action
+
+### Flow Diagram
+```
+Library → "Aggiungi Gioco" → BGG Search → Select → PrivateGame created
+    ↓
+Upload PDF → Copyright disclaimer → Accept
+    ↓
+[Background] Processing: chunking → embedding → indexing
+    ├── Success → AutoCreateAgent → Notification "Agent ready!"
+    └── Failure → Notification "Processing failed" → Retry option
+    ↓
+User receives toast → Click → PrivateGame card with Agent ready
+```
+
+---
+
+## Section 2: Live Session — CardStack + Child Cards
+
+### Existing Infrastructure
+- `LiveGameSession` aggregate root with Status, Players, Teams, RoundScores, TurnRecords, GameState (JSON)
+- `CreateLiveSessionCommand`, `AddPlayerToLiveSessionCommand`, `RecordLiveSessionScoreCommand`
+- `GameStateHub` SignalR: JoinSession, BroadcastStateChange, ProposeScore → ConfirmScore
+- `SessionInvite` with PIN 6-char + UUID link + max uses + expiry
+- `liveSessionsClient` frontend CRUD
+
+### Changes Required
+
+#### Backend
+
+**1. `StartImprovvisataSessionCommand`**
+- Shortcut command that in a single transaction:
+  - Creates `LiveGameSession` from `PrivateGame` (name, gameId, toolkitId)
+  - Sets host = current user
+  - Generates `SessionInvite` (session code + link, expires in 24h, max 10 uses)
+  - Returns: `{ sessionId, inviteCode, shareLink }`
+  - Note: QR code is generated **client-side** from the share link using `qrcode.react` (no backend QR library needed)
+
+**2. Extend `SaveCompleteSessionStateCommand`**
+
+> ⚠️ **IMPORTANT — Existing `SessionSnapshot` uses delta-based JSON Patch storage** (`DeltaDataJson`, `IsCheckpoint`, `SnapshotIndex`, `TriggerType`). Our save/resume use case needs full-state snapshots, not deltas. We create a **new entity `PauseSnapshot`** to avoid conflicting with the existing incremental snapshot model.
+
+Creates `PauseSnapshot`:
+  ```csharp
+  public class PauseSnapshot : Entity  // owned by LiveGameSession
+  {
+      public Guid LiveGameSessionId { get; }
+      public int CurrentTurn { get; }
+      public string? CurrentPhase { get; }
+      public List<PlayerScoreSnapshot> PlayerScores { get; }
+      public List<Guid> AttachmentIds { get; }
+      public List<RuleDisputeEntry> Disputes { get; }
+      public string? AgentConversationSummary { get; }  // nullable — may arrive async
+      public string? GameStateJson { get; }
+      public DateTime SavedAt { get; }
+      public Guid SavedByUserId { get; }                // host UserId, not player name
+      public bool IsAutoSave { get; }
+  }
+  ```
+- `PauseSnapshot` lives in **GameManagement** bounded context (same as `LiveGameSession`)
+- Requires new EF migration: `PauseSnapshots` table with FK to `LiveGameSessions`
+- `RuleDisputeEntry` collection stored as **JSONB column** on `LiveGameSession` (simpler than owned entities, sufficient for V1)
+- `AgentConversationSummary` generation — **async with eventual consistency**:
+  - `SessionSaveRequestedEvent` → KnowledgeBase handler generates summary asynchronously
+  - `PauseSnapshot` is saved immediately with `AgentConversationSummary = null`
+  - When summary is ready: `AgentSummaryGeneratedEvent` → handler updates `PauseSnapshot.AgentConversationSummary`
+  - Timeout: if summary not generated within 60s, resume works without it (agent gets raw last-10-messages as fallback context)
+  - This avoids direct cross-context coupling (Fowler recommendation) and doesn't block the save flow
+
+**3. `ResumeSessionCommand`**
+- Loads `PauseSnapshot` → restores `LiveGameSession` state
+- Sets `Status = LiveSessionStatus.InProgress` and clears `PausedAt` timestamp (uses existing status enum, NOT a boolean `IsPaused`)
+- Triggers `SessionResumedEvent` → agent uses summary for recap generation (falls back to raw messages if summary is null)
+
+**4. Auto-Save** *(spec-panel fix: Nygard #2)*
+- `SessionAutoSaveBackgroundService`: saves session state every 10 minutes for active sessions
+- Also triggers on app backgrounding (frontend sends `AppBackgrounded` SignalR event)
+- Auto-save creates `PauseSnapshot` with `IsAutoSave = true` and uses existing `SnapshotTrigger` enum (add `AutoSave` value)
+- Cleanup rule: on manual save or session completion, **delete all auto-save PauseSnapshots** for that session
+
+**5. Save Concurrency** *(spec-panel fix: Wiegers #3)*
+- `SaveCompleteSessionStateCommand` waits for pending score proposals to flush (max 5s timeout)
+- If timeout: saves with pending proposals flagged, notify host on resume
+
+#### Frontend — CardStack Structure
+
+```
+📱 Card Stack (left panel)
+├── 🎲 Catan — In corso              ← Card parent (session)
+│   ├── 🤖 Agente Catan              ← Child card: AI chat
+│   ├── 📊 Punteggi                   ← Child card: scoreboard
+│   ├── 📷 Foto (3)                   ← Child card: photo gallery
+│   └── 👥 Giocatori (4)             ← Child card: players + invite
+├── 📚 Library
+├── 🔍 Discover
+└── ...
+```
+
+**Card Parent "🎲 Partita"**:
+- Game name + status badge (In corso / Pausata / Completata)
+- Session timer (elapsed time)
+- Connected players count with online indicators
+- Quick actions bar: Invita (QR/link), Pausa, Salva & Esci
+- Red badge on pending score proposals awaiting confirmation
+- Child cards visible only when parent card is active/selected
+
+**Child Card "🤖 Agente"**:
+- Chat interface identical to existing toolkit experience
+- Session context injected into system prompt (players, turn, scores)
+- On resumed session: recap as first message
+- "⚖️ Arbitro" button in chat action bar (see Section 3)
+
+**Child Card "📊 Punteggi"**:
+- Real-time scoreboard per player (SignalR-synced)
+- Host: +/- buttons for quick scoring, exact input field
+- Guest proposals: pending proposals shown with ✅/❌ for host to confirm
+- Round support: "Nuovo Round" toggle saves current round scores, starts new round
+- Visual: player cards with color coding, current leader highlighted
+
+**Child Card "📷 Foto Tavolo"**:
+- Camera capture (device camera) or gallery upload
+- Photo grid with timestamps
+- Photos linked to session via `SessionAttachment` entity (already exists)
+- On save: attachment IDs included in PauseSnapshot
+
+**Child Card "👥 Giocatori"**:
+- Player list with connection status (online/offline via SignalR presence)
+- "Invita" button → shows QR code (rendered client-side via `qrcode.react`) + shareable link + session code
+- Admin invite option: send email invitation
+
+**Guest Score Proposal Rules**:
+- Guests can propose scores **for themselves only** (not for other players)
+- Score delta must be within game-reasonable bounds (configurable, default: -100 to +100 per proposal)
+- Max 3 pending proposals per guest at a time (prevents spam in no-auth model)
+- Host sees all pending proposals with ✅ Approve / ❌ Reject actions
+
+#### Guest Experience (browser-only)
+
+```
+Host shares link → Guest opens in browser (no auth required)
+    ↓
+Landing page:
+  - Game name + host name
+  - Input: "Il tuo nome" → joins session as SessionParticipant
+    ↓
+Guest view (minimal, mobile-optimized):
+  - Current turn + phase indicator (Cockburn fix)
+  - Scoreboard (read-only, real-time via SignalR)
+  - "Proponi punteggio" button → host approves/rejects
+  - Connection via SessionParticipant + ConnectionToken (AllowAnonymous)
+```
+
+**Guest Reconnection** *(spec-panel fix: Cockburn #2)*:
+- `SessionParticipant` persists for invite duration (24h default)
+- On reconnect: browser checks localStorage for `participantToken`
+- If valid: auto-rejoin without re-entering name
+- If expired: re-enter name, new participant created
+
+#### Offline Resilience *(spec-panel fix: Nygard #1)*
+- **Local score buffer**: scores entered while offline are queued in localStorage
+- On reconnect: buffered scores sync automatically via SignalR
+- Visual indicator: "⚡ Offline — punteggi salvati localmente" banner
+- Chat messages: queued locally, sent on reconnect (max 10 pending)
+- Auto-save still works if connection drops temporarily (retry with exponential backoff)
+
+---
+
+## Section 3: Rule Arbitration + Agent Memory + Save/Resume
+
+### 3A. Chat Libre for Rules
+
+No changes to RAG engine needed. Only inject session context into agent's system prompt during active session:
+
+```
+Sei l'assistente per "{GameName}". Sessione attiva con {N} giocatori: {player_names}.
+Turno corrente: {turn}. Fase: {phase}. Punteggi: {score_list}.
+Quando rispondi su regole, cita SEMPRE la pagina del regolamento.
+Se c'è ambiguità nella regola, spiega le possibili interpretazioni.
+
+Verdetti precedenti in questa sessione:
+{list_of_previous_disputes_and_verdicts}
+```
+
+The last line ensures **dispute consistency** *(spec-panel fix: Adzic #3)* — the agent won't contradict its own previous rulings.
+
+### 3B. Arbitro Mode — Official Disputes
+
+**Backend**:
+
+**`RuleDisputeEntry`** — Value Object in `LiveGameSession`:
+```csharp
+public record RuleDisputeEntry
+{
+    public Guid Id { get; init; }
+    public string Description { get; init; }          // "Marco says he can play 2 cards"
+    public string Verdict { get; init; }               // Agent's ruling
+    public List<string> RuleReferences { get; init; }  // ["Page 12, Section 3.2"]
+    public string RaisedByPlayerName { get; init; }
+    public DateTime Timestamp { get; init; }
+}
+```
+
+Stored in `LiveGameSession.Disputes` as **JSONB column** (new collection, requires EF migration + JSON column configuration). This is a new domain model addition — not extending an existing collection.
+
+**Dispute History Per-Game** *(cross-session persistence)*:
+- In addition to storing disputes within `LiveGameSession`, a repository query `GetDisputesByGameId(gameId)` aggregates disputes across all completed/paused sessions for the same game
+- This enables "consultable history" without a separate entity — disputes live in sessions but are queryable per-game
+- Query: `SELECT Disputes FROM LiveGameSessions WHERE GameId = @gameId AND Status IN (Paused, Completed)`
+
+**`SubmitRuleDisputeCommand`**:
+- Input: `SessionId`, `Description`, `RaisedByPlayerName`
+- Queries agent with specialized arbitration prompt:
+  ```
+  MODALITÀ ARBITRO. Emetti un VERDETTO chiaro su questa disputa.
+  Disputa: "{description}"
+  Contesto: {session_context}
+  Verdetti precedenti: {previous_disputes}
+
+  Rispondi in formato strutturato:
+  VERDETTO: [Chi ha ragione e perché — 1-2 frasi]
+  REGOLA: [Citazione esatta dal regolamento con pagina/sezione]
+  NOTA: [Se ambigua, spiega perché e suggerisci come gestirla]
+  ```
+- Parses response into `RuleDisputeEntry`
+- Saves to `LiveGameSession.Disputes`
+- Broadcasts verdict via SignalR to all session participants
+
+**Frontend — Arbitro UI**:
+- "⚖️ Arbitro" button in agent chat action bar
+- Click → modal:
+  - Text field: "Descrivi la disputa"
+  - Dropdown: "Chi contesta?" (player list)
+  - Submit button
+- Loading state: "L'arbitro sta analizzando il regolamento..."
+- Verdict displayed as special card in chat:
+  - Distinct styling: amber border, ⚖️ icon, structured layout
+  - Shows: Verdict, Rule citation, Notes
+- Verdict also appears as **banner/toast in card parent** (visible to everyone at the table)
+
+**Frontend — Dispute History**:
+- Collapsible section "⚖️ Verdetti precedenti" in agent child card
+- List: question, verdict, rule cited, timestamp
+- Persists across sessions — when playing the same game again, previous disputes are consultable
+- Queried per-game via `GetDisputesByGameId` repository method (aggregates from all past sessions)
+
+### 3C. Agent Memory + Structured Save
+
+#### Save Flow
+
+When host clicks "💾 Salva & Esci":
+
+1. **Frontend**: modal confirmation — "Vuoi salvare lo stato della partita?"
+2. **Optional**: "📷 Scatta foto finale del tavolo" prompt
+3. **Frontend → Backend**: `CreatePauseSnapshotCommand`
+4. **Backend**:
+   a. Wait for pending score proposals to flush (max 5s) *(Wiegers fix)*
+   b. Capture structured state: turn, phase, scores, attachments, disputes
+   c. Create `PauseSnapshot` entity immediately (with `AgentConversationSummary = null`)
+   d. Fire `SessionSaveRequestedEvent` → KnowledgeBase handler generates summary asynchronously (cap at **last 50 messages**)
+   e. When summary ready: `AgentSummaryGeneratedEvent` updates `PauseSnapshot` (eventual consistency, max 60s)
+   f. Set `LiveGameSession.Status = LiveSessionStatus.Paused` + `PausedAt = DateTime.UtcNow`
+   g. Disconnect all SignalR participants gracefully
+5. **Frontend**: confirmation — "Sessione salvata! Potrai riprenderla dalla Library."
+
+#### Agent Conversation Summary
+
+Generated by KnowledgeBase context via domain event (no direct cross-context reference):
+
+```
+Riassumi questa sessione di gioco per un futuro resume.
+Cronologia chat (ultimi 50 messaggi): {messages}
+
+Genera un JSON strutturato:
+{
+  "game_state": "descrizione dello stato della partita",
+  "current_situation": "chi sta vincendo, momento critico, etc.",
+  "rules_clarified": ["regola 1 chiarita", "regola 2 chiarita"],
+  "disputes_resolved": [{"question": "...", "verdict": "..."}],
+  "important_notes": ["nota 1", "nota 2"],
+  "suggested_recap": "Messaggio di recap da mostrare ai giocatori al resume"
+}
+```
+
+#### Resume Flow
+
+1. **Library → PrivateGame card** → "Sessioni" section shows paused sessions
+2. Paused session card: date, scores preview, photo thumbnail, "▶️ Riprendi" button
+3. Click → `ResumeSessionCommand`:
+   a. Loads `PauseSnapshot`
+   b. Restores `LiveGameSession` state (turn, phase, scores)
+   c. Sets `Status = LiveSessionStatus.InProgress`, clears `PausedAt`
+   d. Creates new `SessionInvite` (old one may be expired)
+   e. Injects `AgentConversationSummary` into agent system prompt
+4. **Frontend**: recreates card parent + child cards in CardStack
+5. **Agent first message** (auto-generated recap):
+   ```
+   🔄 Bentornati! Ecco dove eravamo:
+
+   📊 Punteggi: Giulia 45, Tu 42, Marco 38, Leo 29
+   🎯 Turno: Round 5, tocca a Marco
+   ⚖️ Regole chiarite: "Una sola carta per turno" (pag.12)
+   📸 3 foto del tavolo salvate
+
+   Pronti a riprendere?
+   ```
+
+**Resume with Different Players** *(spec-panel fix: Adzic #2)*:
+- Agent detects missing players from original roster
+- Recap mentions: "Nota: Leo non è presente oggi. I suoi punti (29) sono congelati."
+- Host can: remove player (freeze score), replace player (transfer score), or add new player (starts at 0)
+
+---
+
+## Cross-Cutting Concerns
+
+### Bounded Context Ownership
+
+| Component | Bounded Context | Rationale |
+|-----------|----------------|-----------|
+| `LiveGameSession` | GameManagement | Aggregate root for live play |
+| `PauseSnapshot` | GameManagement | New entity for save/resume (separate from existing delta-based SessionSnapshot) |
+| `RuleDisputeEntry` | GameManagement | Value Object in LiveGameSession |
+| `SessionInvite` | GameManagement | Already exists here |
+| `SessionParticipant` | GameManagement | Guest identity, no User reference |
+| `SessionAttachment` | GameManagement | Already exists here |
+| `AgentConversationSummary` | KnowledgeBase → GameManagement | Generated via domain event, stored in snapshot |
+| `AgentDefinition` | KnowledgeBase | Unchanged |
+| `Notification` | UserNotifications | Unchanged |
+| `PrivateGame` | UserLibrary | Unchanged |
+| `TierDefinition` | SystemConfiguration | Unchanged |
+
+### SignalR Events (GameStateHub)
+
+Existing:
+- `JoinSession` / `LeaveSession`
+- `BroadcastStateChange`
+- `ProposeScore` → `ConfirmScore`
+
+New:
+- `AppBackgrounded` — triggers auto-save (best-effort: browser `visibilitychange`/`pagehide` events are unreliable on mobile; the 10-min periodic auto-save is the reliable fallback. Consider `navigator.sendBeacon` as alternative signal)
+- `DisputeResolved` — broadcasts verdict to all participants
+- `SessionPaused` — notifies all participants, graceful disconnect
+- `SessionResumed` — notifies reconnected participants
+- `ScoreUpdated` — real-time score sync (distinct from proposal flow)
+- `ParticipantReconnected` — presence update
+
+### Auto-Save Background Service
+
+```csharp
+public class SessionAutoSaveBackgroundService : BackgroundService
+{
+    // Every 10 minutes: find active sessions, create PauseSnapshot (IsAutoSave = true)
+    // Cleanup: on manual save or session completion, delete ALL auto-save PauseSnapshots for that session
+    // Trigger: also on AppBackgrounded SignalR event (best-effort)
+    // Uses existing SnapshotTrigger enum (add AutoSave value if not present)
+}
+```
+
+### Offline Buffer (Frontend)
+
+```typescript
+interface OfflineBuffer {
+  scores: Array<{ playerId: string; delta: number; timestamp: number }>;
+  chatMessages: Array<{ content: string; timestamp: number }>;
+  maxPendingMessages: 10;
+}
+// Stored in localStorage keyed by sessionId
+// Flushed on SignalR reconnect
+// Visual: "⚡ Offline" banner with pending count
+```
+
+### Retention Policy
+
+| Data | Retention | Tier |
+|------|-----------|------|
+| Session snapshots (manual) | Indefinite | All |
+| Session snapshots (auto-save) | Until next manual save or session complete | All |
+| Session photos | 90 days (free), 1 year (premium) | Tier-based |
+| Chat history | 30 days (free), 1 year (premium) | Tier-based |
+| Dispute history | Indefinite (per-game) | All |
+| Guest participant data | 24h after session ends | All |
+
+### Localization
+- V1 is **Italian-only**. All UI strings are hardcoded in Italian.
+- i18n support is deferred to a future iteration.
+- Agent prompts are in Italian by default (language detection from Phase 5 plan is out of scope for vertical slice).
+
+---
+
+## Specification Examples (Gojko Adzic format)
+
+### Happy Path: Complete Game Night
+
+```gherkin
+Scenario: Improvised game night end-to-end
+  Given I am logged in and on my Library page
+  And I have no games in my collection
+
+  When I click "Aggiungi Gioco" and search BGG for "Catan"
+  And I select "Catan" from results
+  Then a PrivateGame "Catan" is created in my library
+
+  When I upload "catan-rules.pdf" and accept the copyright disclaimer
+  Then I see "Processing in corso..." with progress indicator
+
+  When processing completes (chunking → embedding → indexing)
+  Then I receive a notification "🤖 Agente per Catan pronto!"
+  And an AgentDefinition is auto-created with default game prompt
+
+  When I click "Avvia Sessione" on the Catan card
+  Then a LiveGameSession is created with me as host
+  And a SessionInvite is generated (PIN + link)
+  And a card parent "🎲 Catan — In corso" appears in my CardStack
+  With child cards: Agente, Punteggi, Foto, Giocatori
+
+  When I share the invite link with Marco
+  And Marco opens the link and enters his name
+  Then Marco appears in the Giocatori child card as "online"
+  And Marco sees a minimal guest view with live scoreboard
+
+  When I ask the agent "Come si prepara Catan per 3 giocatori?"
+  Then the agent responds with setup instructions citing the rulebook
+
+  When I record scores: Me=42, Marco=38, Giulia=45
+  Then all connected participants see updated scores in real-time
+
+  When Marco proposes a score "+5 for Marco"
+  Then I see a pending proposal badge on the Punteggi card
+  And I can confirm or reject the proposal
+
+  When I click "⚖️ Arbitro" and describe "Marco says he can play 2 cards per turn"
+  Then the agent analyzes and returns a verdict with rule citation
+  And the verdict is saved in the session dispute history
+  And a banner appears on the card parent with the ruling
+
+  When I click "💾 Salva & Esci"
+  Then I optionally take a final photo
+  And the system saves: scores, turn, phase, photos, disputes, agent memory
+  And all participants are disconnected gracefully
+
+  When I return days later and open my Library
+  Then the Catan card shows "1 sessione in pausa"
+
+  When I click "▶️ Riprendi"
+  Then the session is restored with original state
+  And the agent shows a recap: "Eravate al round 5, Giulia stava vincendo..."
+  And I can continue playing
+```
+
+### Error Path: Agent Auto-Creation Failure
+
+```gherkin
+Scenario: PDF processes successfully but agent creation fails
+  Given I uploaded a valid PDF for "Catan"
+  And PDF processing completes successfully
+  When agent auto-creation fails (e.g., agent quota reached, KnowledgeBase service down)
+  Then I receive a notification "⚠️ Agente non creato automaticamente per Catan"
+  And the notification offers "Crea manualmente" linking to agent creation page
+  And the processed PDF/KB cards remain available for manual agent creation
+```
+
+### Error Path: PDF Processing Failure
+
+```gherkin
+Scenario: PDF processing fails
+  Given I uploaded a poorly scanned PDF for "Catan"
+  When processing fails due to low OCR quality
+  Then I receive a notification "⚠️ Processing fallito per Catan"
+  And the notification offers "Riprova" and "Carica un altro PDF"
+  When I click "Riprova"
+  Then the PDF is re-queued for processing (max 3 retries)
+```
+
+### Error Path: Offline During Game
+
+```gherkin
+Scenario: WiFi drops during game
+  Given I am in an active session with 3 players
+  When WiFi connection drops
+  Then I see "⚡ Offline — punteggi salvati localmente"
+  And I can still enter scores (buffered locally)
+  When WiFi reconnects
+  Then buffered scores sync automatically via SignalR
+  And the "Offline" banner disappears
+```
+
+### Edge Case: Resume with Missing Players
+
+```gherkin
+Scenario: Resume with fewer players
+  Given I saved a session with players: Me, Marco, Giulia, Leo
+  When I resume the session with only Me and Marco present
+  Then the agent recap mentions "Giulia e Leo non sono presenti"
+  And their scores are frozen at saved values
+  And I can choose to: keep frozen, remove player, or add replacement
+```
+
+---
+
+## Implementation Priority (Vertical Slice)
+
+### Must Have (Day 1-8)
+1. Create `AutoCreateAgentOnPdfReadyHandler` (full implementation, not just extension) + notification + failure path
+2. `StartImprovvisataSessionCommand` shortcut
+3. `RuleDisputeEntry` JSONB column on `LiveGameSession` + EF migration
+4. `PauseSnapshot` entity + EF migration (separate from existing delta-based `SessionSnapshot`)
+5. Card parent + 4 child cards in CardStack (frontend)
+6. Scoreboard child card with host +/- and real-time sync
+7. Guest landing page (link/session code, no auth, score view + self-proposals with limits)
+8. Session context injection into agent prompt
+9. `SubmitRuleDisputeCommand` + Arbitro UI
+10. `CreatePauseSnapshotCommand` with structured state (async summary)
+11. `ResumeSessionCommand` + Library "sessioni in pausa" UI
+
+### Should Have (Day 9-11)
+12. `AgentConversationSummary` async generation via domain event
+13. Auto-recap on resume (with fallback to raw messages if summary is null)
+14. Photo capture child card (`SessionAttachment`)
+15. Auto-save background service (10 min interval, cleanup on manual save)
+16. Guest score proposal business rules (self-only, delta limits, max pending)
+
+### Nice to Have (Day 12-15)
+17. Offline local buffer + sync on reconnect
+18. Guest reconnection via localStorage token
+19. PDF processing progress SSE events
+20. Dispute history query across sessions per-game (`GetDisputesByGameId`)
+21. Resume with different players management
+22. `navigator.sendBeacon` for reliable app-backgrounding signal
+
+---
+
+## Open Questions for Future Iterations
+
+1. **Multi-game session**: Can a game night have multiple games? (Deferred — single game per session for V1)
+2. **Guest agent access**: Should premium tier allow guests to query the agent? (Deferred to tier system)
+3. **Voice input**: Could players ask rules verbally instead of typing? (Deferred — future feature)
+4. **Spectator mode**: Can someone watch without being a player? (Deferred)
+5. **Tournament mode**: Multiple sessions with brackets? (Deferred — different feature entirely)
+
+---
+
+## Spec Review Changelog
+
+**Review 1** (2026-03-15, automated spec-document-reviewer):
+
+| ID | Severity | Fix Applied |
+|----|----------|-------------|
+| C1 | Critical | Renamed `SessionSnapshot` → `PauseSnapshot` to avoid conflict with existing delta-based `SessionSnapshot` entity |
+| C2 | Critical | Replaced `IsPaused = false` with `Status = LiveSessionStatus.InProgress` + clear `PausedAt` |
+| C3 | Critical | Changed "Extend" to "Create" for `AutoCreateAgentOnPdfReadyHandler` — only exists in test stubs |
+| M1 | Major | Added explicit migration notes for `RuleDisputeEntry` JSONB column and `PauseSnapshot` table |
+| M2 | Major | Specified async-with-eventual-consistency for `AgentConversationSummary` (save immediately, summary arrives async, 60s timeout, fallback to raw messages) |
+| M3 | Major | Resolved dispute storage contradiction: disputes live in `LiveGameSession` per-session, queryable per-game via `GetDisputesByGameId` repository method |
+| M4 | Major | Added guest score proposal business rules: self-only, delta limits (-100/+100), max 3 pending |
+| M5 | Major | QR code generated client-side via `qrcode.react`, removed `qrCodeUrl` from backend response |
+| m1 | Minor | Replaced "PIN" with "session code" for consistency with existing `SessionCode` |
+| m2 | Minor | Added best-effort note for `AppBackgrounded`, `navigator.sendBeacon` alternative |
+| m3 | Minor | Clarified auto-save cleanup: delete ALL auto-saves on manual save/completion |
+| m4 | Minor | Added i18n section: V1 Italian-only, strings hardcoded |
+| m5 | Minor | Updated effort estimate from 8-10 to 12-15 days |
+| m6 | Minor | Added agent auto-creation failure error path (Gherkin scenario) |
+| m7 | Minor | Changed `SavedByPlayerName` to `SavedByUserId` (host is always saver) |


### PR DESCRIPTION
## Summary

Complete end-to-end "Game Night Improvvisata" feature — from BGG game search to session save/resume with AI agent assistance.

### Backend (~50 files, ~190 tests)
- **Domain model**: `PauseSnapshot` entity, `RuleDisputeEntry` VO, Disputes JSONB on `LiveGameSession`
- **Commands**: `StartImprovvisataSession`, `SubmitRuleDispute`, `CreatePauseSnapshot`, `ResumeSessionFromSnapshot`
- **Event handlers**: `AutoCreateAgentOnPdfReadyHandler`, `GenerateAgentSummaryHandler`, `SessionContextPromptBuilder`
- **SignalR**: `DisputeResolved`, `SessionPaused`, `ScoreUpdated`, `AppBackgrounded`
- **Background**: `SessionAutoSaveBackgroundService` (10-min auto-save)
- **Migration**: `AddPauseSnapshotAndDisputesJsonb`

### Frontend (~35 files, ~28 tests)
- **Session UI**: CardStack with MiniNav tabs (Partita, Chat AI, Punteggi, Foto, Giocatori)
- **Components**: ScoreBoard, ArbitroModal, InviteModal (QR), SaveSessionModal, PausedSessionCard, PlayerList
- **Guest**: Public `/join/[inviteToken]` page with score proposals
- **Infrastructure**: Zustand store, SignalR hook, API client extensions

### Code Review Fixes (C1-C3, I6)
- Authorization checks on dispute submission and session save
- AgentAutoCreatedEvent publication for notifications
- Frontend/backend endpoint path alignment

## Test plan
- [x] Backend: ~190 new tests passing
- [x] Frontend: ~28 new tests passing
- [x] TypeScript + build: 0 errors
- [ ] Manual smoke test

🤖 Generated with [Claude Code](https://claude.com/claude-code)