### PR TITLE
fix(pdf): global duplicate detection + staging deploy fixes

### DIFF
--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/CompleteChunkedUploadCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/CompleteChunkedUploadCommandHandler.cs
@@ -106,13 +106,11 @@ internal class CompleteChunkedUploadCommandHandler : ICommandHandler<CompleteChu
                 );
             }
 
-            // Check for duplicate content on the same game
+            // Check for duplicate content globally (same file content across any game)
             if (contentHash != null)
             {
                 var isDuplicate = await _dbContext.PdfDocuments.AnyAsync(
-                    p => p.ContentHash == contentHash &&
-                         ((session.GameId.HasValue && p.GameId == session.GameId) ||
-                          (session.PrivateGameId.HasValue && p.PrivateGameId == session.PrivateGameId)),
+                    p => p.ContentHash == contentHash,
                     cancellationToken).ConfigureAwait(false);
 
                 if (isDuplicate)

--- a/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/UploadPdfCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/DocumentProcessing/Application/Commands/UploadPdfCommandHandler.cs
@@ -132,10 +132,10 @@ internal class UploadPdfCommandHandler : ICommandHandler<UploadPdfCommand, PdfUp
         // Issue #3664: Handle private game PDF uploads
         if (command.PrivateGameId.HasValue)
         {
-            // Compute content hash and check for duplicates (private game)
+            // Compute content hash and check for duplicates (global — same file content across any game)
             var privateContentHash = await ComputeContentHashAsync(file, cancellationToken).ConfigureAwait(false);
             if (await _db.PdfDocuments.AnyAsync(
-                    p => p.ContentHash == privateContentHash && p.PrivateGameId == command.PrivateGameId.Value,
+                    p => p.ContentHash == privateContentHash,
                     cancellationToken).ConfigureAwait(false))
             {
                 return new PdfUploadResult(false, DuplicateContentErrorMessage, null);
@@ -156,10 +156,10 @@ internal class UploadPdfCommandHandler : ICommandHandler<UploadPdfCommand, PdfUp
 
         var gameId = resolvedGameId.Value.ToString();
 
-        // Compute content hash and check for duplicates
+        // Compute content hash and check for duplicates (global — same file content across any game)
         var contentHash = await ComputeContentHashAsync(file, cancellationToken).ConfigureAwait(false);
         if (await _db.PdfDocuments.AnyAsync(
-                p => p.ContentHash == contentHash && p.GameId == resolvedGameId.Value,
+                p => p.ContentHash == contentHash,
                 cancellationToken).ConfigureAwait(false))
         {
             return new PdfUploadResult(false, DuplicateContentErrorMessage, null);

--- a/apps/api/src/Api/Extensions/ObservabilityServiceExtensions.cs
+++ b/apps/api/src/Api/Extensions/ObservabilityServiceExtensions.cs
@@ -78,7 +78,7 @@ internal static class ObservabilityServiceExtensions
             // Add explicit Activity Sources for tracing (not Meter sources)
             .AddSource("Microsoft.AspNetCore")  // ASP.NET Core framework traces
             .AddSource("System.Net.Http")       // HTTP client traces
-            // Add custom MeepleAI Activity Sources for domain-specific tracing
+                                                // Add custom MeepleAI Activity Sources for domain-specific tracing
             .AddSource(MeepleAiActivitySources.ApiSourceName)
             .AddSource(MeepleAiActivitySources.RagSourceName)
             .AddSource(MeepleAiActivitySources.VectorSearchSourceName)

--- a/apps/api/src/Api/Infrastructure/MeepleAiDbContext.cs
+++ b/apps/api/src/Api/Infrastructure/MeepleAiDbContext.cs
@@ -105,7 +105,7 @@ public class MeepleAiDbContext : DbContext
     public DbSet<AlertEntity> Alerts => Set<AlertEntity>(); // OPS-07
     public DbSet<AlertRuleEntity> AlertRules => Set<AlertRuleEntity>(); // ISSUE-921: Dynamic alert rules
     public DbSet<AlertConfigurationEntity> AlertConfigurations => Set<AlertConfigurationEntity>(); // ISSUE-921: Dynamic alert config
-    public DbSet<ServiceHealthStateEntity> ServiceHealthStates { get; set; } // ISSUE-448: Service health monitoring
+    public DbSet<ServiceHealthStateEntity> ServiceHealthStates => Set<ServiceHealthStateEntity>(); // ISSUE-448: Service health monitoring
     public DbSet<UserBackupCodeEntity> UserBackupCodes => Set<UserBackupCodeEntity>(); // AUTH-07
     public DbSet<TempSessionEntity> TempSessions => Set<TempSessionEntity>(); // AUTH-07
     public DbSet<UsedTotpCodeEntity> UsedTotpCodes => Set<UsedTotpCodeEntity>(); // SEC-07: Issue #1787 TOTP Replay Prevention

--- a/apps/api/src/Api/Routing/SharedGameCatalogEndpoints.cs
+++ b/apps/api/src/Api/Routing/SharedGameCatalogEndpoints.cs
@@ -391,7 +391,7 @@ internal static class SharedGameCatalogEndpoints
         // Document Management (Issue #2391 Sprint 1)
         group.MapGet("/admin/shared-games/{id:guid}/documents", HandleGetDocuments)
             .RequireAuthorization("AdminOrEditorPolicy")
-            .WithName("GetGameDocuments")
+            .WithName("GetSharedGameDocuments")
             .WithSummary("Get all documents for a game (Admin/Editor)")
             .Produces<List<SharedGameDocumentDto>>();
 

--- a/apps/web/e2e/flows/admin-user-onboarding.spec.ts
+++ b/apps/web/e2e/flows/admin-user-onboarding.spec.ts
@@ -106,7 +106,8 @@ test.describe('Admin-User Onboarding Flow', () => {
     await test.step('Fill and send invitation', async () => {
       await adminUsersPage.fillInvitationForm(testUserEmail, 'user');
       await adminUsersPage.submitInvitation();
-      await adminUsersPage.waitForNetworkIdle();
+      // Don't use waitForNetworkIdle — admin page has continuous health polling
+      await page.waitForTimeout(3000);
     });
 
     await test.step('Extract invitation token/URL', async () => {

--- a/apps/web/e2e/pages/admin/AdminUsersPage.ts
+++ b/apps/web/e2e/pages/admin/AdminUsersPage.ts
@@ -8,8 +8,8 @@ export class AdminUsersPage extends BasePage {
   }
 
   async goto(): Promise<void> {
-    await this.page.goto('/admin/users');
-    await this.waitForLoad();
+    await this.page.goto('/admin/users', { waitUntil: 'domcontentloaded' });
+    await this.page.waitForTimeout(2000);
   }
 
   async clickInviteButton(): Promise<void> {
@@ -41,13 +41,16 @@ export class AdminUsersPage extends BasePage {
   async changeUserRole(email: string, newRole: string): Promise<void> {
     const userRow = await this.findUserRow(email);
     // InlineRoleSelect: shadcn Select uses a <button> trigger, not native <select>
-    const roleSelect = userRow.locator(
-      'select, [role="combobox"], button:has-text("User"), button:has-text("Editor"), button:has-text("Admin")',
-    ).first();
+    const roleSelect = userRow
+      .locator(
+        'select, [role="combobox"], button:has-text("User"), button:has-text("Editor"), button:has-text("Admin")'
+      )
+      .first();
     await expect(roleSelect).toBeVisible({ timeout: 5_000 });
     await roleSelect.click();
     // Select the new role from dropdown
-    await this.page.getByRole('option', { name: new RegExp(`^${newRole}$`, 'i') })
+    await this.page
+      .getByRole('option', { name: new RegExp(`^${newRole}$`, 'i') })
       .or(this.page.getByText(new RegExp(`^${newRole}$`, 'i')).last())
       .click();
 

--- a/apps/web/next-env.d.ts
+++ b/apps/web/next-env.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
-import './.next/types/routes.d.ts';
+import './.next/dev/types/routes.d.ts';
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/infra/compose.staging.yml
+++ b/infra/compose.staging.yml
@@ -50,6 +50,7 @@ services:
       - ./secrets/staging/redis.secret
       - ./secrets/staging/qdrant.secret
       - ./secrets/staging/embedding-service.secret
+      - ./secrets/staging/email.secret
       - ./secrets/staging/storage.secret
     environment:
       ASPNETCORE_ENVIRONMENT: Staging
@@ -68,6 +69,8 @@ services:
       FrontendUrl: "https://meepleai.app"
       Authentication__SessionCookie__Secure: "true"
       Authentication__SessionCookie__SameSite: "Lax"
+    volumes:
+      - ./secrets:/app/infra/secrets:ro
     labels:
       - "traefik.enable=true"
       - "traefik.http.routers.api.rule=Host(`meepleai.app`) && PathPrefix(`/api`)"


### PR DESCRIPTION
## Summary

- **Global PDF duplicate detection**: ContentHash check now global (no GameId filter) — prevents re-uploading same file across different games
- **Staging deploy fixes**: secrets volume mount, email.secret in env_file, duplicate endpoint name
- **DbSet nullable**: ServiceHealthStates CS8618 fix
- **E2E**: replace networkidle with timeout for admin pages (health polling blocks networkidle)

## Test plan

- [x] Backend build: 0 errors
- [x] Frontend typecheck: 0 errors  
- [x] Pre-push: FE + BE build pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)