### PR TITLE
feat(admin): PDF→KB workflow improvements

### DIFF
--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/UploadPdfCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/UploadPdfCommand.cs
@@ -13,5 +13,6 @@ internal record UploadPdfCommand(
     PdfUploadMetadata? Metadata,       // New: game metadata for auto-creation
     Guid? PrivateGameId,               // Issue #3664: Private game ID
     Guid UserId,
-    IFormFile File
+    IFormFile File,
+    string? Priority = null            // "normal" | "urgent" | null — admin priority override
 ) : ICommand<PdfUploadResult>;

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/UploadPdfCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/UploadPdfCommandHandler.cs
@@ -174,6 +174,15 @@ internal class UploadPdfCommandHandler : ICommandHandler<UploadPdfCommand, PdfUp
             return new PdfUploadResult(false, storageResult.ErrorMessage ?? "Failed to store file", null);
         }
 
+        // Apply priority from command (admin upload with priority override)
+        if (!string.IsNullOrWhiteSpace(command.Priority))
+        {
+            pdfDoc!.ProcessingPriority = string.Equals(command.Priority, "urgent", StringComparison.OrdinalIgnoreCase)
+                ? "Urgent"
+                : "High"; // Admin default
+            await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+        }
+
         // Reserve quota and start background processing
         return await ReserveQuotaAndStartProcessingAsync(
             userId, gameId, file, storageResult, pdfDoc!, cancellationToken).ConfigureAwait(false);

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/UploadPdfCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/UploadPdfCommandHandler.cs
@@ -177,9 +177,20 @@ internal class UploadPdfCommandHandler : ICommandHandler<UploadPdfCommand, PdfUp
         // Apply priority from command (admin upload with priority override)
         if (!string.IsNullOrWhiteSpace(command.Priority))
         {
-            pdfDoc!.ProcessingPriority = string.Equals(command.Priority, "urgent", StringComparison.OrdinalIgnoreCase)
-                ? "Urgent"
-                : "High"; // Admin default
+            var priorityEnum = string.Equals(command.Priority, "urgent", StringComparison.OrdinalIgnoreCase)
+                ? ProcessingPriority.Urgent
+                : ProcessingPriority.High;
+
+            pdfDoc!.ProcessingPriority = priorityEnum.ToString();
+
+            // Also update the ProcessingJob priority int for Quartz queue ordering
+            var job = await _db.ProcessingJobs
+                .FirstOrDefaultAsync(j => j.PdfDocumentId == pdfDoc.Id, cancellationToken).ConfigureAwait(false);
+            if (job != null)
+            {
+                job.Priority = (int)priorityEnum;
+            }
+
             await _db.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
         }
 

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/DTOs/QueueStreamEventDto.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/DTOs/QueueStreamEventDto.cs
@@ -53,13 +53,25 @@ internal sealed record LogEntryData(string Level, string Message);
 
 /// <summary>
 /// Data payload for job-completed events.
+/// Enriched with game info at the SSE stream handler layer.
 /// </summary>
-internal sealed record JobCompletedData(double TotalDurationSeconds);
+internal sealed record JobCompletedData(
+    double TotalDurationSeconds,
+    string? FileName,
+    Guid? SharedGameId,
+    string? GameName);
 
 /// <summary>
 /// Data payload for job-failed events.
+/// Enriched with game info at the SSE stream handler layer.
 /// </summary>
-internal sealed record JobFailedData(string Error, string? FailedAtStep, int RetryCount);
+internal sealed record JobFailedData(
+    string Error,
+    string? FailedAtStep,
+    int RetryCount,
+    string? FileName,
+    Guid? SharedGameId,
+    string? GameName);
 
 /// <summary>
 /// Data payload for job-queued events (queue-wide stream).

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/EventHandlers/QueueStreamEventHandlers.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/EventHandlers/QueueStreamEventHandlers.cs
@@ -1,7 +1,9 @@
 using Api.BoundedContexts.DocumentProcessing.Application.DTOs;
 using Api.BoundedContexts.DocumentProcessing.Domain.Events;
 using Api.BoundedContexts.DocumentProcessing.Infrastructure.Services;
+using Api.Infrastructure;
 using MediatR;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 
 namespace Api.BoundedContexts.DocumentProcessing.Application.EventHandlers;
@@ -87,20 +89,38 @@ internal sealed class JobStepCompletedStreamHandler : INotificationHandler<JobSt
 internal sealed class JobCompletedStreamHandler : INotificationHandler<JobCompletedEvent>
 {
     private readonly IQueueStreamService _streamService;
+    private readonly MeepleAiDbContext _db;
     private readonly ILogger<JobCompletedStreamHandler> _logger;
 
-    public JobCompletedStreamHandler(IQueueStreamService streamService, ILogger<JobCompletedStreamHandler> logger)
+    public JobCompletedStreamHandler(IQueueStreamService streamService, MeepleAiDbContext db, ILogger<JobCompletedStreamHandler> logger)
     {
         _streamService = streamService;
+        _db = db;
         _logger = logger;
     }
 
     public async Task Handle(JobCompletedEvent notification, CancellationToken cancellationToken)
     {
+        var pdfDoc = await _db.PdfDocuments
+            .Where(p => p.Id == notification.PdfDocumentId)
+            .Select(p => new { p.FileName })
+            .FirstOrDefaultAsync(cancellationToken).ConfigureAwait(false);
+
+        var gameInfo = await _db.SharedGameDocuments
+            .Where(sgd => sgd.PdfDocumentId == notification.PdfDocumentId)
+            .Select(sgd => new { sgd.SharedGameId, GameName = sgd.SharedGame.Title })
+            .FirstOrDefaultAsync(cancellationToken).ConfigureAwait(false);
+
+        var data = new JobCompletedData(
+            notification.TotalDuration.TotalSeconds,
+            pdfDoc?.FileName,
+            gameInfo?.SharedGameId,
+            gameInfo?.GameName);
+
         var evt = new QueueStreamEvent(
             QueueStreamEventType.JobCompleted,
             notification.JobId,
-            new JobCompletedData(notification.TotalDuration.TotalSeconds),
+            data,
             DateTimeOffset.UtcNow);
 
         await _streamService.PublishJobEventAsync(evt, cancellationToken).ConfigureAwait(false);
@@ -111,20 +131,40 @@ internal sealed class JobCompletedStreamHandler : INotificationHandler<JobComple
 internal sealed class JobFailedStreamHandler : INotificationHandler<JobFailedEvent>
 {
     private readonly IQueueStreamService _streamService;
+    private readonly MeepleAiDbContext _db;
     private readonly ILogger<JobFailedStreamHandler> _logger;
 
-    public JobFailedStreamHandler(IQueueStreamService streamService, ILogger<JobFailedStreamHandler> logger)
+    public JobFailedStreamHandler(IQueueStreamService streamService, MeepleAiDbContext db, ILogger<JobFailedStreamHandler> logger)
     {
         _streamService = streamService;
+        _db = db;
         _logger = logger;
     }
 
     public async Task Handle(JobFailedEvent notification, CancellationToken cancellationToken)
     {
+        var pdfDoc = await _db.PdfDocuments
+            .Where(p => p.Id == notification.PdfDocumentId)
+            .Select(p => new { p.FileName })
+            .FirstOrDefaultAsync(cancellationToken).ConfigureAwait(false);
+
+        var gameInfo = await _db.SharedGameDocuments
+            .Where(sgd => sgd.PdfDocumentId == notification.PdfDocumentId)
+            .Select(sgd => new { sgd.SharedGameId, GameName = sgd.SharedGame.Title })
+            .FirstOrDefaultAsync(cancellationToken).ConfigureAwait(false);
+
+        var data = new JobFailedData(
+            notification.ErrorMessage,
+            notification.FailedAtStep?.ToString(),
+            notification.RetryCount,
+            pdfDoc?.FileName,
+            gameInfo?.SharedGameId,
+            gameInfo?.GameName);
+
         var evt = new QueueStreamEvent(
             QueueStreamEventType.JobFailed,
             notification.JobId,
-            new JobFailedData(notification.ErrorMessage, notification.FailedAtStep?.ToString(), notification.RetryCount),
+            data,
             DateTimeOffset.UtcNow);
 
         await _streamService.PublishJobEventAsync(evt, cancellationToken).ConfigureAwait(false);

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Handlers/Queue/GetProcessingQueueQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Handlers/Queue/GetProcessingQueueQueryHandler.cs
@@ -46,6 +46,14 @@ internal class GetProcessingQueueQueryHandler : IQueryHandler<GetProcessingQueue
             dbQuery = dbQuery.Where(j => j.CreatedAt <= query.ToDate.Value);
         }
 
+        // Filter by game ID (matches PdfDocument.GameId or PdfDocument.SharedGameId)
+        if (query.GameId.HasValue)
+        {
+            dbQuery = dbQuery.Where(j =>
+                j.PdfDocument.GameId == query.GameId.Value ||
+                j.PdfDocument.SharedGameId == query.GameId.Value);
+        }
+
         // Search text (matches PDF filename, case-insensitive via EF.Functions.ILike for PostgreSQL)
         if (!string.IsNullOrWhiteSpace(query.SearchText))
         {

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Jobs/PdfProcessingQuartzJob.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Jobs/PdfProcessingQuartzJob.cs
@@ -206,7 +206,7 @@ public sealed class PdfProcessingQuartzJob : IJob
             var totalDurationSec = totalMs / 1000.0;
             await PublishEventSafeAsync(new QueueStreamEvent(
                 QueueStreamEventType.JobCompleted, jobEntity.Id,
-                new JobCompletedData(totalDurationSec),
+                new JobCompletedData(totalDurationSec, null, null, null),
                 completedAt), ct).ConfigureAwait(false);
 
             _logger.LogInformation(
@@ -293,7 +293,7 @@ public sealed class PdfProcessingQuartzJob : IJob
 
         await PublishEventSafeAsync(new QueueStreamEvent(
             QueueStreamEventType.JobFailed, jobEntity.Id,
-            new JobFailedData(error, jobEntity.CurrentStep, jobEntity.RetryCount),
+            new JobFailedData(error, jobEntity.CurrentStep, jobEntity.RetryCount, null, null, null),
             now), ct).ConfigureAwait(false);
     }
 

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Queries/Queue/GetProcessingQueueQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Queries/Queue/GetProcessingQueueQuery.cs
@@ -13,5 +13,6 @@ internal record GetProcessingQueueQuery(
     DateTimeOffset? FromDate = null,
     DateTimeOffset? ToDate = null,
     int Page = 1,
-    int PageSize = 20
+    int PageSize = 20,
+    Guid? GameId = null
 ) : IQuery<PaginatedQueueResponse>;

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Validators/UploadPdfCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Validators/UploadPdfCommandValidator.cs
@@ -1,0 +1,25 @@
+using Api.BoundedContexts.DocumentProcessing.Application.Commands;
+using FluentValidation;
+
+namespace Api.BoundedContexts.DocumentProcessing.Application.Validators;
+
+/// <summary>
+/// Validator for UploadPdfCommand.
+/// Validates file, user, and optional priority parameter.
+/// </summary>
+internal sealed class UploadPdfCommandValidator : AbstractValidator<UploadPdfCommand>
+{
+    private static readonly string[] ValidPriorities = ["normal", "urgent"];
+
+    public UploadPdfCommandValidator()
+    {
+        RuleFor(x => x.File).NotNull();
+        RuleFor(x => x.UserId).NotEmpty();
+        When(x => x.Priority != null, () =>
+        {
+            RuleFor(x => x.Priority)
+                .Must(p => ValidPriorities.Contains(p!.ToLowerInvariant(), StringComparer.Ordinal))
+                .WithMessage("Priority must be 'normal' or 'urgent'");
+        });
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/DTOs/RecentlyProcessedDocumentDto.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/DTOs/RecentlyProcessedDocumentDto.cs
@@ -1,0 +1,17 @@
+namespace Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
+
+/// <summary>
+/// DTO representing a recently processed PDF document linked to a SharedGame.
+/// Used by the admin "Recently Processed" widget.
+/// </summary>
+public sealed record RecentlyProcessedDocumentDto(
+    Guid PdfDocumentId,
+    Guid? JobId,
+    string FileName,
+    string ProcessingState,
+    DateTime Timestamp,
+    string? ErrorCategory,
+    bool CanRetry,
+    Guid SharedGameId,
+    string GameName,
+    string? ThumbnailUrl);

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetRecentlyProcessedDocuments/GetRecentlyProcessedDocumentsQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetRecentlyProcessedDocuments/GetRecentlyProcessedDocumentsQuery.cs
@@ -1,0 +1,11 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
+using MediatR;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Queries.GetRecentlyProcessedDocuments;
+
+/// <summary>
+/// Query to retrieve recently processed PDF documents linked to SharedGames.
+/// Cross-BC read query joining DocumentProcessing and SharedGameCatalog data.
+/// </summary>
+public sealed record GetRecentlyProcessedDocumentsQuery(int Limit = 10)
+    : IRequest<List<RecentlyProcessedDocumentDto>>;

--- a/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetRecentlyProcessedDocuments/GetRecentlyProcessedDocumentsQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetRecentlyProcessedDocuments/GetRecentlyProcessedDocumentsQueryHandler.cs
@@ -1,0 +1,63 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
+using Api.Infrastructure;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Queries.GetRecentlyProcessedDocuments;
+
+/// <summary>
+/// Handler for GetRecentlyProcessedDocumentsQuery.
+/// Cross-BC read query joining SharedGameDocuments, PdfDocuments, SharedGames,
+/// and ProcessingJobs to build the admin "Recently Processed" widget data.
+/// </summary>
+internal sealed class GetRecentlyProcessedDocumentsQueryHandler
+    : IRequestHandler<GetRecentlyProcessedDocumentsQuery, List<RecentlyProcessedDocumentDto>>
+{
+    private const int MaxRetries = 3;
+
+    private readonly MeepleAiDbContext _db;
+
+    public GetRecentlyProcessedDocumentsQueryHandler(MeepleAiDbContext db)
+    {
+        _db = db ?? throw new ArgumentNullException(nameof(db));
+    }
+
+    public async Task<List<RecentlyProcessedDocumentDto>> Handle(
+        GetRecentlyProcessedDocumentsQuery request,
+        CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        var limit = Math.Clamp(request.Limit, 1, 50);
+
+        // Cross-BC read query (deliberate — follows GetGameRagReadinessQueryHandler pattern)
+        // Join: SharedGameDocuments → PdfDocuments (on PdfDocumentId)
+        //       SharedGameDocuments → SharedGames (on SharedGameId)
+        //       Left-join ProcessingJobs (on PdfDocumentId) for JobId
+        var results = await (
+            from sgd in _db.SharedGameDocuments
+            join pd in _db.PdfDocuments on sgd.PdfDocumentId equals pd.Id
+            join sg in _db.SharedGames on sgd.SharedGameId equals sg.Id
+            join pj in _db.ProcessingJobs on pd.Id equals pj.PdfDocumentId into jobs
+            from pj in jobs.DefaultIfEmpty()
+            where !sg.IsDeleted
+            orderby pd.ProcessedAt ?? pd.UploadedAt descending
+            select new RecentlyProcessedDocumentDto(
+                pd.Id,
+                pj != null ? pj.Id : (Guid?)null,
+                pd.FileName,
+                pd.ProcessingState,
+                pd.ProcessedAt ?? pd.UploadedAt,
+                pd.ErrorCategory,
+                pd.ProcessingState == "Failed" && pd.RetryCount < MaxRetries,
+                sg.Id,
+                sg.Title,
+                sg.ThumbnailUrl)
+        )
+        .Take(limit)
+        .ToListAsync(cancellationToken)
+        .ConfigureAwait(false);
+
+        return results;
+    }
+}

--- a/apps/api/src/Api/Routing/AdminQueueEndpoints.cs
+++ b/apps/api/src/Api/Routing/AdminQueueEndpoints.cs
@@ -189,6 +189,7 @@ internal static class AdminQueueEndpoints
         [FromQuery] DateTimeOffset? toDate,
         [FromQuery] int? page,
         [FromQuery] int? pageSize,
+        [FromQuery] Guid? gameId,
         IMediator mediator,
         CancellationToken ct)
     {
@@ -198,7 +199,8 @@ internal static class AdminQueueEndpoints
             FromDate: fromDate,
             ToDate: toDate,
             Page: page ?? 1,
-            PageSize: pageSize ?? 20);
+            PageSize: pageSize ?? 20,
+            GameId: gameId);
         var result = await mediator.Send(query, ct).ConfigureAwait(false);
         return Results.Ok(result);
     }

--- a/apps/api/src/Api/Routing/AdminSharedGameContentEndpoints.cs
+++ b/apps/api/src/Api/Routing/AdminSharedGameContentEndpoints.cs
@@ -1,7 +1,9 @@
 using Api.BoundedContexts.Administration.Application.Queries;
 using Api.BoundedContexts.DocumentProcessing.Application.Commands.BulkUploadPdfs;
 using Api.BoundedContexts.SharedGameCatalog.Application.Commands;
+using Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
 using Api.BoundedContexts.SharedGameCatalog.Application.Queries.GetDocumentOverview;
+using Api.BoundedContexts.SharedGameCatalog.Application.Queries.GetRecentlyProcessedDocuments;
 using Api.Extensions;
 using Api.Filters;
 using Api.Middleware.Exceptions;
@@ -51,6 +53,22 @@ internal static class AdminSharedGameContentEndpoints
             .WithDescription("Returns processing status breakdown, per-document details, agent linkage, and RAG readiness assessment.")
             .Produces<DocumentOverviewResult>(StatusCodes.Status200OK)
             .ProducesProblem(StatusCodes.Status404NotFound);
+
+        // GET /api/v1/admin/shared-games/recently-processed
+        // Recently processed PDF documents widget
+        contentGroup.MapGet("/recently-processed", async (
+                [FromQuery] int? limit,
+                IMediator mediator,
+                CancellationToken ct) =>
+            {
+                var result = await mediator.Send(
+                    new GetRecentlyProcessedDocumentsQuery(limit ?? 10), ct).ConfigureAwait(false);
+                return Results.Ok(result);
+            })
+            .WithName("GetRecentlyProcessedDocuments")
+            .WithSummary("Get recently processed PDF documents for SharedGames (Admin)")
+            .WithDescription("Returns recently processed documents with processing status, error info, and linked game details.")
+            .Produces<List<RecentlyProcessedDocumentDto>>(StatusCodes.Status200OK);
 
         // GET /api/v1/admin/shared-games/mau
         // Issue #113: MAU Monitoring Dashboard

--- a/apps/api/src/Api/Routing/PdfEndpoints.cs
+++ b/apps/api/src/Api/Routing/PdfEndpoints.cs
@@ -454,6 +454,11 @@ internal static class PdfEndpoints
 
         var userId = session!.User!.Id;
         var priority = context.Request.Query["priority"].FirstOrDefault();
+        // Bug fix: Only allow priority override for admin users to prevent privilege escalation
+        if (priority != null && !string.Equals(session.User.Role, "Admin", StringComparison.OrdinalIgnoreCase))
+        {
+            priority = null;
+        }
         var result = await mediator.Send(new UploadPdfCommand(gameId, metadata, privateGameId, userId, file!, Priority: priority), ct).ConfigureAwait(false);
 
         if (!result.Success)

--- a/apps/api/src/Api/Routing/PdfEndpoints.cs
+++ b/apps/api/src/Api/Routing/PdfEndpoints.cs
@@ -453,7 +453,8 @@ internal static class PdfEndpoints
         }
 
         var userId = session!.User!.Id;
-        var result = await mediator.Send(new UploadPdfCommand(gameId, metadata, privateGameId, userId, file!), ct).ConfigureAwait(false);
+        var priority = context.Request.Query["priority"].FirstOrDefault();
+        var result = await mediator.Send(new UploadPdfCommand(gameId, metadata, privateGameId, userId, file!, Priority: priority), ct).ConfigureAwait(false);
 
         if (!result.Success)
         {

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Commands/UploadPdfPriorityTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Commands/UploadPdfPriorityTests.cs
@@ -1,0 +1,226 @@
+using Api.BoundedContexts.DocumentProcessing.Application.Commands;
+using Api.BoundedContexts.DocumentProcessing.Application.Validators;
+using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
+using Api.Tests.Constants;
+using FluentAssertions;
+using FluentValidation.TestHelper;
+using Microsoft.AspNetCore.Http;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.DocumentProcessing.Application.Commands;
+
+/// <summary>
+/// Tests for the Priority parameter on UploadPdfCommand.
+/// Validates priority parsing, validator behavior, and default resolution.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+public class UploadPdfPriorityTests
+{
+    private readonly UploadPdfCommandValidator _validator = new();
+
+    private static IFormFile CreateMockFile()
+    {
+        var fileMock = new Mock<IFormFile>();
+        fileMock.Setup(f => f.Length).Returns(1024);
+        fileMock.Setup(f => f.FileName).Returns("test.pdf");
+        fileMock.Setup(f => f.ContentType).Returns("application/pdf");
+        return fileMock.Object;
+    }
+
+    #region Validator Tests
+
+    [Fact]
+    public void Validator_WithNullPriority_ShouldPass()
+    {
+        // Arrange
+        var command = new UploadPdfCommand(
+            GameId: "game-1",
+            Metadata: null,
+            PrivateGameId: null,
+            UserId: Guid.NewGuid(),
+            File: CreateMockFile(),
+            Priority: null);
+
+        // Act
+        var result = _validator.TestValidate(command);
+
+        // Assert
+        result.ShouldNotHaveValidationErrorFor(x => x.Priority);
+    }
+
+    [Theory]
+    [InlineData("normal")]
+    [InlineData("urgent")]
+    [InlineData("Normal")]
+    [InlineData("URGENT")]
+    public void Validator_WithValidPriority_ShouldPass(string priority)
+    {
+        // Arrange
+        var command = new UploadPdfCommand(
+            GameId: "game-1",
+            Metadata: null,
+            PrivateGameId: null,
+            UserId: Guid.NewGuid(),
+            File: CreateMockFile(),
+            Priority: priority);
+
+        // Act
+        var result = _validator.TestValidate(command);
+
+        // Assert
+        result.ShouldNotHaveValidationErrorFor(x => x.Priority);
+    }
+
+    [Theory]
+    [InlineData("invalid")]
+    [InlineData("high")]
+    [InlineData("low")]
+    [InlineData("critical")]
+    [InlineData("")]
+    public void Validator_WithInvalidPriority_ShouldFail(string priority)
+    {
+        // Arrange
+        var command = new UploadPdfCommand(
+            GameId: "game-1",
+            Metadata: null,
+            PrivateGameId: null,
+            UserId: Guid.NewGuid(),
+            File: CreateMockFile(),
+            Priority: priority);
+
+        // Act
+        var result = _validator.TestValidate(command);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(x => x.Priority)
+            .WithErrorMessage("Priority must be 'normal' or 'urgent'");
+    }
+
+    [Fact]
+    public void Validator_WithNullFile_ShouldFail()
+    {
+        // Arrange
+        var command = new UploadPdfCommand(
+            GameId: "game-1",
+            Metadata: null,
+            PrivateGameId: null,
+            UserId: Guid.NewGuid(),
+            File: null!,
+            Priority: "urgent");
+
+        // Act
+        var result = _validator.TestValidate(command);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(x => x.File);
+    }
+
+    [Fact]
+    public void Validator_WithEmptyUserId_ShouldFail()
+    {
+        // Arrange
+        var command = new UploadPdfCommand(
+            GameId: "game-1",
+            Metadata: null,
+            PrivateGameId: null,
+            UserId: Guid.Empty,
+            File: CreateMockFile(),
+            Priority: "normal");
+
+        // Act
+        var result = _validator.TestValidate(command);
+
+        // Assert
+        result.ShouldHaveValidationErrorFor(x => x.UserId);
+    }
+
+    #endregion
+
+    #region Priority Resolution Tests
+
+    [Fact]
+    public void UrgentPriority_MapsToProcessingPriorityUrgent()
+    {
+        // Arrange
+        var requestedPriority = "urgent";
+
+        // Act — same logic as UploadPdfCommandHandler
+        var resolvedPriority = requestedPriority.ToLowerInvariant() == "urgent"
+            ? ProcessingPriority.Urgent
+            : ProcessingPriority.High;
+
+        // Assert
+        resolvedPriority.Should().Be(ProcessingPriority.Urgent);
+        ((int)resolvedPriority).Should().Be(30);
+    }
+
+    [Fact]
+    public void NullPriority_DefaultsToProcessingPriorityHigh()
+    {
+        // Arrange
+        string? requestedPriority = null;
+
+        // Act — same logic as UploadPdfCommandHandler
+        var resolvedPriority = requestedPriority?.ToLowerInvariant() == "urgent"
+            ? ProcessingPriority.Urgent
+            : ProcessingPriority.High;
+
+        // Assert
+        resolvedPriority.Should().Be(ProcessingPriority.High);
+        ((int)resolvedPriority).Should().Be(20);
+    }
+
+    [Fact]
+    public void NormalPriority_DefaultsToProcessingPriorityHigh()
+    {
+        // Arrange — "normal" is a valid value but maps to High (admin default)
+        var requestedPriority = "normal";
+
+        // Act
+        var resolvedPriority = requestedPriority.ToLowerInvariant() == "urgent"
+            ? ProcessingPriority.Urgent
+            : ProcessingPriority.High;
+
+        // Assert
+        resolvedPriority.Should().Be(ProcessingPriority.High);
+        ((int)resolvedPriority).Should().Be(20);
+    }
+
+    #endregion
+
+    #region Command Construction Tests
+
+    [Fact]
+    public void UploadPdfCommand_DefaultPriority_IsNull()
+    {
+        // Arrange & Act
+        var command = new UploadPdfCommand(
+            GameId: "game-1",
+            Metadata: null,
+            PrivateGameId: null,
+            UserId: Guid.NewGuid(),
+            File: CreateMockFile());
+
+        // Assert — Priority defaults to null when not specified
+        command.Priority.Should().BeNull();
+    }
+
+    [Fact]
+    public void UploadPdfCommand_WithPriority_PreservesValue()
+    {
+        // Arrange & Act
+        var command = new UploadPdfCommand(
+            GameId: "game-1",
+            Metadata: null,
+            PrivateGameId: null,
+            UserId: Guid.NewGuid(),
+            File: CreateMockFile(),
+            Priority: "urgent");
+
+        // Assert
+        command.Priority.Should().Be("urgent");
+    }
+
+    #endregion
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/EventHandlers/QueueStreamEventHandlerEnrichmentTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/EventHandlers/QueueStreamEventHandlerEnrichmentTests.cs
@@ -1,0 +1,285 @@
+using Api.BoundedContexts.DocumentProcessing.Application.DTOs;
+using Api.BoundedContexts.DocumentProcessing.Application.EventHandlers;
+using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
+using Api.BoundedContexts.DocumentProcessing.Domain.Events;
+using Api.BoundedContexts.DocumentProcessing.Infrastructure.Services;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.SharedKernel.Application.Services;
+using Api.Tests.Constants;
+using FluentAssertions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.DocumentProcessing.Application.EventHandlers;
+
+/// <summary>
+/// Tests that JobCompleted and JobFailed SSE stream handlers enrich DTOs
+/// with game info from PdfDocuments and SharedGameDocuments tables.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "DocumentProcessing")]
+public sealed class QueueStreamEventHandlerEnrichmentTests : IDisposable
+{
+    private readonly MeepleAiDbContext _db;
+    private readonly Mock<IQueueStreamService> _streamServiceMock = new();
+
+    public QueueStreamEventHandlerEnrichmentTests()
+    {
+        var options = new DbContextOptionsBuilder<MeepleAiDbContext>()
+            .UseInMemoryDatabase(databaseName: $"EnrichmentTests_{Guid.NewGuid()}")
+            .Options;
+        _db = new MeepleAiDbContext(options, Mock.Of<IMediator>(), Mock.Of<IDomainEventCollector>());
+    }
+
+    public void Dispose() => _db.Dispose();
+
+    #region JobCompletedStreamHandler enrichment
+
+    [Fact]
+    public async Task JobCompletedStreamHandler_EnrichesWithGameInfo_WhenSharedGameDocumentExists()
+    {
+        // Arrange
+        var pdfDocId = Guid.NewGuid();
+        var sharedGameId = Guid.NewGuid();
+
+        _db.PdfDocuments.Add(new PdfDocumentEntity
+        {
+            Id = pdfDocId,
+            FileName = "catan-rules.pdf",
+            FilePath = "/uploads/catan-rules.pdf",
+            FileSizeBytes = 1024,
+            ContentType = "application/pdf",
+            UploadedByUserId = Guid.NewGuid(),
+            UploadedAt = DateTime.UtcNow
+        });
+
+        _db.Set<SharedGameEntity>().Add(new SharedGameEntity
+        {
+            Id = sharedGameId,
+            Title = "Catan",
+            Description = "Classic trading game"
+        });
+
+        _db.SharedGameDocuments.Add(new SharedGameDocumentEntity
+        {
+            Id = Guid.NewGuid(),
+            SharedGameId = sharedGameId,
+            PdfDocumentId = pdfDocId,
+            DocumentType = 0,
+            CreatedAt = DateTime.UtcNow,
+            CreatedBy = Guid.NewGuid()
+        });
+
+        await _db.SaveChangesAsync();
+
+        var handler = new JobCompletedStreamHandler(
+            _streamServiceMock.Object, _db, Mock.Of<ILogger<JobCompletedStreamHandler>>());
+
+        QueueStreamEvent? captured = null;
+        _streamServiceMock
+            .Setup(s => s.PublishJobEventAsync(It.IsAny<QueueStreamEvent>(), It.IsAny<CancellationToken>()))
+            .Callback<QueueStreamEvent, CancellationToken>((e, _) => captured = e)
+            .Returns(Task.CompletedTask);
+
+        var notification = new JobCompletedEvent(Guid.NewGuid(), pdfDocId, Guid.NewGuid(), TimeSpan.FromSeconds(30));
+
+        // Act
+        await handler.Handle(notification, CancellationToken.None);
+
+        // Assert
+        captured.Should().NotBeNull();
+        var data = captured!.Data.Should().BeOfType<JobCompletedData>().Which;
+        data.TotalDurationSeconds.Should().Be(30);
+        data.FileName.Should().Be("catan-rules.pdf");
+        data.SharedGameId.Should().Be(sharedGameId);
+        data.GameName.Should().Be("Catan");
+    }
+
+    [Fact]
+    public async Task JobCompletedStreamHandler_HandlesNullGameInfo_WhenNoSharedGameDocument()
+    {
+        // Arrange
+        var pdfDocId = Guid.NewGuid();
+
+        _db.PdfDocuments.Add(new PdfDocumentEntity
+        {
+            Id = pdfDocId,
+            FileName = "orphan-doc.pdf",
+            FilePath = "/uploads/orphan-doc.pdf",
+            FileSizeBytes = 512,
+            ContentType = "application/pdf",
+            UploadedByUserId = Guid.NewGuid(),
+            UploadedAt = DateTime.UtcNow
+        });
+
+        await _db.SaveChangesAsync();
+
+        var handler = new JobCompletedStreamHandler(
+            _streamServiceMock.Object, _db, Mock.Of<ILogger<JobCompletedStreamHandler>>());
+
+        QueueStreamEvent? captured = null;
+        _streamServiceMock
+            .Setup(s => s.PublishJobEventAsync(It.IsAny<QueueStreamEvent>(), It.IsAny<CancellationToken>()))
+            .Callback<QueueStreamEvent, CancellationToken>((e, _) => captured = e)
+            .Returns(Task.CompletedTask);
+
+        var notification = new JobCompletedEvent(Guid.NewGuid(), pdfDocId, Guid.NewGuid(), TimeSpan.FromSeconds(15));
+
+        // Act
+        await handler.Handle(notification, CancellationToken.None);
+
+        // Assert
+        captured.Should().NotBeNull();
+        var data = captured!.Data.Should().BeOfType<JobCompletedData>().Which;
+        data.TotalDurationSeconds.Should().Be(15);
+        data.FileName.Should().Be("orphan-doc.pdf");
+        data.SharedGameId.Should().BeNull();
+        data.GameName.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task JobCompletedStreamHandler_HandlesNullFileName_WhenPdfDocumentNotFound()
+    {
+        // Arrange — no PDF document or shared game in DB
+        var handler = new JobCompletedStreamHandler(
+            _streamServiceMock.Object, _db, Mock.Of<ILogger<JobCompletedStreamHandler>>());
+
+        QueueStreamEvent? captured = null;
+        _streamServiceMock
+            .Setup(s => s.PublishJobEventAsync(It.IsAny<QueueStreamEvent>(), It.IsAny<CancellationToken>()))
+            .Callback<QueueStreamEvent, CancellationToken>((e, _) => captured = e)
+            .Returns(Task.CompletedTask);
+
+        var notification = new JobCompletedEvent(Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), TimeSpan.FromSeconds(10));
+
+        // Act
+        await handler.Handle(notification, CancellationToken.None);
+
+        // Assert
+        captured.Should().NotBeNull();
+        var data = captured!.Data.Should().BeOfType<JobCompletedData>().Which;
+        data.TotalDurationSeconds.Should().Be(10);
+        data.FileName.Should().BeNull();
+        data.SharedGameId.Should().BeNull();
+        data.GameName.Should().BeNull();
+    }
+
+    #endregion
+
+    #region JobFailedStreamHandler enrichment
+
+    [Fact]
+    public async Task JobFailedStreamHandler_EnrichesWithGameInfo_WhenSharedGameDocumentExists()
+    {
+        // Arrange
+        var pdfDocId = Guid.NewGuid();
+        var sharedGameId = Guid.NewGuid();
+
+        _db.PdfDocuments.Add(new PdfDocumentEntity
+        {
+            Id = pdfDocId,
+            FileName = "terraforming-mars.pdf",
+            FilePath = "/uploads/terraforming-mars.pdf",
+            FileSizeBytes = 2048,
+            ContentType = "application/pdf",
+            UploadedByUserId = Guid.NewGuid(),
+            UploadedAt = DateTime.UtcNow
+        });
+
+        _db.Set<SharedGameEntity>().Add(new SharedGameEntity
+        {
+            Id = sharedGameId,
+            Title = "Terraforming Mars",
+            Description = "Sci-fi engine builder"
+        });
+
+        _db.SharedGameDocuments.Add(new SharedGameDocumentEntity
+        {
+            Id = Guid.NewGuid(),
+            SharedGameId = sharedGameId,
+            PdfDocumentId = pdfDocId,
+            DocumentType = 0,
+            CreatedAt = DateTime.UtcNow,
+            CreatedBy = Guid.NewGuid()
+        });
+
+        await _db.SaveChangesAsync();
+
+        var handler = new JobFailedStreamHandler(
+            _streamServiceMock.Object, _db, Mock.Of<ILogger<JobFailedStreamHandler>>());
+
+        QueueStreamEvent? captured = null;
+        _streamServiceMock
+            .Setup(s => s.PublishJobEventAsync(It.IsAny<QueueStreamEvent>(), It.IsAny<CancellationToken>()))
+            .Callback<QueueStreamEvent, CancellationToken>((e, _) => captured = e)
+            .Returns(Task.CompletedTask);
+
+        var notification = new JobFailedEvent(
+            Guid.NewGuid(), pdfDocId, Guid.NewGuid(),
+            "OCR failed", ProcessingStepType.Extract, 1);
+
+        // Act
+        await handler.Handle(notification, CancellationToken.None);
+
+        // Assert
+        captured.Should().NotBeNull();
+        var data = captured!.Data.Should().BeOfType<JobFailedData>().Which;
+        data.Error.Should().Be("OCR failed");
+        data.FailedAtStep.Should().Be("Extract");
+        data.RetryCount.Should().Be(1);
+        data.FileName.Should().Be("terraforming-mars.pdf");
+        data.SharedGameId.Should().Be(sharedGameId);
+        data.GameName.Should().Be("Terraforming Mars");
+    }
+
+    [Fact]
+    public async Task JobFailedStreamHandler_HandlesNullGameInfo_WhenNoSharedGameDocument()
+    {
+        // Arrange
+        var pdfDocId = Guid.NewGuid();
+
+        _db.PdfDocuments.Add(new PdfDocumentEntity
+        {
+            Id = pdfDocId,
+            FileName = "user-upload.pdf",
+            FilePath = "/uploads/user-upload.pdf",
+            FileSizeBytes = 768,
+            ContentType = "application/pdf",
+            UploadedByUserId = Guid.NewGuid(),
+            UploadedAt = DateTime.UtcNow
+        });
+
+        await _db.SaveChangesAsync();
+
+        var handler = new JobFailedStreamHandler(
+            _streamServiceMock.Object, _db, Mock.Of<ILogger<JobFailedStreamHandler>>());
+
+        QueueStreamEvent? captured = null;
+        _streamServiceMock
+            .Setup(s => s.PublishJobEventAsync(It.IsAny<QueueStreamEvent>(), It.IsAny<CancellationToken>()))
+            .Callback<QueueStreamEvent, CancellationToken>((e, _) => captured = e)
+            .Returns(Task.CompletedTask);
+
+        var notification = new JobFailedEvent(
+            Guid.NewGuid(), pdfDocId, Guid.NewGuid(),
+            "Chunk failed", ProcessingStepType.Chunk, 0);
+
+        // Act
+        await handler.Handle(notification, CancellationToken.None);
+
+        // Assert
+        captured.Should().NotBeNull();
+        var data = captured!.Data.Should().BeOfType<JobFailedData>().Which;
+        data.Error.Should().Be("Chunk failed");
+        data.FileName.Should().Be("user-upload.pdf");
+        data.SharedGameId.Should().BeNull();
+        data.GameName.Should().BeNull();
+    }
+
+    #endregion
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/EventHandlers/QueueStreamEventHandlersTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/EventHandlers/QueueStreamEventHandlersTests.cs
@@ -3,8 +3,12 @@ using Api.BoundedContexts.DocumentProcessing.Application.EventHandlers;
 using Api.BoundedContexts.DocumentProcessing.Domain.Enums;
 using Api.BoundedContexts.DocumentProcessing.Domain.Events;
 using Api.BoundedContexts.DocumentProcessing.Infrastructure.Services;
+using Api.Infrastructure;
+using Api.SharedKernel.Application.Services;
 using Api.Tests.Constants;
 using FluentAssertions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Logging;
 using Moq;
 using Xunit;
@@ -12,9 +16,20 @@ using Xunit;
 namespace Api.Tests.BoundedContexts.DocumentProcessing.Application.EventHandlers;
 
 [Trait("Category", TestCategories.Unit)]
-public sealed class QueueStreamEventHandlersTests
+public sealed class QueueStreamEventHandlersTests : IDisposable
 {
     private readonly Mock<IQueueStreamService> _streamServiceMock = new();
+    private readonly MeepleAiDbContext _db;
+
+    public QueueStreamEventHandlersTests()
+    {
+        var options = new DbContextOptionsBuilder<MeepleAiDbContext>()
+            .UseInMemoryDatabase(databaseName: $"QueueStreamTests_{Guid.NewGuid()}")
+            .Options;
+        _db = new MeepleAiDbContext(options, Mock.Of<IMediator>(), Mock.Of<IDomainEventCollector>());
+    }
+
+    public void Dispose() => _db.Dispose();
 
     [Fact]
     public async Task JobQueuedStreamHandler_PublishesJobQueuedEvent()
@@ -97,7 +112,7 @@ public sealed class QueueStreamEventHandlersTests
     {
         // Arrange
         var loggerMock = new Mock<ILogger<JobCompletedStreamHandler>>();
-        var handler = new JobCompletedStreamHandler(_streamServiceMock.Object, loggerMock.Object);
+        var handler = new JobCompletedStreamHandler(_streamServiceMock.Object, _db, loggerMock.Object);
         var notification = new JobCompletedEvent(
             Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), TimeSpan.FromSeconds(45));
 
@@ -122,7 +137,7 @@ public sealed class QueueStreamEventHandlersTests
     {
         // Arrange
         var loggerMock = new Mock<ILogger<JobFailedStreamHandler>>();
-        var handler = new JobFailedStreamHandler(_streamServiceMock.Object, loggerMock.Object);
+        var handler = new JobFailedStreamHandler(_streamServiceMock.Object, _db, loggerMock.Object);
         var notification = new JobFailedEvent(
             Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(),
             "Extract failed", ProcessingStepType.Extract, 2);

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Queries/GetProcessingQueueGameFilterTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Queries/GetProcessingQueueGameFilterTests.cs
@@ -1,0 +1,221 @@
+using Api.BoundedContexts.DocumentProcessing.Application.Handlers.Queue;
+using Api.BoundedContexts.DocumentProcessing.Application.Queries.Queue;
+using Api.Infrastructure.Entities;
+using Api.Infrastructure.Entities.DocumentProcessing;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.Tests.Constants;
+using Api.Tests.TestHelpers;
+using FluentAssertions;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.DocumentProcessing.Application.Queries;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "DocumentProcessing")]
+public sealed class GetProcessingQueueGameFilterTests : IDisposable
+{
+    private readonly Api.Infrastructure.MeepleAiDbContext _dbContext;
+    private readonly GetProcessingQueueQueryHandler _handler;
+
+    // Shared test data
+    private readonly Guid _gameId = Guid.NewGuid();
+    private readonly Guid _otherGameId = Guid.NewGuid();
+    private readonly Guid _userId = Guid.NewGuid();
+
+    public GetProcessingQueueGameFilterTests()
+    {
+        _dbContext = TestDbContextFactory.CreateInMemoryDbContext();
+        _handler = new GetProcessingQueueQueryHandler(_dbContext);
+    }
+
+    public void Dispose()
+    {
+        _dbContext.Dispose();
+    }
+
+    [Fact]
+    public async Task Handle_WithGameId_ReturnsOnlyJobsForThatGame()
+    {
+        // Arrange
+        var pdfForGame = CreatePdfDocument("game-rules.pdf");
+        var pdfForOtherGame = CreatePdfDocument("other-rules.pdf");
+        var pdfUnlinked = CreatePdfDocument("unlinked.pdf");
+
+        _dbContext.PdfDocuments.AddRange(pdfForGame, pdfForOtherGame, pdfUnlinked);
+
+        var jobForGame = CreateProcessingJob(pdfForGame.Id);
+        var jobForOtherGame = CreateProcessingJob(pdfForOtherGame.Id);
+        var jobUnlinked = CreateProcessingJob(pdfUnlinked.Id);
+
+        _dbContext.ProcessingJobs.AddRange(jobForGame, jobForOtherGame, jobUnlinked);
+
+        _dbContext.SharedGameDocuments.AddRange(
+            new SharedGameDocumentEntity
+            {
+                Id = Guid.NewGuid(),
+                SharedGameId = _gameId,
+                PdfDocumentId = pdfForGame.Id,
+                CreatedBy = _userId,
+                CreatedAt = DateTime.UtcNow
+            },
+            new SharedGameDocumentEntity
+            {
+                Id = Guid.NewGuid(),
+                SharedGameId = _otherGameId,
+                PdfDocumentId = pdfForOtherGame.Id,
+                CreatedBy = _userId,
+                CreatedAt = DateTime.UtcNow
+            });
+
+        await _dbContext.SaveChangesAsync();
+
+        var query = new GetProcessingQueueQuery(GameId: _gameId);
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.Jobs.Should().HaveCount(1);
+        result.Jobs[0].PdfDocumentId.Should().Be(pdfForGame.Id);
+        result.Total.Should().Be(1);
+    }
+
+    [Fact]
+    public async Task Handle_WithoutGameId_ReturnsAllJobs()
+    {
+        // Arrange
+        var pdf1 = CreatePdfDocument("rules-1.pdf");
+        var pdf2 = CreatePdfDocument("rules-2.pdf");
+        var pdf3 = CreatePdfDocument("rules-3.pdf");
+
+        _dbContext.PdfDocuments.AddRange(pdf1, pdf2, pdf3);
+
+        _dbContext.ProcessingJobs.AddRange(
+            CreateProcessingJob(pdf1.Id),
+            CreateProcessingJob(pdf2.Id),
+            CreateProcessingJob(pdf3.Id));
+
+        _dbContext.SharedGameDocuments.Add(new SharedGameDocumentEntity
+        {
+            Id = Guid.NewGuid(),
+            SharedGameId = _gameId,
+            PdfDocumentId = pdf1.Id,
+            CreatedBy = _userId,
+            CreatedAt = DateTime.UtcNow
+        });
+
+        await _dbContext.SaveChangesAsync();
+
+        var query = new GetProcessingQueueQuery(); // No GameId
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.Jobs.Should().HaveCount(3);
+        result.Total.Should().Be(3);
+    }
+
+    [Fact]
+    public async Task Handle_WithGameId_NoMatchingDocuments_ReturnsEmpty()
+    {
+        // Arrange
+        var pdf = CreatePdfDocument("some-rules.pdf");
+        _dbContext.PdfDocuments.Add(pdf);
+        _dbContext.ProcessingJobs.Add(CreateProcessingJob(pdf.Id));
+
+        // Link to a different game
+        _dbContext.SharedGameDocuments.Add(new SharedGameDocumentEntity
+        {
+            Id = Guid.NewGuid(),
+            SharedGameId = _otherGameId,
+            PdfDocumentId = pdf.Id,
+            CreatedBy = _userId,
+            CreatedAt = DateTime.UtcNow
+        });
+
+        await _dbContext.SaveChangesAsync();
+
+        var query = new GetProcessingQueueQuery(GameId: _gameId);
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.Jobs.Should().BeEmpty();
+        result.Total.Should().Be(0);
+    }
+
+    [Fact]
+    public async Task Handle_WithGameIdAndStatusFilter_CombinesFilters()
+    {
+        // Arrange
+        var pdfQueued = CreatePdfDocument("queued-rules.pdf");
+        var pdfFailed = CreatePdfDocument("failed-rules.pdf");
+
+        _dbContext.PdfDocuments.AddRange(pdfQueued, pdfFailed);
+
+        var jobQueued = CreateProcessingJob(pdfQueued.Id, status: "Queued");
+        var jobFailed = CreateProcessingJob(pdfFailed.Id, status: "Failed");
+
+        _dbContext.ProcessingJobs.AddRange(jobQueued, jobFailed);
+
+        _dbContext.SharedGameDocuments.AddRange(
+            new SharedGameDocumentEntity
+            {
+                Id = Guid.NewGuid(),
+                SharedGameId = _gameId,
+                PdfDocumentId = pdfQueued.Id,
+                CreatedBy = _userId,
+                CreatedAt = DateTime.UtcNow
+            },
+            new SharedGameDocumentEntity
+            {
+                Id = Guid.NewGuid(),
+                SharedGameId = _gameId,
+                PdfDocumentId = pdfFailed.Id,
+                CreatedBy = _userId,
+                CreatedAt = DateTime.UtcNow
+            });
+
+        await _dbContext.SaveChangesAsync();
+
+        var query = new GetProcessingQueueQuery(StatusFilter: "Queued", GameId: _gameId);
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.Jobs.Should().HaveCount(1);
+        result.Jobs[0].PdfDocumentId.Should().Be(pdfQueued.Id);
+    }
+
+    private PdfDocumentEntity CreatePdfDocument(string fileName)
+    {
+        return new PdfDocumentEntity
+        {
+            Id = Guid.NewGuid(),
+            FileName = fileName,
+            FilePath = $"/uploads/{fileName}",
+            FileSizeBytes = 1024,
+            ContentType = "application/pdf",
+            UploadedByUserId = _userId,
+            UploadedAt = DateTime.UtcNow
+        };
+    }
+
+    private ProcessingJobEntity CreateProcessingJob(Guid pdfDocumentId, string status = "Queued")
+    {
+        return new ProcessingJobEntity
+        {
+            Id = Guid.NewGuid(),
+            PdfDocumentId = pdfDocumentId,
+            UserId = _userId,
+            Status = status,
+            Priority = 0,
+            CreatedAt = DateTimeOffset.UtcNow,
+            RetryCount = 0,
+            MaxRetries = 3
+        };
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Infrastructure/Services/QueueStreamServiceTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Infrastructure/Services/QueueStreamServiceTests.cs
@@ -51,7 +51,7 @@ public sealed class QueueStreamServiceTests
 
         var completedEvt = new QueueStreamEvent(
             QueueStreamEventType.JobCompleted, jobId,
-            new JobCompletedData(5.0), DateTimeOffset.UtcNow);
+            new JobCompletedData(5.0, null, null, null), DateTimeOffset.UtcNow);
         await _service.PublishJobEventAsync(completedEvt, cts.Token);
 
         await subscriberTask;
@@ -157,7 +157,7 @@ public sealed class QueueStreamServiceTests
         // Act - publish a terminal event (JobFailed)
         var failedEvt = new QueueStreamEvent(
             QueueStreamEventType.JobFailed, jobId,
-            new JobFailedData("Test error", null, 0), DateTimeOffset.UtcNow);
+            new JobFailedData("Test error", null, 0, null, null, null), DateTimeOffset.UtcNow);
         await _service.PublishJobEventAsync(failedEvt, cts.Token);
 
         await subscriberTask;

--- a/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Queries/GetRecentlyProcessedDocuments/GetRecentlyProcessedDocumentsQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Queries/GetRecentlyProcessedDocuments/GetRecentlyProcessedDocumentsQueryHandlerTests.cs
@@ -1,0 +1,394 @@
+using Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
+using Api.BoundedContexts.SharedGameCatalog.Application.Queries.GetRecentlyProcessedDocuments;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities;
+using Api.Infrastructure.Entities.DocumentProcessing;
+using Api.Infrastructure.Entities.SharedGameCatalog;
+using Api.SharedKernel.Application.Services;
+using Api.Tests.Constants;
+using FluentAssertions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.SharedGameCatalog.Application.Queries.GetRecentlyProcessedDocuments;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "SharedGameCatalog")]
+public sealed class GetRecentlyProcessedDocumentsQueryHandlerTests : IDisposable
+{
+    private readonly MeepleAiDbContext _dbContext;
+    private readonly GetRecentlyProcessedDocumentsQueryHandler _sut;
+
+    public GetRecentlyProcessedDocumentsQueryHandlerTests()
+    {
+        _dbContext = CreateInMemoryContext();
+        _sut = new GetRecentlyProcessedDocumentsQueryHandler(_dbContext);
+    }
+
+    public void Dispose()
+    {
+        _dbContext.Dispose();
+    }
+
+    [Fact]
+    public async Task Handle_ReturnsDocumentsOrderedByTimestampDesc()
+    {
+        // Arrange
+        var gameId = Guid.NewGuid();
+        SeedSharedGame(gameId, "Test Game");
+
+        var oldPdfId = Guid.NewGuid();
+        var newPdfId = Guid.NewGuid();
+        var newestPdfId = Guid.NewGuid();
+
+        SeedPdfDocument(oldPdfId, "old-rules.pdf", "Ready",
+            processedAt: new DateTime(2026, 1, 1, 0, 0, 0, DateTimeKind.Utc));
+        SeedPdfDocument(newPdfId, "new-rules.pdf", "Ready",
+            processedAt: new DateTime(2026, 2, 1, 0, 0, 0, DateTimeKind.Utc));
+        SeedPdfDocument(newestPdfId, "newest-rules.pdf", "Extracting",
+            uploadedAt: new DateTime(2026, 3, 1, 0, 0, 0, DateTimeKind.Utc));
+
+        SeedSharedGameDocument(gameId, oldPdfId);
+        SeedSharedGameDocument(gameId, newPdfId);
+        SeedSharedGameDocument(gameId, newestPdfId);
+
+        await _dbContext.SaveChangesAsync();
+
+        var query = new GetRecentlyProcessedDocumentsQuery(Limit: 2);
+
+        // Act
+        var result = await _sut.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.Should().HaveCount(2);
+        result[0].FileName.Should().Be("newest-rules.pdf");
+        result[1].FileName.Should().Be("new-rules.pdf");
+    }
+
+    [Fact]
+    public async Task Handle_RespectsLimit()
+    {
+        // Arrange
+        var gameId = Guid.NewGuid();
+        SeedSharedGame(gameId, "Limit Game");
+
+        for (var i = 0; i < 5; i++)
+        {
+            var pdfId = Guid.NewGuid();
+            SeedPdfDocument(pdfId, $"doc-{i}.pdf", "Ready",
+                processedAt: DateTime.UtcNow.AddMinutes(-i));
+            SeedSharedGameDocument(gameId, pdfId);
+        }
+
+        await _dbContext.SaveChangesAsync();
+
+        var query = new GetRecentlyProcessedDocumentsQuery(Limit: 3);
+
+        // Act
+        var result = await _sut.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.Should().HaveCount(3);
+    }
+
+    [Fact]
+    public async Task Handle_ExcludesDocumentsWithoutSharedGame()
+    {
+        // Arrange
+        var gameId = Guid.NewGuid();
+        SeedSharedGame(gameId, "Linked Game");
+
+        var linkedPdfId = Guid.NewGuid();
+        var orphanPdfId = Guid.NewGuid();
+
+        SeedPdfDocument(linkedPdfId, "linked.pdf", "Ready", processedAt: DateTime.UtcNow);
+        SeedPdfDocument(orphanPdfId, "orphan.pdf", "Ready", processedAt: DateTime.UtcNow);
+
+        // Only link the first one
+        SeedSharedGameDocument(gameId, linkedPdfId);
+
+        await _dbContext.SaveChangesAsync();
+
+        var query = new GetRecentlyProcessedDocumentsQuery(Limit: 10);
+
+        // Act
+        var result = await _sut.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.Should().HaveCount(1);
+        result[0].PdfDocumentId.Should().Be(linkedPdfId);
+    }
+
+    [Fact]
+    public async Task Handle_MapsFieldsCorrectly()
+    {
+        // Arrange
+        var gameId = Guid.NewGuid();
+        var pdfId = Guid.NewGuid();
+        var thumbUrl = "https://example.com/thumb.jpg";
+        var processedAt = new DateTime(2026, 3, 15, 12, 0, 0, DateTimeKind.Utc);
+
+        SeedSharedGame(gameId, "Catan", thumbnailUrl: thumbUrl);
+        SeedPdfDocument(pdfId, "catan-rules.pdf", "Ready",
+            processedAt: processedAt, errorCategory: null, retryCount: 0);
+        SeedSharedGameDocument(gameId, pdfId);
+
+        await _dbContext.SaveChangesAsync();
+
+        var query = new GetRecentlyProcessedDocumentsQuery(Limit: 10);
+
+        // Act
+        var result = await _sut.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.Should().HaveCount(1);
+        var dto = result[0];
+        dto.PdfDocumentId.Should().Be(pdfId);
+        dto.FileName.Should().Be("catan-rules.pdf");
+        dto.ProcessingState.Should().Be("Ready");
+        dto.Timestamp.Should().Be(processedAt);
+        dto.ErrorCategory.Should().BeNull();
+        dto.CanRetry.Should().BeFalse();
+        dto.SharedGameId.Should().Be(gameId);
+        dto.GameName.Should().Be("Catan");
+        dto.ThumbnailUrl.Should().Be(thumbUrl);
+    }
+
+    [Fact]
+    public async Task Handle_FailedDocument_SetsCanRetryCorrectly()
+    {
+        // Arrange
+        var gameId = Guid.NewGuid();
+        SeedSharedGame(gameId, "Failed Game");
+
+        var retryablePdfId = Guid.NewGuid();
+        var exhaustedPdfId = Guid.NewGuid();
+
+        SeedPdfDocument(retryablePdfId, "retryable.pdf", "Failed",
+            processedAt: DateTime.UtcNow, errorCategory: "Network", retryCount: 1);
+        SeedPdfDocument(exhaustedPdfId, "exhausted.pdf", "Failed",
+            processedAt: DateTime.UtcNow.AddMinutes(-1), errorCategory: "Parsing", retryCount: 3);
+
+        SeedSharedGameDocument(gameId, retryablePdfId);
+        SeedSharedGameDocument(gameId, exhaustedPdfId);
+
+        await _dbContext.SaveChangesAsync();
+
+        var query = new GetRecentlyProcessedDocumentsQuery(Limit: 10);
+
+        // Act
+        var result = await _sut.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.Should().HaveCount(2);
+
+        var retryable = result.First(d => d.PdfDocumentId == retryablePdfId);
+        retryable.CanRetry.Should().BeTrue();
+        retryable.ErrorCategory.Should().Be("Network");
+
+        var exhausted = result.First(d => d.PdfDocumentId == exhaustedPdfId);
+        exhausted.CanRetry.Should().BeFalse();
+        exhausted.ErrorCategory.Should().Be("Parsing");
+    }
+
+    [Fact]
+    public async Task Handle_IncludesJobIdWhenProcessingJobExists()
+    {
+        // Arrange
+        var gameId = Guid.NewGuid();
+        var pdfId = Guid.NewGuid();
+        var jobId = Guid.NewGuid();
+
+        SeedSharedGame(gameId, "Job Game");
+        SeedPdfDocument(pdfId, "with-job.pdf", "Extracting", uploadedAt: DateTime.UtcNow);
+        SeedSharedGameDocument(gameId, pdfId);
+        SeedProcessingJob(jobId, pdfId);
+
+        await _dbContext.SaveChangesAsync();
+
+        var query = new GetRecentlyProcessedDocumentsQuery(Limit: 10);
+
+        // Act
+        var result = await _sut.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.Should().HaveCount(1);
+        result[0].JobId.Should().Be(jobId);
+    }
+
+    [Fact]
+    public async Task Handle_JobIdIsNullWhenNoProcessingJob()
+    {
+        // Arrange
+        var gameId = Guid.NewGuid();
+        var pdfId = Guid.NewGuid();
+
+        SeedSharedGame(gameId, "No Job Game");
+        SeedPdfDocument(pdfId, "no-job.pdf", "Ready", processedAt: DateTime.UtcNow);
+        SeedSharedGameDocument(gameId, pdfId);
+
+        await _dbContext.SaveChangesAsync();
+
+        var query = new GetRecentlyProcessedDocumentsQuery(Limit: 10);
+
+        // Act
+        var result = await _sut.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.Should().HaveCount(1);
+        result[0].JobId.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Handle_ExcludesDeletedSharedGames()
+    {
+        // Arrange
+        var activeGameId = Guid.NewGuid();
+        var deletedGameId = Guid.NewGuid();
+
+        SeedSharedGame(activeGameId, "Active Game");
+        SeedSharedGame(deletedGameId, "Deleted Game", isDeleted: true);
+
+        var activePdfId = Guid.NewGuid();
+        var deletedPdfId = Guid.NewGuid();
+
+        SeedPdfDocument(activePdfId, "active.pdf", "Ready", processedAt: DateTime.UtcNow);
+        SeedPdfDocument(deletedPdfId, "deleted.pdf", "Ready", processedAt: DateTime.UtcNow);
+
+        SeedSharedGameDocument(activeGameId, activePdfId);
+        SeedSharedGameDocument(deletedGameId, deletedPdfId);
+
+        await _dbContext.SaveChangesAsync();
+
+        var query = new GetRecentlyProcessedDocumentsQuery(Limit: 10);
+
+        // Act
+        var result = await _sut.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.Should().HaveCount(1);
+        result[0].GameName.Should().Be("Active Game");
+    }
+
+    [Fact]
+    public async Task Handle_UsesUploadedAtWhenProcessedAtIsNull()
+    {
+        // Arrange
+        var gameId = Guid.NewGuid();
+        var pdfId = Guid.NewGuid();
+        var uploadedAt = new DateTime(2026, 3, 10, 8, 0, 0, DateTimeKind.Utc);
+
+        SeedSharedGame(gameId, "Pending Game");
+        SeedPdfDocument(pdfId, "pending.pdf", "Extracting",
+            uploadedAt: uploadedAt, processedAt: null);
+        SeedSharedGameDocument(gameId, pdfId);
+
+        await _dbContext.SaveChangesAsync();
+
+        var query = new GetRecentlyProcessedDocumentsQuery(Limit: 10);
+
+        // Act
+        var result = await _sut.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.Should().HaveCount(1);
+        result[0].Timestamp.Should().Be(uploadedAt);
+    }
+
+    // ==========================================
+    // Helper methods
+    // ==========================================
+
+    private static MeepleAiDbContext CreateInMemoryContext()
+    {
+        var options = new DbContextOptionsBuilder<MeepleAiDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options;
+
+        return new MeepleAiDbContext(
+            options,
+            new Mock<IMediator>().Object,
+            new Mock<IDomainEventCollector>().Object);
+    }
+
+    private void SeedSharedGame(
+        Guid id,
+        string title,
+        string? thumbnailUrl = null,
+        bool isDeleted = false)
+    {
+        _dbContext.SharedGames.Add(new SharedGameEntity
+        {
+            Id = id,
+            Title = title,
+            YearPublished = 2024,
+            Description = "Test game",
+            MinPlayers = 2,
+            MaxPlayers = 4,
+            PlayingTimeMinutes = 60,
+            MinAge = 10,
+            ImageUrl = "https://example.com/image.jpg",
+            ThumbnailUrl = thumbnailUrl ?? "https://example.com/thumb.jpg",
+            Status = 1, // Published
+            CreatedBy = Guid.NewGuid(),
+            CreatedAt = DateTime.UtcNow,
+            IsDeleted = isDeleted
+        });
+    }
+
+    private void SeedPdfDocument(
+        Guid id,
+        string fileName,
+        string processingState,
+        DateTime? uploadedAt = null,
+        DateTime? processedAt = null,
+        string? errorCategory = null,
+        int retryCount = 0)
+    {
+        _dbContext.PdfDocuments.Add(new PdfDocumentEntity
+        {
+            Id = id,
+            FileName = fileName,
+            FilePath = $"/uploads/{fileName}",
+            FileSizeBytes = 1024,
+            ContentType = "application/pdf",
+            UploadedByUserId = Guid.NewGuid(),
+            UploadedAt = uploadedAt ?? DateTime.UtcNow,
+            ProcessingState = processingState,
+            ProcessedAt = processedAt,
+            ErrorCategory = errorCategory,
+            RetryCount = retryCount,
+            Language = "en"
+        });
+    }
+
+    private void SeedSharedGameDocument(Guid sharedGameId, Guid pdfDocumentId)
+    {
+        _dbContext.SharedGameDocuments.Add(new SharedGameDocumentEntity
+        {
+            Id = Guid.NewGuid(),
+            SharedGameId = sharedGameId,
+            PdfDocumentId = pdfDocumentId,
+            DocumentType = 0, // Rulebook
+            Version = "1.0",
+            IsActive = true,
+            CreatedAt = DateTime.UtcNow,
+            CreatedBy = Guid.NewGuid()
+        });
+    }
+
+    private void SeedProcessingJob(Guid jobId, Guid pdfDocumentId)
+    {
+        _dbContext.ProcessingJobs.Add(new ProcessingJobEntity
+        {
+            Id = jobId,
+            PdfDocumentId = pdfDocumentId,
+            UserId = Guid.NewGuid(),
+            Status = "Processing",
+            Priority = 0,
+            CreatedAt = DateTimeOffset.UtcNow
+        });
+    }
+}

--- a/apps/web/src/app/admin/(dashboard)/layout.tsx
+++ b/apps/web/src/app/admin/(dashboard)/layout.tsx
@@ -2,6 +2,7 @@ import { type ReactNode } from 'react';
 
 import { type Metadata } from 'next';
 
+import { PdfProcessingNotifier } from '@/components/admin/layout/PdfProcessingNotifier';
 import { RequireRole } from '@/components/auth/RequireRole';
 import { UnifiedShell } from '@/components/layout/UnifiedShell';
 
@@ -22,6 +23,7 @@ export const metadata: Metadata = {
 export default function DashboardLayout({ children }: { children: ReactNode }) {
   return (
     <RequireRole allowedRoles={['Admin']}>
+      <PdfProcessingNotifier />
       <UnifiedShell isAdmin>{children}</UnifiedShell>
     </RequireRole>
   );

--- a/apps/web/src/app/admin/(dashboard)/shared-games/[id]/client.tsx
+++ b/apps/web/src/app/admin/(dashboard)/shared-games/[id]/client.tsx
@@ -28,6 +28,7 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { useRouter } from 'next/navigation';
 
+import { GameProcessingQueue } from '@/components/admin/shared-games/GameProcessingQueue';
 import { PdfIndexingStatus } from '@/components/admin/shared-games/PdfIndexingStatus';
 import { PdfUploadSection } from '@/components/admin/shared-games/PdfUploadSection';
 import { Badge } from '@/components/ui/data-display/badge';
@@ -652,6 +653,9 @@ export function GameDetailClient({ params }: GameDetailClientProps) {
               <PdfUploadSection gameId={gameId} onPdfUploaded={() => refetchDocuments()} />
             </CardContent>
           </Card>
+
+          {/* Processing queue mini-widget */}
+          <GameProcessingQueue gameId={gameId} />
 
           {/* Document list */}
           <Card className="bg-white/70 dark:bg-zinc-800/70 backdrop-blur-md border-slate-200/50 dark:border-zinc-700/50">

--- a/apps/web/src/app/admin/(dashboard)/shared-games/all/page.tsx
+++ b/apps/web/src/app/admin/(dashboard)/shared-games/all/page.tsx
@@ -4,6 +4,7 @@ import { type Metadata } from 'next';
 
 import { GameCatalogGrid } from '@/components/admin/shared-games/game-catalog-grid';
 import { GameFilters } from '@/components/admin/shared-games/game-filters';
+import { RecentlyProcessedWidget } from '@/components/admin/shared-games/RecentlyProcessedWidget';
 
 export const metadata: Metadata = {
   title: 'All Games',
@@ -30,6 +31,9 @@ export default function AllGamesPage() {
           Browse and manage the shared game catalog
         </p>
       </div>
+
+      {/* Recently Processed PDFs */}
+      <RecentlyProcessedWidget />
 
       {/* Filters */}
       <Suspense fallback={<CardSkeleton height="h-[160px]" />}>

--- a/apps/web/src/components/admin/layout/PdfProcessingNotifier.tsx
+++ b/apps/web/src/components/admin/layout/PdfProcessingNotifier.tsx
@@ -1,0 +1,157 @@
+'use client';
+
+import { useEffect, useRef, useCallback } from 'react';
+
+import { useRouter } from 'next/navigation';
+import { toast } from 'sonner';
+
+import { api } from '@/lib/api';
+
+/**
+ * SSE event payload for PDF processing job completion/failure.
+ * Matches the backend enriched JobCompleted/JobFailed events from
+ * GET /api/v1/admin/queue/stream
+ */
+interface PdfJobEvent {
+  type?: string;
+  jobId: string;
+  fileName?: string;
+  sharedGameId?: string;
+  gameName?: string;
+  error?: string;
+}
+
+/**
+ * Invisible component that listens to SSE events from the admin queue stream
+ * and shows sonner toast notifications for PDF processing outcomes.
+ *
+ * Mounted in the admin dashboard layout so it's active on all admin pages.
+ * Returns null — no DOM output.
+ */
+export function PdfProcessingNotifier() {
+  const router = useRouter();
+  const eventSourceRef = useRef<EventSource | null>(null);
+  const reconnectTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const reconnectDelayRef = useRef(1000);
+
+  const buildTitle = useCallback((fileName?: string, gameName?: string): string => {
+    const name = fileName ?? 'File';
+    if (gameName) {
+      return `${name} per ${gameName}`;
+    }
+    return name;
+  }, []);
+
+  const handleJobCompleted = useCallback(
+    (event: PdfJobEvent) => {
+      const title = buildTitle(event.fileName, event.gameName);
+      toast.success(title, {
+        description: 'Indicizzazione completata',
+        duration: 8000,
+        action: event.sharedGameId
+          ? {
+              label: 'Vai al gioco',
+              onClick: () => router.push(`/admin/shared-games/${event.sharedGameId}`),
+            }
+          : undefined,
+      });
+    },
+    [buildTitle, router]
+  );
+
+  const handleJobFailed = useCallback(
+    (event: PdfJobEvent) => {
+      const title = buildTitle(event.fileName, event.gameName);
+      const errorMessage = event.error
+        ? `Elaborazione fallita: ${event.error}`
+        : 'Elaborazione fallita';
+      toast.error(title, {
+        description: errorMessage,
+        duration: 8000,
+        action: event.jobId
+          ? {
+              label: 'Riprova',
+              onClick: () => {
+                api.admin.retryJob(event.jobId).catch(() => {
+                  toast.error('Impossibile riprovare il job');
+                });
+              },
+            }
+          : undefined,
+      });
+    },
+    [buildTitle]
+  );
+
+  const parseEvent = useCallback((data: string) => {
+    try {
+      return JSON.parse(data) as PdfJobEvent;
+    } catch {
+      return null;
+    }
+  }, []);
+
+  const connect = useCallback(() => {
+    // Use relative URL so the browser routes through the Next.js proxy (no CORS)
+    const es = new EventSource('/api/v1/admin/queue/stream');
+    eventSourceRef.current = es;
+
+    // Named event listeners (backend sends `event: JobCompleted` / `event: JobFailed`)
+    es.addEventListener('JobCompleted', (e: MessageEvent) => {
+      const parsed = parseEvent(e.data);
+      if (parsed) handleJobCompleted(parsed);
+    });
+
+    es.addEventListener('JobFailed', (e: MessageEvent) => {
+      const parsed = parseEvent(e.data);
+      if (parsed) handleJobFailed(parsed);
+    });
+
+    // Fallback: unnamed events where type is inside the JSON payload
+    es.onmessage = (e: MessageEvent) => {
+      const parsed = parseEvent(e.data);
+      if (!parsed) return;
+
+      if (parsed.type === 'JobCompleted') {
+        handleJobCompleted(parsed);
+      } else if (parsed.type === 'JobFailed') {
+        handleJobFailed(parsed);
+      }
+    };
+
+    es.onopen = () => {
+      // Reset backoff on successful connection
+      reconnectDelayRef.current = 1000;
+    };
+
+    es.onerror = () => {
+      es.close();
+      eventSourceRef.current = null;
+
+      // Exponential backoff reconnect: 1s, 2s, 4s, ... max 30s
+      const delay = reconnectDelayRef.current;
+      reconnectTimeoutRef.current = setTimeout(() => {
+        reconnectTimeoutRef.current = null;
+        connect();
+      }, delay);
+      reconnectDelayRef.current = Math.min(delay * 2, 30000);
+    };
+  }, [parseEvent, handleJobCompleted, handleJobFailed]);
+
+  useEffect(() => {
+    connect();
+
+    return () => {
+      if (eventSourceRef.current) {
+        eventSourceRef.current.close();
+        eventSourceRef.current = null;
+      }
+      if (reconnectTimeoutRef.current) {
+        clearTimeout(reconnectTimeoutRef.current);
+        reconnectTimeoutRef.current = null;
+      }
+    };
+  }, [connect]);
+
+  return null;
+}

--- a/apps/web/src/components/admin/layout/__tests__/PdfProcessingNotifier.test.tsx
+++ b/apps/web/src/components/admin/layout/__tests__/PdfProcessingNotifier.test.tsx
@@ -1,0 +1,412 @@
+/**
+ * PdfProcessingNotifier Tests
+ *
+ * Validates SSE-driven toast notifications for PDF processing events.
+ *
+ * Tests:
+ * - Shows success toast on JobCompleted event
+ * - Shows error toast with "Riprova" on JobFailed event
+ * - Handles events without game info gracefully (no "per null")
+ * - Cleans up EventSource on unmount
+ */
+
+import { render, act } from '@testing-library/react';
+import { vi, describe, it, expect, beforeEach, afterEach } from 'vitest';
+
+// ─── Hoisted mocks ──────────────────────────────────────────────────────────
+
+const { mockPush, mockToastSuccess, mockToastError, mockRetryJob } = vi.hoisted(() => ({
+  mockPush: vi.fn(),
+  mockToastSuccess: vi.fn(),
+  mockToastError: vi.fn(),
+  mockRetryJob: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: mockPush }),
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: mockToastSuccess,
+    error: mockToastError,
+  },
+}));
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    admin: {
+      retryJob: mockRetryJob,
+    },
+  },
+}));
+
+// ─── EventSource mock ───────────────────────────────────────────────────────
+
+type EventHandler = (event: MessageEvent) => void;
+
+class MockEventSource {
+  static instances: MockEventSource[] = [];
+
+  url: string;
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  onopen: (() => void) | null = null;
+  onerror: (() => void) | null = null;
+  closed = false;
+
+  private namedListeners = new Map<string, EventHandler[]>();
+
+  constructor(url: string) {
+    this.url = url;
+    MockEventSource.instances.push(this);
+  }
+
+  addEventListener(type: string, handler: EventHandler) {
+    const existing = this.namedListeners.get(type) ?? [];
+    existing.push(handler);
+    this.namedListeners.set(type, existing);
+  }
+
+  removeEventListener(type: string, handler: EventHandler) {
+    const existing = this.namedListeners.get(type) ?? [];
+    this.namedListeners.set(
+      type,
+      existing.filter(h => h !== handler)
+    );
+  }
+
+  close() {
+    this.closed = true;
+  }
+
+  // Test helpers
+
+  /** Simulate a named SSE event (event: JobCompleted / event: JobFailed) */
+  emitNamed(eventType: string, data: object) {
+    const handlers = this.namedListeners.get(eventType) ?? [];
+    const messageEvent = new MessageEvent(eventType, {
+      data: JSON.stringify(data),
+    });
+    for (const handler of handlers) {
+      handler(messageEvent);
+    }
+  }
+
+  /** Simulate an unnamed SSE event (generic onmessage) */
+  emitMessage(data: object) {
+    if (this.onmessage) {
+      const messageEvent = new MessageEvent('message', {
+        data: JSON.stringify(data),
+      });
+      this.onmessage(messageEvent);
+    }
+  }
+}
+
+// ─── Test setup ─────────────────────────────────────────────────────────────
+
+// Dynamic import to ensure mocks are in place before module loads
+let PdfProcessingNotifier: typeof import('../PdfProcessingNotifier').PdfProcessingNotifier;
+
+beforeEach(async () => {
+  MockEventSource.instances = [];
+  vi.stubGlobal('EventSource', MockEventSource);
+  vi.useFakeTimers();
+
+  // Fresh import each test to avoid stale closure over mocks
+  const mod = await import('../PdfProcessingNotifier');
+  PdfProcessingNotifier = mod.PdfProcessingNotifier;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+  vi.useRealTimers();
+  vi.resetModules();
+  mockPush.mockReset();
+  mockToastSuccess.mockReset();
+  mockToastError.mockReset();
+  mockRetryJob.mockReset().mockResolvedValue(undefined);
+});
+
+// ─── Tests ──────────────────────────────────────────────────────────────────
+
+describe('PdfProcessingNotifier', () => {
+  it('renders nothing (returns null)', () => {
+    const { container } = render(<PdfProcessingNotifier />);
+    expect(container.innerHTML).toBe('');
+  });
+
+  it('connects to SSE endpoint on mount', () => {
+    render(<PdfProcessingNotifier />);
+    expect(MockEventSource.instances).toHaveLength(1);
+    expect(MockEventSource.instances[0].url).toBe('/api/v1/admin/queue/stream');
+  });
+
+  it('shows success toast on named JobCompleted event', () => {
+    render(<PdfProcessingNotifier />);
+    const es = MockEventSource.instances[0];
+
+    act(() => {
+      es.emitNamed('JobCompleted', {
+        jobId: 'job-1',
+        fileName: 'rules.pdf',
+        sharedGameId: 'game-123',
+        gameName: 'Catan',
+      });
+    });
+
+    expect(mockToastSuccess).toHaveBeenCalledWith('rules.pdf per Catan', {
+      description: 'Indicizzazione completata',
+      duration: 8000,
+      action: {
+        label: 'Vai al gioco',
+        onClick: expect.any(Function),
+      },
+    });
+  });
+
+  it('navigates to shared game on success toast action click', () => {
+    render(<PdfProcessingNotifier />);
+    const es = MockEventSource.instances[0];
+
+    act(() => {
+      es.emitNamed('JobCompleted', {
+        jobId: 'job-1',
+        fileName: 'rules.pdf',
+        sharedGameId: 'game-123',
+        gameName: 'Catan',
+      });
+    });
+
+    const call = mockToastSuccess.mock.calls[0];
+    const action = call[1].action;
+    action.onClick();
+
+    expect(mockPush).toHaveBeenCalledWith('/admin/shared-games/game-123');
+  });
+
+  it('shows error toast on named JobFailed event', () => {
+    render(<PdfProcessingNotifier />);
+    const es = MockEventSource.instances[0];
+
+    act(() => {
+      es.emitNamed('JobFailed', {
+        jobId: 'job-2',
+        fileName: 'manual.pdf',
+        sharedGameId: 'game-456',
+        gameName: 'Agricola',
+        error: 'OCR timeout',
+      });
+    });
+
+    expect(mockToastError).toHaveBeenCalledWith('manual.pdf per Agricola', {
+      description: 'Elaborazione fallita: OCR timeout',
+      duration: 8000,
+      action: {
+        label: 'Riprova',
+        onClick: expect.any(Function),
+      },
+    });
+  });
+
+  it('calls retryJob on error toast action click', () => {
+    render(<PdfProcessingNotifier />);
+    const es = MockEventSource.instances[0];
+
+    act(() => {
+      es.emitNamed('JobFailed', {
+        jobId: 'job-2',
+        fileName: 'manual.pdf',
+        gameName: 'Agricola',
+        error: 'OCR timeout',
+      });
+    });
+
+    const call = mockToastError.mock.calls[0];
+    const action = call[1].action;
+    action.onClick();
+
+    expect(mockRetryJob).toHaveBeenCalledWith('job-2');
+  });
+
+  it('handles events without game info gracefully', () => {
+    render(<PdfProcessingNotifier />);
+    const es = MockEventSource.instances[0];
+
+    act(() => {
+      es.emitNamed('JobCompleted', {
+        jobId: 'job-3',
+        fileName: 'rules.pdf',
+      });
+    });
+
+    // Title should be just the filename, no "per null" or "per undefined"
+    expect(mockToastSuccess).toHaveBeenCalledWith('rules.pdf', {
+      description: 'Indicizzazione completata',
+      duration: 8000,
+      action: undefined,
+    });
+  });
+
+  it('handles events without fileName gracefully', () => {
+    render(<PdfProcessingNotifier />);
+    const es = MockEventSource.instances[0];
+
+    act(() => {
+      es.emitNamed('JobCompleted', {
+        jobId: 'job-4',
+        gameName: 'Catan',
+      });
+    });
+
+    // Falls back to "File" when fileName is missing
+    expect(mockToastSuccess).toHaveBeenCalledWith('File per Catan', {
+      description: 'Indicizzazione completata',
+      duration: 8000,
+      action: undefined,
+    });
+  });
+
+  it('handles unnamed events via onmessage with type field', () => {
+    render(<PdfProcessingNotifier />);
+    const es = MockEventSource.instances[0];
+
+    act(() => {
+      es.emitMessage({
+        type: 'JobCompleted',
+        jobId: 'job-5',
+        fileName: 'setup.pdf',
+        sharedGameId: 'game-789',
+        gameName: 'Wingspan',
+      });
+    });
+
+    expect(mockToastSuccess).toHaveBeenCalledWith('setup.pdf per Wingspan', {
+      description: 'Indicizzazione completata',
+      duration: 8000,
+      action: {
+        label: 'Vai al gioco',
+        onClick: expect.any(Function),
+      },
+    });
+  });
+
+  it('handles unnamed JobFailed events via onmessage', () => {
+    render(<PdfProcessingNotifier />);
+    const es = MockEventSource.instances[0];
+
+    act(() => {
+      es.emitMessage({
+        type: 'JobFailed',
+        jobId: 'job-6',
+        fileName: 'broken.pdf',
+        gameName: 'Gloomhaven',
+        error: 'Parse error',
+      });
+    });
+
+    expect(mockToastError).toHaveBeenCalledWith('broken.pdf per Gloomhaven', {
+      description: 'Elaborazione fallita: Parse error',
+      duration: 8000,
+      action: {
+        label: 'Riprova',
+        onClick: expect.any(Function),
+      },
+    });
+  });
+
+  it('cleans up EventSource on unmount', () => {
+    const { unmount } = render(<PdfProcessingNotifier />);
+    const es = MockEventSource.instances[0];
+
+    expect(es.closed).toBe(false);
+    unmount();
+    expect(es.closed).toBe(true);
+  });
+
+  it('reconnects with exponential backoff on error', () => {
+    render(<PdfProcessingNotifier />);
+    const es = MockEventSource.instances[0];
+
+    // Trigger error
+    act(() => {
+      if (es.onerror) es.onerror();
+    });
+
+    expect(es.closed).toBe(true);
+    expect(MockEventSource.instances).toHaveLength(1);
+
+    // Advance by 1s (first backoff)
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+
+    expect(MockEventSource.instances).toHaveLength(2);
+    const es2 = MockEventSource.instances[1];
+
+    // Trigger another error
+    act(() => {
+      if (es2.onerror) es2.onerror();
+    });
+
+    // Should NOT reconnect after 1s (backoff is now 2s)
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(MockEventSource.instances).toHaveLength(2);
+
+    // Advance another 1s (total 2s)
+    act(() => {
+      vi.advanceTimersByTime(1000);
+    });
+    expect(MockEventSource.instances).toHaveLength(3);
+  });
+
+  it('clears reconnect timeout on unmount', () => {
+    const { unmount } = render(<PdfProcessingNotifier />);
+    const es = MockEventSource.instances[0];
+
+    // Trigger error to start reconnect timer
+    act(() => {
+      if (es.onerror) es.onerror();
+    });
+
+    unmount();
+
+    // Advance time — should NOT create a new EventSource
+    act(() => {
+      vi.advanceTimersByTime(5000);
+    });
+
+    expect(MockEventSource.instances).toHaveLength(1);
+  });
+
+  it('ignores unknown event types in onmessage', () => {
+    render(<PdfProcessingNotifier />);
+    const es = MockEventSource.instances[0];
+
+    act(() => {
+      es.emitMessage({
+        type: 'Heartbeat',
+        jobId: 'hb-1',
+      });
+    });
+
+    expect(mockToastSuccess).not.toHaveBeenCalled();
+    expect(mockToastError).not.toHaveBeenCalled();
+  });
+
+  it('ignores malformed JSON in events', () => {
+    render(<PdfProcessingNotifier />);
+    const es = MockEventSource.instances[0];
+
+    act(() => {
+      if (es.onmessage) {
+        es.onmessage(new MessageEvent('message', { data: 'not-json' }));
+      }
+    });
+
+    expect(mockToastSuccess).not.toHaveBeenCalled();
+    expect(mockToastError).not.toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/components/admin/shared-games/GameProcessingQueue.tsx
+++ b/apps/web/src/components/admin/shared-games/GameProcessingQueue.tsx
@@ -1,0 +1,122 @@
+/**
+ * GameProcessingQueue — Mini-widget showing active/queued processing jobs for a game.
+ *
+ * Displays game-specific job count, global queue depth, individual job rows with
+ * priority badges, progress indicators, and a deep-link to the full queue page.
+ *
+ * Polls every 10 seconds for live updates.
+ */
+
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import Link from 'next/link';
+
+import { Badge } from '@/components/ui/data-display/badge';
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardFooter,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/data-display/card';
+import { Progress } from '@/components/ui/feedback/progress';
+import { api } from '@/lib/api';
+
+// ─── Priority helpers ────────────────────────────────────────────────────────
+
+type PriorityConfig = {
+  label: string;
+  variant: 'destructive' | 'default' | 'secondary' | 'outline';
+};
+
+function getPriorityConfig(priority: number): PriorityConfig {
+  if (priority >= 3) return { label: 'Urgente', variant: 'destructive' };
+  if (priority === 2) return { label: 'Alta', variant: 'default' };
+  if (priority === 1) return { label: 'Normale', variant: 'secondary' };
+  return { label: 'Bassa', variant: 'outline' };
+}
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+interface GameProcessingQueueProps {
+  gameId: string;
+}
+
+export function GameProcessingQueue({ gameId }: GameProcessingQueueProps) {
+  const { data: gameQueue } = useQuery({
+    queryKey: ['admin', 'queue', 'game', gameId],
+    queryFn: () =>
+      api.admin.getQueueJobs({
+        gameId,
+        limit: 5,
+        status: ['Queued', 'Processing'],
+      }),
+    refetchInterval: 10_000,
+  });
+
+  const { data: queueStatus } = useQuery({
+    queryKey: ['admin', 'queue', 'status'],
+    queryFn: () => api.admin.getQueueStatus(),
+    refetchInterval: 10_000,
+  });
+
+  const gameJobCount = gameQueue?.total ?? 0;
+  const globalQueueDepth = queueStatus?.queueDepth ?? 0;
+
+  // Hide widget entirely when there are no jobs anywhere
+  if (gameJobCount === 0 && globalQueueDepth === 0) {
+    return null;
+  }
+
+  const jobs = gameQueue?.jobs ?? [];
+
+  return (
+    <Card className="bg-white/70 dark:bg-zinc-800/70 backdrop-blur-md border-slate-200/50 dark:border-zinc-700/50">
+      <CardHeader className="pb-3">
+        <CardTitle className="font-quicksand text-base">Coda elaborazione</CardTitle>
+        <CardDescription>
+          {gameJobCount} di questo gioco &middot; {globalQueueDepth} totali
+        </CardDescription>
+      </CardHeader>
+
+      {jobs.length > 0 && (
+        <CardContent className="space-y-2">
+          {jobs.map(job => {
+            const priorityCfg = getPriorityConfig(job.priority);
+            const isProcessing = job.status === 'Processing';
+
+            return (
+              <div
+                key={job.id}
+                className="flex items-center gap-3 rounded-lg border px-3 py-2 text-sm"
+              >
+                <Badge variant={priorityCfg.variant} className="shrink-0 text-xs">
+                  {priorityCfg.label}
+                </Badge>
+                <span className="flex-1 truncate text-xs">{job.pdfFileName}</span>
+                <div className="w-24 shrink-0">
+                  {isProcessing ? (
+                    <Progress value={50} className="h-1.5" />
+                  ) : (
+                    <span className="text-xs text-muted-foreground">In coda</span>
+                  )}
+                </div>
+              </div>
+            );
+          })}
+        </CardContent>
+      )}
+
+      <CardFooter className="pt-2">
+        <Link
+          href={`/admin/knowledge-base/queue?gameId=${gameId}`}
+          className="text-xs text-primary underline underline-offset-2 hover:text-primary/80"
+        >
+          Apri coda completa &rarr;
+        </Link>
+      </CardFooter>
+    </Card>
+  );
+}

--- a/apps/web/src/components/admin/shared-games/PdfUploadSection.tsx
+++ b/apps/web/src/components/admin/shared-games/PdfUploadSection.tsx
@@ -14,7 +14,7 @@
 
 import { useState, useCallback, useEffect, useRef } from 'react';
 
-import { FileUp, X, FileText, CheckCircle2, AlertCircle, Loader2 } from 'lucide-react';
+import { FileUp, X, FileText, CheckCircle2, AlertCircle, Loader2, Zap } from 'lucide-react';
 import { toast } from 'sonner';
 
 import { KbCardStatusRow } from '@/components/documents/KbCardStatusRow';
@@ -26,6 +26,13 @@ import {
   CardTitle,
 } from '@/components/ui/data-display/card';
 import { Progress } from '@/components/ui/feedback/progress';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/overlays/select';
 import { Button } from '@/components/ui/primitives/button';
 import type { PdfDocumentDto } from '@/lib/api/schemas/pdf.schemas';
 
@@ -48,6 +55,8 @@ export interface PdfUploadSectionProps {
   disabled?: boolean;
   /** Initially uploaded PDF (for edit mode) */
   existingPdf?: UploadedPdf | null;
+  /** Show priority selector for upload queue ordering (default: true) */
+  showPrioritySelector?: boolean;
 }
 
 // ========== Component ==========
@@ -58,8 +67,10 @@ export function PdfUploadSection({
   onPdfRemoved,
   disabled = false,
   existingPdf = null,
+  showPrioritySelector,
 }: PdfUploadSectionProps) {
   const [file, setFile] = useState<File | null>(null);
+  const [priority, setPriority] = useState<'normal' | 'urgent'>('normal');
   const [uploadedPdf, setUploadedPdf] = useState<UploadedPdf | null>(existingPdf);
   const [uploading, setUploading] = useState(false);
   const [uploadProgress, setUploadProgress] = useState(0);
@@ -258,7 +269,9 @@ export function PdfUploadSection({
             reject(new Error("Errore di rete durante l'upload"));
           });
 
-          xhr.open('POST', '/api/v1/ingest/pdf');
+          const uploadUrl =
+            priority === 'urgent' ? '/api/v1/ingest/pdf?priority=urgent' : '/api/v1/ingest/pdf';
+          xhr.open('POST', uploadUrl);
           xhr.withCredentials = true;
           xhr.send(formData);
         }
@@ -274,6 +287,7 @@ export function PdfUploadSection({
 
       setUploadedPdf(uploaded);
       setFile(null);
+      setPriority('normal');
       toast.success('PDF caricato con successo!');
       onPdfUploaded?.(uploaded);
 
@@ -314,7 +328,7 @@ export function PdfUploadSection({
     } finally {
       setUploading(false);
     }
-  }, [file, gameId, onPdfUploaded, linkPdfToGame]);
+  }, [file, gameId, onPdfUploaded, linkPdfToGame, priority]);
 
   // Remove uploaded PDF
   const handleRemove = useCallback(() => {
@@ -455,6 +469,27 @@ export function PdfUploadSection({
               <div className="flex items-center gap-2 p-3 bg-destructive/10 border border-destructive/20 rounded-lg text-destructive text-sm">
                 <AlertCircle className="h-4 w-4 flex-shrink-0" />
                 <span>{error}</span>
+              </div>
+            )}
+
+            {/* Priority Selector */}
+            {showPrioritySelector !== false && file && !uploading && (
+              <div className="flex items-center gap-2 mt-3" data-testid="priority-selector">
+                <span className="text-sm text-muted-foreground">Priorita:</span>
+                <Select value={priority} onValueChange={v => setPriority(v as 'normal' | 'urgent')}>
+                  <SelectTrigger className="w-[280px]">
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    <SelectItem value="normal">Normale — Elaborazione standard</SelectItem>
+                    <SelectItem value="urgent">
+                      <span className="flex items-center gap-1 text-amber-600">
+                        <Zap className="h-3 w-3" />
+                        Urgente — in testa alla coda
+                      </span>
+                    </SelectItem>
+                  </SelectContent>
+                </Select>
               </div>
             )}
 

--- a/apps/web/src/components/admin/shared-games/RecentlyProcessedWidget.tsx
+++ b/apps/web/src/components/admin/shared-games/RecentlyProcessedWidget.tsx
@@ -1,0 +1,264 @@
+/**
+ * RecentlyProcessedWidget — Collapsible card showing the 10 most recent PDFs
+ * processed across all shared games. Polls every 15 seconds.
+ *
+ * Collapse state is persisted in localStorage.
+ */
+
+'use client';
+
+import { useCallback, useState } from 'react';
+
+import { useMutation, useQuery, useQueryClient } from '@tanstack/react-query';
+import { formatDistanceToNow } from 'date-fns';
+import { it as itLocale } from 'date-fns/locale';
+import {
+  ChevronDownIcon,
+  ChevronUpIcon,
+  ExternalLinkIcon,
+  FileTextIcon,
+  Loader2Icon,
+  RefreshCwIcon,
+} from 'lucide-react';
+import Image from 'next/image';
+import Link from 'next/link';
+import { toast } from 'sonner';
+
+import { Button } from '@/components/ui/button';
+import { Badge } from '@/components/ui/data-display/badge';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/data-display/card';
+import { api } from '@/lib/api';
+import { type RecentlyProcessedDocument } from '@/lib/api/clients/sharedGamesClient';
+
+// ─── localStorage key ────────────────────────────────────────────────────────
+
+const COLLAPSE_KEY = 'admin:recentPdfs:collapsed';
+
+function readCollapsed(): boolean {
+  if (typeof window === 'undefined') return false;
+  return localStorage.getItem(COLLAPSE_KEY) === 'true';
+}
+
+// ─── Status helpers ──────────────────────────────────────────────────────────
+
+interface StatusConfig {
+  label: string;
+  variant: 'default' | 'destructive' | 'secondary';
+  spinning: boolean;
+}
+
+function getStatusConfig(state: string): StatusConfig {
+  if (state === 'Ready') return { label: 'Indicizzato', variant: 'default', spinning: false };
+  if (state === 'Failed') return { label: 'Fallito', variant: 'destructive', spinning: false };
+  return { label: 'Elaborazione', variant: 'secondary', spinning: true };
+}
+
+// ─── Component ───────────────────────────────────────────────────────────────
+
+export function RecentlyProcessedWidget() {
+  const [collapsed, setCollapsed] = useState(readCollapsed);
+  const queryClient = useQueryClient();
+
+  const { data, isLoading } = useQuery({
+    queryKey: ['admin', 'shared-games', 'recently-processed'],
+    queryFn: () => api.sharedGames.getRecentlyProcessed(10),
+    refetchInterval: 15_000,
+  });
+
+  const retryMutation = useMutation({
+    mutationFn: (jobId: string) => api.admin.retryJob(jobId),
+    onSuccess: () => {
+      toast.success('Riprocessamento avviato');
+      queryClient.invalidateQueries({
+        queryKey: ['admin', 'shared-games', 'recently-processed'],
+      });
+    },
+    onError: () => {
+      toast.error('Errore durante il riprocessamento');
+    },
+  });
+
+  const toggleCollapse = useCallback(() => {
+    setCollapsed(prev => {
+      const next = !prev;
+      localStorage.setItem(COLLAPSE_KEY, String(next));
+      return next;
+    });
+  }, []);
+
+  const documents = data ?? [];
+
+  // Hide entirely when no documents and not loading
+  if (!isLoading && documents.length === 0) {
+    return null;
+  }
+
+  return (
+    <Card className="bg-white/70 dark:bg-zinc-800/70 backdrop-blur-md border-slate-200/50 dark:border-zinc-700/50">
+      <CardHeader className="pb-3">
+        <CardTitle className="flex items-center justify-between text-base">
+          <div className="flex items-center gap-2">
+            <div className="h-8 w-8 rounded-lg bg-gradient-to-br from-blue-500 to-indigo-600 flex items-center justify-center">
+              <FileTextIcon className="h-4 w-4 text-white" />
+            </div>
+            <span className="font-quicksand">Ultimi PDF Elaborati</span>
+          </div>
+          <Button
+            variant="ghost"
+            size="sm"
+            onClick={toggleCollapse}
+            aria-label={collapsed ? 'Espandi' : 'Comprimi'}
+          >
+            {collapsed ? (
+              <ChevronDownIcon className="h-4 w-4" />
+            ) : (
+              <ChevronUpIcon className="h-4 w-4" />
+            )}
+          </Button>
+        </CardTitle>
+      </CardHeader>
+
+      {!collapsed && (
+        <CardContent className="pt-0">
+          <div className="overflow-x-auto">
+            <table className="w-full text-sm" role="table">
+              <thead>
+                <tr className="text-left text-xs text-muted-foreground border-b border-slate-200/50 dark:border-zinc-700/50">
+                  <th className="pb-2 font-medium">PDF</th>
+                  <th className="pb-2 font-medium">Gioco</th>
+                  <th className="pb-2 font-medium">Stato</th>
+                  <th className="pb-2 font-medium">Tempo</th>
+                  <th className="pb-2 font-medium text-right">Azione</th>
+                </tr>
+              </thead>
+              <tbody className="divide-y divide-slate-200/30 dark:divide-zinc-700/30">
+                {documents.map(doc => (
+                  <DocumentRow
+                    key={doc.pdfDocumentId}
+                    doc={doc}
+                    onRetry={retryMutation.mutate}
+                    retryingJobId={
+                      retryMutation.isPending ? (retryMutation.variables as string) : null
+                    }
+                  />
+                ))}
+              </tbody>
+            </table>
+          </div>
+
+          {/* Footer link */}
+          <div className="mt-4 text-center">
+            <Link
+              href="/admin/knowledge-base/documents"
+              className="text-xs text-amber-600 hover:text-amber-700 dark:text-amber-400 inline-flex items-center gap-1"
+            >
+              Vedi tutti <ExternalLinkIcon className="h-3 w-3" />
+            </Link>
+          </div>
+        </CardContent>
+      )}
+    </Card>
+  );
+}
+
+// ─── Row sub-component ───────────────────────────────────────────────────────
+
+interface DocumentRowProps {
+  doc: RecentlyProcessedDocument;
+  onRetry: (jobId: string) => void;
+  retryingJobId: string | null;
+}
+
+function DocumentRow({ doc, onRetry, retryingJobId }: DocumentRowProps) {
+  const status = getStatusConfig(doc.processingState);
+
+  return (
+    <tr className="hover:bg-slate-50/50 dark:hover:bg-zinc-900/30">
+      {/* PDF */}
+      <td className="py-2 pr-3">
+        <div className="flex items-center gap-2 min-w-0">
+          <FileTextIcon className="h-4 w-4 text-slate-500 shrink-0" />
+          <span className="truncate max-w-[180px]" title={doc.fileName}>
+            {doc.fileName}
+          </span>
+        </div>
+      </td>
+
+      {/* Gioco */}
+      <td className="py-2 pr-3">
+        <Link
+          href={`/admin/shared-games/${doc.sharedGameId}`}
+          className="flex items-center gap-2 text-amber-600 hover:text-amber-700 dark:text-amber-400 min-w-0"
+        >
+          {doc.thumbnailUrl ? (
+            <Image
+              src={doc.thumbnailUrl}
+              alt=""
+              width={24}
+              height={24}
+              className="rounded shrink-0"
+            />
+          ) : null}
+          <span className="truncate max-w-[140px]">{doc.gameName}</span>
+        </Link>
+      </td>
+
+      {/* Stato */}
+      <td className="py-2 pr-3">
+        <Badge variant={status.variant} className="gap-1">
+          {status.spinning && <Loader2Icon className="h-3 w-3 animate-spin" />}
+          {status.label}
+        </Badge>
+      </td>
+
+      {/* Tempo */}
+      <td className="py-2 pr-3 text-xs text-muted-foreground whitespace-nowrap">
+        {formatDistanceToNow(new Date(doc.timestamp), { addSuffix: true, locale: itLocale })}
+      </td>
+
+      {/* Azione */}
+      <td className="py-2 text-right">
+        <ActionCell doc={doc} onRetry={onRetry} retryingJobId={retryingJobId} />
+      </td>
+    </tr>
+  );
+}
+
+// ─── Action cell ─────────────────────────────────────────────────────────────
+
+interface ActionCellProps {
+  doc: RecentlyProcessedDocument;
+  onRetry: (jobId: string) => void;
+  retryingJobId: string | null;
+}
+
+function ActionCell({ doc, onRetry, retryingJobId }: ActionCellProps) {
+  if (doc.processingState === 'Ready') {
+    return (
+      <Button variant="ghost" size="sm" asChild>
+        <Link href={`/admin/shared-games/${doc.sharedGameId}`}>Vai al gioco</Link>
+      </Button>
+    );
+  }
+
+  if (doc.processingState === 'Failed' && doc.canRetry && doc.jobId) {
+    const isRetrying = retryingJobId === doc.jobId;
+    return (
+      <Button variant="outline" size="sm" onClick={() => onRetry(doc.jobId!)} disabled={isRetrying}>
+        {isRetrying ? (
+          <Loader2Icon className="h-3 w-3 animate-spin mr-1" />
+        ) : (
+          <RefreshCwIcon className="h-3 w-3 mr-1" />
+        )}
+        Riprova
+      </Button>
+    );
+  }
+
+  // Processing or Failed without retry
+  return (
+    <Button variant="ghost" size="sm" asChild>
+      <Link href="/admin/knowledge-base/documents">Vai alla coda</Link>
+    </Button>
+  );
+}

--- a/apps/web/src/components/admin/shared-games/__tests__/GameProcessingQueue.test.tsx
+++ b/apps/web/src/components/admin/shared-games/__tests__/GameProcessingQueue.test.tsx
@@ -1,0 +1,217 @@
+/**
+ * GameProcessingQueue Tests
+ *
+ * Validates the mini-widget displays game-specific and global queue counts,
+ * priority badges, progress indicators, deep-link, and hides when empty.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { GameProcessingQueue } from '../GameProcessingQueue';
+
+// ============================================================================
+// Mocks
+// ============================================================================
+
+const mockGetQueueJobs = vi.fn();
+const mockGetQueueStatus = vi.fn();
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    admin: {
+      getQueueJobs: (...args: unknown[]) => mockGetQueueJobs(...args),
+      getQueueStatus: (...args: unknown[]) => mockGetQueueStatus(...args),
+    },
+  },
+}));
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function createTestQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+    },
+  });
+}
+
+function renderWidget(gameId = 'game-123') {
+  const qc = createTestQueryClient();
+  return render(
+    <QueryClientProvider client={qc}>
+      <GameProcessingQueue gameId={gameId} />
+    </QueryClientProvider>
+  );
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('GameProcessingQueue', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders game-specific and global queue counts', async () => {
+    mockGetQueueJobs.mockResolvedValue({
+      jobs: [
+        {
+          id: 'job-1',
+          pdfDocumentId: 'pdf-1',
+          pdfFileName: 'rules.pdf',
+          userId: 'user-1',
+          status: 'Queued',
+          priority: 1,
+          currentStep: null,
+          createdAt: '2026-03-16T10:00:00Z',
+          startedAt: null,
+          completedAt: null,
+          errorMessage: null,
+          retryCount: 0,
+          maxRetries: 3,
+          canRetry: true,
+        },
+      ],
+      total: 2,
+      page: 1,
+      pageSize: 5,
+      totalPages: 1,
+    });
+    mockGetQueueStatus.mockResolvedValue({
+      queueDepth: 7,
+      backpressureThreshold: 100,
+      isUnderPressure: false,
+      isPaused: false,
+      maxConcurrentWorkers: 4,
+      estimatedWaitMinutes: 5,
+    });
+
+    renderWidget();
+
+    expect(await screen.findByText('Coda elaborazione')).toBeInTheDocument();
+    // "2 di questo gioco · 7 totali"
+    expect(await screen.findByText(/2 di questo gioco/)).toBeInTheDocument();
+    expect(screen.getByText(/7 totali/)).toBeInTheDocument();
+  });
+
+  it('renders job rows with priority badges', async () => {
+    mockGetQueueJobs.mockResolvedValue({
+      jobs: [
+        {
+          id: 'job-urgent',
+          pdfDocumentId: 'pdf-1',
+          pdfFileName: 'urgent-rules.pdf',
+          userId: 'user-1',
+          status: 'Processing',
+          priority: 3,
+          currentStep: 'Chunking',
+          createdAt: '2026-03-16T10:00:00Z',
+          startedAt: '2026-03-16T10:01:00Z',
+          completedAt: null,
+          errorMessage: null,
+          retryCount: 0,
+          maxRetries: 3,
+          canRetry: true,
+        },
+        {
+          id: 'job-normal',
+          pdfDocumentId: 'pdf-2',
+          pdfFileName: 'normal-rules.pdf',
+          userId: 'user-1',
+          status: 'Queued',
+          priority: 1,
+          currentStep: null,
+          createdAt: '2026-03-16T10:02:00Z',
+          startedAt: null,
+          completedAt: null,
+          errorMessage: null,
+          retryCount: 0,
+          maxRetries: 3,
+          canRetry: true,
+        },
+      ],
+      total: 2,
+      page: 1,
+      pageSize: 5,
+      totalPages: 1,
+    });
+    mockGetQueueStatus.mockResolvedValue({
+      queueDepth: 2,
+      backpressureThreshold: 100,
+      isUnderPressure: false,
+      isPaused: false,
+      maxConcurrentWorkers: 4,
+      estimatedWaitMinutes: 1,
+    });
+
+    renderWidget();
+
+    // Priority badges
+    expect(await screen.findByText('Urgente')).toBeInTheDocument();
+    expect(screen.getByText('Normale')).toBeInTheDocument();
+
+    // File names
+    expect(screen.getByText('urgent-rules.pdf')).toBeInTheDocument();
+    expect(screen.getByText('normal-rules.pdf')).toBeInTheDocument();
+
+    // "In coda" for queued job
+    expect(screen.getByText('In coda')).toBeInTheDocument();
+  });
+
+  it('renders deep-link with correct gameId param', async () => {
+    mockGetQueueJobs.mockResolvedValue({
+      jobs: [],
+      total: 1,
+      page: 1,
+      pageSize: 5,
+      totalPages: 1,
+    });
+    mockGetQueueStatus.mockResolvedValue({
+      queueDepth: 3,
+      backpressureThreshold: 100,
+      isUnderPressure: false,
+      isPaused: false,
+      maxConcurrentWorkers: 4,
+      estimatedWaitMinutes: 2,
+    });
+
+    renderWidget('my-game-456');
+
+    const link = await screen.findByText(/Apri coda completa/);
+    const anchor = link.closest('a');
+    expect(anchor).toHaveAttribute('href', '/admin/knowledge-base/queue?gameId=my-game-456');
+  });
+
+  it('returns null when there are no jobs', async () => {
+    mockGetQueueJobs.mockResolvedValue({
+      jobs: [],
+      total: 0,
+      page: 1,
+      pageSize: 5,
+      totalPages: 0,
+    });
+    mockGetQueueStatus.mockResolvedValue({
+      queueDepth: 0,
+      backpressureThreshold: 100,
+      isUnderPressure: false,
+      isPaused: false,
+      maxConcurrentWorkers: 4,
+      estimatedWaitMinutes: 0,
+    });
+
+    const { container } = renderWidget();
+
+    // Wait for queries to resolve
+    await vi.waitFor(() => {
+      expect(mockGetQueueJobs).toHaveBeenCalled();
+    });
+
+    // Widget should not render anything
+    expect(container.innerHTML).toBe('');
+  });
+});

--- a/apps/web/src/components/admin/shared-games/__tests__/PdfUploadSection.priority.test.tsx
+++ b/apps/web/src/components/admin/shared-games/__tests__/PdfUploadSection.priority.test.tsx
@@ -1,0 +1,172 @@
+/**
+ * PdfUploadSection Priority Selector Tests
+ *
+ * Tests for the priority selector feature that allows admins
+ * to mark PDF uploads as urgent (processed first in the queue).
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+
+import { PdfUploadSection } from '../PdfUploadSection';
+
+// ============================================================================
+// Test Utilities
+// ============================================================================
+
+function createTestQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+        gcTime: 0,
+      },
+    },
+  });
+}
+
+function renderWithProviders(component: React.ReactElement) {
+  const queryClient = createTestQueryClient();
+  return render(<QueryClientProvider client={queryClient}>{component}</QueryClientProvider>);
+}
+
+function createMockPdf(): File {
+  return new File(['pdf-content'], 'rules.pdf', { type: 'application/pdf' });
+}
+
+// ============================================================================
+// Mock XHR
+// ============================================================================
+
+let mockXHR: {
+  open: ReturnType<typeof vi.fn>;
+  send: ReturnType<typeof vi.fn>;
+  upload: { addEventListener: ReturnType<typeof vi.fn> };
+  addEventListener: ReturnType<typeof vi.fn>;
+  withCredentials: boolean;
+  status: number;
+  responseText: string;
+};
+
+beforeEach(() => {
+  mockXHR = {
+    open: vi.fn(),
+    send: vi.fn(),
+    upload: { addEventListener: vi.fn() },
+    addEventListener: vi.fn(),
+    withCredentials: false,
+    status: 200,
+    responseText: JSON.stringify({ documentId: 'doc-123', fileName: 'rules.pdf' }),
+  };
+  vi.clearAllMocks();
+  global.XMLHttpRequest = vi.fn(() => mockXHR) as unknown as typeof XMLHttpRequest;
+});
+
+afterEach(() => {
+  vi.restoreAllMocks();
+});
+
+// ============================================================================
+// Helper: select file via the hidden input
+// ============================================================================
+
+async function selectFile(user: ReturnType<typeof userEvent.setup>) {
+  const file = createMockPdf();
+  const dropZone = screen.getByText(/Trascina un PDF/i);
+  // Click the drop zone to trigger file input
+  await user.click(dropZone);
+  // Find the hidden file input and upload the file
+  const input = document.getElementById('admin-pdf-input') as HTMLInputElement;
+  await user.upload(input, file);
+  return file;
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('PdfUploadSection Priority Selector', () => {
+  const defaultProps = {
+    gameId: 'game-123',
+    onPdfUploaded: vi.fn(),
+    onPdfRemoved: vi.fn(),
+  };
+
+  it('shows priority selector after file selection when showPrioritySelector is not false', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<PdfUploadSection {...defaultProps} />);
+
+    // Priority selector should not be visible before file selection
+    expect(screen.queryByTestId('priority-selector')).not.toBeInTheDocument();
+
+    // Select a file
+    await selectFile(user);
+
+    // Priority selector should now be visible
+    await waitFor(() => {
+      expect(screen.getByTestId('priority-selector')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Priorita:')).toBeInTheDocument();
+  });
+
+  it('shows priority selector when showPrioritySelector is explicitly true', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<PdfUploadSection {...defaultProps} showPrioritySelector={true} />);
+
+    await selectFile(user);
+
+    await waitFor(() => {
+      expect(screen.getByTestId('priority-selector')).toBeInTheDocument();
+    });
+  });
+
+  it('does not show selector when showPrioritySelector is false', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<PdfUploadSection {...defaultProps} showPrioritySelector={false} />);
+
+    await selectFile(user);
+
+    // File should be selected (upload button visible) but no priority selector
+    await waitFor(() => {
+      expect(screen.getByText('Carica PDF')).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId('priority-selector')).not.toBeInTheDocument();
+  });
+
+  it('defaults to normal priority (no query param in URL)', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<PdfUploadSection {...defaultProps} />);
+
+    await selectFile(user);
+
+    // Click upload button
+    const uploadBtn = await screen.findByText('Carica PDF');
+    await user.click(uploadBtn);
+
+    // XHR should be opened with the base URL (no priority query param)
+    expect(mockXHR.open).toHaveBeenCalledWith('POST', '/api/v1/ingest/pdf');
+  });
+
+  it('includes ?priority=urgent in XHR URL when Urgente is selected', async () => {
+    const user = userEvent.setup();
+    renderWithProviders(<PdfUploadSection {...defaultProps} />);
+
+    await selectFile(user);
+
+    // Open the select and pick Urgente
+    const trigger = screen.getByRole('combobox');
+    await user.click(trigger);
+
+    const urgentOption = await screen.findByText(/Urgente/i);
+    await user.click(urgentOption);
+
+    // Click upload button
+    const uploadBtn = await screen.findByText('Carica PDF');
+    await user.click(uploadBtn);
+
+    // XHR should be opened with priority=urgent query param
+    expect(mockXHR.open).toHaveBeenCalledWith('POST', '/api/v1/ingest/pdf?priority=urgent');
+  });
+});

--- a/apps/web/src/components/admin/shared-games/__tests__/RecentlyProcessedWidget.test.tsx
+++ b/apps/web/src/components/admin/shared-games/__tests__/RecentlyProcessedWidget.test.tsx
@@ -1,0 +1,228 @@
+/**
+ * RecentlyProcessedWidget Tests
+ *
+ * Validates the widget displays recently processed PDFs with correct status
+ * badges, retry actions, collapse persistence, and empty state.
+ */
+
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+import { RecentlyProcessedWidget } from '../RecentlyProcessedWidget';
+import { type RecentlyProcessedDocument } from '@/lib/api/clients/sharedGamesClient';
+
+// ============================================================================
+// Mocks
+// ============================================================================
+
+const mockGetRecentlyProcessed = vi.fn();
+const mockRetryJob = vi.fn();
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    sharedGames: {
+      getRecentlyProcessed: (...args: unknown[]) => mockGetRecentlyProcessed(...args),
+    },
+    admin: {
+      retryJob: (...args: unknown[]) => mockRetryJob(...args),
+    },
+  },
+}));
+
+vi.mock('sonner', () => ({
+  toast: {
+    success: vi.fn(),
+    error: vi.fn(),
+  },
+}));
+
+// ============================================================================
+// Fixtures
+// ============================================================================
+
+function makeDoc(overrides: Partial<RecentlyProcessedDocument> = {}): RecentlyProcessedDocument {
+  return {
+    pdfDocumentId: 'pdf-1',
+    jobId: 'job-1',
+    fileName: 'rules.pdf',
+    processingState: 'Ready',
+    timestamp: '2026-03-16T10:00:00Z',
+    errorCategory: null,
+    canRetry: false,
+    sharedGameId: 'game-1',
+    gameName: 'Catan',
+    thumbnailUrl: null,
+    ...overrides,
+  };
+}
+
+const readyDoc = makeDoc();
+const failedDoc = makeDoc({
+  pdfDocumentId: 'pdf-2',
+  jobId: 'job-2',
+  fileName: 'broken.pdf',
+  processingState: 'Failed',
+  errorCategory: 'ParseError',
+  canRetry: true,
+  sharedGameId: 'game-2',
+  gameName: 'Azul',
+});
+const processingDoc = makeDoc({
+  pdfDocumentId: 'pdf-3',
+  jobId: 'job-3',
+  fileName: 'uploading.pdf',
+  processingState: 'Processing',
+  sharedGameId: 'game-3',
+  gameName: 'Wingspan',
+});
+
+// ============================================================================
+// Helpers
+// ============================================================================
+
+function createTestQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: { retry: false, gcTime: 0 },
+    },
+  });
+}
+
+function renderWidget() {
+  const qc = createTestQueryClient();
+  return render(
+    <QueryClientProvider client={qc}>
+      <RecentlyProcessedWidget />
+    </QueryClientProvider>
+  );
+}
+
+// ============================================================================
+// Tests
+// ============================================================================
+
+describe('RecentlyProcessedWidget', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    localStorage.clear();
+  });
+
+  it('renders table with PDF rows', async () => {
+    mockGetRecentlyProcessed.mockResolvedValue([readyDoc, failedDoc, processingDoc]);
+
+    renderWidget();
+
+    await waitFor(() => {
+      expect(screen.getByText('rules.pdf')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('broken.pdf')).toBeInTheDocument();
+    expect(screen.getByText('uploading.pdf')).toBeInTheDocument();
+    expect(screen.getByText('Catan')).toBeInTheDocument();
+    expect(screen.getByText('Azul')).toBeInTheDocument();
+    expect(screen.getByText('Wingspan')).toBeInTheDocument();
+  });
+
+  it('shows correct status badges for Ready/Failed/Processing', async () => {
+    mockGetRecentlyProcessed.mockResolvedValue([readyDoc, failedDoc, processingDoc]);
+
+    renderWidget();
+
+    await waitFor(() => {
+      expect(screen.getByText('Indicizzato')).toBeInTheDocument();
+    });
+
+    expect(screen.getByText('Fallito')).toBeInTheDocument();
+    expect(screen.getByText('Elaborazione')).toBeInTheDocument();
+  });
+
+  it('shows retry button for Failed + canRetry documents', async () => {
+    mockGetRecentlyProcessed.mockResolvedValue([failedDoc]);
+    mockRetryJob.mockResolvedValue(undefined);
+
+    const user = userEvent.setup();
+    renderWidget();
+
+    const retryBtn = await screen.findByRole('button', { name: /riprova/i });
+    expect(retryBtn).toBeInTheDocument();
+
+    await user.click(retryBtn);
+
+    await waitFor(() => {
+      expect(mockRetryJob).toHaveBeenCalledWith('job-2');
+    });
+  });
+
+  it('shows "Vai al gioco" for Ready documents', async () => {
+    mockGetRecentlyProcessed.mockResolvedValue([readyDoc]);
+
+    renderWidget();
+
+    const link = await screen.findByRole('link', { name: /vai al gioco/i });
+    expect(link).toHaveAttribute('href', '/admin/shared-games/game-1');
+  });
+
+  it('shows "Vai alla coda" for Processing documents', async () => {
+    mockGetRecentlyProcessed.mockResolvedValue([processingDoc]);
+
+    renderWidget();
+
+    const link = await screen.findByRole('link', { name: /vai alla coda/i });
+    expect(link).toHaveAttribute('href', '/admin/knowledge-base/documents');
+  });
+
+  it('collapse toggle persists to localStorage', async () => {
+    mockGetRecentlyProcessed.mockResolvedValue([readyDoc]);
+
+    const user = userEvent.setup();
+    renderWidget();
+
+    // Wait for content to render
+    await screen.findByText('rules.pdf');
+
+    // Click collapse button
+    const collapseBtn = screen.getByRole('button', { name: /comprimi/i });
+    await user.click(collapseBtn);
+
+    expect(localStorage.getItem('admin:recentPdfs:collapsed')).toBe('true');
+
+    // Table content should be hidden
+    expect(screen.queryByText('rules.pdf')).not.toBeInTheDocument();
+
+    // Expand again
+    const expandBtn = screen.getByRole('button', { name: /espandi/i });
+    await user.click(expandBtn);
+
+    expect(localStorage.getItem('admin:recentPdfs:collapsed')).toBe('false');
+    await waitFor(() => {
+      expect(screen.getByText('rules.pdf')).toBeInTheDocument();
+    });
+  });
+
+  it('returns null when empty and not loading', async () => {
+    mockGetRecentlyProcessed.mockResolvedValue([]);
+
+    const { container } = renderWidget();
+
+    await waitFor(() => {
+      expect(container.innerHTML).toBe('');
+    });
+  });
+
+  it('reads collapse state from localStorage on mount', async () => {
+    localStorage.setItem('admin:recentPdfs:collapsed', 'true');
+    mockGetRecentlyProcessed.mockResolvedValue([readyDoc]);
+
+    renderWidget();
+
+    // Should show expand button since it starts collapsed
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /espandi/i })).toBeInTheDocument();
+    });
+
+    // Table content should not be visible
+    expect(screen.queryByText('rules.pdf')).not.toBeInTheDocument();
+  });
+});

--- a/apps/web/src/lib/api/clients/adminClient.ts
+++ b/apps/web/src/lib/api/clients/adminClient.ts
@@ -3201,6 +3201,23 @@ export function createAdminClient({ httpClient }: CreateAdminClientParams) {
     },
 
     /**
+     * Get queue jobs filtered by gameId (for mini-widget)
+     * GET /api/v1/admin/queue?gameId=...&pageSize=...&statusFilter=...
+     */
+    async getQueueJobs(params: {
+      gameId?: string;
+      limit?: number;
+      status?: string[];
+    }): Promise<PaginatedQueue | null> {
+      const qs = new URLSearchParams();
+      if (params.gameId) qs.set('gameId', params.gameId);
+      if (params.limit) qs.set('pageSize', String(params.limit));
+      if (params.status) qs.set('statusFilter', params.status.join(','));
+      const query = qs.toString();
+      return httpClient.get(`/api/v1/admin/queue${query ? `?${query}` : ''}`, PaginatedQueueSchema);
+    },
+
+    /**
      * Enqueue a new processing job
      * POST /api/v1/admin/queue/enqueue
      */

--- a/apps/web/src/lib/api/clients/adminClient.ts
+++ b/apps/web/src/lib/api/clients/adminClient.ts
@@ -3212,7 +3212,7 @@ export function createAdminClient({ httpClient }: CreateAdminClientParams) {
       const qs = new URLSearchParams();
       if (params.gameId) qs.set('gameId', params.gameId);
       if (params.limit) qs.set('pageSize', String(params.limit));
-      if (params.status) qs.set('statusFilter', params.status.join(','));
+      if (params.status) qs.set('status', params.status.join(','));
       const query = qs.toString();
       return httpClient.get(`/api/v1/admin/queue${query ? `?${query}` : ''}`, PaginatedQueueSchema);
     },

--- a/apps/web/src/lib/api/clients/sharedGamesClient.ts
+++ b/apps/web/src/lib/api/clients/sharedGamesClient.ts
@@ -8,6 +8,23 @@
 import { z } from 'zod';
 
 import { type HttpClient } from '../core/httpClient';
+
+// ========== Recently Processed Documents ==========
+
+export const RecentlyProcessedDocumentSchema = z.object({
+  pdfDocumentId: z.string(),
+  jobId: z.string().nullable(),
+  fileName: z.string(),
+  processingState: z.string(),
+  timestamp: z.string(),
+  errorCategory: z.string().nullable(),
+  canRetry: z.boolean(),
+  sharedGameId: z.string(),
+  gameName: z.string(),
+  thumbnailUrl: z.string().nullable(),
+});
+
+export type RecentlyProcessedDocument = z.infer<typeof RecentlyProcessedDocumentSchema>;
 import {
   agentDefinitionDtoSchema,
   kbCardDtoSchema,
@@ -870,6 +887,23 @@ export function createSharedGamesClient({ httpClient }: CreateSharedGamesClientP
         `/api/v1/admin/shared-games/${gameId}/rag-readiness`,
         GameRagReadinessSchema
       );
+    },
+
+    // ========== Recently Processed Documents ==========
+
+    /**
+     * Get recently processed PDF documents across all shared games (ADMIN)
+     * GET /api/v1/admin/shared-games/recently-processed?limit={limit}
+     *
+     * @param limit - Max number of results (default 10)
+     * @returns List of recently processed documents
+     */
+    async getRecentlyProcessed(limit = 10): Promise<RecentlyProcessedDocument[]> {
+      const result = await httpClient.get(
+        `/api/v1/admin/shared-games/recently-processed?limit=${limit}`,
+        z.array(RecentlyProcessedDocumentSchema)
+      );
+      return result ?? [];
     },
   };
 }

--- a/docs/superpowers/plans/2026-03-15-admin-pdf-kb-workflow.md
+++ b/docs/superpowers/plans/2026-03-15-admin-pdf-kb-workflow.md
@@ -1,0 +1,1351 @@
+# Admin PDF→KB Workflow Improvements — Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Eliminate admin context-switching in the SharedGame PDF→KB workflow by adding 4 inline UX improvements.
+
+**Architecture:** Backend-first approach — new MediatR query + command modifications + SSE DTO enrichment, then frontend components consuming them. Each feature is independent and can be committed/tested separately.
+
+**Tech Stack:** .NET 9 (MediatR, EF Core, SSE), Next.js 16 (React Query, sonner, shadcn/ui), XHR uploads
+
+**Spec:** `docs/superpowers/specs/2026-03-15-admin-pdf-kb-workflow-design.md`
+
+---
+
+## Chunk 1: Feature 1 — Recently Processed Widget (Backend + Frontend)
+
+### Task 1: Backend — GetRecentlyProcessedDocumentsQuery + DTO
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/DTOs/RecentlyProcessedDocumentDto.cs`
+- Create: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetRecentlyProcessedDocuments/GetRecentlyProcessedDocumentsQuery.cs`
+- Create: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetRecentlyProcessedDocuments/GetRecentlyProcessedDocumentsQueryHandler.cs`
+- Reference: `apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetGameRagReadiness/GetGameRagReadinessQueryHandler.cs` (cross-BC pattern)
+
+- [ ] **Step 1: Create the DTO**
+
+```csharp
+// RecentlyProcessedDocumentDto.cs
+namespace Api.BoundedContexts.SharedGameCatalog.Application.DTOs;
+
+public sealed record RecentlyProcessedDocumentDto(
+    Guid PdfDocumentId,
+    Guid? JobId,               // ProcessingJob.Id for retry action
+    string FileName,
+    string ProcessingState,
+    DateTime Timestamp,
+    string? ErrorCategory,
+    bool CanRetry,
+    Guid SharedGameId,
+    string GameName,
+    string? ThumbnailUrl);
+```
+
+- [ ] **Step 2: Create the query record**
+
+```csharp
+// GetRecentlyProcessedDocumentsQuery.cs
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Queries.GetRecentlyProcessedDocuments;
+
+public sealed record GetRecentlyProcessedDocumentsQuery(int Limit = 10)
+    : IRequest<List<RecentlyProcessedDocumentDto>>;
+```
+
+- [ ] **Step 3: Write the failing test for the handler**
+
+Create test at `apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Queries/GetRecentlyProcessedDocumentsQueryHandlerTests.cs`:
+
+```csharp
+[Fact]
+public async Task Handle_ReturnsDocumentsOrderedByTimestampDesc()
+{
+    // Arrange: seed 3 PdfDocuments linked to SharedGames via SharedGameDocuments
+    // with different CompletedAt timestamps
+    // Act: send GetRecentlyProcessedDocumentsQuery(Limit: 2)
+    // Assert: returns 2 items, ordered by most recent first
+}
+
+[Fact]
+public async Task Handle_ExcludesDocumentsWithoutSharedGame()
+{
+    // Arrange: seed 1 PdfDocument WITH SharedGameDocument, 1 WITHOUT
+    // Act: send query
+    // Assert: returns only the one with SharedGameDocument
+}
+
+[Fact]
+public async Task Handle_MapsProcessingStateCorrectly()
+{
+    // Arrange: seed PdfDocument with ProcessingState = "Ready"
+    // Act: send query
+    // Assert: result.ProcessingState == "Ready"
+}
+```
+
+- [ ] **Step 4: Run tests to verify they fail**
+
+Run: `cd apps/api && dotnet test --filter "GetRecentlyProcessedDocumentsQueryHandler" -v n`
+Expected: FAIL — handler class does not exist yet
+
+- [ ] **Step 5: Implement the handler**
+
+```csharp
+// GetRecentlyProcessedDocumentsQueryHandler.cs
+namespace Api.BoundedContexts.SharedGameCatalog.Application.Queries.GetRecentlyProcessedDocuments;
+
+public sealed class GetRecentlyProcessedDocumentsQueryHandler
+    : IRequestHandler<GetRecentlyProcessedDocumentsQuery, List<RecentlyProcessedDocumentDto>>
+{
+    private readonly MeepleAiDbContext _db;
+
+    public GetRecentlyProcessedDocumentsQueryHandler(MeepleAiDbContext db) => _db = db;
+
+    public async Task<List<RecentlyProcessedDocumentDto>> Handle(
+        GetRecentlyProcessedDocumentsQuery request, CancellationToken ct)
+    {
+        // Cross-BC read query (deliberate, follows GetGameRagReadinessQueryHandler pattern)
+        return await _db.SharedGameDocuments
+            .Where(sgd => sgd.PdfDocumentId != null)
+            .Join(_db.PdfDocuments,
+                sgd => sgd.PdfDocumentId,
+                pd => pd.Id,
+                (sgd, pd) => new { sgd, pd })
+            .Join(_db.SharedGames,
+                x => x.sgd.SharedGameId,
+                sg => sg.Id,
+                (x, sg) => new RecentlyProcessedDocumentDto(
+                    x.pd.Id,
+                    x.pd.FileName,
+                    x.pd.ProcessingState.ToString(),
+                    x.pd.CompletedAt ?? x.pd.UpdatedAt,
+                    x.pd.ErrorCategory != null ? x.pd.ErrorCategory.ToString() : null,
+                    x.pd.CanRetry,
+                    sg.Id,
+                    sg.Name,
+                    sg.ThumbnailUrl))
+            .OrderByDescending(d => d.Timestamp)
+            .Take(request.Limit)
+            .ToListAsync(ct);
+    }
+}
+```
+
+Note: Adapt the LINQ to match actual EF entity properties and navigation patterns in `MeepleAiDbContext`. Use `GetGameRagReadinessQueryHandler.cs` as reference for how cross-BC joins are done in this codebase.
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `cd apps/api && dotnet test --filter "GetRecentlyProcessedDocumentsQueryHandler" -v n`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/DTOs/RecentlyProcessedDocumentDto.cs
+git add apps/api/src/Api/BoundedContexts/SharedGameCatalog/Application/Queries/GetRecentlyProcessedDocuments/
+git add apps/api/tests/Api.Tests/BoundedContexts/SharedGameCatalog/Application/Queries/GetRecentlyProcessedDocumentsQueryHandlerTests.cs
+git commit -m "feat(shared-games): add GetRecentlyProcessedDocumentsQuery cross-BC read"
+```
+
+---
+
+### Task 2: Backend — Register endpoint in AdminSharedGameContentEndpoints
+
+**Files:**
+- Modify: `apps/api/src/Api/Routing/AdminSharedGameContentEndpoints.cs`
+
+- [ ] **Step 1: Add the endpoint registration**
+
+In `AdminSharedGameContentEndpoints.cs`, inside `MapAdminSharedGameContentEndpoints()`, add after the existing route group setup:
+
+```csharp
+group.MapGet("/recently-processed", async (
+    [FromQuery] int? limit,
+    IMediator mediator,
+    CancellationToken ct) =>
+{
+    var result = await mediator.Send(
+        new GetRecentlyProcessedDocumentsQuery(limit ?? 10), ct);
+    return Results.Ok(result);
+})
+.WithName("GetRecentlyProcessedDocuments")
+.WithDescription("Get recently processed PDF documents for SharedGames")
+.Produces<List<RecentlyProcessedDocumentDto>>();
+```
+
+- [ ] **Step 2: Verify the API builds and responds**
+
+Run: `cd apps/api/src/Api && dotnet build`
+Expected: BUILD SUCCEEDED
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/api/src/Api/Routing/AdminSharedGameContentEndpoints.cs
+git commit -m "feat(shared-games): register GET /recently-processed endpoint"
+```
+
+---
+
+### Task 3: Frontend — API client method + RecentlyProcessedWidget
+
+**Files:**
+- Modify: `apps/web/src/lib/api/clients/sharedGamesClient.ts` (~line 873, after `getGameRagReadiness`)
+- Create: `apps/web/src/components/admin/shared-games/RecentlyProcessedWidget.tsx`
+- Modify: `apps/web/src/app/admin/(dashboard)/shared-games/all/page.tsx`
+
+- [ ] **Step 1: Add API client method**
+
+In `sharedGamesClient.ts`, add after the last method:
+
+```typescript
+async getRecentlyProcessed(limit: number = 10): Promise<RecentlyProcessedDocument[]> {
+  const res = await this.http.get<RecentlyProcessedDocument[]>(
+    `/api/v1/admin/shared-games/recently-processed?limit=${limit}`
+  );
+  return res ?? [];
+},
+```
+
+Add the type near the top with other interfaces:
+
+```typescript
+export interface RecentlyProcessedDocument {
+  pdfDocumentId: string;
+  jobId: string | null;
+  fileName: string;
+  processingState: string;
+  timestamp: string;
+  errorCategory: string | null;
+  canRetry: boolean;
+  sharedGameId: string;
+  gameName: string;
+  thumbnailUrl: string | null;
+}
+```
+
+- [ ] **Step 2: Write the failing test for RecentlyProcessedWidget**
+
+Create `apps/web/src/components/admin/shared-games/__tests__/RecentlyProcessedWidget.test.tsx`:
+
+```typescript
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { describe, it, expect, vi } from 'vitest';
+
+// Mock api client
+const mockGetRecentlyProcessed = vi.fn();
+vi.mock('@/lib/api', () => ({
+  apiClient: {
+    sharedGames: { getRecentlyProcessed: mockGetRecentlyProcessed },
+  },
+}));
+
+// Mock React Query
+vi.mock('@tanstack/react-query', async () => {
+  const actual = await vi.importActual('@tanstack/react-query');
+  return { ...actual };
+});
+
+describe('RecentlyProcessedWidget', () => {
+  it('renders table with PDF rows', async () => {
+    // ...setup with QueryClientProvider + mock data
+    // Assert: file name, game name, status badge visible
+  });
+
+  it('shows "Indicizzato" badge for Ready state', async () => {
+    // Mock data with processingState: "Ready"
+    // Assert: screen.getByText('Indicizzato')
+  });
+
+  it('shows "Elaborazione" badge for processing states', async () => {
+    // Mock data with processingState: "Extracting"
+    // Assert: screen.getByText('Elaborazione')
+  });
+
+  it('shows "Fallito" badge with retry button for Failed state', async () => {
+    // Mock data with processingState: "Failed", canRetry: true
+    // Assert: screen.getByText('Fallito'), screen.getByText('Riprova')
+  });
+
+  it('collapses and persists state in localStorage', async () => {
+    // Render, click collapse toggle
+    // Assert: localStorage.setItem called with 'admin:recentPdfs:collapsed'
+  });
+
+  it('renders empty state when no documents', async () => {
+    // Mock empty array
+    // Assert: widget not rendered or shows empty message
+  });
+});
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `cd apps/web && pnpm test -- --run RecentlyProcessedWidget`
+Expected: FAIL — component does not exist
+
+- [ ] **Step 4: Implement RecentlyProcessedWidget**
+
+Create `apps/web/src/components/admin/shared-games/RecentlyProcessedWidget.tsx`:
+
+```tsx
+'use client';
+
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import { ChevronDown, ChevronUp, FileText, ExternalLink, RotateCcw, Loader2 } from 'lucide-react';
+import Link from 'next/link';
+import { apiClient } from '@/lib/api';
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { toast } from 'sonner';
+import type { RecentlyProcessedDocument } from '@/lib/api/clients/sharedGamesClient';
+
+function getStatusBadge(state: string) {
+  if (state === 'Ready') return <Badge variant="default" className="bg-green-100 text-green-800">Indicizzato</Badge>;
+  if (state === 'Failed') return <Badge variant="destructive">Fallito</Badge>;
+  return (
+    <Badge variant="secondary" className="bg-blue-100 text-blue-800">
+      <Loader2 className="mr-1 h-3 w-3 animate-spin" />
+      Elaborazione
+    </Badge>
+  );
+}
+
+function formatRelativeTime(timestamp: string): string {
+  const diff = Date.now() - new Date(timestamp).getTime();
+  const minutes = Math.floor(diff / 60000);
+  if (minutes < 1) return 'Ora';
+  if (minutes < 60) return `${minutes}min fa`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `${hours}h fa`;
+  return `${Math.floor(hours / 24)}g fa`;
+}
+
+export function RecentlyProcessedWidget() {
+  const [collapsed, setCollapsed] = useState(() =>
+    typeof window !== 'undefined'
+      ? localStorage.getItem('admin:recentPdfs:collapsed') === 'true'
+      : false
+  );
+
+  const { data: documents = [], isLoading } = useQuery({
+    queryKey: ['admin', 'recently-processed'],
+    queryFn: () => apiClient.sharedGames.getRecentlyProcessed(10),
+    refetchInterval: 15_000,
+  });
+
+  const toggleCollapse = () => {
+    const next = !collapsed;
+    setCollapsed(next);
+    localStorage.setItem('admin:recentPdfs:collapsed', String(next));
+  };
+
+  const handleRetry = async (jobId: string) => {
+    try {
+      await apiClient.admin.retryJob(jobId);
+      toast.success('Riprocessamento avviato');
+    } catch {
+      toast.error('Errore nel riprocessamento');
+    }
+  };
+
+  if (!isLoading && documents.length === 0) return null;
+
+  return (
+    <Card className="mb-6">
+      <CardHeader className="cursor-pointer flex flex-row items-center justify-between py-3" onClick={toggleCollapse}>
+        <CardTitle className="text-base font-medium">Ultimi PDF elaborati</CardTitle>
+        {collapsed ? <ChevronDown className="h-4 w-4" /> : <ChevronUp className="h-4 w-4" />}
+      </CardHeader>
+      {!collapsed && (
+        <CardContent className="pt-0">
+          {isLoading ? (
+            <div className="flex items-center justify-center py-4">
+              <Loader2 className="h-5 w-5 animate-spin text-muted-foreground" />
+            </div>
+          ) : (
+            <>
+              <div className="overflow-x-auto">
+                <table className="w-full text-sm">
+                  <thead>
+                    <tr className="border-b text-left text-muted-foreground">
+                      <th className="pb-2 font-medium">PDF</th>
+                      <th className="pb-2 font-medium">Gioco</th>
+                      <th className="pb-2 font-medium">Stato</th>
+                      <th className="pb-2 font-medium">Tempo</th>
+                      <th className="pb-2 font-medium">Azione</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {documents.map((doc) => (
+                      <tr key={doc.pdfDocumentId} className="border-b last:border-0">
+                        <td className="py-2">
+                          <div className="flex items-center gap-2">
+                            <FileText className="h-4 w-4 text-muted-foreground" />
+                            <span className="truncate max-w-[200px]" title={doc.fileName}>
+                              {doc.fileName}
+                            </span>
+                          </div>
+                        </td>
+                        <td className="py-2">
+                          <Link
+                            href={`/admin/shared-games/${doc.sharedGameId}`}
+                            className="text-primary hover:underline flex items-center gap-1"
+                          >
+                            {doc.thumbnailUrl && (
+                              <img src={doc.thumbnailUrl} alt="" className="h-6 w-6 rounded object-cover" />
+                            )}
+                            <span className="truncate max-w-[150px]">{doc.gameName}</span>
+                          </Link>
+                        </td>
+                        <td className="py-2">{getStatusBadge(doc.processingState)}</td>
+                        <td className="py-2 text-muted-foreground">{formatRelativeTime(doc.timestamp)}</td>
+                        <td className="py-2">
+                          {doc.processingState === 'Ready' && (
+                            <Button variant="ghost" size="sm" asChild>
+                              <Link href={`/admin/shared-games/${doc.sharedGameId}`}>
+                                <ExternalLink className="h-3 w-3 mr-1" />Vai al gioco
+                              </Link>
+                            </Button>
+                          )}
+                          {doc.processingState === 'Failed' && doc.canRetry && doc.jobId && (
+                            <Button variant="ghost" size="sm" onClick={() => handleRetry(doc.jobId!)}>
+                              <RotateCcw className="h-3 w-3 mr-1" />Riprova
+                            </Button>
+                          )}
+                          {doc.processingState !== 'Ready' && doc.processingState !== 'Failed' && (
+                            <Button variant="ghost" size="sm" asChild>
+                              <Link href="/admin/knowledge-base/queue">
+                                <ExternalLink className="h-3 w-3 mr-1" />Vai alla coda
+                              </Link>
+                            </Button>
+                          )}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+              <div className="mt-3 text-right">
+                <Link href="/admin/knowledge-base/documents" className="text-sm text-primary hover:underline">
+                  Vedi tutti →
+                </Link>
+              </div>
+            </>
+          )}
+        </CardContent>
+      )}
+    </Card>
+  );
+}
+```
+
+- [ ] **Step 5: Mount widget in the SharedGames all page**
+
+In `apps/web/src/app/admin/(dashboard)/shared-games/all/page.tsx`, add import and render above `GameCatalogGrid`:
+
+```tsx
+import { RecentlyProcessedWidget } from '@/components/admin/shared-games/RecentlyProcessedWidget';
+
+// Inside the component JSX, before the first <Suspense>:
+<RecentlyProcessedWidget />
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `cd apps/web && pnpm test -- --run RecentlyProcessedWidget`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/web/src/lib/api/clients/sharedGamesClient.ts
+git add apps/web/src/components/admin/shared-games/RecentlyProcessedWidget.tsx
+git add apps/web/src/components/admin/shared-games/__tests__/RecentlyProcessedWidget.test.tsx
+git add apps/web/src/app/admin/(dashboard)/shared-games/all/page.tsx
+git commit -m "feat(admin): add RecentlyProcessedWidget to SharedGames landing"
+```
+
+---
+
+## Chunk 2: Feature 2 — Priority Urgent Selector (Backend + Frontend)
+
+### Task 4: Backend — Add Priority to UploadPdfCommand
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/UploadPdfCommand.cs` (line 11-17)
+- Modify: `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/UploadPdfCommandHandler.cs`
+- Create: `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Validators/UploadPdfCommandValidator.cs`
+- Modify: `apps/api/src/Api/Routing/PdfEndpoints.cs` (MapStandardUploadEndpoint — pass priority from query string)
+
+- [ ] **Step 1: Write the failing test**
+
+Create/extend test at `apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/Commands/UploadPdfCommandTests.cs`:
+
+```csharp
+[Fact]
+public async Task Handle_WithUrgentPriority_SetsProcessingJobPriorityToUrgent()
+{
+    // Arrange: UploadPdfCommand with Priority = "urgent", admin user
+    // Act: send command
+    // Assert: ProcessingJob.Priority == ProcessingPriority.Urgent
+}
+
+[Fact]
+public async Task Handle_WithNullPriority_DefaultsToNormalPriority()
+{
+    // Arrange: UploadPdfCommand with Priority = null
+    // Act: send command
+    // Assert: ProcessingJob.Priority == ProcessingPriority.Normal (or High for admin)
+}
+
+[Fact]
+public async Task Validator_RejectsInvalidPriorityValues()
+{
+    // Arrange: UploadPdfCommand with Priority = "invalid"
+    // Act: validate
+    // Assert: validation error
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd apps/api && dotnet test --filter "UploadPdfCommand" -v n`
+Expected: FAIL
+
+- [ ] **Step 3: Add Priority property to UploadPdfCommand**
+
+In `UploadPdfCommand.cs`, add to the existing `internal record` (keep the existing access modifier):
+
+```csharp
+internal record UploadPdfCommand(
+    // ... existing properties unchanged
+    string? Priority = null   // "normal" | "urgent" | null
+) : ICommand<PdfUploadResult>;
+```
+
+**Important**: Do NOT change `internal record` to `public sealed record`. Match existing codebase conventions.
+
+- [ ] **Step 4: Create UploadPdfCommandValidator**
+
+```csharp
+// UploadPdfCommandValidator.cs
+namespace Api.BoundedContexts.DocumentProcessing.Application.Validators;
+
+internal sealed class UploadPdfCommandValidator : AbstractValidator<UploadPdfCommand>
+{
+    private static readonly string[] ValidPriorities = ["normal", "urgent"];
+
+    public UploadPdfCommandValidator()
+    {
+        RuleFor(x => x.File).NotNull();
+        RuleFor(x => x.UserId).NotEmpty();
+        When(x => x.Priority != null, () =>
+        {
+            RuleFor(x => x.Priority)
+                .Must(p => ValidPriorities.Contains(p!.ToLowerInvariant()))
+                .WithMessage("Priority must be 'normal' or 'urgent'");
+        });
+    }
+}
+```
+
+- [ ] **Step 5: Modify UploadPdfCommandHandler to respect priority**
+
+In `UploadPdfCommandHandler.cs`, where `ProcessingJob` is created, add priority mapping:
+
+```csharp
+var priority = request.Priority?.ToLowerInvariant() == "urgent"
+    ? ProcessingPriority.Urgent
+    : ProcessingPriority.High; // Admin default
+// Apply to the ProcessingJob creation
+```
+
+- [ ] **Step 6: Pass priority from endpoint to command**
+
+In `PdfEndpoints.cs`, in the `HandleStandardUpload` private static method, read priority from the query string before constructing `UploadPdfCommand`:
+
+```csharp
+// Inside HandleStandardUpload body, before constructing UploadPdfCommand:
+var priority = context.Request.Query["priority"].FirstOrDefault();
+
+// Then pass it when constructing the command (~line 455):
+var command = new UploadPdfCommand(
+    // ... existing parameters unchanged
+    Priority: priority
+);
+```
+
+**Note**: `HandleStandardUpload` reads form data from `context.Request.ReadFormAsync()`, not from method parameters. The priority comes from query string, not form data. Do NOT change the method signature.
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+Run: `cd apps/api && dotnet test --filter "UploadPdfCommand" -v n`
+Expected: PASS
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/UploadPdfCommand.cs
+git add apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/UploadPdfCommandHandler.cs
+git add apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Validators/UploadPdfCommandValidator.cs
+git add apps/api/src/Api/Routing/PdfEndpoints.cs
+git add apps/api/tests/
+git commit -m "feat(doc-processing): add priority parameter to PDF upload command"
+```
+
+---
+
+### Task 5: Frontend — Priority selector in PdfUploadSection
+
+**Files:**
+- Modify: `apps/web/src/components/admin/shared-games/PdfUploadSection.tsx` (lines 34-51 props, lines 210-317 upload)
+
+- [ ] **Step 1: Write the failing test**
+
+Add to existing or create `apps/web/src/components/admin/shared-games/__tests__/PdfUploadSection.priority.test.tsx`:
+
+```typescript
+describe('PdfUploadSection priority selector', () => {
+  it('shows priority selector after file selection when showPrioritySelector=true', async () => {
+    // Render with showPrioritySelector={true}
+    // Select a file
+    // Assert: screen.getByText('Normale') or screen.getByRole('combobox')
+  });
+
+  it('does not show priority selector when showPrioritySelector=false', async () => {
+    // Render with showPrioritySelector={false}
+    // Select a file
+    // Assert: no priority selector
+  });
+
+  it('sends priority=urgent query param when Urgente selected', async () => {
+    // Render, select file, pick "Urgente", click upload
+    // Assert: XHR open called with /api/v1/ingest/pdf?priority=urgent
+  });
+
+  it('defaults to no priority param when Normale selected', async () => {
+    // Render, select file, keep "Normale", click upload
+    // Assert: XHR open called with /api/v1/ingest/pdf (no query param)
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd apps/web && pnpm test -- --run PdfUploadSection.priority`
+Expected: FAIL
+
+- [ ] **Step 3: Add priority selector to PdfUploadSection**
+
+In `PdfUploadSection.tsx`:
+
+1. Add prop `showPrioritySelector?: boolean` (default `true`) to `PdfUploadSectionProps` interface (~line 34)
+2. Add state: `const [priority, setPriority] = useState<'normal' | 'urgent'>('normal');`
+3. After file validation area (~line 384), render the selector when `showPrioritySelector && selectedFile`:
+
+```tsx
+{showPrioritySelector && selectedFile && !isUploading && (
+  <div className="flex items-center gap-2 mt-3">
+    <Select value={priority} onValueChange={(v) => setPriority(v as 'normal' | 'urgent')}>
+      <SelectTrigger className="w-[260px]">
+        <SelectValue />
+      </SelectTrigger>
+      <SelectContent>
+        <SelectItem value="normal">Normale — Elaborazione standard</SelectItem>
+        <SelectItem value="urgent">
+          <span className="flex items-center gap-1 text-amber-600">
+            <Zap className="h-3 w-3" />Urgente — in testa alla coda
+          </span>
+        </SelectItem>
+      </SelectContent>
+    </Select>
+  </div>
+)}
+```
+
+4. In `handleUpload()` (~line 261), modify XHR URL:
+
+```typescript
+const url = priority === 'urgent'
+  ? '/api/v1/ingest/pdf?priority=urgent'
+  : '/api/v1/ingest/pdf';
+xhr.open('POST', url);
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `cd apps/web && pnpm test -- --run PdfUploadSection.priority`
+Expected: PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/admin/shared-games/PdfUploadSection.tsx
+git add apps/web/src/components/admin/shared-games/__tests__/PdfUploadSection.priority.test.tsx
+git commit -m "feat(admin): add priority selector to PdfUploadSection"
+```
+
+---
+
+## Chunk 3: Feature 3 — Mini-Queue Widget (Backend + Frontend)
+
+### Task 6: Backend — Add GameId filter to GetProcessingQueueQuery
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Queries/Queue/GetProcessingQueueQuery.cs` (line 10-17)
+- Modify: `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Handlers/Queue/GetProcessingQueueQueryHandler.cs` (handler is in Handlers/, not Queries/)
+
+- [ ] **Step 1: Write the failing test**
+
+```csharp
+[Fact]
+public async Task Handle_WithGameIdFilter_ReturnsOnlyJobsForThatGame()
+{
+    // Arrange: seed 2 jobs — one linked to SharedGame A, one to SharedGame B
+    // Act: send GetProcessingQueueQuery with GameId = SharedGame A's ID
+    // Assert: returns only the job for SharedGame A
+}
+
+[Fact]
+public async Task Handle_WithoutGameIdFilter_ReturnsAllJobs()
+{
+    // Arrange: seed 2 jobs for different games
+    // Act: send GetProcessingQueueQuery without GameId
+    // Assert: returns both jobs
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd apps/api && dotnet test --filter "GetProcessingQueueQuery" -v n`
+Expected: FAIL
+
+- [ ] **Step 3: Add GameId to the query record**
+
+In `GetProcessingQueueQuery.cs`:
+
+```csharp
+public sealed record GetProcessingQueueQuery(
+    string? StatusFilter = null,
+    string? SearchText = null,
+    DateTimeOffset? FromDate = null,
+    DateTimeOffset? ToDate = null,
+    Guid? GameId = null,       // NEW — filter by SharedGame
+    int Page = 1,
+    int PageSize = 20
+) : IQuery<PaginatedQueueResponse>;
+```
+
+- [ ] **Step 4: Implement the GameId filter in the handler**
+
+In the handler's `Handle` method, add a conditional join when `GameId` is provided:
+
+```csharp
+if (request.GameId.HasValue)
+{
+    query = query.Where(j =>
+        _db.SharedGameDocuments
+            .Any(sgd => sgd.PdfDocumentId == j.PdfDocumentId
+                      && sgd.SharedGameId == request.GameId.Value));
+}
+```
+
+- [ ] **Step 5: Pass GameId from the admin queue endpoint**
+
+In `AdminQueueEndpoints.cs`, add `[FromQuery] Guid? gameId = null` to the GET queue handler and pass it to the query.
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `cd apps/api && dotnet test --filter "GetProcessingQueueQuery" -v n`
+Expected: PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Queries/Queue/
+git add apps/api/src/Api/Routing/AdminQueueEndpoints.cs
+git add apps/api/tests/
+git commit -m "feat(doc-processing): add GameId filter to GetProcessingQueueQuery"
+```
+
+---
+
+### Task 7: Frontend — GameProcessingQueue component
+
+**Files:**
+- Modify: `apps/web/src/lib/api/clients/adminClient.ts` — add `getQueueJobs()` method
+- Create: `apps/web/src/components/admin/shared-games/GameProcessingQueue.tsx`
+- Modify: `apps/web/src/app/admin/(dashboard)/shared-games/[id]/client.tsx`
+
+- [ ] **Step 0: Add getQueueJobs to adminClient**
+
+In `apps/web/src/lib/api/clients/adminClient.ts`, add:
+
+```typescript
+interface QueueJobsParams {
+  gameId?: string;
+  limit?: number;
+  status?: string[];
+}
+
+async getQueueJobs(params: QueueJobsParams) {
+  const searchParams = new URLSearchParams();
+  if (params.gameId) searchParams.set('gameId', params.gameId);
+  if (params.limit) searchParams.set('pageSize', String(params.limit));
+  if (params.status) searchParams.set('statusFilter', params.status.join(','));
+  const res = await this.http.get(`/api/v1/admin/queue?${searchParams}`);
+  return res;
+},
+```
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/web/src/components/admin/shared-games/__tests__/GameProcessingQueue.test.tsx`:
+
+```typescript
+describe('GameProcessingQueue', () => {
+  it('renders game-specific and global queue counts', async () => {
+    // Mock: 3 jobs for this game, 12 total
+    // Assert: "3 di questo gioco · 12 totali"
+  });
+
+  it('renders job rows with priority badges and progress', async () => {
+    // Mock: 1 Urgent processing at 67%, 1 Normal queued
+    // Assert: "Urgente" badge, progress bar, "In coda" text
+  });
+
+  it('renders deep-link to full queue with gameId param', async () => {
+    // Assert: link href contains /admin/knowledge-base/queue?gameId=
+  });
+
+  it('renders empty state when no jobs', async () => {
+    // Mock: empty jobs, 0 global
+    // Assert: widget hidden or "Nessun documento in coda"
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd apps/web && pnpm test -- --run GameProcessingQueue`
+Expected: FAIL
+
+- [ ] **Step 3: Implement GameProcessingQueue**
+
+Create `apps/web/src/components/admin/shared-games/GameProcessingQueue.tsx`:
+
+```tsx
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+import { ExternalLink, Loader2 } from 'lucide-react';
+import Link from 'next/link';
+import { apiClient } from '@/lib/api';
+import { Badge } from '@/components/ui/badge';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { Progress } from '@/components/ui/progress';
+
+const PRIORITY_CONFIG: Record<number, { label: string; className: string }> = {
+  30: { label: 'Urgente', className: 'bg-red-100 text-red-800' },
+  20: { label: 'Alta', className: 'bg-amber-100 text-amber-800' },
+  10: { label: 'Normale', className: 'bg-blue-100 text-blue-800' },
+  0: { label: 'Bassa', className: 'bg-gray-100 text-gray-800' },
+};
+
+interface GameProcessingQueueProps {
+  gameId: string;
+}
+
+export function GameProcessingQueue({ gameId }: GameProcessingQueueProps) {
+  const { data: queueData } = useQuery({
+    queryKey: ['admin', 'queue', 'game', gameId],
+    queryFn: () => apiClient.admin.getQueueJobs({
+      gameId,
+      limit: 5,
+      status: ['Queued', 'Processing'],
+    }),
+    refetchInterval: 10_000,
+  });
+
+  const { data: queueStatus } = useQuery({
+    queryKey: ['admin', 'queue', 'status'],
+    queryFn: () => apiClient.admin.getQueueStatus(),
+    refetchInterval: 10_000,
+  });
+
+  const jobs = queueData?.items ?? [];
+  const gameCount = queueData?.totalCount ?? 0;
+  const globalCount = queueStatus?.queueDepth ?? 0;
+
+  if (gameCount === 0 && globalCount === 0) return null;
+
+  return (
+    <Card className="mt-4">
+      <CardHeader className="py-3">
+        <div className="flex items-center justify-between">
+          <CardTitle className="text-base font-medium">Coda elaborazione</CardTitle>
+          <span className="text-sm text-muted-foreground">
+            <strong>{gameCount}</strong> di questo gioco · <strong>{globalCount}</strong> totali
+          </span>
+        </div>
+      </CardHeader>
+      <CardContent className="pt-0">
+        {jobs.length === 0 ? (
+          <p className="text-sm text-muted-foreground py-2">Nessun documento in coda per questo gioco</p>
+        ) : (
+          <div className="space-y-2">
+            {jobs.map((job) => {
+              const priorityCfg = PRIORITY_CONFIG[job.priority] ?? PRIORITY_CONFIG[10];
+              return (
+                <div key={job.id} className="flex items-center gap-3 text-sm">
+                  <Badge variant="outline" className={priorityCfg.className}>
+                    {priorityCfg.label}
+                  </Badge>
+                  <span className="truncate flex-1" title={job.fileName}>
+                    {job.fileName}
+                  </span>
+                  <div className="w-24">
+                    {job.status === 'Processing' && job.progress != null ? (
+                      <Progress value={job.progress} className="h-2" />
+                    ) : (
+                      <span className="text-muted-foreground text-xs">In coda</span>
+                    )}
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        )}
+        <div className="mt-3 border-t pt-2">
+          <Link
+            href={`/admin/knowledge-base/queue?gameId=${gameId}`}
+            className="text-sm text-primary hover:underline inline-flex items-center gap-1"
+          >
+            <ExternalLink className="h-3 w-3" />
+            Apri coda completa →
+          </Link>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}
+```
+
+- [ ] **Step 4: Mount in GameDetailClient Documents tab**
+
+In `apps/web/src/app/admin/(dashboard)/shared-games/[id]/client.tsx`, import and add below `PdfUploadSection` in the Documents tab:
+
+```tsx
+import { GameProcessingQueue } from '@/components/admin/shared-games/GameProcessingQueue';
+
+// Inside Documents tab, after PdfUploadSection:
+<GameProcessingQueue gameId={gameId} />
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd apps/web && pnpm test -- --run GameProcessingQueue`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/components/admin/shared-games/GameProcessingQueue.tsx
+git add apps/web/src/components/admin/shared-games/__tests__/GameProcessingQueue.test.tsx
+git add apps/web/src/app/admin/(dashboard)/shared-games/[id]/client.tsx
+git commit -m "feat(admin): add GameProcessingQueue mini-widget with deep-link"
+```
+
+---
+
+## Chunk 4: Feature 4 — Toast Notifications (Backend SSE + Frontend)
+
+### Task 8: Backend — Enrich SSE DTOs with game info
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/DTOs/QueueStreamEventDto.cs` (lines 57, 62)
+- Modify: `apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/EventHandlers/QueueStreamEventHandlers.cs` (lines 87-133)
+
+- [ ] **Step 1: Write the failing test**
+
+Create test at `apps/api/tests/Api.Tests/BoundedContexts/DocumentProcessing/Application/EventHandlers/QueueStreamEventHandlerEnrichmentTests.cs`:
+
+```csharp
+[Fact]
+public async Task JobCompletedStreamHandler_EnrichesWithGameInfo_WhenSharedGameDocumentExists()
+{
+    // Arrange: PdfDocument linked to SharedGameDocument → SharedGame "Catan"
+    // Arrange: JobCompletedEvent for that PdfDocument
+    // Act: handler publishes QueueStreamEvent
+    // Assert: QueueStreamEvent.Data contains GameName = "Catan", SharedGameId, FileName
+}
+
+[Fact]
+public async Task JobCompletedStreamHandler_HandlesNoSharedGame_Gracefully()
+{
+    // Arrange: PdfDocument NOT linked to any SharedGame
+    // Act: handler publishes QueueStreamEvent
+    // Assert: QueueStreamEvent.Data has null GameName and SharedGameId
+}
+
+// Same 2 tests for JobFailedStreamHandler
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd apps/api && dotnet test --filter "StreamHandler" -v n`
+Expected: FAIL
+
+- [ ] **Step 3: Enhance SSE DTO records**
+
+In `QueueStreamEventDto.cs`:
+
+```csharp
+// Line 57 — replace existing
+public sealed record JobCompletedData(
+    double TotalDurationSeconds,
+    string? FileName,
+    Guid? SharedGameId,
+    string? GameName);
+
+// Line 62 — replace existing
+public sealed record JobFailedData(
+    string Error,
+    string? FailedAtStep,
+    int RetryCount,
+    string? FileName,
+    Guid? SharedGameId,
+    string? GameName);
+```
+
+- [ ] **Step 4: Enrich stream handlers with game lookup**
+
+In `QueueStreamEventHandlers.cs`, modify `JobCompletedStreamHandler` (~line 87):
+
+1. Inject `MeepleAiDbContext _db` in constructor
+2. In `Handle()`, after receiving the domain event, resolve game info:
+
+```csharp
+var pdfDoc = await _db.PdfDocuments
+    .Where(p => p.Id == notification.PdfDocumentId)
+    .Select(p => new { p.FileName })
+    .FirstOrDefaultAsync(ct);
+
+var gameInfo = await _db.SharedGameDocuments
+    .Where(sgd => sgd.PdfDocumentId == notification.PdfDocumentId)
+    .Select(sgd => new { sgd.SharedGameId, GameName = sgd.SharedGame.Name })
+    .FirstOrDefaultAsync(ct);
+
+var data = new JobCompletedData(
+    notification.TotalDuration.TotalSeconds,
+    pdfDoc?.FileName,
+    gameInfo?.SharedGameId,
+    gameInfo?.GameName);
+```
+
+Apply same pattern to `JobFailedStreamHandler` (~line 111).
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd apps/api && dotnet test --filter "StreamHandler" -v n`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/DTOs/QueueStreamEventDto.cs
+git add apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/EventHandlers/QueueStreamEventHandlers.cs
+git add apps/api/tests/
+git commit -m "feat(doc-processing): enrich SSE JobCompleted/Failed DTOs with game info"
+```
+
+---
+
+### Task 9: Frontend — PdfProcessingNotifier component
+
+**Files:**
+- Create: `apps/web/src/components/admin/layout/PdfProcessingNotifier.tsx`
+- Modify: `apps/web/src/app/admin/(dashboard)/layout.tsx`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `apps/web/src/components/admin/layout/__tests__/PdfProcessingNotifier.test.tsx`:
+
+```typescript
+describe('PdfProcessingNotifier', () => {
+  it('shows success toast on JobCompleted SSE event', async () => {
+    // Mock EventSource with JobCompleted event containing gameName + fileName
+    // Assert: toast.success called with "rulebook.pdf per Catan"
+  });
+
+  it('shows error toast on JobFailed SSE event', async () => {
+    // Mock EventSource with JobFailed event
+    // Assert: toast.error called with "Elaborazione fallita"
+  });
+
+  it('ignores events without game info', async () => {
+    // Mock EventSource with JobCompleted event where gameName is null
+    // Assert: toast still shows with fileName only (no "per null")
+  });
+
+  it('cleans up SSE connection on unmount', async () => {
+    // Render, then unmount
+    // Assert: EventSource.close() called
+  });
+});
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `cd apps/web && pnpm test -- --run PdfProcessingNotifier`
+Expected: FAIL
+
+- [ ] **Step 3: Implement PdfProcessingNotifier**
+
+Create `apps/web/src/components/admin/layout/PdfProcessingNotifier.tsx`:
+
+```tsx
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { useRouter } from 'next/navigation';
+import { toast } from 'sonner';
+import { apiClient } from '@/lib/api';
+
+interface SseJobEvent {
+  type: string;
+  jobId: string;
+  data: {
+    fileName?: string;
+    sharedGameId?: string;
+    gameName?: string;
+    error?: string;
+  };
+}
+
+export function PdfProcessingNotifier() {
+  const router = useRouter();
+  const eventSourceRef = useRef<EventSource | null>(null);
+  const reconnectTimeoutRef = useRef<ReturnType<typeof setTimeout>>();
+  const reconnectDelayRef = useRef(1000);
+
+  useEffect(() => {
+    function connect() {
+      const es = new EventSource('/api/v1/admin/queue/stream');
+      eventSourceRef.current = es;
+
+      // Note: If SSE server sends named events (e.g., `event: JobCompleted`),
+      // use addEventListener instead of onmessage. Check IQueueStreamService
+      // implementation. If events are unnamed, onmessage works.
+      es.onmessage = (event) => {
+        try {
+          const parsed: SseJobEvent = JSON.parse(event.data);
+          handleEvent(parsed);
+        } catch { /* ignore parse errors */ }
+      };
+
+      es.onerror = () => {
+        es.close();
+        // Exponential backoff: 1s, 2s, 4s, ... max 30s
+        reconnectTimeoutRef.current = setTimeout(() => {
+          reconnectDelayRef.current = Math.min(reconnectDelayRef.current * 2, 30_000);
+          connect();
+        }, reconnectDelayRef.current);
+      };
+
+      es.onopen = () => {
+        reconnectDelayRef.current = 1000; // Reset on successful connection
+      };
+    }
+
+    function handleEvent(event: SseJobEvent) {
+      const { fileName, sharedGameId, gameName, error } = event.data ?? {};
+
+      if (event.type === 'JobCompleted') {
+        const title = gameName
+          ? `${fileName} per ${gameName}`
+          : fileName ?? 'PDF';
+
+        toast.success(title, {
+          description: 'Indicizzazione completata',
+          duration: 8000,
+          action: sharedGameId ? {
+            label: 'Vai al gioco',
+            onClick: () => router.push(`/admin/shared-games/${sharedGameId}`),
+          } : undefined,
+        });
+      }
+
+      if (event.type === 'JobFailed') {
+        const title = gameName
+          ? `${fileName} per ${gameName}`
+          : fileName ?? 'PDF';
+
+        toast.error(title, {
+          description: `Elaborazione fallita${error ? `: ${error}` : ''}`,
+          duration: 8000,
+          action: {
+            label: 'Riprova',
+            onClick: async () => {
+              try {
+                await apiClient.admin.retryJob(event.jobId);
+                toast.success('Riprocessamento avviato');
+              } catch { toast.error('Errore nel riprocessamento'); }
+            },
+          },
+        });
+      }
+    }
+
+    connect();
+
+    return () => {
+      eventSourceRef.current?.close();
+      if (reconnectTimeoutRef.current) clearTimeout(reconnectTimeoutRef.current);
+    };
+  }, [router]);
+
+  return null; // Invisible component — only side effects
+}
+```
+
+- [ ] **Step 4: Mount in admin dashboard layout**
+
+In `apps/web/src/app/admin/(dashboard)/layout.tsx`:
+
+```tsx
+import { PdfProcessingNotifier } from '@/components/admin/layout/PdfProcessingNotifier';
+
+// Inside DashboardLayout, as sibling to UnifiedShell:
+<PdfProcessingNotifier />
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `cd apps/web && pnpm test -- --run PdfProcessingNotifier`
+Expected: PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/components/admin/layout/PdfProcessingNotifier.tsx
+git add apps/web/src/components/admin/layout/__tests__/PdfProcessingNotifier.test.tsx
+git add apps/web/src/app/admin/(dashboard)/layout.tsx
+git commit -m "feat(admin): add PdfProcessingNotifier global SSE toast notifications"
+```
+
+---
+
+## Chunk 5: Integration Testing + Final Validation
+
+### Task 10: E2E smoke tests
+
+**Files:**
+- Create: `apps/web/e2e/admin/pdf-kb-workflow.spec.ts`
+
+- [ ] **Step 1: Write E2E test scenarios**
+
+**Important E2E conventions** (from MEMORY.md):
+- Set `PLAYWRIGHT_AUTH_BYPASS=true` env var to bypass middleware session validation
+- Use `page.context().route()` NOT `page.route()` for API mocking with Next.js dev server
+- Use `.first()` on `getByText` when multiple elements may match (strict mode)
+- Use error code 400 (not 500) for error mocks to avoid httpClient retry
+
+```typescript
+import { test, expect } from '@playwright/test';
+
+test.describe('Admin PDF→KB Workflow', () => {
+  test('RecentlyProcessedWidget visible on SharedGames landing', async ({ page }) => {
+    await page.goto('/admin/shared-games/all');
+    // Route mock for /recently-processed
+    await expect(page.getByText('Ultimi PDF elaborati')).toBeVisible();
+  });
+
+  test('Priority selector appears during PDF upload', async ({ page }) => {
+    await page.goto('/admin/shared-games/test-game-id');
+    // Navigate to Documents tab, select file
+    // Assert: priority selector visible with "Normale" and "Urgente"
+  });
+
+  test('GameProcessingQueue shows in game detail', async ({ page }) => {
+    await page.goto('/admin/shared-games/test-game-id');
+    // Assert: "Coda elaborazione" section visible
+    // Assert: deep-link contains correct gameId
+  });
+
+  test('Deep-link navigates to queue with gameId filter', async ({ page }) => {
+    await page.goto('/admin/shared-games/test-game-id');
+    const link = page.getByText('Apri coda completa →');
+    await expect(link).toHaveAttribute('href', /gameId=/);
+  });
+});
+```
+
+- [ ] **Step 2: Run E2E tests**
+
+Run: `cd apps/web && pnpm test:e2e -- --grep "PDF→KB Workflow"`
+Expected: PASS (with appropriate API mocking via `page.context().route()`)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add apps/web/e2e/admin/pdf-kb-workflow.spec.ts
+git commit -m "test(e2e): add admin PDF→KB workflow smoke tests"
+```
+
+---
+
+### Task 11: Full build validation + typecheck
+
+- [ ] **Step 1: Run backend build + tests**
+
+```bash
+cd apps/api/src/Api && dotnet build
+cd apps/api && dotnet test -v n
+```
+Expected: BUILD SUCCEEDED, all tests PASS
+
+- [ ] **Step 2: Run frontend typecheck + lint + tests**
+
+```bash
+cd apps/web && pnpm typecheck && pnpm lint && pnpm test -- --run
+```
+Expected: All pass
+
+- [ ] **Step 3: Final commit with all changes**
+
+If any residual formatting changes from lint-staged:
+
+```bash
+git status
+# If changes exist:
+git add -A && git commit -m "style: formatting from lint-staged"
+```
+
+- [ ] **Step 4: Create PR**
+
+```bash
+git push -u origin feature/admin-pdf-kb-workflow
+gh pr create --base main-dev --title "feat(admin): PDF→KB workflow improvements" --body "## Summary
+- RecentlyProcessedWidget on SharedGames landing (10 latest PDFs)
+- Priority Urgent selector during PDF upload
+- GameProcessingQueue mini-widget + deep-link in game detail
+- PdfProcessingNotifier global SSE toast notifications
+
+## Test plan
+- [ ] Backend: GetRecentlyProcessedDocumentsQuery tests
+- [ ] Backend: UploadPdfCommand priority tests
+- [ ] Backend: GetProcessingQueueQuery GameId filter tests
+- [ ] Backend: SSE stream handler enrichment tests
+- [ ] Frontend: RecentlyProcessedWidget tests
+- [ ] Frontend: PdfUploadSection priority tests
+- [ ] Frontend: GameProcessingQueue tests
+- [ ] Frontend: PdfProcessingNotifier tests
+- [ ] E2E: Admin PDF→KB workflow smoke tests
+- [ ] Manual: Upload PDF → verify widget → verify queue → verify toast
+
+Closes #TBD"
+```

--- a/docs/superpowers/specs/2026-03-15-admin-pdf-kb-workflow-design.md
+++ b/docs/superpowers/specs/2026-03-15-admin-pdf-kb-workflow-design.md
@@ -1,0 +1,343 @@
+# Admin PDF→KB Workflow Improvements
+
+**Date**: 2026-03-15
+**Status**: Draft
+**Scope**: 4 UX improvements to the admin SharedGame PDF→KB pipeline
+
+## Problem Statement
+
+The admin PDF→KB workflow requires excessive context-switching between SharedGames and KnowledgeBase sections. Key gaps:
+
+1. No visibility of recently processed PDFs on the SharedGames landing page
+2. No way to prioritize urgent PDF processing during upload
+3. No inline queue visibility in the game detail page
+4. No cross-page notification when PDF processing completes
+
+## Feature 1: Recently Processed Widget
+
+### Overview
+
+A collapsible widget on `/admin/shared-games/all` showing the 10 most recent PDFs with processing status, placed above the existing `GameCatalogGrid`.
+
+### Component: `RecentlyProcessedWidget`
+
+**Location**: `apps/web/src/components/admin/shared-games/RecentlyProcessedWidget.tsx`
+
+**Layout**: Collapsible card with header "Ultimi PDF elaborati" + collapse toggle. Table with 5 columns:
+
+| Column | Content | Notes |
+|--------|---------|-------|
+| PDF | Filename + icon | Truncated at 40 chars |
+| Gioco | Game name + thumbnail (24px) | Link to game detail |
+| Stato | Status badge (mapped from `processingState`) | Same color system as KbStatusBadge |
+| Tempo | Relative timestamp ("2min fa") | `completedAt` or `updatedAt` |
+| Azione | Context action button | "Vai al gioco" / "Vai alla coda" / "Riprova" |
+
+**Footer**: "Vedi tutti →" link to `/admin/knowledge-base/documents`
+
+**Collapse state**: Persisted in `localStorage` key `admin:recentPdfs:collapsed`.
+
+**Status mapping** (`processingState` → Italian label → color):
+
+| Backend `processingState` | Display Label | Color |
+|---------------------------|---------------|-------|
+| `"Ready"` | "Indicizzato" | Green |
+| `"Uploading"`, `"Extracting"`, `"Chunking"`, `"Embedding"`, `"Indexing"`, `"Pending"` | "Elaborazione" | Blue (animated) |
+| `"Failed"` | "Fallito" | Red |
+
+### Backend: New Query + Endpoint
+
+**Endpoint**: `GET /api/v1/admin/shared-games/recently-processed?limit=10`
+
+**Query**: `GetRecentlyProcessedDocumentsQuery` (MediatR)
+
+**Handler logic**:
+```
+SELECT pd.Id, pd.FileName, pd.ProcessingState, pd.UpdatedAt, pd.CompletedAt,
+       pd.ErrorCategory, pd.CanRetry,
+       sgd.SharedGameId, sg.Name AS GameName, sg.ThumbnailUrl
+FROM pdf_documents pd
+JOIN shared_game_documents sgd ON sgd.PdfDocumentId = pd.Id
+JOIN shared_games sg ON sg.Id = sgd.SharedGameId
+WHERE sgd.SharedGameId IS NOT NULL
+ORDER BY COALESCE(pd.CompletedAt, pd.UpdatedAt) DESC
+LIMIT @limit
+```
+
+**Response DTO**: `RecentlyProcessedDocumentDto`
+```csharp
+public sealed record RecentlyProcessedDocumentDto(
+    Guid PdfDocumentId,
+    string FileName,
+    string ProcessingState,      // "Ready", "Extracting", "Failed", etc.
+    DateTime Timestamp,          // CompletedAt ?? UpdatedAt
+    string? ErrorCategory,
+    bool CanRetry,
+    Guid SharedGameId,
+    string GameName,
+    string? ThumbnailUrl);
+```
+
+**Routing**: Registered in `AdminSharedGameContentEndpoints.cs` (existing file) with admin authorization.
+
+**Note — Cross-BC read query**: This query joins tables from DocumentProcessing BC (`pdf_documents`) with SharedGameCatalog BC (`shared_game_documents`, `shared_games`) via `MeepleAiDbContext`. This is a deliberate cross-BC read following the existing precedent set by `GetGameRagReadinessQueryHandler` in SharedGameCatalog. The query is placed in SharedGameCatalog Application because the primary consumer is the SharedGames admin UI.
+
+### Frontend Integration
+
+- `sharedGamesClient.ts`: Add `getRecentlyProcessed(limit?: number)` method
+- Page `/admin/shared-games/all/page.tsx`: Import and render `RecentlyProcessedWidget` above `GameCatalogGrid`
+- Uses `useQuery` with `refetchInterval: 15_000` (15s polling for near-real-time updates)
+- Retry action calls existing `POST /admin/queue/{jobId}/retry` endpoint
+
+---
+
+## Feature 2: Priority Urgent Selector
+
+### Overview
+
+A priority selector in `PdfUploadSection` that allows admins to mark uploads as "Urgente" (top of queue).
+
+### UI Changes to `PdfUploadSection`
+
+**New prop**:
+```typescript
+interface PdfUploadSectionProps {
+  // ... existing props
+  showPrioritySelector?: boolean;  // default: true for admin context
+}
+```
+
+**Selector**: Appears after file selection, before upload starts. Two-option `Select` (shadcn):
+- **Normale** (default) — "Elaborazione standard"
+- **Urgente — in testa alla coda** — "Priorita massima, elaborato per primo"
+
+**Visual**: Urgent option has amber accent (`text-amber-600`) + `Zap` icon.
+
+### Backend Changes
+
+**Endpoint modification**: `POST /api/v1/ingest/pdf`
+
+Add optional query parameter: `?priority=urgent`
+
+**Command**: `UploadPdfCommand` — add optional `Priority` property (string, nullable). The existing `UploadPdfCommandHandler` checks: if `priority=urgent` and user is admin, set `ProcessingPriority.Urgent(30)` on the auto-enqueued `ProcessingJob`. Non-admin users cannot set urgent (silently ignored, defaults to `Normal`).
+
+**Note — Enqueue relationship**: The upload endpoint auto-enqueues via `UploadPdfCommandHandler`. The existing `EnqueuePdfCommand` (used in `AdminQueueEndpoints`) already supports a `Priority` field for manual re-enqueue. This change adds the same capability to the upload path. Both flows ultimately set `ProcessingJob.Priority`.
+
+**Validation**: Create `UploadPdfCommandValidator.cs` — `priority` must be `null`, `"normal"`, or `"urgent"`.
+
+### Upload Flow
+
+1. Admin selects file → priority selector appears
+2. Admin picks "Urgente" (or keeps "Normale")
+3. XHR upload sends `FormData` to `/api/v1/ingest/pdf?priority=urgent`
+4. `UploadPdfCommandHandler` creates `PdfDocument` + `ProcessingJob` with `Priority.Urgent`
+5. Quartz scheduler picks it up first (ORDER BY Priority DESC)
+
+---
+
+## Feature 3: Mini-Queue Widget + Deep-Link
+
+### Overview
+
+An inline processing queue widget in the Documents tab of `/admin/shared-games/[id]`, showing this game's jobs + global queue count, with a deep-link to the full queue dashboard.
+
+### Component: `GameProcessingQueue`
+
+**Location**: `apps/web/src/components/admin/shared-games/GameProcessingQueue.tsx`
+
+**Position**: Below `PdfUploadSection` in the Documents tab of `GameDetailClient`.
+
+**Layout**:
+```
+┌─────────────────────────────────────────────────┐
+│ Coda elaborazione                               │
+│ 3 di questo gioco · 12 totali                   │
+├─────────────────────────────────────────────────┤
+│ 🔴 rulebook.pdf    Urgente   ████░░ 67%        │
+│ 🟡 errata.pdf      Normale   ░░░░░░ In coda    │
+│ 🟡 homerule.pdf    Normale   ░░░░░░ In coda    │
+├─────────────────────────────────────────────────┤
+│ Apri coda completa →                            │
+└─────────────────────────────────────────────────┘
+```
+
+**Props**:
+```typescript
+interface GameProcessingQueueProps {
+  gameId: string;
+}
+```
+
+**Rows**: Max 5 jobs for this game. Each row shows:
+- Priority badge: `Urgente` (red) / `Alta` (amber) / `Normale` (blue) / `Bassa` (gray)
+- Filename (truncated)
+- Progress bar or status text ("In coda", percentage, "Completato", "Fallito")
+
+**Header counts**:
+- Game-specific: from `GET /api/v1/admin/queue?gameId={id}&status=Queued,Processing` → count
+- Global: from `GET /api/v1/admin/queue/status` → `queueDepth` field
+
+**Backend change required**: `GetProcessingQueueQuery` currently has no `GameId` filter. Add optional `Guid? GameId` parameter. The handler must join `ProcessingJobs` → `PdfDocument` → `SharedGameDocument` (on `PdfDocumentId`) to filter by `SharedGameDocument.SharedGameId == gameId`. This is a non-trivial handler change — see "Modified Files (Backend)" section.
+
+**Deep-link footer**: `` <Link href={`/admin/knowledge-base/queue?gameId=${gameId}`}>Apri coda completa →</Link> ``
+
+### Real-Time Updates
+
+- SSE connection to `GET /api/v1/admin/queue/stream`
+- Client-side filter: only process events where `event.gameId === gameId`
+- On `JobCompleted`/`JobFailed`: refetch query data
+- On `StepCompleted`: update progress inline
+
+### Data Fetching
+
+Two parallel `useQuery` calls:
+1. `adminClient.getQueueJobs({ gameId, limit: 5, status: ['Queued', 'Processing'] })`
+2. `adminClient.getQueueStatus()` → returns `{ queueDepth, processingCount, ... }`
+
+Both with `refetchInterval: 10_000` as fallback (SSE is primary update mechanism).
+
+---
+
+## Feature 4: Toast Notification on PDF Completion
+
+### Overview
+
+A global SSE listener mounted in the admin dashboard layout that shows toast notifications when any PDF completes or fails processing, regardless of which admin page is active.
+
+### Component: `PdfProcessingNotifier`
+
+**Location**: `apps/web/src/components/admin/layout/PdfProcessingNotifier.tsx`
+
+**Mount point**: Inside `apps/web/src/app/admin/(dashboard)/layout.tsx`, rendered as a client component alongside `UnifiedShell`. This ensures it's mounted once for all admin pages and unmounted when leaving the admin section.
+
+### SSE Connection
+
+- Connects to `GET /api/v1/admin/queue/stream` on mount
+- Filters for event types: `JobCompleted`, `JobFailed`
+- Auto-reconnect on connection loss (exponential backoff: 1s, 2s, 4s, max 30s)
+- Disconnects on unmount (cleanup in `useEffect` return)
+
+### Toast Display
+
+**Success toast** (JobCompleted):
+```
+✅ rulebook.pdf per Catan
+   Indicizzazione completata
+   [Vai al gioco]
+```
+
+**Failure toast** (JobFailed):
+```
+❌ manual.pdf per Ark Nova
+   Elaborazione fallita: Parsing error
+   [Riprova]
+```
+
+**Behavior**:
+- Auto-dismiss after 8 seconds
+- Click "Vai al gioco" → `router.push(`/admin/shared-games/${gameId}`)`
+- Click "Riprova" → `POST /api/v1/admin/queue/${jobId}/retry` + dismiss
+- Max 3 concurrent toasts (older ones dismissed)
+- Uses `toast` from `sonner` (NOT `useToast` — that's a `console.warn` stub for E2E testing)
+
+### Backend SSE Payload Enhancement
+
+**Important**: Domain events (`JobCompletedEvent`, `JobFailedEvent`) must NOT be modified — they are internal domain concerns and should not carry read-model data like game names. Instead, enrich the SSE DTOs at the stream handler layer.
+
+**SSE DTOs to modify** (in `QueueStreamEventDto.cs`):
+
+```csharp
+// Current JobCompletedData
+public sealed record JobCompletedData(int TotalDurationSeconds);
+
+// Enhanced JobCompletedData
+public sealed record JobCompletedData(
+    int TotalDurationSeconds,
+    string? FileName,          // NEW
+    Guid? SharedGameId,        // NEW
+    string? GameName);         // NEW
+
+// Same pattern for JobFailedData — add FileName, SharedGameId, GameName, ErrorCategory
+```
+
+**Enrichment**: In `JobCompletedStreamHandler` and `JobFailedStreamHandler` (within `QueueStreamEventHandlers.cs`), inject `ISharedGameDocumentRepository` (or use `MeepleAiDbContext` directly) to resolve `PdfDocumentId → SharedGameDocument → SharedGame` at the SSE emission layer. Use a lightweight query:
+
+```csharp
+var gameInfo = await _dbContext.SharedGameDocuments
+    .Where(sgd => sgd.PdfDocumentId == notification.PdfDocumentId)
+    .Select(sgd => new { sgd.SharedGameId, GameName = sgd.SharedGame.Name })
+    .FirstOrDefaultAsync(ct);
+```
+
+**Domain events remain unchanged**: `JobCompletedEvent`, `JobFailedEvent` keep their current structure.
+
+---
+
+## Shared Concerns
+
+### Authentication & Authorization
+
+All endpoints require admin role. Existing `RequireAdminSession()` pattern applies.
+
+### Error Handling
+
+- Widget data fetch failures: Show "Impossibile caricare" inline message with retry button
+- SSE connection failures: Silent reconnect with backoff, no user-facing error
+- Priority parameter validation: Invalid values default to `Normal`
+
+### Testing Strategy
+
+| Feature | Unit Tests | Integration Tests | E2E |
+|---------|-----------|-------------------|-----|
+| RecentlyProcessedWidget | Component render + states | Query handler | Navigate + verify |
+| PrioritySelector | Select interaction | Ingest with priority | Upload + verify queue order |
+| GameProcessingQueue | Render + counts | Queue filter by game | Deep-link navigation |
+| PdfProcessingNotifier | Toast display logic | SSE event parsing | Cross-page notification |
+
+**Target**: 15-20 unit tests, 8-10 integration tests, 4 E2E scenarios.
+
+### Localization
+
+All user-facing strings in Italian, consistent with existing admin UI:
+- "Ultimi PDF elaborati", "Coda elaborazione", "Indicizzazione completata"
+- "Elaborazione fallita", "Vai al gioco", "Apri coda completa"
+- "Urgente — in testa alla coda", "Elaborazione standard"
+
+---
+
+## Files to Create/Modify
+
+### New Files (Frontend)
+- `apps/web/src/components/admin/shared-games/RecentlyProcessedWidget.tsx`
+- `apps/web/src/components/admin/shared-games/GameProcessingQueue.tsx`
+- `apps/web/src/components/admin/layout/PdfProcessingNotifier.tsx`
+
+### Modified Files (Frontend)
+- `apps/web/src/components/admin/shared-games/PdfUploadSection.tsx` — add priority selector
+- `apps/web/src/app/admin/(dashboard)/shared-games/all/page.tsx` — add RecentlyProcessedWidget
+- `apps/web/src/app/admin/(dashboard)/shared-games/[id]/client.tsx` — add GameProcessingQueue
+- `apps/web/src/app/admin/(dashboard)/layout.tsx` — mount PdfProcessingNotifier
+- `apps/web/src/lib/api/clients/sharedGamesClient.ts` — add `getRecentlyProcessed()`
+- `apps/web/src/lib/api/clients/adminClient.ts` — add queue status method if missing
+
+### New Files (Backend)
+- `GetRecentlyProcessedDocumentsQuery.cs` + Handler (SharedGameCatalog Application/Queries) — cross-BC read query
+- `RecentlyProcessedDocumentDto.cs` (SharedGameCatalog Application/DTOs)
+- `UploadPdfCommandValidator.cs` (DocumentProcessing Application/Validators) — new validator
+
+### Modified Files (Backend)
+- `UploadPdfCommand.cs` — add optional `Priority` property
+- `UploadPdfCommandHandler.cs` — respect priority parameter when auto-enqueuing
+- `AdminSharedGameContentEndpoints.cs` — register `/recently-processed` route
+- `GetProcessingQueueQuery.cs` + Handler — add optional `Guid? GameId` filter with SharedGameDocument join
+- `QueueStreamEventHandlers.cs` — inject repo, enrich `JobCompletedData`/`JobFailedData` DTOs with game info
+- `QueueStreamEventDto.cs` — add `FileName?`, `SharedGameId?`, `GameName?` to `JobCompletedData`/`JobFailedData`
+
+---
+
+## Out of Scope
+
+- Drag-and-drop reorder in mini-queue (full queue dashboard already supports this)
+- Notification preferences/settings (all admins see all notifications)
+- WebSocket upgrade (SSE is sufficient for this use case)
+- Mobile-specific layout (admin dashboard is desktop-first)


### PR DESCRIPTION
## Summary
- **RecentlyProcessedWidget**: Collapsible widget on `/admin/shared-games/all` showing 10 most recent PDFs with status, game link, and retry actions
- **Priority Urgent selector**: Admin can mark PDF uploads as "Urgente" to jump to top of processing queue
- **GameProcessingQueue mini-widget**: Inline queue visibility in game detail page with game-specific + global counts and deep-link to full queue
- **PdfProcessingNotifier**: Global SSE toast notifications when PDFs complete/fail processing, active across all admin pages

## Changes
- **Backend**: New cross-BC query (SharedGameCatalog), UploadPdfCommand priority param, GetProcessingQueueQuery GameId filter, SSE DTO enrichment with game info
- **Frontend**: 4 new components, 2 API client methods, 3 page integrations
- **Tests**: 32 new frontend tests + 35 new backend tests

## Test plan
- [x] Backend: GetRecentlyProcessedDocumentsQuery (9 tests)
- [x] Backend: UploadPdfCommand priority (17 tests)
- [x] Backend: GetProcessingQueueQuery GameId filter (4 tests)
- [x] Backend: SSE stream handler enrichment (5 tests)
- [x] Frontend: RecentlyProcessedWidget (8 tests)
- [x] Frontend: PdfUploadSection priority (5 tests)
- [x] Frontend: GameProcessingQueue (4 tests)
- [x] Frontend: PdfProcessingNotifier (15 tests)
- [ ] Manual: Upload PDF → verify widget → verify queue → verify toast

🤖 Generated with [Claude Code](https://claude.com/claude-code)