### PR TITLE
feat: dashboard search → add game → chat flow

### DIFF
--- a/apps/web/src/__tests__/components/chat-unified/EmbeddedChatView.test.tsx
+++ b/apps/web/src/__tests__/components/chat-unified/EmbeddedChatView.test.tsx
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { EmbeddedChatView } from '@/components/chat-unified/EmbeddedChatView';
+
+const mockSendMessage = vi.fn();
+const mockReset = vi.fn();
+const mockStopStreaming = vi.fn();
+
+let mockState = {
+  statusMessage: null as string | null,
+  currentAnswer: '',
+  followUpQuestions: [] as string[],
+  isStreaming: false,
+  error: null as string | null,
+  chatThreadId: 't1',
+  totalTokens: 0,
+  debugSteps: [],
+  modelDowngrade: null,
+  strategyTier: null,
+  executionId: null,
+};
+
+vi.mock('@/hooks/useAgentChatStream', () => ({
+  useAgentChatStream: () => ({
+    state: mockState,
+    sendMessage: mockSendMessage,
+    stopStreaming: mockStopStreaming,
+    reset: mockReset,
+  }),
+}));
+
+describe('EmbeddedChatView', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockState = {
+      statusMessage: null,
+      currentAnswer: '',
+      followUpQuestions: [],
+      isStreaming: false,
+      error: null,
+      chatThreadId: 't1',
+      totalTokens: 0,
+      debugSteps: [],
+      modelDowngrade: null,
+      strategyTier: null,
+      executionId: null,
+    };
+  });
+
+  it('renders the embedded chat view container', () => {
+    render(<EmbeddedChatView threadId="t1" agentId="a1" gameId="g1" />);
+    expect(screen.getByTestId('embedded-chat-view')).toBeInTheDocument();
+  });
+
+  it('renders input area with placeholder', () => {
+    render(<EmbeddedChatView threadId="t1" agentId="a1" gameId="g1" />);
+    expect(screen.getByPlaceholderText(/scrivi/i)).toBeInTheDocument();
+  });
+
+  it('renders send button', () => {
+    render(<EmbeddedChatView threadId="t1" agentId="a1" gameId="g1" />);
+    expect(screen.getByRole('button', { name: /invia/i })).toBeInTheDocument();
+  });
+
+  it('renders welcome state when no messages', () => {
+    render(<EmbeddedChatView threadId="t1" agentId="a1" gameId="g1" />);
+    expect(screen.getByText(/chiedi qualsiasi cosa/i)).toBeInTheDocument();
+  });
+
+  it('sends message via SSE on submit', async () => {
+    render(<EmbeddedChatView threadId="t1" agentId="a1" gameId="g1" />);
+    const input = screen.getByPlaceholderText(/scrivi/i);
+    fireEvent.change(input, { target: { value: 'Come si gioca?' } });
+    fireEvent.submit(input.closest('form')!);
+    await waitFor(() => {
+      expect(mockSendMessage).toHaveBeenCalledWith(
+        'a1',
+        'Come si gioca?',
+        't1',
+        expect.anything(),
+        undefined
+      );
+    });
+  });
+
+  it('clears input after sending', async () => {
+    render(<EmbeddedChatView threadId="t1" agentId="a1" gameId="g1" />);
+    const input = screen.getByPlaceholderText(/scrivi/i) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'Test message' } });
+    fireEvent.submit(input.closest('form')!);
+    await waitFor(() => {
+      expect(input.value).toBe('');
+    });
+  });
+
+  it('adds user message to the list on send', async () => {
+    render(<EmbeddedChatView threadId="t1" agentId="a1" gameId="g1" />);
+    const input = screen.getByPlaceholderText(/scrivi/i);
+    fireEvent.change(input, { target: { value: 'Ciao!' } });
+    fireEvent.submit(input.closest('form')!);
+    await waitFor(() => {
+      expect(screen.getByText('Ciao!')).toBeInTheDocument();
+    });
+    // Welcome message should be gone
+    expect(screen.queryByText(/chiedi qualsiasi cosa/i)).not.toBeInTheDocument();
+  });
+
+  it('does not send empty messages', () => {
+    render(<EmbeddedChatView threadId="t1" agentId="a1" gameId="g1" />);
+    const input = screen.getByPlaceholderText(/scrivi/i);
+    fireEvent.submit(input.closest('form')!);
+    expect(mockSendMessage).not.toHaveBeenCalled();
+  });
+
+  it('shows streaming answer when isStreaming with currentAnswer', () => {
+    mockState = {
+      ...mockState,
+      isStreaming: true,
+      currentAnswer: 'Streaming response...',
+    };
+    render(<EmbeddedChatView threadId="t1" agentId="a1" gameId="g1" />);
+    expect(screen.getByTestId('message-streaming')).toBeInTheDocument();
+    expect(screen.getByText('Streaming response...')).toBeInTheDocument();
+  });
+
+  it('shows status message during streaming', () => {
+    mockState = {
+      ...mockState,
+      isStreaming: true,
+      statusMessage: 'Connecting...',
+    };
+    render(<EmbeddedChatView threadId="t1" agentId="a1" gameId="g1" />);
+    expect(screen.getByTestId('stream-status')).toBeInTheDocument();
+    expect(screen.getByText('Connecting...')).toBeInTheDocument();
+  });
+
+  it('shows error message when error state is set', () => {
+    mockState = {
+      ...mockState,
+      error: 'Something went wrong',
+    };
+    render(<EmbeddedChatView threadId="t1" agentId="a1" gameId="g1" />);
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument();
+  });
+
+  it('disables input while streaming', () => {
+    mockState = {
+      ...mockState,
+      isStreaming: true,
+    };
+    render(<EmbeddedChatView threadId="t1" agentId="a1" gameId="g1" />);
+    expect(screen.getByPlaceholderText(/scrivi/i)).toBeDisabled();
+  });
+});

--- a/apps/web/src/__tests__/components/dashboard/AddToLibraryModal.test.tsx
+++ b/apps/web/src/__tests__/components/dashboard/AddToLibraryModal.test.tsx
@@ -1,0 +1,249 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+import { AddToLibraryModal } from '@/components/dashboard/AddToLibraryModal';
+
+// Mock the api module
+const mockAddGame = vi.fn();
+const mockCreateThread = vi.fn();
+vi.mock('@/lib/api', () => ({
+  api: {
+    library: {
+      addGame: (...args: unknown[]) => mockAddGame(...args),
+    },
+    chat: {
+      createThread: (...args: unknown[]) => mockCreateThread(...args),
+    },
+  },
+}));
+
+// Mock useAddGameToLibrary — we bypass the hook and call api directly in component,
+// but let's mock the hook as the component uses it
+const mockMutateAsync = vi.fn();
+const mockMutationState = {
+  mutateAsync: mockMutateAsync,
+  isPending: false,
+};
+vi.mock('@/hooks/queries/useLibrary', () => ({
+  useAddGameToLibrary: () => mockMutationState,
+  libraryKeys: {
+    all: ['library'],
+    lists: () => ['library', 'list'],
+    stats: () => ['library', 'stats'],
+    quota: () => ['library', 'quota'],
+    gameStatus: (id: string) => ['library', 'status', id],
+  },
+}));
+
+// Mock @tanstack/react-query for useQueryClient
+const mockInvalidateQueries = vi.fn();
+vi.mock('@tanstack/react-query', async () => {
+  const actual = await vi.importActual('@tanstack/react-query');
+  return {
+    ...actual,
+    useQueryClient: () => ({
+      invalidateQueries: mockInvalidateQueries,
+    }),
+  };
+});
+
+describe('AddToLibraryModal', () => {
+  const mockGame = {
+    id: 'game-123',
+    name: 'Catan',
+    imageUrl: '/catan.jpg',
+    playerCount: '3-4',
+  };
+
+  const mockOnClose = vi.fn();
+  const mockOnSuccess = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockMutationState.isPending = false;
+  });
+
+  function renderModal(props: Partial<React.ComponentProps<typeof AddToLibraryModal>> = {}) {
+    return render(
+      <AddToLibraryModal
+        game={mockGame}
+        isOpen={true}
+        onClose={mockOnClose}
+        onSuccess={mockOnSuccess}
+        {...props}
+      />
+    );
+  }
+
+  // =========================================================================
+  // 1. Renders game info and CTA when open
+  // =========================================================================
+  it('renders game info and CTA when open', () => {
+    renderModal();
+
+    expect(screen.getByText('Catan')).toBeInTheDocument();
+    expect(screen.getByText('3-4 giocatori')).toBeInTheDocument();
+    expect(
+      screen.getByText("Per chattare con l'AI su questo gioco, aggiungilo alla tua libreria.")
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /aggiungi e chiedi/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /annulla/i })).toBeInTheDocument();
+  });
+
+  // =========================================================================
+  // 2. Does not render when closed (isOpen=false)
+  // =========================================================================
+  it('does not render content when isOpen is false', () => {
+    renderModal({ isOpen: false });
+
+    expect(screen.queryByText('Catan')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /aggiungi e chiedi/i })).not.toBeInTheDocument();
+  });
+
+  // =========================================================================
+  // 3. Does not render when game is null
+  // =========================================================================
+  it('does not render content when game is null', () => {
+    renderModal({ game: null });
+
+    expect(screen.queryByRole('button', { name: /aggiungi e chiedi/i })).not.toBeInTheDocument();
+  });
+
+  // =========================================================================
+  // 4. Orchestrates add + create thread on confirm, calls onSuccess
+  // =========================================================================
+  it('orchestrates add game + create thread on confirm', async () => {
+    const mockLibraryEntry = { gameId: 'game-123', id: 'entry-1' };
+    const mockThread = { id: 'thread-456', agentId: 'agent-789', gameId: 'game-123' };
+
+    mockMutateAsync.mockResolvedValueOnce(mockLibraryEntry);
+    mockCreateThread.mockResolvedValueOnce(mockThread);
+
+    renderModal();
+
+    fireEvent.click(screen.getByRole('button', { name: /aggiungi e chiedi/i }));
+
+    await waitFor(() => {
+      expect(mockMutateAsync).toHaveBeenCalledWith({ gameId: 'game-123' });
+    });
+
+    await waitFor(() => {
+      expect(mockCreateThread).toHaveBeenCalledWith({
+        gameId: 'game-123',
+        title: 'Catan',
+      });
+    });
+
+    await waitFor(() => {
+      expect(mockOnSuccess).toHaveBeenCalledWith({
+        gameId: 'game-123',
+        threadId: 'thread-456',
+        agentId: 'agent-789',
+      });
+    });
+  });
+
+  // =========================================================================
+  // 5. Shows error when addGame fails
+  // =========================================================================
+  it('shows error message when addGame fails', async () => {
+    mockMutateAsync.mockRejectedValueOnce(new Error('Quota exceeded'));
+
+    renderModal();
+
+    fireEvent.click(screen.getByRole('button', { name: /aggiungi e chiedi/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/non è stato possibile aggiungere il gioco/i)).toBeInTheDocument();
+    });
+
+    // onSuccess should NOT have been called
+    expect(mockOnSuccess).not.toHaveBeenCalled();
+    // createThread should NOT have been called
+    expect(mockCreateThread).not.toHaveBeenCalled();
+  });
+
+  // =========================================================================
+  // 6. Shows "Riprova" when createThread fails
+  // =========================================================================
+  it('shows retry button when createThread fails after addGame succeeds', async () => {
+    const mockLibraryEntry = { gameId: 'game-123', id: 'entry-1' };
+    mockMutateAsync.mockResolvedValueOnce(mockLibraryEntry);
+    mockCreateThread.mockRejectedValueOnce(new Error('Thread creation failed'));
+
+    renderModal();
+
+    fireEvent.click(screen.getByRole('button', { name: /aggiungi e chiedi/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/gioco aggiunto.*riprova/i)).toBeInTheDocument();
+    });
+
+    // Retry button should be visible
+    const retryButton = screen.getByRole('button', { name: /riprova/i });
+    expect(retryButton).toBeInTheDocument();
+
+    // Now retry succeeds
+    const mockThread = { id: 'thread-456', agentId: 'agent-789', gameId: 'game-123' };
+    mockCreateThread.mockResolvedValueOnce(mockThread);
+
+    fireEvent.click(retryButton);
+
+    await waitFor(() => {
+      expect(mockOnSuccess).toHaveBeenCalledWith({
+        gameId: 'game-123',
+        threadId: 'thread-456',
+        agentId: 'agent-789',
+      });
+    });
+  });
+
+  // =========================================================================
+  // 7. Calls onClose on cancel
+  // =========================================================================
+  it('calls onClose when cancel button is clicked', () => {
+    renderModal();
+
+    fireEvent.click(screen.getByRole('button', { name: /annulla/i }));
+
+    expect(mockOnClose).toHaveBeenCalledTimes(1);
+  });
+
+  // =========================================================================
+  // 8. Button is disabled during loading
+  // =========================================================================
+  it('disables confirm button during loading', async () => {
+    // Make the mutation hang
+    mockMutateAsync.mockImplementation(() => new Promise(() => {}));
+
+    renderModal();
+
+    fireEvent.click(screen.getByRole('button', { name: /aggiungi e chiedi/i }));
+
+    await waitFor(() => {
+      const button = screen.getByRole('button', { name: /aggiungendo/i });
+      expect(button).toBeDisabled();
+    });
+  });
+
+  // =========================================================================
+  // 9. Renders game image when imageUrl is provided
+  // =========================================================================
+  it('renders game thumbnail when imageUrl is provided', () => {
+    renderModal();
+
+    const img = screen.getByRole('img', { name: 'Catan' });
+    expect(img).toBeInTheDocument();
+  });
+
+  // =========================================================================
+  // 10. Shows placeholder when imageUrl is null
+  // =========================================================================
+  it('shows placeholder when imageUrl is null', () => {
+    renderModal({ game: { ...mockGame, imageUrl: null } });
+
+    expect(screen.queryByRole('img', { name: 'Catan' })).not.toBeInTheDocument();
+    // Placeholder icon should exist
+    expect(screen.getByTestId('game-placeholder-icon')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/__tests__/components/dashboard/AddToLibraryModal.test.tsx
+++ b/apps/web/src/__tests__/components/dashboard/AddToLibraryModal.test.tsx
@@ -139,6 +139,7 @@ describe('AddToLibraryModal', () => {
         gameId: 'game-123',
         threadId: 'thread-456',
         agentId: 'agent-789',
+        gameName: 'Catan',
       });
     });
   });
@@ -194,6 +195,7 @@ describe('AddToLibraryModal', () => {
         gameId: 'game-123',
         threadId: 'thread-456',
         agentId: 'agent-789',
+        gameName: 'Catan',
       });
     });
   });

--- a/apps/web/src/__tests__/components/dashboard/SearchExpander.test.tsx
+++ b/apps/web/src/__tests__/components/dashboard/SearchExpander.test.tsx
@@ -1,0 +1,208 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+
+import { SearchExpander } from '@/components/dashboard/SearchExpander';
+import type { SharedGameSearchResult } from '@/components/dashboard/SearchExpander';
+
+// Mock the api module (project pattern: import { api } from '@/lib/api')
+const mockSearch = vi.fn();
+vi.mock('@/lib/api', () => ({
+  api: {
+    sharedGames: {
+      search: (...args: unknown[]) => mockSearch(...args),
+    },
+  },
+}));
+
+// Mock the user library hook
+// useLibrary returns UseQueryResult<PaginatedLibraryResponse>
+// PaginatedLibraryResponse has items: UserLibraryEntry[] with gameId field
+vi.mock('@/hooks/queries/useLibrary', () => ({
+  useLibrary: () => ({
+    data: {
+      items: [],
+      totalCount: 0,
+      page: 1,
+      pageSize: 20,
+      totalPages: 0,
+      hasNextPage: false,
+      hasPreviousPage: false,
+    },
+    isLoading: false,
+  }),
+}));
+
+// Mock next/navigation
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+describe('SearchExpander', () => {
+  const mockOnViewGame = vi.fn();
+  const mockOnAskAboutGame = vi.fn<(game: SharedGameSearchResult) => void>();
+  const mockOnClose = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSearch.mockResolvedValue({
+      items: [
+        {
+          id: 'g1',
+          title: 'Catan',
+          thumbnailUrl: '/catan.jpg',
+          imageUrl: '/catan-full.jpg',
+          minPlayers: 3,
+          maxPlayers: 4,
+          yearPublished: 1995,
+          playingTimeMinutes: 90,
+          minAge: 10,
+          description: 'A strategy game',
+          complexityRating: 2.3,
+          averageRating: 7.2,
+          status: 'Published',
+          isRagPublic: false,
+          createdAt: '2024-01-01T00:00:00Z',
+          modifiedAt: null,
+          bggId: 13,
+        },
+        {
+          id: 'g2',
+          title: 'Catan: Seafarers',
+          thumbnailUrl: '/seafarers.jpg',
+          imageUrl: '/seafarers-full.jpg',
+          minPlayers: 3,
+          maxPlayers: 4,
+          yearPublished: 1997,
+          playingTimeMinutes: 120,
+          minAge: 10,
+          description: 'An expansion',
+          complexityRating: 2.5,
+          averageRating: 7.0,
+          status: 'Published',
+          isRagPublic: false,
+          createdAt: '2024-01-01T00:00:00Z',
+          modifiedAt: null,
+          bggId: 325,
+        },
+      ],
+      total: 2,
+      page: 1,
+      pageSize: 5,
+    });
+  });
+
+  it('renders search input when open', () => {
+    render(
+      <SearchExpander
+        isOpen={true}
+        onClose={mockOnClose}
+        onViewGame={mockOnViewGame}
+        onAskAboutGame={mockOnAskAboutGame}
+      />
+    );
+    expect(screen.getByPlaceholderText(/cerca un gioco/i)).toBeInTheDocument();
+  });
+
+  it('does not render when closed', () => {
+    render(
+      <SearchExpander
+        isOpen={false}
+        onClose={mockOnClose}
+        onViewGame={mockOnViewGame}
+        onAskAboutGame={mockOnAskAboutGame}
+      />
+    );
+    expect(screen.queryByPlaceholderText(/cerca un gioco/i)).not.toBeInTheDocument();
+  });
+
+  it('searches after debounce and shows results', async () => {
+    render(
+      <SearchExpander
+        isOpen={true}
+        onClose={mockOnClose}
+        onViewGame={mockOnViewGame}
+        onAskAboutGame={mockOnAskAboutGame}
+      />
+    );
+
+    const input = screen.getByPlaceholderText(/cerca un gioco/i);
+    await act(async () => {
+      fireEvent.change(input, { target: { value: 'Catan' } });
+    });
+
+    await waitFor(() => {
+      expect(mockSearch).toHaveBeenCalledWith(
+        expect.objectContaining({ searchTerm: 'Catan', pageSize: 5 })
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Catan')).toBeInTheDocument();
+      expect(screen.getByText('Catan: Seafarers')).toBeInTheDocument();
+    });
+  });
+
+  it('calls onViewGame when "Vedi" is clicked', async () => {
+    render(
+      <SearchExpander
+        isOpen={true}
+        onClose={mockOnClose}
+        onViewGame={mockOnViewGame}
+        onAskAboutGame={mockOnAskAboutGame}
+      />
+    );
+
+    const input = screen.getByPlaceholderText(/cerca un gioco/i);
+    await act(async () => {
+      fireEvent.change(input, { target: { value: 'Catan' } });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Catan')).toBeInTheDocument();
+    });
+
+    const vediButtons = screen.getAllByText(/vedi/i);
+    fireEvent.click(vediButtons[0]);
+    expect(mockOnViewGame).toHaveBeenCalledWith('g1');
+  });
+
+  it('calls onAskAboutGame when "Chiedi" is clicked', async () => {
+    render(
+      <SearchExpander
+        isOpen={true}
+        onClose={mockOnClose}
+        onViewGame={mockOnViewGame}
+        onAskAboutGame={mockOnAskAboutGame}
+      />
+    );
+
+    const input = screen.getByPlaceholderText(/cerca un gioco/i);
+    await act(async () => {
+      fireEvent.change(input, { target: { value: 'Catan' } });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Catan')).toBeInTheDocument();
+    });
+
+    const chiediButtons = screen.getAllByText(/chiedi/i);
+    fireEvent.click(chiediButtons[0]);
+    expect(mockOnAskAboutGame).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'g1', title: 'Catan' })
+    );
+  });
+
+  it('closes on ESC key', () => {
+    render(
+      <SearchExpander
+        isOpen={true}
+        onClose={mockOnClose}
+        onViewGame={mockOnViewGame}
+        onAskAboutGame={mockOnAskAboutGame}
+      />
+    );
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(mockOnClose).toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/__tests__/stores/useDashboardSearchStore.test.ts
+++ b/apps/web/src/__tests__/stores/useDashboardSearchStore.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useDashboardSearchStore } from '@/stores/useDashboardSearchStore';
+
+describe('useDashboardSearchStore', () => {
+  beforeEach(() => {
+    useDashboardSearchStore.getState().reset();
+  });
+
+  it('starts with search closed', () => {
+    const state = useDashboardSearchStore.getState();
+    expect(state.isSearchOpen).toBe(false);
+    expect(state.selectedGame).toBeNull();
+    expect(state.drawerState).toBeNull();
+  });
+
+  it('opens and closes search', () => {
+    const { openSearch, closeSearch } = useDashboardSearchStore.getState();
+    openSearch();
+    expect(useDashboardSearchStore.getState().isSearchOpen).toBe(true);
+    closeSearch();
+    expect(useDashboardSearchStore.getState().isSearchOpen).toBe(false);
+  });
+
+  it('sets selected game for modal', () => {
+    const game = { id: 'g1', name: 'Catan', imageUrl: null, playerCount: '3-4' };
+    useDashboardSearchStore.getState().setSelectedGame(game);
+    expect(useDashboardSearchStore.getState().selectedGame).toEqual(game);
+  });
+
+  it('sets drawer state for live chat', () => {
+    const drawer = { threadId: 't1', agentId: 'a1', gameId: 'g1', gameName: 'Catan' };
+    useDashboardSearchStore.getState().openChatDrawer(drawer);
+    expect(useDashboardSearchStore.getState().drawerState).toEqual(drawer);
+  });
+
+  it('clears drawer state on close', () => {
+    const drawer = { threadId: 't1', agentId: 'a1', gameId: 'g1', gameName: 'Catan' };
+    useDashboardSearchStore.getState().openChatDrawer(drawer);
+    useDashboardSearchStore.getState().closeChatDrawer();
+    expect(useDashboardSearchStore.getState().drawerState).toBeNull();
+  });
+
+  it('reset clears everything', () => {
+    useDashboardSearchStore.getState().openSearch();
+    useDashboardSearchStore
+      .getState()
+      .setSelectedGame({ id: 'g1', name: 'X', imageUrl: null, playerCount: '2' });
+    useDashboardSearchStore.getState().reset();
+    const state = useDashboardSearchStore.getState();
+    expect(state.isSearchOpen).toBe(false);
+    expect(state.selectedGame).toBeNull();
+    expect(state.drawerState).toBeNull();
+  });
+});

--- a/apps/web/src/components/chat-unified/EmbeddedChatView.tsx
+++ b/apps/web/src/components/chat-unified/EmbeddedChatView.tsx
@@ -30,22 +30,28 @@ export interface EmbeddedChatViewProps {
   agentId: string;
   /** Game ID for context */
   gameId: string;
+  /** Game name for ProxyGameContext */
+  gameName?: string;
 }
 
 // ============================================================================
 // Component
 // ============================================================================
 
-export function EmbeddedChatView({ threadId, agentId, gameId }: EmbeddedChatViewProps) {
+export function EmbeddedChatView({ threadId, agentId, gameId, gameName }: EmbeddedChatViewProps) {
   const messagesEndRef = useRef<HTMLDivElement>(null);
   const [messages, setMessages] = useState<ChatMessage[]>([]);
   const [inputValue, setInputValue] = useState('');
 
   // SSE streaming
-  const { state: streamState, sendMessage: sendViaSSE } = useAgentChatStream({
+  const {
+    state: streamState,
+    sendMessage: sendViaSSE,
+    stopStreaming,
+  } = useAgentChatStream({
     onComplete: (answer, metadata) => {
       const assistantMessage: ChatMessage = {
-        id: `assistant-${Date.now()}`,
+        id: `assistant-${crypto.randomUUID()}`,
         role: 'assistant',
         content: answer,
         timestamp: new Date().toISOString(),
@@ -59,6 +65,13 @@ export function EmbeddedChatView({ threadId, agentId, gameId }: EmbeddedChatView
     messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
   }, [messages, streamState.currentAnswer]);
 
+  // Stop SSE streaming on unmount
+  useEffect(() => {
+    return () => {
+      stopStreaming();
+    };
+  }, [stopStreaming]);
+
   // Send message handler
   const handleSend = useCallback(
     (e: React.FormEvent) => {
@@ -68,7 +81,7 @@ export function EmbeddedChatView({ threadId, agentId, gameId }: EmbeddedChatView
 
       // Optimistic UI: add user message
       const userMessage: ChatMessage = {
-        id: `user-${Date.now()}`,
+        id: `user-${crypto.randomUUID()}`,
         role: 'user',
         content,
         timestamp: new Date().toISOString(),
@@ -77,9 +90,15 @@ export function EmbeddedChatView({ threadId, agentId, gameId }: EmbeddedChatView
       setInputValue('');
 
       // Send via SSE
-      sendViaSSE(agentId, content, threadId, { gameName: '', agentTypology: '' }, undefined);
+      sendViaSSE(
+        agentId,
+        content,
+        threadId,
+        { gameName: gameName ?? '', agentTypology: '' },
+        undefined
+      );
     },
-    [inputValue, agentId, threadId, sendViaSSE]
+    [inputValue, agentId, threadId, gameName, sendViaSSE]
   );
 
   return (

--- a/apps/web/src/components/chat-unified/EmbeddedChatView.tsx
+++ b/apps/web/src/components/chat-unified/EmbeddedChatView.tsx
@@ -1,0 +1,194 @@
+/**
+ * EmbeddedChatView - Compact chat for ExtraMeepleCardDrawer (liveChat mode)
+ *
+ * Minimal version of ChatThreadView: messages + input only.
+ * No side panel, no debug, no voice, no thread header.
+ */
+
+'use client';
+
+import React, { useState, useCallback, useRef, useEffect } from 'react';
+
+import { useAgentChatStream } from '@/hooks/useAgentChatStream';
+import { cn } from '@/lib/utils';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface ChatMessage {
+  id: string;
+  role: 'user' | 'assistant';
+  content: string;
+  timestamp?: string;
+}
+
+export interface EmbeddedChatViewProps {
+  /** Chat thread ID */
+  threadId: string;
+  /** Agent ID for SSE streaming */
+  agentId: string;
+  /** Game ID for context */
+  gameId: string;
+}
+
+// ============================================================================
+// Component
+// ============================================================================
+
+export function EmbeddedChatView({ threadId, agentId, gameId }: EmbeddedChatViewProps) {
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [inputValue, setInputValue] = useState('');
+
+  // SSE streaming
+  const { state: streamState, sendMessage: sendViaSSE } = useAgentChatStream({
+    onComplete: (answer, metadata) => {
+      const assistantMessage: ChatMessage = {
+        id: `assistant-${Date.now()}`,
+        role: 'assistant',
+        content: answer,
+        timestamp: new Date().toISOString(),
+      };
+      setMessages(prev => [...prev, assistantMessage]);
+    },
+  });
+
+  // Auto-scroll on new messages or streaming content
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages, streamState.currentAnswer]);
+
+  // Send message handler
+  const handleSend = useCallback(
+    (e: React.FormEvent) => {
+      e.preventDefault();
+      const content = inputValue.trim();
+      if (!content) return;
+
+      // Optimistic UI: add user message
+      const userMessage: ChatMessage = {
+        id: `user-${Date.now()}`,
+        role: 'user',
+        content,
+        timestamp: new Date().toISOString(),
+      };
+      setMessages(prev => [...prev, userMessage]);
+      setInputValue('');
+
+      // Send via SSE
+      sendViaSSE(agentId, content, threadId, { gameName: '', agentTypology: '' }, undefined);
+    },
+    [inputValue, agentId, threadId, sendViaSSE]
+  );
+
+  return (
+    <div className="flex flex-col h-full" data-testid="embedded-chat-view">
+      {/* Error banner */}
+      {streamState.error && (
+        <div
+          role="alert"
+          className="mx-3 mt-2 p-2 bg-red-50 dark:bg-red-500/10 text-red-700 dark:text-red-400 rounded-lg text-xs border border-red-200 dark:border-red-500/20"
+        >
+          {streamState.error}
+        </div>
+      )}
+
+      {/* Messages area */}
+      <div className="flex-1 overflow-y-auto p-4 space-y-3">
+        {/* Empty state */}
+        {messages.length === 0 && !streamState.isStreaming && (
+          <div className="flex items-center justify-center h-full">
+            <p className="text-sm text-muted-foreground font-nunito">
+              Chiedi qualsiasi cosa sul gioco!
+            </p>
+          </div>
+        )}
+
+        {/* Message bubbles */}
+        {messages.map(msg => (
+          <div
+            key={msg.id}
+            className={cn(
+              'max-w-[90%] rounded-2xl px-3 py-2',
+              msg.role === 'user'
+                ? 'ml-auto bg-amber-500 text-white'
+                : 'mr-auto bg-white/70 dark:bg-card/70 backdrop-blur-md border border-border/50'
+            )}
+            data-testid={`message-${msg.role}`}
+          >
+            <p className="text-sm whitespace-pre-wrap font-nunito">{msg.content}</p>
+          </div>
+        ))}
+
+        {/* Streaming status */}
+        {streamState.statusMessage && (
+          <div
+            className="flex items-center gap-2 text-xs text-muted-foreground font-nunito"
+            data-testid="stream-status"
+          >
+            <div className="h-3 w-3 border-2 border-amber-500/30 border-t-amber-500 rounded-full animate-spin" />
+            {streamState.statusMessage}
+          </div>
+        )}
+
+        {/* Streaming response bubble */}
+        {streamState.isStreaming && streamState.currentAnswer && (
+          <div
+            className="max-w-[90%] mr-auto rounded-2xl px-3 py-2 bg-white/70 dark:bg-card/70 backdrop-blur-md border border-border/50"
+            data-testid="message-streaming"
+          >
+            <p className="text-sm whitespace-pre-wrap font-nunito">{streamState.currentAnswer}</p>
+            <div className="mt-1 flex items-center gap-1">
+              <div className="h-1.5 w-1.5 rounded-full bg-amber-500 animate-pulse" />
+              <span className="text-[10px] text-muted-foreground">In scrittura...</span>
+            </div>
+          </div>
+        )}
+
+        <div ref={messagesEndRef} />
+      </div>
+
+      {/* Input area */}
+      <form onSubmit={handleSend} className="p-3 border-t border-border">
+        <div className="flex items-center gap-2">
+          <input
+            type="text"
+            value={inputValue}
+            onChange={e => setInputValue(e.target.value)}
+            placeholder="Scrivi la tua domanda..."
+            disabled={streamState.isStreaming}
+            className={cn(
+              'flex-1 rounded-xl border border-border/50 px-3 py-2',
+              'bg-white/70 dark:bg-card/70 backdrop-blur-md text-sm font-nunito',
+              'placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-amber-500/40',
+              'disabled:opacity-50 disabled:cursor-not-allowed'
+            )}
+            data-testid="embedded-chat-input"
+          />
+          <button
+            type="submit"
+            disabled={!inputValue.trim() || streamState.isStreaming}
+            className={cn(
+              'p-2 rounded-xl transition-all duration-200 flex-shrink-0',
+              inputValue.trim() && !streamState.isStreaming
+                ? 'bg-amber-500 hover:bg-amber-600 text-white cursor-pointer'
+                : 'bg-muted text-muted-foreground cursor-not-allowed'
+            )}
+            aria-label="Invia messaggio"
+            data-testid="embedded-send-btn"
+          >
+            <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8"
+              />
+            </svg>
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/apps/web/src/components/dashboard/AddToLibraryModal.tsx
+++ b/apps/web/src/components/dashboard/AddToLibraryModal.tsx
@@ -1,0 +1,225 @@
+'use client';
+
+/**
+ * AddToLibraryModal — Confirmation modal for adding a shared library game
+ * to the user's personal library and creating a chat thread in one action.
+ *
+ * Orchestration flow:
+ * 1. Add game to library via useAddGameToLibrary mutation
+ * 2. Create chat thread via api.chat.createThread
+ * 3. Call onSuccess with IDs so the chat drawer can open
+ *
+ * Error handling:
+ * - If step 1 fails: show error, no side effects
+ * - If step 2 fails: game stays in library, show "Riprova" to retry thread creation only
+ */
+
+import { useState, useCallback } from 'react';
+
+import { Gamepad2 } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/overlays/dialog';
+import { useAddGameToLibrary } from '@/hooks/queries/useLibrary';
+import { api } from '@/lib/api';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface AddToLibraryModalGame {
+  id: string;
+  name: string;
+  imageUrl: string | null;
+  playerCount: string;
+}
+
+export interface AddToLibraryModalProps {
+  game: AddToLibraryModalGame | null;
+  isOpen: boolean;
+  onClose: () => void;
+  onSuccess: (result: { gameId: string; threadId: string; agentId: string }) => void;
+}
+
+type ModalState =
+  | { phase: 'idle' }
+  | { phase: 'loading' }
+  | { phase: 'addFailed'; message: string }
+  | { phase: 'threadFailed'; message: string };
+
+// ============================================================================
+// Component
+// ============================================================================
+
+export function AddToLibraryModal({ game, isOpen, onClose, onSuccess }: AddToLibraryModalProps) {
+  const [state, setState] = useState<ModalState>({ phase: 'idle' });
+  const addGameMutation = useAddGameToLibrary();
+
+  const resetState = useCallback(() => {
+    setState({ phase: 'idle' });
+  }, []);
+
+  const handleOpenChange = useCallback(
+    (open: boolean) => {
+      if (!open) {
+        onClose();
+        resetState();
+      }
+    },
+    [onClose, resetState]
+  );
+
+  const createThread = useCallback(async (gameId: string, gameName: string) => {
+    const thread = await api.chat.createThread({
+      gameId,
+      title: gameName,
+    });
+    return thread;
+  }, []);
+
+  const handleConfirm = useCallback(async () => {
+    if (!game) return;
+
+    setState({ phase: 'loading' });
+
+    // Step 1: Add game to library
+    try {
+      await addGameMutation.mutateAsync({ gameId: game.id });
+    } catch {
+      setState({
+        phase: 'addFailed',
+        message: 'Non è stato possibile aggiungere il gioco alla libreria.',
+      });
+      return;
+    }
+
+    // Step 2: Create chat thread
+    try {
+      const thread = await createThread(game.id, game.name);
+      setState({ phase: 'idle' });
+      onSuccess({
+        gameId: game.id,
+        threadId: thread.id,
+        agentId: thread.agentId ?? '',
+      });
+    } catch {
+      setState({
+        phase: 'threadFailed',
+        message: 'Gioco aggiunto alla libreria, ma la creazione della chat è fallita. Riprova.',
+      });
+    }
+  }, [game, addGameMutation, createThread, onSuccess]);
+
+  const handleRetryThread = useCallback(async () => {
+    if (!game) return;
+
+    setState({ phase: 'loading' });
+
+    try {
+      const thread = await createThread(game.id, game.name);
+      setState({ phase: 'idle' });
+      onSuccess({
+        gameId: game.id,
+        threadId: thread.id,
+        agentId: thread.agentId ?? '',
+      });
+    } catch {
+      setState({
+        phase: 'threadFailed',
+        message: 'Gioco aggiunto alla libreria, ma la creazione della chat è fallita. Riprova.',
+      });
+    }
+  }, [game, createThread, onSuccess]);
+
+  const isLoading = state.phase === 'loading';
+  const showContent = isOpen && game !== null;
+
+  return (
+    <Dialog open={showContent} onOpenChange={handleOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Aggiungi alla libreria</DialogTitle>
+          <DialogDescription>
+            Per chattare con l&apos;AI su questo gioco, aggiungilo alla tua libreria.
+          </DialogDescription>
+        </DialogHeader>
+
+        {game && (
+          <>
+            {/* Game preview */}
+            <div className="flex items-center gap-4 rounded-lg border border-border/50 p-3">
+              <div className="h-16 w-16 flex-shrink-0 overflow-hidden rounded-md bg-muted">
+                {game.imageUrl ? (
+                  <img src={game.imageUrl} alt={game.name} className="h-full w-full object-cover" />
+                ) : (
+                  <div
+                    className="flex h-full w-full items-center justify-center"
+                    data-testid="game-placeholder-icon"
+                  >
+                    <Gamepad2 className="h-8 w-8 text-muted-foreground" />
+                  </div>
+                )}
+              </div>
+              <div className="min-w-0 flex-1">
+                <p className="truncate font-semibold">{game.name}</p>
+                <p className="text-sm text-muted-foreground">{game.playerCount} giocatori</p>
+              </div>
+            </div>
+
+            {/* Error messages */}
+            {state.phase === 'addFailed' && (
+              <p className="text-sm text-destructive" role="alert">
+                {state.message}
+              </p>
+            )}
+
+            {state.phase === 'threadFailed' && (
+              <p className="text-sm text-destructive" role="alert">
+                {state.message}
+              </p>
+            )}
+
+            {/* Actions */}
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => handleOpenChange(false)}
+                disabled={isLoading}
+              >
+                Annulla
+              </Button>
+
+              {state.phase === 'threadFailed' ? (
+                <Button
+                  type="button"
+                  onClick={handleRetryThread}
+                  disabled={isLoading}
+                  className="bg-gradient-to-r from-purple-600 to-purple-500 text-white hover:from-purple-700 hover:to-purple-600"
+                >
+                  {isLoading ? 'Creando chat...' : 'Riprova'}
+                </Button>
+              ) : (
+                <Button
+                  type="button"
+                  onClick={handleConfirm}
+                  disabled={isLoading}
+                  className="bg-gradient-to-r from-purple-600 to-purple-500 text-white hover:from-purple-700 hover:to-purple-600"
+                >
+                  {isLoading ? 'Aggiungendo...' : 'Aggiungi e Chiedi 🤖'}
+                </Button>
+              )}
+            </DialogFooter>
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/dashboard/AddToLibraryModal.tsx
+++ b/apps/web/src/components/dashboard/AddToLibraryModal.tsx
@@ -45,7 +45,12 @@ export interface AddToLibraryModalProps {
   game: AddToLibraryModalGame | null;
   isOpen: boolean;
   onClose: () => void;
-  onSuccess: (result: { gameId: string; threadId: string; agentId: string }) => void;
+  onSuccess: (result: {
+    gameId: string;
+    threadId: string;
+    agentId: string;
+    gameName: string;
+  }) => void;
 }
 
 type ModalState =
@@ -108,6 +113,7 @@ export function AddToLibraryModal({ game, isOpen, onClose, onSuccess }: AddToLib
         gameId: game.id,
         threadId: thread.id,
         agentId: thread.agentId ?? '',
+        gameName: game.name,
       });
     } catch {
       setState({
@@ -129,6 +135,7 @@ export function AddToLibraryModal({ game, isOpen, onClose, onSuccess }: AddToLib
         gameId: game.id,
         threadId: thread.id,
         agentId: thread.agentId ?? '',
+        gameName: game.name,
       });
     } catch {
       setState({

--- a/apps/web/src/components/dashboard/DashboardRenderer.tsx
+++ b/apps/web/src/components/dashboard/DashboardRenderer.tsx
@@ -1,9 +1,12 @@
 'use client';
 
-import { Suspense } from 'react';
+import { Suspense, useCallback } from 'react';
 
 import { AnimatePresence, motion } from 'framer-motion';
 
+import { useDashboardSearchStore } from '@/stores/useDashboardSearchStore';
+
+import { AddToLibraryModal } from './AddToLibraryModal';
 import { useDashboardMode } from './useDashboardMode';
 import { HeroZone, StatsZone, CardsZone, AgentsSidebar, SessionBar, ScoreboardZone } from './zones';
 import './dashboard-transitions.css';
@@ -22,6 +25,15 @@ function ZoneSkeleton({ testId }: { testId: string }) {
  */
 export function DashboardRenderer() {
   const { state, isGameMode, isExploration } = useDashboardMode();
+  const { selectedGame, setSelectedGame, openChatDrawer } = useDashboardSearchStore();
+
+  const handleModalSuccess = useCallback(
+    ({ gameId, threadId, agentId }: { gameId: string; threadId: string; agentId: string }) => {
+      setSelectedGame(null);
+      openChatDrawer({ threadId, agentId, gameId, gameName: selectedGame?.name ?? '' });
+    },
+    [selectedGame, setSelectedGame, openChatDrawer]
+  );
 
   return (
     <div data-testid="dashboard-renderer" className="flex flex-col gap-6 w-full">
@@ -79,6 +91,13 @@ export function DashboardRenderer() {
           </motion.div>
         )}
       </AnimatePresence>
+
+      <AddToLibraryModal
+        game={selectedGame}
+        isOpen={selectedGame !== null}
+        onClose={() => setSelectedGame(null)}
+        onSuccess={handleModalSuccess}
+      />
     </div>
   );
 }

--- a/apps/web/src/components/dashboard/DashboardRenderer.tsx
+++ b/apps/web/src/components/dashboard/DashboardRenderer.tsx
@@ -4,6 +4,7 @@ import { Suspense, useCallback } from 'react';
 
 import { AnimatePresence, motion } from 'framer-motion';
 
+import { ExtraMeepleCardDrawer } from '@/components/ui/data-display/extra-meeple-card';
 import { useDashboardSearchStore } from '@/stores/useDashboardSearchStore';
 
 import { AddToLibraryModal } from './AddToLibraryModal';
@@ -25,7 +26,8 @@ function ZoneSkeleton({ testId }: { testId: string }) {
  */
 export function DashboardRenderer() {
   const { state, isGameMode, isExploration } = useDashboardMode();
-  const { selectedGame, setSelectedGame, openChatDrawer } = useDashboardSearchStore();
+  const { selectedGame, setSelectedGame, openChatDrawer, drawerState, closeChatDrawer } =
+    useDashboardSearchStore();
 
   const handleModalSuccess = useCallback(
     ({ gameId, threadId, agentId }: { gameId: string; threadId: string; agentId: string }) => {
@@ -98,6 +100,17 @@ export function DashboardRenderer() {
         onClose={() => setSelectedGame(null)}
         onSuccess={handleModalSuccess}
       />
+
+      {drawerState && (
+        <ExtraMeepleCardDrawer
+          entityType="chatSession"
+          entityId={drawerState.threadId}
+          open={true}
+          onClose={closeChatDrawer}
+          liveChatData={drawerState}
+          data-testid="dashboard-chat-drawer"
+        />
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/dashboard/DashboardRenderer.tsx
+++ b/apps/web/src/components/dashboard/DashboardRenderer.tsx
@@ -30,11 +30,21 @@ export function DashboardRenderer() {
     useDashboardSearchStore();
 
   const handleModalSuccess = useCallback(
-    ({ gameId, threadId, agentId }: { gameId: string; threadId: string; agentId: string }) => {
+    ({
+      gameId,
+      threadId,
+      agentId,
+      gameName,
+    }: {
+      gameId: string;
+      threadId: string;
+      agentId: string;
+      gameName: string;
+    }) => {
       setSelectedGame(null);
-      openChatDrawer({ threadId, agentId, gameId, gameName: selectedGame?.name ?? '' });
+      openChatDrawer({ threadId, agentId, gameId, gameName });
     },
-    [selectedGame, setSelectedGame, openChatDrawer]
+    [setSelectedGame, openChatDrawer]
   );
 
   return (

--- a/apps/web/src/components/dashboard/SearchExpander.tsx
+++ b/apps/web/src/components/dashboard/SearchExpander.tsx
@@ -1,0 +1,229 @@
+'use client';
+
+/**
+ * SearchExpander - Glassmorphism search bar with dropdown results
+ *
+ * Searches the shared game catalog with debounce (300ms).
+ * Shows results with dual actions: "Vedi" (view) and "Chiedi" (ask AI).
+ * Indicates if a game is already in the user's library.
+ */
+
+import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
+
+import { Search, Loader2 } from 'lucide-react';
+
+import { useLibrary } from '@/hooks/queries/useLibrary';
+import { api } from '@/lib/api';
+import type { SharedGame } from '@/lib/api/schemas/shared-games.schemas';
+
+// ========== Types ==========
+
+export interface SharedGameSearchResult extends SharedGame {
+  isInLibrary?: boolean;
+}
+
+export interface SearchExpanderProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onViewGame: (gameId: string) => void;
+  onAskAboutGame: (game: SharedGameSearchResult) => void;
+}
+
+// ========== Constants ==========
+
+const DEBOUNCE_MS = 300;
+const PAGE_SIZE = 5;
+
+// ========== Component ==========
+
+export function SearchExpander({
+  isOpen,
+  onClose,
+  onViewGame,
+  onAskAboutGame,
+}: SearchExpanderProps) {
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<SharedGame[]>([]);
+  const [isSearching, setIsSearching] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Fetch user library to check which games are already owned
+  const { data: libraryData } = useLibrary();
+
+  // Build a Set of library game IDs for O(1) lookup
+  const libraryGameIds = useMemo(() => {
+    if (!libraryData?.items) return new Set<string>();
+    return new Set(libraryData.items.map(entry => entry.gameId));
+  }, [libraryData?.items]);
+
+  // Debounced search
+  const performSearch = useCallback(async (searchTerm: string) => {
+    if (!searchTerm.trim()) {
+      setResults([]);
+      setIsSearching(false);
+      return;
+    }
+
+    setIsSearching(true);
+    try {
+      const response = await api.sharedGames.search({
+        searchTerm,
+        pageSize: PAGE_SIZE,
+      });
+      setResults(response.items);
+    } catch {
+      setResults([]);
+    } finally {
+      setIsSearching(false);
+    }
+  }, []);
+
+  // Handle input change with debounce
+  useEffect(() => {
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current);
+    }
+
+    if (!query.trim()) {
+      setResults([]);
+      return;
+    }
+
+    debounceRef.current = setTimeout(() => {
+      performSearch(query);
+    }, DEBOUNCE_MS);
+
+    return () => {
+      if (debounceRef.current) {
+        clearTimeout(debounceRef.current);
+      }
+    };
+  }, [query, performSearch]);
+
+  // Auto-focus input when opened
+  useEffect(() => {
+    if (isOpen) {
+      // Small delay to ensure the DOM is ready
+      const timer = setTimeout(() => {
+        inputRef.current?.focus();
+      }, 50);
+      return () => clearTimeout(timer);
+    } else {
+      // Reset state when closed
+      setQuery('');
+      setResults([]);
+    }
+  }, [isOpen]);
+
+  // ESC key handler
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen, onClose]);
+
+  // Don't render when closed
+  if (!isOpen) return null;
+
+  // Enrich results with library status
+  const enrichedResults: SharedGameSearchResult[] = results.map(game => ({
+    ...game,
+    isInLibrary: libraryGameIds.has(game.id),
+  }));
+
+  const formatPlayers = (min: number, max: number) => {
+    if (min === max) return `${min} giocatori`;
+    return `${min}-${max} giocatori`;
+  };
+
+  return (
+    <div data-testid="search-expander" className="absolute inset-x-4 bottom-20 z-50">
+      {/* Search Input */}
+      <div className="bg-white/5 backdrop-blur-xl border border-white/10 rounded-2xl p-3 shadow-2xl">
+        <div className="relative">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-white/40" />
+          <input
+            ref={inputRef}
+            type="text"
+            value={query}
+            onChange={e => setQuery(e.target.value)}
+            placeholder="Cerca un gioco..."
+            className="w-full bg-white/5 border border-white/10 rounded-xl py-2.5 pl-10 pr-4 text-sm text-white placeholder:text-white/40 focus:outline-none focus:ring-1 focus:ring-white/20"
+          />
+          {isSearching && (
+            <Loader2 className="absolute right-3 top-1/2 -translate-y-1/2 h-4 w-4 text-white/40 animate-spin" />
+          )}
+        </div>
+
+        {/* Results Dropdown */}
+        {enrichedResults.length > 0 && (
+          <div className="mt-2 space-y-1 max-h-[280px] overflow-y-auto">
+            {enrichedResults.map(game => (
+              <div
+                key={game.id}
+                className="flex items-center gap-3 p-2 rounded-xl hover:bg-white/5 transition-colors"
+              >
+                {/* Thumbnail */}
+                {game.thumbnailUrl && (
+                  <img
+                    src={game.thumbnailUrl}
+                    alt={game.title}
+                    className="h-10 w-10 rounded-lg object-cover flex-shrink-0"
+                  />
+                )}
+
+                {/* Game Info */}
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2">
+                    <span className="text-sm font-medium text-white truncate">{game.title}</span>
+                    {game.isInLibrary && (
+                      <span className="text-[10px] px-1.5 py-0.5 rounded-full bg-emerald-500/20 text-emerald-400 whitespace-nowrap">
+                        ✓ In libreria
+                      </span>
+                    )}
+                  </div>
+                  <span className="text-xs text-white/40">
+                    {formatPlayers(game.minPlayers, game.maxPlayers)}
+                  </span>
+                </div>
+
+                {/* Action Buttons */}
+                <div className="flex items-center gap-1.5 flex-shrink-0">
+                  <button
+                    onClick={() => onViewGame(game.id)}
+                    className="px-2.5 py-1 text-xs font-medium rounded-lg bg-blue-500/20 text-blue-400 hover:bg-blue-500/30 transition-colors"
+                  >
+                    Vedi
+                  </button>
+                  <button
+                    onClick={() => onAskAboutGame(game)}
+                    className={`px-2.5 py-1 text-xs font-medium rounded-lg transition-colors ${
+                      game.isInLibrary
+                        ? 'bg-emerald-500/20 text-emerald-400 hover:bg-emerald-500/30'
+                        : 'bg-purple-500/20 text-purple-400 hover:bg-purple-500/30'
+                    }`}
+                  >
+                    Chiedi
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {/* Empty state when searching with no results */}
+        {query.trim() && !isSearching && results.length === 0 && (
+          <div className="mt-2 py-4 text-center text-xs text-white/30">Nessun gioco trovato</div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/dashboard/zones/HeroZone.tsx
+++ b/apps/web/src/components/dashboard/zones/HeroZone.tsx
@@ -2,7 +2,10 @@
 
 import { useMemo } from 'react';
 
+import { Search } from 'lucide-react';
+
 import { useDashboardData } from '@/hooks/useDashboardData';
+import { useDashboardSearchStore } from '@/stores/useDashboardSearchStore';
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -60,19 +63,6 @@ function GameNightBanner({
   );
 }
 
-function WelcomePrompt() {
-  return (
-    <div className="mt-4 flex items-center gap-3 rounded-xl bg-white/60 dark:bg-white/10 px-4 py-3 backdrop-blur-sm">
-      <span className="text-2xl" role="img" aria-label="wave">
-        👋
-      </span>
-      <p className="text-sm text-amber-900 dark:text-amber-100">
-        Aggiungi il tuo primo gioco alla libreria per iniziare!
-      </p>
-    </div>
-  );
-}
-
 // ---------------------------------------------------------------------------
 // HeroZone
 // ---------------------------------------------------------------------------
@@ -113,7 +103,24 @@ export function HeroZone() {
 
       {upcomingGameNight && <GameNightBanner gameNight={upcomingGameNight} />}
 
-      {isNewUser && <WelcomePrompt />}
+      {isNewUser && (
+        <div className="mt-4 rounded-xl bg-gradient-to-br from-purple-500/10 to-blue-500/10 border border-purple-500/20 p-6 text-center">
+          <p className="text-sm text-purple-300 mb-4">
+            {greeting}
+            {user?.username ? `, ${user.username}` : ''}!<br />
+            Hai una domanda su un gioco da tavolo? Cerca nella community e chiedi all&apos;AI!
+          </p>
+          <button
+            onClick={() => useDashboardSearchStore.getState().openSearch()}
+            className="inline-flex items-center gap-2 rounded-lg bg-purple-500/15 border border-purple-500/25 px-4 py-2 text-sm font-medium text-purple-300 hover:bg-purple-500/25 transition-colors"
+            data-testid="hero-search-cta"
+          >
+            <Search className="w-4 h-4" />
+            Cerca un gioco
+          </button>
+          <p className="mt-2 text-xs text-muted-foreground">oppure usa la barra in basso ↓</p>
+        </div>
+      )}
     </section>
   );
 }

--- a/apps/web/src/components/dashboard/zones/__tests__/HeroZone.test.tsx
+++ b/apps/web/src/components/dashboard/zones/__tests__/HeroZone.test.tsx
@@ -2,7 +2,7 @@
  * @vitest-environment jsdom
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import React from 'react';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 
@@ -16,6 +16,14 @@ const mockUseDashboardData = vi.fn();
 
 vi.mock('@/hooks/useDashboardData', () => ({
   useDashboardData: () => mockUseDashboardData(),
+}));
+
+const mockOpenSearch = vi.fn();
+
+vi.mock('@/stores/useDashboardSearchStore', () => ({
+  useDashboardSearchStore: {
+    getState: () => ({ openSearch: mockOpenSearch }),
+  },
 }));
 
 // ---------------------------------------------------------------------------
@@ -146,7 +154,7 @@ describe('HeroZone', () => {
     expect(zone).toBeInTheDocument();
   });
 
-  it('shows welcome prompt for new user with zero games', () => {
+  it('shows search CTA for new user with zero games', () => {
     mockUseDashboardData.mockReturnValue({
       data: {
         ...MOCK_DASHBOARD_DATA,
@@ -160,7 +168,27 @@ describe('HeroZone', () => {
 
     renderWithProviders(<HeroZone />);
 
-    expect(screen.getByText(/Aggiungi il tuo primo gioco/)).toBeInTheDocument();
+    expect(screen.getByTestId('hero-search-cta')).toBeInTheDocument();
+    expect(screen.getByText(/Cerca un gioco/)).toBeInTheDocument();
+    expect(screen.getByText(/Hai una domanda su un gioco da tavolo/)).toBeInTheDocument();
+  });
+
+  it('calls openSearch when search CTA is clicked', () => {
+    mockUseDashboardData.mockReturnValue({
+      data: {
+        ...MOCK_DASHBOARD_DATA,
+        stats: {
+          ...MOCK_DASHBOARD_DATA.stats,
+          libraryCount: 0,
+        },
+      },
+      isLoading: false,
+    });
+
+    renderWithProviders(<HeroZone />);
+
+    fireEvent.click(screen.getByTestId('hero-search-cta'));
+    expect(mockOpenSearch).toHaveBeenCalledOnce();
   });
 
   it('shows stats summary for existing user', () => {
@@ -175,7 +203,7 @@ describe('HeroZone', () => {
     expect(screen.getByText(/12 partite questo mese/)).toBeInTheDocument();
   });
 
-  it('does not show welcome prompt for user with games', () => {
+  it('does not show search CTA for user with games', () => {
     mockUseDashboardData.mockReturnValue({
       data: MOCK_DASHBOARD_DATA,
       isLoading: false,
@@ -183,6 +211,6 @@ describe('HeroZone', () => {
 
     renderWithProviders(<HeroZone />);
 
-    expect(screen.queryByText(/Aggiungi il tuo primo gioco/)).not.toBeInTheDocument();
+    expect(screen.queryByTestId('hero-search-cta')).not.toBeInTheDocument();
   });
 });

--- a/apps/web/src/components/layout/SmartFAB/SmartFAB.tsx
+++ b/apps/web/src/components/layout/SmartFAB/SmartFAB.tsx
@@ -19,15 +19,20 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
+import { Search } from 'lucide-react';
 import Link from 'next/link';
-import { usePathname } from 'next/navigation';
+import { usePathname, useRouter } from 'next/navigation';
 
+import { SearchExpander } from '@/components/dashboard/SearchExpander';
+import type { SharedGameSearchResult } from '@/components/dashboard/SearchExpander';
 import { resolveSmartFab } from '@/config/smart-fab';
 import type { SmartFabAction } from '@/config/smart-fab';
 import { useNavigation } from '@/context/NavigationContext';
 import { usePrefersReducedMotion } from '@/hooks/useResponsive';
 import { useScrollDirection } from '@/hooks/useScrollDirection';
+import { api } from '@/lib/api';
 import { cn } from '@/lib/utils';
+import { useDashboardSearchStore } from '@/stores/useDashboardSearchStore';
 
 // ─── QuickMenu Item ──────────────────────────────────────────────────────────
 
@@ -132,6 +137,7 @@ function QuickMenuItem({
 
 export function SmartFAB() {
   const pathname = usePathname();
+  const router = useRouter();
   const scrollDirection = useScrollDirection({ threshold: 50 });
   const prefersReducedMotion = usePrefersReducedMotion();
   const { actionBarActions } = useNavigation();
@@ -140,6 +146,53 @@ export function SmartFAB() {
   const [isMorphing, setIsMorphing] = useState(false);
   const longPressRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const prevPathnameRef = useRef(pathname);
+
+  // Dashboard search state
+  const { isSearchOpen, openSearch, closeSearch, setSelectedGame, openChatDrawer } =
+    useDashboardSearchStore();
+
+  const isDashboard = pathname === '/dashboard';
+
+  const handleViewGame = useCallback(
+    (gameId: string) => {
+      closeSearch();
+      router.push(`/shared-games/${gameId}`);
+    },
+    [closeSearch, router]
+  );
+
+  const handleAskAboutGame = useCallback(
+    async (game: SharedGameSearchResult) => {
+      closeSearch();
+      const gameName = game.title;
+      const gameResult = {
+        id: game.id,
+        name: gameName,
+        imageUrl: game.thumbnailUrl ?? null,
+        playerCount: `${game.minPlayers}-${game.maxPlayers}`,
+      };
+      if (game.isInLibrary) {
+        // Game is in library — create thread directly and open drawer
+        try {
+          const thread = await api.chat.createThread({
+            gameId: game.id,
+            title: gameName,
+          });
+          openChatDrawer({
+            threadId: thread.id,
+            agentId: thread.agentId ?? '',
+            gameId: game.id,
+            gameName,
+          });
+        } catch {
+          setSelectedGame(gameResult);
+        }
+      } else {
+        setSelectedGame(gameResult);
+      }
+    },
+    [closeSearch, setSelectedGame, openChatDrawer]
+  );
 
   const resolved = useMemo(() => resolveSmartFab(pathname), [pathname]);
   const { primary: action, secondary: secondaryActions } = resolved;
@@ -310,6 +363,27 @@ export function SmartFAB() {
             />
           ))}
         </div>
+      )}
+
+      {/* Dashboard search button + expander */}
+      {isDashboard && (
+        <>
+          <button
+            type="button"
+            onClick={openSearch}
+            className="mb-3 flex h-10 w-10 items-center justify-center rounded-full bg-gradient-to-br from-blue-500 to-purple-600 shadow-lg shadow-blue-500/20"
+            data-testid="smart-fab-search"
+            aria-label="Cerca un gioco"
+          >
+            <Search className="h-5 w-5 text-white" />
+          </button>
+          <SearchExpander
+            isOpen={isSearchOpen}
+            onClose={closeSearch}
+            onViewGame={handleViewGame}
+            onAskAboutGame={handleAskAboutGame}
+          />
+        </>
       )}
 
       {/* Main FAB button */}

--- a/apps/web/src/components/layout/SmartFAB/__tests__/SmartFAB.test.tsx
+++ b/apps/web/src/components/layout/SmartFAB/__tests__/SmartFAB.test.tsx
@@ -13,9 +13,11 @@ import { SmartFAB } from '../SmartFAB';
 // ─── Mocks ───────────────────────────────────────────────────────────────────
 
 const mockPathname = vi.fn(() => '/dashboard');
+const mockPush = vi.fn();
 
 vi.mock('next/navigation', () => ({
   usePathname: () => mockPathname(),
+  useRouter: () => ({ push: mockPush }),
 }));
 
 vi.mock('next/link', () => ({
@@ -46,6 +48,26 @@ vi.mock('@/hooks/useScrollDirection', () => ({
 
 vi.mock('@/hooks/useResponsive', () => ({
   usePrefersReducedMotion: () => false,
+}));
+
+vi.mock('@/stores/useDashboardSearchStore', () => ({
+  useDashboardSearchStore: () => ({
+    isSearchOpen: false,
+    openSearch: vi.fn(),
+    closeSearch: vi.fn(),
+    setSelectedGame: vi.fn(),
+    openChatDrawer: vi.fn(),
+  }),
+}));
+
+vi.mock('@/components/dashboard/SearchExpander', () => ({
+  SearchExpander: () => null,
+}));
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    chat: { createThread: vi.fn() },
+  },
 }));
 
 // ─── Helpers ─────────────────────────────────────────────────────────────────

--- a/apps/web/src/components/ui/data-display/extra-meeple-card/ExtraMeepleCardDrawer.tsx
+++ b/apps/web/src/components/ui/data-display/extra-meeple-card/ExtraMeepleCardDrawer.tsx
@@ -39,6 +39,7 @@ import {
   Zap,
 } from 'lucide-react';
 
+import { EmbeddedChatView } from '@/components/chat-unified/EmbeddedChatView';
 import { useDashboardMode } from '@/components/dashboard';
 import { Sheet, SheetClose, SheetContent, SheetTitle } from '@/components/ui/navigation/sheet';
 import { cn } from '@/lib/utils';
@@ -83,6 +84,13 @@ export interface ExtraMeepleCardDrawerProps {
    * Maps the MeepleEntityType to the LinkEntityType for the API call.
    */
   linkEntityType?: LinkEntityType;
+  /** When present with chatSession entity type, renders EmbeddedChatView instead of ChatDrawerContent */
+  liveChatData?: {
+    threadId: string;
+    agentId: string;
+    gameId: string;
+    gameName: string;
+  };
   className?: string;
   'data-testid'?: string;
 }
@@ -132,6 +140,7 @@ export const ExtraMeepleCardDrawer = React.memo(function ExtraMeepleCardDrawer({
   open,
   onClose,
   linkEntityType,
+  liveChatData,
   className,
   'data-testid': testId,
 }: ExtraMeepleCardDrawerProps) {
@@ -210,6 +219,7 @@ export const ExtraMeepleCardDrawer = React.memo(function ExtraMeepleCardDrawer({
             entityType={entityType}
             entityId={entityId}
             linkEntityType={linkEntityType}
+            liveChatData={liveChatData}
           />
         </div>
       </SheetContent>
@@ -225,10 +235,12 @@ function DrawerEntityRouter({
   entityType,
   entityId,
   linkEntityType,
+  liveChatData,
 }: {
   entityType: DrawerEntityType;
   entityId: string;
   linkEntityType?: LinkEntityType;
+  liveChatData?: ExtraMeepleCardDrawerProps['liveChatData'];
 }) {
   switch (entityType) {
     case 'game':
@@ -237,6 +249,15 @@ function DrawerEntityRouter({
       return <AgentDrawerContent entityId={entityId} />;
     case 'chatSession':
     case 'chat':
+      if (liveChatData) {
+        return (
+          <EmbeddedChatView
+            threadId={liveChatData.threadId}
+            agentId={liveChatData.agentId}
+            gameId={liveChatData.gameId}
+          />
+        );
+      }
       return <ChatDrawerContent entityId={entityId} />;
     case 'kb':
       return <KbDrawerContent entityId={entityId} />;

--- a/apps/web/src/components/ui/data-display/extra-meeple-card/ExtraMeepleCardDrawer.tsx
+++ b/apps/web/src/components/ui/data-display/extra-meeple-card/ExtraMeepleCardDrawer.tsx
@@ -255,6 +255,7 @@ function DrawerEntityRouter({
             threadId={liveChatData.threadId}
             agentId={liveChatData.agentId}
             gameId={liveChatData.gameId}
+            gameName={liveChatData.gameName}
           />
         );
       }

--- a/apps/web/src/stores/useDashboardSearchStore.ts
+++ b/apps/web/src/stores/useDashboardSearchStore.ts
@@ -1,0 +1,40 @@
+import { create } from 'zustand';
+
+export interface SearchGameResult {
+  id: string;
+  name: string;
+  imageUrl: string | null;
+  playerCount: string;
+}
+
+export interface ChatDrawerState {
+  threadId: string;
+  agentId: string;
+  gameId: string;
+  gameName: string;
+  kbCardCount?: number;
+}
+
+interface DashboardSearchState {
+  isSearchOpen: boolean;
+  selectedGame: SearchGameResult | null;
+  drawerState: ChatDrawerState | null;
+  openSearch: () => void;
+  closeSearch: () => void;
+  setSelectedGame: (game: SearchGameResult | null) => void;
+  openChatDrawer: (state: ChatDrawerState) => void;
+  closeChatDrawer: () => void;
+  reset: () => void;
+}
+
+export const useDashboardSearchStore = create<DashboardSearchState>(set => ({
+  isSearchOpen: false,
+  selectedGame: null,
+  drawerState: null,
+  openSearch: () => set({ isSearchOpen: true }),
+  closeSearch: () => set({ isSearchOpen: false, selectedGame: null }),
+  setSelectedGame: game => set({ selectedGame: game }),
+  openChatDrawer: state => set({ drawerState: state, isSearchOpen: false, selectedGame: null }),
+  closeChatDrawer: () => set({ drawerState: null }),
+  reset: () => set({ isSearchOpen: false, selectedGame: null, drawerState: null }),
+}));

--- a/docs/superpowers/plans/2026-03-17-dashboard-search-chat-flow.md
+++ b/docs/superpowers/plans/2026-03-17-dashboard-search-chat-flow.md
@@ -1,0 +1,1221 @@
+# Dashboard Search → Add Game → Chat Flow — Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Enable new users to search for shared library games from the dashboard, add them to their library, and chat with AI about them via a drawer — all without leaving the dashboard.
+
+**Architecture:** Zustand store (`useDashboardSearchStore`) coordinates search state between SmartFAB and HeroZone (both are prop-less, hook-driven components). Three new components (SearchExpander, AddToLibraryModal, EmbeddedChatView) plus modifications to SmartFAB, HeroZone, ExtraMeepleCardDrawer, and DashboardRenderer.
+
+**Tech Stack:** Next.js 16, React 19, Zustand, React Query, Tailwind 4, shadcn/ui, Vitest, @testing-library/react
+
+**Spec:** `docs/superpowers/specs/2026-03-17-dashboard-search-chat-flow-design.md`
+
+---
+
+## File Map
+
+### New Files
+
+| File | Responsibility |
+|------|----------------|
+| `apps/web/src/stores/useDashboardSearchStore.ts` | Zustand store: `isSearchOpen`, `openSearch()`, `closeSearch()`, `selectedGame`, `drawerState` |
+| `apps/web/src/components/dashboard/SearchExpander.tsx` | Search bar + results dropdown, mounted inside SmartFAB |
+| `apps/web/src/components/dashboard/AddToLibraryModal.tsx` | Confirmation modal: add game + create chat thread |
+| `apps/web/src/components/chat-unified/EmbeddedChatView.tsx` | Compact ChatThreadView: messages + input only |
+| `apps/web/src/__tests__/stores/useDashboardSearchStore.test.ts` | Store unit tests |
+| `apps/web/src/__tests__/components/dashboard/SearchExpander.test.tsx` | SearchExpander unit tests |
+| `apps/web/src/__tests__/components/dashboard/AddToLibraryModal.test.tsx` | AddToLibraryModal unit tests |
+| `apps/web/src/__tests__/components/chat-unified/EmbeddedChatView.test.tsx` | EmbeddedChatView unit tests |
+
+### Modified Files
+
+| File | Change |
+|------|--------|
+| `apps/web/src/components/layout/SmartFAB/SmartFAB.tsx` | Add 🔍 icon + mount SearchExpander when `isSearchOpen` |
+| `apps/web/src/components/dashboard/zones/HeroZone.tsx` | Enhanced empty state with CTA triggering `openSearch()` |
+| `apps/web/src/components/ui/data-display/extra-meeple-card/ExtraMeepleCardDrawer.tsx` | Add `liveChat` mode to `chatSession` branch |
+| `apps/web/src/components/dashboard/DashboardRenderer.tsx` | Mount ExtraMeepleCardDrawer for live chat drawer |
+
+---
+
+## Chunk 0: Setup + Pre-Implementation Verification
+
+### Task 0: Create Feature Branch + Verify Assumptions
+
+- [ ] **Step 1: Create feature branch**
+
+```bash
+git checkout main-dev && git pull
+git checkout -b feature/dashboard-search-chat-flow
+git config branch.feature/dashboard-search-chat-flow.parent main-dev
+```
+
+- [ ] **Step 2: Verify which HeroZone is active**
+
+Run: `cd apps/web && grep -r "HeroZone\|hero-zone" src/components/dashboard/DashboardRenderer.tsx`
+
+Determine whether `DashboardRenderer` imports from `./zones/HeroZone` or `../dashboard-v2/hero-zone`. If v2 is active, all HeroZone modifications in this plan apply to `components/dashboard-v2/hero-zone.tsx` instead of `components/dashboard/zones/HeroZone.tsx`.
+
+- [ ] **Step 3: Verify ChatThreadDto includes agentId**
+
+Run: `cd apps/web && grep -r "agentId" src/lib/api/clients/chatClient.ts`
+
+Confirm `ChatThreadDto` response contains `agentId`. If not, the `createThread` response will need `agentId` fetched separately (e.g., from agent defaults for the game). Document what you find.
+
+- [ ] **Step 4: Check existing library hooks**
+
+Run: `cd apps/web && grep -rl "useLibrary\|useUserLibrary" src/hooks/`
+
+Identify if a hook exists that returns user library game IDs. The actual file is likely `src/hooks/queries/useLibrary.ts` (NOT `useUserLibrary`). Note the exact export names for Task 2.
+
+- [ ] **Step 5: Commit branch marker**
+
+```bash
+git commit --allow-empty -m "chore: start dashboard-search-chat-flow feature branch"
+```
+
+---
+
+## Chunk 1: Foundation — Zustand Store + SearchExpander
+
+### Task 1: Dashboard Search Store
+
+**Files:**
+- Create: `apps/web/src/stores/useDashboardSearchStore.ts`
+- Test: `apps/web/src/__tests__/stores/useDashboardSearchStore.test.ts`
+
+- [ ] **Step 1: Write the store test**
+
+```typescript
+// apps/web/src/__tests__/stores/useDashboardSearchStore.test.ts
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useDashboardSearchStore } from '@/stores/useDashboardSearchStore';
+
+describe('useDashboardSearchStore', () => {
+  beforeEach(() => {
+    useDashboardSearchStore.getState().reset();
+  });
+
+  it('starts with search closed', () => {
+    const state = useDashboardSearchStore.getState();
+    expect(state.isSearchOpen).toBe(false);
+    expect(state.selectedGame).toBeNull();
+    expect(state.drawerState).toBeNull();
+  });
+
+  it('opens and closes search', () => {
+    const { openSearch, closeSearch } = useDashboardSearchStore.getState();
+    openSearch();
+    expect(useDashboardSearchStore.getState().isSearchOpen).toBe(true);
+    closeSearch();
+    expect(useDashboardSearchStore.getState().isSearchOpen).toBe(false);
+  });
+
+  it('sets selected game for modal', () => {
+    const game = { id: 'g1', name: 'Catan', imageUrl: null, playerCount: '3-4' };
+    useDashboardSearchStore.getState().setSelectedGame(game);
+    expect(useDashboardSearchStore.getState().selectedGame).toEqual(game);
+  });
+
+  it('sets drawer state for live chat', () => {
+    const drawer = { threadId: 't1', agentId: 'a1', gameId: 'g1', gameName: 'Catan' };
+    useDashboardSearchStore.getState().openChatDrawer(drawer);
+    expect(useDashboardSearchStore.getState().drawerState).toEqual(drawer);
+  });
+
+  it('clears drawer state on close', () => {
+    const drawer = { threadId: 't1', agentId: 'a1', gameId: 'g1', gameName: 'Catan' };
+    useDashboardSearchStore.getState().openChatDrawer(drawer);
+    useDashboardSearchStore.getState().closeChatDrawer();
+    expect(useDashboardSearchStore.getState().drawerState).toBeNull();
+  });
+
+  it('reset clears everything', () => {
+    useDashboardSearchStore.getState().openSearch();
+    useDashboardSearchStore.getState().setSelectedGame({ id: 'g1', name: 'X', imageUrl: null, playerCount: '2' });
+    useDashboardSearchStore.getState().reset();
+    const state = useDashboardSearchStore.getState();
+    expect(state.isSearchOpen).toBe(false);
+    expect(state.selectedGame).toBeNull();
+    expect(state.drawerState).toBeNull();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/web && pnpm vitest run src/__tests__/stores/useDashboardSearchStore.test.ts`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Implement the store**
+
+```typescript
+// apps/web/src/stores/useDashboardSearchStore.ts
+import { create } from 'zustand';
+
+export interface SearchGameResult {
+  id: string;
+  name: string;
+  imageUrl: string | null;
+  playerCount: string;
+}
+
+export interface ChatDrawerState {
+  threadId: string;
+  agentId: string;
+  gameId: string;
+  gameName: string;
+  kbCardCount?: number;
+}
+
+interface DashboardSearchState {
+  isSearchOpen: boolean;
+  selectedGame: SearchGameResult | null;
+  drawerState: ChatDrawerState | null;
+  openSearch: () => void;
+  closeSearch: () => void;
+  setSelectedGame: (game: SearchGameResult | null) => void;
+  openChatDrawer: (state: ChatDrawerState) => void;
+  closeChatDrawer: () => void;
+  reset: () => void;
+}
+
+export const useDashboardSearchStore = create<DashboardSearchState>((set) => ({
+  isSearchOpen: false,
+  selectedGame: null,
+  drawerState: null,
+  openSearch: () => set({ isSearchOpen: true }),
+  closeSearch: () => set({ isSearchOpen: false, selectedGame: null }),
+  setSelectedGame: (game) => set({ selectedGame: game }),
+  openChatDrawer: (state) => set({ drawerState: state, isSearchOpen: false, selectedGame: null }),
+  closeChatDrawer: () => set({ drawerState: null }),
+  reset: () => set({ isSearchOpen: false, selectedGame: null, drawerState: null }),
+}));
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/web && pnpm vitest run src/__tests__/stores/useDashboardSearchStore.test.ts`
+Expected: All 6 tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/stores/useDashboardSearchStore.ts apps/web/src/__tests__/stores/useDashboardSearchStore.test.ts
+git commit -m "feat(dashboard): add search store for cross-component coordination"
+```
+
+---
+
+### Task 2: SearchExpander Component
+
+**Files:**
+- Create: `apps/web/src/components/dashboard/SearchExpander.tsx`
+- Test: `apps/web/src/__tests__/components/dashboard/SearchExpander.test.tsx`
+- Reference: `apps/web/src/lib/api/clients/sharedGamesClient.ts` (search method uses `searchTerm` param)
+
+- [ ] **Step 1: Write the test**
+
+```tsx
+// apps/web/src/__tests__/components/dashboard/SearchExpander.test.tsx
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+import { SearchExpander } from '@/components/dashboard/SearchExpander';
+
+// Mock the shared games client
+const mockSearch = vi.fn();
+vi.mock('@/lib/api/clients/sharedGamesClient', () => ({
+  createSharedGamesClient: () => ({ search: mockSearch }),
+}));
+
+// Mock the user library hook (to check "in library" status)
+// NOTE: The mock path below is a placeholder. In Task 0 Step 4 you identified the actual
+// hook file and export name. Update this mock to match. If no hook exists, you must create
+// a `useUserLibraryGameIds` hook in `src/hooks/queries/useLibrary.ts` that returns a
+// Set<string> of game IDs from the user's library (wrap existing library client).
+const mockLibraryGames = new Set<string>();
+vi.mock('@/hooks/queries/useLibrary', () => ({
+  useUserLibraryGameIds: () => ({ data: mockLibraryGames }),
+}));
+
+// Mock router
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+describe('SearchExpander', () => {
+  const mockOnViewGame = vi.fn();
+  const mockOnAskAboutGame = vi.fn();
+  const mockOnClose = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSearch.mockResolvedValue({
+      items: [
+        { id: 'g1', name: 'Catan', thumbnailUrl: '/catan.jpg', minPlayers: 3, maxPlayers: 4 },
+        { id: 'g2', name: 'Catan: Seafarers', thumbnailUrl: '/seafarers.jpg', minPlayers: 3, maxPlayers: 4 },
+      ],
+      total: 2,
+      page: 1,
+      pageSize: 5,
+    });
+  });
+
+  it('renders search input when open', () => {
+    render(
+      <SearchExpander
+        isOpen={true}
+        onClose={mockOnClose}
+        onViewGame={mockOnViewGame}
+        onAskAboutGame={mockOnAskAboutGame}
+      />
+    );
+    expect(screen.getByPlaceholderText(/cerca un gioco/i)).toBeInTheDocument();
+  });
+
+  it('does not render when closed', () => {
+    render(
+      <SearchExpander
+        isOpen={false}
+        onClose={mockOnClose}
+        onViewGame={mockOnViewGame}
+        onAskAboutGame={mockOnAskAboutGame}
+      />
+    );
+    expect(screen.queryByPlaceholderText(/cerca un gioco/i)).not.toBeInTheDocument();
+  });
+
+  it('searches after debounce and shows results', async () => {
+    render(
+      <SearchExpander
+        isOpen={true}
+        onClose={mockOnClose}
+        onViewGame={mockOnViewGame}
+        onAskAboutGame={mockOnAskAboutGame}
+      />
+    );
+
+    const input = screen.getByPlaceholderText(/cerca un gioco/i);
+    await act(async () => {
+      fireEvent.change(input, { target: { value: 'Catan' } });
+    });
+
+    await waitFor(() => {
+      expect(mockSearch).toHaveBeenCalledWith(
+        expect.objectContaining({ searchTerm: 'Catan', pageSize: 5 })
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Catan')).toBeInTheDocument();
+      expect(screen.getByText('Catan: Seafarers')).toBeInTheDocument();
+    });
+  });
+
+  it('calls onViewGame when "Vedi" is clicked', async () => {
+    render(
+      <SearchExpander
+        isOpen={true}
+        onClose={mockOnClose}
+        onViewGame={mockOnViewGame}
+        onAskAboutGame={mockOnAskAboutGame}
+      />
+    );
+
+    const input = screen.getByPlaceholderText(/cerca un gioco/i);
+    await act(async () => {
+      fireEvent.change(input, { target: { value: 'Catan' } });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Catan')).toBeInTheDocument();
+    });
+
+    const vediButtons = screen.getAllByText(/vedi/i);
+    fireEvent.click(vediButtons[0]);
+    expect(mockOnViewGame).toHaveBeenCalledWith('g1');
+  });
+
+  it('calls onAskAboutGame when "Chiedi" is clicked', async () => {
+    render(
+      <SearchExpander
+        isOpen={true}
+        onClose={mockOnClose}
+        onViewGame={mockOnViewGame}
+        onAskAboutGame={mockOnAskAboutGame}
+      />
+    );
+
+    const input = screen.getByPlaceholderText(/cerca un gioco/i);
+    await act(async () => {
+      fireEvent.change(input, { target: { value: 'Catan' } });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Catan')).toBeInTheDocument();
+    });
+
+    const chiediButtons = screen.getAllByText(/chiedi/i);
+    fireEvent.click(chiediButtons[0]);
+    expect(mockOnAskAboutGame).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'g1', name: 'Catan' })
+    );
+  });
+
+  it('closes on ESC key', () => {
+    render(
+      <SearchExpander
+        isOpen={true}
+        onClose={mockOnClose}
+        onViewGame={mockOnViewGame}
+        onAskAboutGame={mockOnAskAboutGame}
+      />
+    );
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(mockOnClose).toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/web && pnpm vitest run src/__tests__/components/dashboard/SearchExpander.test.tsx`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Implement SearchExpander**
+
+Create `apps/web/src/components/dashboard/SearchExpander.tsx`:
+
+Key implementation details:
+- Import `createSharedGamesClient` from `@/lib/api/clients/sharedGamesClient`
+- Use `useCallback` with 300ms debounce via `setTimeout`/`clearTimeout`
+- Render: input with glassmorphism (`bg-white/5 backdrop-blur-xl border border-white/10 rounded-2xl`)
+- Results: list of items with game thumbnail, name, player count, dual action buttons
+- Check `useUserLibraryGameIds()` to determine if game is in library (show ✓ badge, green "Chiedi" button)
+- "Vedi" button calls `onViewGame(game.id)`
+- "Chiedi" button calls `onAskAboutGame(game)` with full game object
+- ESC listener via `useEffect` with `keydown` event
+- Auto-focus input on mount via `useRef` + `useEffect`
+- `data-testid="search-expander"` on wrapper
+
+**Note:** If `useUserLibraryGameIds` hook doesn't exist, create a simple wrapper around the library client that returns a `Set<string>` of game IDs in the user's library. Check `apps/web/src/hooks/queries/` for existing library hooks first.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/web && pnpm vitest run src/__tests__/components/dashboard/SearchExpander.test.tsx`
+Expected: All 6 tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/dashboard/SearchExpander.tsx apps/web/src/__tests__/components/dashboard/SearchExpander.test.tsx
+git commit -m "feat(dashboard): add SearchExpander component with debounced search and dual actions"
+```
+
+---
+
+### Task 3: SmartFAB Extension — Add Search Icon
+
+**Files:**
+- Modify: `apps/web/src/components/layout/SmartFAB/SmartFAB.tsx`
+- Reference: `apps/web/src/stores/useDashboardSearchStore.ts`
+- Reference: `apps/web/src/components/dashboard/SearchExpander.tsx`
+
+- [ ] **Step 1: Read SmartFAB current implementation**
+
+Run: `cd apps/web && cat src/components/layout/SmartFAB/SmartFAB.tsx`
+
+Understand:
+- How `resolveSmartFab(pathname)` works (from `@/config/smart-fab`)
+- Where the primary button and QuickMenu render
+- The fixed positioning wrapper (lines 285-331)
+
+- [ ] **Step 2: Add search icon and SearchExpander mount**
+
+In `SmartFAB.tsx`, add:
+
+```typescript
+import { useDashboardSearchStore } from '@/stores/useDashboardSearchStore';
+import { SearchExpander } from '@/components/dashboard/SearchExpander';
+import { Search } from 'lucide-react';
+import { useRouter } from 'next/navigation';
+```
+
+Inside the component body, add:
+```typescript
+const { isSearchOpen, openSearch, closeSearch, setSelectedGame } = useDashboardSearchStore();
+const router = useRouter();
+
+const handleViewGame = useCallback((gameId: string) => {
+  closeSearch();
+  router.push(`/shared-games/${gameId}`);
+}, [closeSearch, router]);
+
+// "Already in library" flow: skip modal, go directly to creating thread + opening drawer.
+// "Not in library" flow: open AddToLibraryModal via setSelectedGame.
+const handleAskAboutGame = useCallback(async (game: SearchGameResult & { isInLibrary?: boolean }) => {
+  closeSearch();
+  if (game.isInLibrary) {
+    // Skip modal — create thread directly and open drawer
+    try {
+      const chatClient = createChatClient({ httpClient });
+      const thread = await chatClient.createThread({ gameId: game.id, title: game.name });
+      openChatDrawer({ threadId: thread.id, agentId: thread.agentId, gameId: game.id, gameName: game.name });
+    } catch {
+      // Fallback: open modal anyway so user can retry
+      setSelectedGame(game);
+    }
+  } else {
+    setSelectedGame(game);
+  }
+}, [closeSearch, setSelectedGame, openChatDrawer]);
+```
+
+In the JSX, add a search button BEFORE the primary action button (inside the fixed wrapper). When on the dashboard pathname (`/dashboard`), render:
+```tsx
+{pathname === '/dashboard' && (
+  <>
+    <button
+      onClick={openSearch}
+      className="w-10 h-10 rounded-full bg-gradient-to-br from-blue-500 to-purple-600 flex items-center justify-center shadow-lg shadow-blue-500/20"
+      data-testid="smart-fab-search"
+      aria-label="Cerca un gioco"
+    >
+      <Search className="w-5 h-5 text-white" />
+    </button>
+    <SearchExpander
+      isOpen={isSearchOpen}
+      onClose={closeSearch}
+      onViewGame={handleViewGame}
+      onAskAboutGame={handleAskAboutGame}
+    />
+  </>
+)}
+```
+
+Position the SearchExpander above the FAB using absolute positioning (the SearchExpander itself handles its own overlay positioning).
+
+- [ ] **Step 3: Run existing SmartFAB tests**
+
+Run: `cd apps/web && pnpm vitest run --reporter=verbose 2>&1 | grep -i "smartfab\|SmartFAB"`
+
+Fix any test failures caused by the new search button rendering.
+
+- [ ] **Step 4: Verify manually**
+
+Run: `cd apps/web && pnpm dev`
+Navigate to dashboard. Verify:
+- 🔍 button visible in SmartFAB area
+- Click opens SearchExpander
+- ESC closes it
+- Search returns results from shared library
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/layout/SmartFAB/SmartFAB.tsx
+git commit -m "feat(dashboard): add search icon to SmartFAB with SearchExpander integration"
+```
+
+---
+
+## Chunk 2: AddToLibraryModal + HeroZone
+
+### Task 4: AddToLibraryModal Component
+
+**Files:**
+- Create: `apps/web/src/components/dashboard/AddToLibraryModal.tsx`
+- Test: `apps/web/src/__tests__/components/dashboard/AddToLibraryModal.test.tsx`
+- Reference: `apps/web/src/lib/api/clients/libraryClient.ts` — `addGame(gameId)` method
+- Reference: `apps/web/src/lib/api/clients/chatClient.ts` — `createThread({ gameId, agentId })` method
+
+- [ ] **Step 1: Write the test**
+
+```tsx
+// apps/web/src/__tests__/components/dashboard/AddToLibraryModal.test.tsx
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { AddToLibraryModal } from '@/components/dashboard/AddToLibraryModal';
+
+const mockAddGame = vi.fn();
+const mockCreateThread = vi.fn();
+
+vi.mock('@/lib/api/clients/libraryClient', () => ({
+  createLibraryClient: () => ({ addGame: mockAddGame }),
+}));
+
+vi.mock('@/lib/api/clients/chatClient', () => ({
+  createChatClient: () => ({ createThread: mockCreateThread }),
+}));
+
+describe('AddToLibraryModal', () => {
+  const game = { id: 'g1', name: 'Catan', imageUrl: '/catan.jpg', playerCount: '3-4' };
+  const mockOnClose = vi.fn();
+  const mockOnSuccess = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockAddGame.mockResolvedValue({ id: 'lib1', gameId: 'g1' });
+    mockCreateThread.mockResolvedValue({ id: 't1', agentId: 'a1', gameId: 'g1' });
+  });
+
+  it('renders game info and CTA', () => {
+    render(
+      <AddToLibraryModal game={game} isOpen={true} onClose={mockOnClose} onSuccess={mockOnSuccess} />
+    );
+    expect(screen.getByText('Catan')).toBeInTheDocument();
+    expect(screen.getByText(/aggiungi e chiedi/i)).toBeInTheDocument();
+    expect(screen.getByText(/per chattare con l'ai/i)).toBeInTheDocument();
+  });
+
+  it('does not render when closed', () => {
+    render(
+      <AddToLibraryModal game={game} isOpen={false} onClose={mockOnClose} onSuccess={mockOnSuccess} />
+    );
+    expect(screen.queryByText('Catan')).not.toBeInTheDocument();
+  });
+
+  it('orchestrates add + create thread on confirm', async () => {
+    render(
+      <AddToLibraryModal game={game} isOpen={true} onClose={mockOnClose} onSuccess={mockOnSuccess} />
+    );
+
+    fireEvent.click(screen.getByText(/aggiungi e chiedi/i));
+
+    await waitFor(() => {
+      expect(mockAddGame).toHaveBeenCalledWith('g1', expect.any(Object));
+    });
+
+    await waitFor(() => {
+      expect(mockCreateThread).toHaveBeenCalledWith(
+        expect.objectContaining({ gameId: 'g1' })
+      );
+    });
+
+    await waitFor(() => {
+      expect(mockOnSuccess).toHaveBeenCalledWith(
+        expect.objectContaining({ gameId: 'g1', threadId: 't1', agentId: 'a1' })
+      );
+    });
+  });
+
+  it('shows error when addGame fails', async () => {
+    mockAddGame.mockRejectedValue(new Error('Network error'));
+
+    render(
+      <AddToLibraryModal game={game} isOpen={true} onClose={mockOnClose} onSuccess={mockOnSuccess} />
+    );
+
+    fireEvent.click(screen.getByText(/aggiungi e chiedi/i));
+
+    await waitFor(() => {
+      expect(screen.getByText(/errore/i)).toBeInTheDocument();
+    });
+
+    expect(mockOnSuccess).not.toHaveBeenCalled();
+  });
+
+  it('shows retry when createThread fails (game stays in library)', async () => {
+    mockCreateThread.mockRejectedValue(new Error('Thread creation failed'));
+
+    render(
+      <AddToLibraryModal game={game} isOpen={true} onClose={mockOnClose} onSuccess={mockOnSuccess} />
+    );
+
+    fireEvent.click(screen.getByText(/aggiungi e chiedi/i));
+
+    await waitFor(() => {
+      expect(mockAddGame).toHaveBeenCalled();
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText(/riprova/i)).toBeInTheDocument();
+    });
+
+    expect(mockOnSuccess).not.toHaveBeenCalled();
+  });
+
+  it('calls onClose when cancel is clicked', () => {
+    render(
+      <AddToLibraryModal game={game} isOpen={true} onClose={mockOnClose} onSuccess={mockOnSuccess} />
+    );
+
+    fireEvent.click(screen.getByText(/annulla/i));
+    expect(mockOnClose).toHaveBeenCalled();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/web && pnpm vitest run src/__tests__/components/dashboard/AddToLibraryModal.test.tsx`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Implement AddToLibraryModal**
+
+Create `apps/web/src/components/dashboard/AddToLibraryModal.tsx`:
+
+Key implementation details:
+- Use shadcn `Dialog` component (`@/components/ui/navigation/dialog` — verify exact import path)
+- State: `isLoading`, `error`, `retryMode` (when thread creation fails after successful add)
+- On confirm:
+  1. `setIsLoading(true)`
+  2. `await libraryClient.addGame(game.id, {})`
+  3. `const thread = await chatClient.createThread({ gameId: game.id, title: game.name })`
+  4. `onSuccess({ gameId: game.id, threadId: thread.id, agentId: thread.agentId })`
+- On addGame error: show error message, stay in modal
+- On createThread error: show "Riprova" button that only retries step 3 (game already added)
+- Invalidate dashboard queries via `queryClient.invalidateQueries({ queryKey: ['dashboard'] })`
+
+**Note:** Check exact `queryKey` patterns by searching for `useQuery` with `dashboard` key in `apps/web/src/hooks/`.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/web && pnpm vitest run src/__tests__/components/dashboard/AddToLibraryModal.test.tsx`
+Expected: All 6 tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/dashboard/AddToLibraryModal.tsx apps/web/src/__tests__/components/dashboard/AddToLibraryModal.test.tsx
+git commit -m "feat(dashboard): add AddToLibraryModal with orchestrated add + chat creation"
+```
+
+---
+
+### Task 5: HeroZone Enhanced Empty State
+
+**Files:**
+- Modify: `apps/web/src/components/dashboard/zones/HeroZone.tsx`
+- Reference: `apps/web/src/stores/useDashboardSearchStore.ts`
+
+- [ ] **Step 1: Read current HeroZone**
+
+Run: `cd apps/web && cat src/components/dashboard/zones/HeroZone.tsx`
+
+Identify:
+- The `isNewUser` conditional (around line 91)
+- The `<WelcomePrompt />` component rendering
+- The `useDashboardData()` hook usage
+
+- [ ] **Step 2: Modify the isNewUser branch**
+
+Replace the `{isNewUser && <WelcomePrompt />}` block with:
+
+```tsx
+{isNewUser && (
+  <div className="mt-4 rounded-xl bg-gradient-to-br from-purple-500/10 to-blue-500/10 border border-purple-500/20 p-6 text-center">
+    <p className="text-sm text-purple-300 mb-4">
+      {greeting}{user?.username ? `, ${user.username}` : ''}!<br />
+      Hai una domanda su un gioco da tavolo? Cerca nella community e chiedi all&apos;AI!
+    </p>
+    <button
+      onClick={() => useDashboardSearchStore.getState().openSearch()}
+      className="inline-flex items-center gap-2 rounded-lg bg-purple-500/15 border border-purple-500/25 px-4 py-2 text-sm font-medium text-purple-300 hover:bg-purple-500/25 transition-colors"
+      data-testid="hero-search-cta"
+    >
+      <Search className="w-4 h-4" />
+      Cerca un gioco
+    </button>
+    <p className="mt-2 text-xs text-muted-foreground">
+      oppure usa la barra in basso ↓
+    </p>
+  </div>
+)}
+```
+
+Add imports at top:
+```typescript
+import { Search } from 'lucide-react';
+import { useDashboardSearchStore } from '@/stores/useDashboardSearchStore';
+```
+
+- [ ] **Step 3: Verify manually**
+
+Run: `cd apps/web && pnpm dev`
+- Clear localStorage/session to simulate new user (or use a test account with empty library)
+- Navigate to dashboard
+- Verify: enhanced empty state shows with "Cerca un gioco" CTA
+- Click CTA → SearchExpander opens in SmartFAB area
+
+- [ ] **Step 4: Run existing HeroZone tests to verify no regression**
+
+Run: `cd apps/web && pnpm vitest run --reporter=verbose 2>&1 | grep -i herozone`
+
+If existing tests reference `WelcomePrompt`, update them to expect the new CTA button text instead.
+
+- [ ] **Step 5: Remove dead WelcomePrompt code**
+
+If the `WelcomePrompt` component/function was only used in this `isNewUser` branch, remove its definition to avoid lint warnings about dead code. Check if it's imported elsewhere first: `grep -r "WelcomePrompt" src/`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/components/dashboard/zones/HeroZone.tsx
+git commit -m "feat(dashboard): enhance HeroZone empty state with search CTA for new users"
+```
+
+---
+
+### Task 6: Wire AddToLibraryModal into Dashboard Flow
+
+**Files:**
+- Modify: `apps/web/src/components/dashboard/DashboardRenderer.tsx`
+- Reference: `apps/web/src/stores/useDashboardSearchStore.ts`
+- Reference: `apps/web/src/components/dashboard/AddToLibraryModal.tsx`
+
+- [ ] **Step 1: Read DashboardRenderer**
+
+Run: `cd apps/web && cat src/components/dashboard/DashboardRenderer.tsx`
+
+Understand its JSX structure and where to mount the modal.
+
+- [ ] **Step 2: Add AddToLibraryModal mount**
+
+In `DashboardRenderer.tsx`, add:
+
+```typescript
+import { useDashboardSearchStore } from '@/stores/useDashboardSearchStore';
+import { AddToLibraryModal } from './AddToLibraryModal';
+```
+
+Inside the component body:
+```typescript
+const { selectedGame, setSelectedGame, openChatDrawer } = useDashboardSearchStore();
+
+const handleModalSuccess = useCallback(({ gameId, threadId, agentId }: { gameId: string; threadId: string; agentId: string }) => {
+  setSelectedGame(null);
+  openChatDrawer({ threadId, agentId, gameId, gameName: selectedGame?.name ?? '' });
+}, [selectedGame, setSelectedGame, openChatDrawer]);
+```
+
+At the end of the JSX (before closing div):
+```tsx
+<AddToLibraryModal
+  game={selectedGame}
+  isOpen={selectedGame !== null}
+  onClose={() => setSelectedGame(null)}
+  onSuccess={handleModalSuccess}
+/>
+```
+
+- [ ] **Step 3: Verify the modal flow**
+
+Run: `cd apps/web && pnpm dev`
+- Dashboard → SmartFAB search → type game name → click "Chiedi" on a game not in library
+- Modal appears with game info
+- Click "Aggiungi e Chiedi" → game added (check network tab) + thread created
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/src/components/dashboard/DashboardRenderer.tsx
+git commit -m "feat(dashboard): wire AddToLibraryModal into dashboard renderer"
+```
+
+---
+
+## Chunk 3: EmbeddedChatView + Drawer Integration
+
+### Task 7: EmbeddedChatView Component
+
+**Files:**
+- Create: `apps/web/src/components/chat-unified/EmbeddedChatView.tsx`
+- Test: `apps/web/src/__tests__/components/chat-unified/EmbeddedChatView.test.tsx`
+- Reference: `apps/web/src/hooks/useAgentChatStream.ts` — `{ state, sendMessage, stopStreaming, reset }`
+- Reference: `apps/web/src/components/chat-unified/ChatThreadView.tsx` — message rendering patterns
+
+- [ ] **Step 1: Write the test**
+
+```tsx
+// apps/web/src/__tests__/components/chat-unified/EmbeddedChatView.test.tsx
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { EmbeddedChatView } from '@/components/chat-unified/EmbeddedChatView';
+
+const mockSendMessage = vi.fn();
+const mockReset = vi.fn();
+
+vi.mock('@/hooks/useAgentChatStream', () => ({
+  useAgentChatStream: () => ({
+    state: {
+      statusMessage: null,
+      currentAnswer: '',
+      followUpQuestions: [],
+      isStreaming: false,
+      error: null,
+      chatThreadId: 't1',
+      totalTokens: 0,
+      debugSteps: [],
+      modelDowngrade: null,
+      strategyTier: null,
+      executionId: null,
+    },
+    sendMessage: mockSendMessage,
+    stopStreaming: vi.fn(),
+    reset: mockReset,
+  }),
+}));
+
+// Mock chat thread history
+vi.mock('@/lib/api/clients/chatClient', () => ({
+  createChatClient: () => ({
+    getMessages: vi.fn().mockResolvedValue({ items: [] }),
+  }),
+}));
+
+describe('EmbeddedChatView', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it('renders input area', () => {
+    render(<EmbeddedChatView threadId="t1" agentId="a1" gameId="g1" />);
+    expect(screen.getByPlaceholderText(/scrivi/i)).toBeInTheDocument();
+  });
+
+  it('sends message via SSE on submit', async () => {
+    render(<EmbeddedChatView threadId="t1" agentId="a1" gameId="g1" />);
+
+    const input = screen.getByPlaceholderText(/scrivi/i);
+    fireEvent.change(input, { target: { value: 'Come si gioca?' } });
+    fireEvent.submit(input.closest('form')!);
+
+    await waitFor(() => {
+      expect(mockSendMessage).toHaveBeenCalledWith(
+        'a1',
+        'Come si gioca?',
+        't1',
+        expect.anything(),
+        undefined
+      );
+    });
+  });
+
+  it('renders welcome state when no messages', () => {
+    render(<EmbeddedChatView threadId="t1" agentId="a1" gameId="g1" />);
+    expect(screen.getByText(/chiedi qualsiasi cosa/i)).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd apps/web && pnpm vitest run src/__tests__/components/chat-unified/EmbeddedChatView.test.tsx`
+Expected: FAIL — module not found
+
+- [ ] **Step 3: Implement EmbeddedChatView**
+
+Create `apps/web/src/components/chat-unified/EmbeddedChatView.tsx`:
+
+Key implementation details:
+- Extract the message rendering + input logic from `ChatThreadView.tsx` — study lines 50-91 (state), 181-187 (auto-scroll), 267-324 (handleSendMessage)
+- **DO NOT** import ChatThreadView — build a focused component that reuses the same hooks
+- Structure:
+  ```tsx
+  <div className="flex flex-col h-full" data-testid="embedded-chat-view">
+    {/* Messages area */}
+    <div className="flex-1 overflow-y-auto p-4 space-y-3">
+      {messages.length === 0 && !streamState.currentAnswer && (
+        <p className="text-center text-sm text-muted-foreground">Chiedi qualsiasi cosa sul gioco!</p>
+      )}
+      {messages.map(msg => (
+        <MessageBubble key={msg.id} message={msg} />
+      ))}
+      {streamState.currentAnswer && (
+        <StreamingBubble content={streamState.currentAnswer} />
+      )}
+      <div ref={messagesEndRef} />
+    </div>
+    {/* Input area */}
+    <form onSubmit={handleSend} className="p-3 border-t border-border">
+      <div className="flex items-center gap-2">
+        <input ... />
+        <button type="submit" disabled={isSending}>📤</button>
+      </div>
+    </form>
+  </div>
+  ```
+- Use `useAgentChatStream` with callbacks that append to local `messages` state
+- `sendMessage(agentId, content, threadId, proxyGameContext)` — where `proxyGameContext = { gameId }`
+- Auto-scroll via `useRef` + `useEffect` on messages/currentAnswer change
+
+**Note:** Check if `MessageBubble` or similar rendering component exists in `apps/web/src/components/chat-unified/`. If so, reuse it. Otherwise, create a minimal inline bubble renderer.
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd apps/web && pnpm vitest run src/__tests__/components/chat-unified/EmbeddedChatView.test.tsx`
+Expected: All 3 tests PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/chat-unified/EmbeddedChatView.tsx apps/web/src/__tests__/components/chat-unified/EmbeddedChatView.test.tsx
+git commit -m "feat(chat): add EmbeddedChatView for compact drawer chat"
+```
+
+---
+
+### Task 8: ExtraMeepleCardDrawer — Add liveChat Mode
+
+**Files:**
+- Modify: `apps/web/src/components/ui/data-display/extra-meeple-card/ExtraMeepleCardDrawer.tsx`
+- Reference: `apps/web/src/components/chat-unified/EmbeddedChatView.tsx`
+
+- [ ] **Step 1: Read current drawer implementation**
+
+Run: `cd apps/web && cat src/components/ui/data-display/extra-meeple-card/ExtraMeepleCardDrawer.tsx`
+
+Identify:
+- `DrawerEntityRouter` function (lines 223-262)
+- `ChatDrawerContent` function (lines 318-329)
+- The `ExtraMeepleCardDrawerProps` interface (lines 72-88)
+
+- [ ] **Step 2: Extend props with mode discriminator**
+
+Add to `ExtraMeepleCardDrawerProps`:
+```typescript
+export interface ExtraMeepleCardDrawerProps {
+  entityType: DrawerEntityType;
+  entityId: string;
+  open: boolean;
+  onClose: () => void;
+  linkEntityType?: LinkEntityType;
+  className?: string;
+  'data-testid'?: string;
+  // NEW: live chat mode data
+  liveChatData?: {
+    threadId: string;
+    agentId: string;
+    gameId: string;
+    gameName: string;
+  };
+}
+```
+
+- [ ] **Step 3: Extend DrawerEntityRouter signature and modify chatSession branch**
+
+The `DrawerEntityRouter` function (lines ~223-232) currently accepts only `{ entityType, entityId, linkEntityType }`. You MUST:
+
+1. Add `liveChatData` to `DrawerEntityRouter`'s parameter type:
+```typescript
+function DrawerEntityRouter({
+  entityType,
+  entityId,
+  linkEntityType,
+  liveChatData,  // NEW
+}: {
+  entityType: DrawerEntityType;
+  entityId: string;
+  linkEntityType?: LinkEntityType;
+  liveChatData?: ExtraMeepleCardDrawerProps['liveChatData'];  // NEW
+}) {
+```
+
+2. Update the call site in the parent component (around line ~209) to pass `liveChatData`:
+```typescript
+<DrawerEntityRouter
+  entityType={entityType}
+  entityId={entityId}
+  linkEntityType={linkEntityType}
+  liveChatData={liveChatData}  // NEW — pass through from parent props
+/>
+```
+
+3. Modify the `chatSession`/`chat` case:
+```typescript
+case 'chatSession':
+case 'chat':
+  if (liveChatData) {
+    return (
+      <EmbeddedChatView
+        threadId={liveChatData.threadId}
+        agentId={liveChatData.agentId}
+        gameId={liveChatData.gameId}
+      />
+    );
+  }
+  return <ChatDrawerContent entityId={entityId} />;
+```
+
+Add import:
+```typescript
+import { EmbeddedChatView } from '@/components/chat-unified/EmbeddedChatView';
+```
+
+- [ ] **Step 4: Verify no existing tests break**
+
+Run: `cd apps/web && pnpm vitest run --reporter=verbose 2>&1 | grep -i "extrameeple\|drawer"`
+
+Fix any failures.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/components/ui/data-display/extra-meeple-card/ExtraMeepleCardDrawer.tsx
+git commit -m "feat(drawer): add liveChat mode to chatSession branch in ExtraMeepleCardDrawer"
+```
+
+---
+
+### Task 9: Wire Chat Drawer into DashboardRenderer
+
+**Files:**
+- Modify: `apps/web/src/components/dashboard/DashboardRenderer.tsx`
+- Reference: `apps/web/src/stores/useDashboardSearchStore.ts`
+- Reference: `apps/web/src/components/ui/data-display/extra-meeple-card/ExtraMeepleCardDrawer.tsx`
+
+- [ ] **Step 1: Read current DashboardRenderer (after Task 6 changes)**
+
+Run: `cd apps/web && cat src/components/dashboard/DashboardRenderer.tsx`
+
+- [ ] **Step 2: Add ExtraMeepleCardDrawer mount for live chat**
+
+Add import:
+```typescript
+import { ExtraMeepleCardDrawer } from '@/components/ui/data-display/extra-meeple-card';
+```
+
+Use the `drawerState` from the store (already imported in Task 6):
+```typescript
+const { selectedGame, setSelectedGame, openChatDrawer, drawerState, closeChatDrawer } = useDashboardSearchStore();
+```
+
+Add at the end of JSX (after the AddToLibraryModal from Task 6):
+```tsx
+{drawerState && (
+  <ExtraMeepleCardDrawer
+    entityType="chatSession"
+    entityId={drawerState.threadId}
+    open={true}
+    onClose={closeChatDrawer}
+    liveChatData={drawerState}
+    data-testid="dashboard-chat-drawer"
+  />
+)}
+```
+
+- [ ] **Step 3: Test the complete flow end-to-end**
+
+Run: `cd apps/web && pnpm dev`
+
+Complete flow:
+1. Dashboard (new user) → see enhanced HeroZone
+2. Click "Cerca un gioco" CTA or 🔍 in SmartFAB
+3. Type a game name → see results
+4. Click "Chiedi" on a shared library game → AddToLibraryModal appears
+5. Click "Aggiungi e Chiedi" → game added + thread created
+6. Modal closes → ExtraMeepleCardDrawer opens with EmbeddedChatView
+7. Type a question → get AI response via SSE
+8. Close drawer → chat card should appear in dashboard "Active Chats" (via query invalidation)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add apps/web/src/components/dashboard/DashboardRenderer.tsx
+git commit -m "feat(dashboard): wire chat drawer with live chat mode into dashboard"
+```
+
+---
+
+## Chunk 4: Polish + Final Verification
+
+### Task 10: Type Check + Lint
+
+- [ ] **Step 1: Run TypeScript check**
+
+Run: `cd apps/web && pnpm typecheck`
+Expected: 0 errors. Fix any type issues.
+
+- [ ] **Step 2: Run lint**
+
+Run: `cd apps/web && pnpm lint`
+Expected: 0 errors. Fix any lint issues.
+
+- [ ] **Step 3: Commit fixes if any**
+
+```bash
+git add apps/web/src/  # Stage only specific changed files, not -A
+git commit -m "fix(dashboard): resolve type and lint issues in search-chat flow"
+```
+
+---
+
+### Task 11: Run All Tests
+
+- [ ] **Step 1: Run full test suite**
+
+Run: `cd apps/web && pnpm test`
+Expected: All tests pass.
+
+- [ ] **Step 2: Run only new tests to verify coverage**
+
+Run: `cd apps/web && pnpm vitest run src/__tests__/stores/useDashboardSearchStore.test.ts src/__tests__/components/dashboard/SearchExpander.test.tsx src/__tests__/components/dashboard/AddToLibraryModal.test.tsx src/__tests__/components/chat-unified/EmbeddedChatView.test.tsx`
+Expected: All 18+ tests PASS.
+
+- [ ] **Step 3: Fix any failures and commit**
+
+```bash
+git add apps/web/src/  # Stage only specific changed files, not -A
+git commit -m "fix(dashboard): resolve test failures in search-chat flow"
+```
+
+---
+
+### Task 12: Push + PR
+
+- [ ] **Step 1: Verify branch**
+
+Run: `git branch --show-current`
+Expected: `feature/dashboard-search-chat-flow` (created in Task 0)
+
+- [ ] **Step 2: Push and create PR**
+
+```bash
+git push -u origin feature/dashboard-search-chat-flow
+```
+
+Create PR to `main-dev` (parent branch):
+```bash
+gh pr create --base main-dev --title "feat: dashboard search → add game → chat flow" --body-file <(cat <<'EOF'
+## Summary
+
+- **SearchExpander** in SmartFAB: debounced search across shared game library with dual actions (Vedi/Chiedi)
+- **AddToLibraryModal**: one-click add game + create chat thread orchestration
+- **EmbeddedChatView**: compact ChatThreadView for drawer usage (messages + input only)
+- **ExtraMeepleCardDrawer**: liveChat mode for chatSession entity type
+- **HeroZone**: enhanced empty state guiding new users to search
+
+## User Flow
+
+New user → dashboard → search game → "Chiedi" → add to library modal → chat in drawer
+
+## Test plan
+
+- [ ] New user sees enhanced HeroZone with "Cerca un gioco" CTA
+- [ ] CTA opens SearchExpander in SmartFAB area
+- [ ] Search returns shared library games with dual actions
+- [ ] "Vedi" navigates to shared game page
+- [ ] "Chiedi" on non-library game opens AddToLibraryModal
+- [ ] "Aggiungi e Chiedi" adds game + creates thread + opens drawer
+- [ ] EmbeddedChatView in drawer works with SSE streaming
+- [ ] Close drawer → chat card visible in Active Chats
+- [ ] TypeScript + lint pass
+- [ ] All unit tests pass
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)
+```
+
+- [ ] **Step 3: Update issue status**
+
+Update the related GitHub issue (if any) with PR link and mark as in-progress.
+
+- [ ] **Step 4: Clean up**
+
+```bash
+git branch -D feature/dashboard-search-chat-flow  # After merge
+git remote prune origin
+```

--- a/docs/superpowers/plans/2026-03-17-replace-mocked-data.md
+++ b/docs/superpowers/plans/2026-03-17-replace-mocked-data.md
@@ -1,0 +1,650 @@
+# Replace Mocked Data Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace all hardcoded/mocked data in the frontend with real API calls across 11 tasks (C4 deferred).
+
+**Architecture:** Phase 1 wires 7 frontend components to existing backend APIs. Phase 2 creates/modifies 4 backend endpoints then wires frontend. Each task is independent and can be parallelized.
+
+**Tech Stack:** Next.js (React 19), @tanstack/react-query, .NET 9 Minimal APIs + MediatR CQRS, FluentValidation
+
+**Spec:** `docs/superpowers/specs/2026-03-17-replace-mocked-data-design.md`
+
+---
+
+## Chunk 1: Phase 1 — Frontend Quick Wins
+
+### Task 1: A1 — Wire 2FA Status + Recovery Codes
+
+**Files:**
+- Modify: `apps/web/src/app/(authenticated)/settings/security/page.tsx`
+- Reference: `apps/web/src/lib/api/clients/authClient.ts` (for API methods)
+
+**Context:** Component at line 23 has `useState(false)` for 2FA status, lines 31-37 have hardcoded recovery codes. Lines 28-29 have commented-out useQuery. Backend endpoints `POST /api/v1/auth/2fa/setup`, `enable`, `disable` exist.
+
+- [ ] **Step 1: Read the current security page and authClient**
+
+Read `security/page.tsx` and `authClient.ts` to confirm the exact API method names for 2FA status and setup.
+
+- [ ] **Step 2: Replace hardcoded 2FA status with API query**
+
+Replace `useState(false)` with a query to fetch 2FA status:
+
+```tsx
+// Replace line 23:
+// const [is2FAEnabled, setIs2FAEnabled] = useState(false);
+// With:
+const { data: twoFactorStatus, isLoading: is2FALoading } = useQuery({
+  queryKey: ['2fa-status'],
+  queryFn: () => api.auth.get2FAStatus(),
+  retry: false,
+});
+const is2FAEnabled = twoFactorStatus?.isEnabled ?? false;
+```
+
+If `get2FAStatus()` doesn't exist in authClient, check for an equivalent method (e.g. profile endpoint that includes 2FA status).
+
+- [ ] **Step 3: Replace hardcoded recovery codes with setup response**
+
+Remove the hardcoded `recoveryCodes` array (lines 31-37). Recovery codes should come from the `setup2FA()` API response and be stored in component state only after user completes setup:
+
+```tsx
+const [recoveryCodes, setRecoveryCodes] = useState<string[]>([]);
+
+// In the setup handler:
+const setupResult = await api.auth.setup2FA();
+setRecoveryCodes(setupResult.recoveryCodes);
+```
+
+- [ ] **Step 4: Remove hardcoded TOTP secret**
+
+Line 102 has `JBSWY3DPEHPK3PXP`. Replace with the secret from the setup API response.
+
+- [ ] **Step 5: Add loading state for 2FA status**
+
+Show skeleton/spinner while `is2FALoading` is true.
+
+- [ ] **Step 6: Test manually**
+
+Verify: page loads without errors, 2FA status reflects real state, setup flow returns real codes.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/web/src/app/\(authenticated\)/settings/security/page.tsx
+git commit -m "feat(settings): wire 2FA status and recovery codes to real API"
+```
+
+---
+
+### Task 2: A2 — Wire Avatar Upload
+
+**Files:**
+- Modify: `apps/web/src/app/(public)/settings/page.tsx` (~line 770)
+
+**Context:** The `onUpload` callback in `<AvatarUpload>` has `api.auth.uploadAvatar(file)` commented out. The upload UI and optimistic update already work — just need to uncomment the API call.
+
+- [ ] **Step 1: Read settings page around line 760-790**
+
+Find the exact commented-out code and surrounding error handling.
+
+- [ ] **Step 2: Uncomment the avatar upload API call**
+
+```tsx
+// Replace:
+// TODO: Upload to backend when API is available
+// await api.auth.uploadAvatar(file);
+
+// With:
+await api.auth.uploadAvatar(file);
+```
+
+- [ ] **Step 3: Verify error handling exists**
+
+Ensure there's a try/catch that reverts the optimistic preview on failure. If not, add one:
+
+```tsx
+try {
+  await api.auth.uploadAvatar(file);
+} catch (err) {
+  // Revert optimistic preview
+  setAvatarPreview(null);
+  toast.error('Failed to upload avatar');
+}
+```
+
+- [ ] **Step 4: Test manually**
+
+Upload an avatar image, verify it persists after page reload.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/app/\(public\)/settings/page.tsx
+git commit -m "feat(settings): wire avatar upload to backend API"
+```
+
+---
+
+### Task 3: B1-B3 — Wire Agent Analytics to Real Data
+
+**Files:**
+- Modify: `apps/web/src/app/admin/(dashboard)/agents/analytics/page.tsx`
+- Delete: `apps/web/src/components/admin/agents/agent-kpi-cards.tsx` (mock version)
+- Delete: `apps/web/src/components/admin/agents/cost-breakdown-chart.tsx` (mock version)
+- Delete: `apps/web/src/components/admin/agents/usage-trend-chart.tsx` (mock version)
+- Possibly delete: `apps/web/src/components/admin/agents/top-queries-table.tsx` (check if mock)
+- Reference: `apps/web/src/app/(authenticated)/admin/agents/metrics/client.tsx` (real implementation)
+- Reference: `apps/web/src/components/admin/agents/CostBreakdownChart.tsx` (real component with props)
+- Reference: `apps/web/src/components/admin/agents/MetricsKpiCards.tsx` (real component)
+- Reference: `apps/web/src/components/admin/agents/UsageChart.tsx` (real component)
+- Reference: `apps/web/src/components/admin/agents/TopAgentsTable.tsx` (real component)
+
+**Context:** There are TWO sets of components:
+1. **Mock (kebab-case):** `agent-kpi-cards.tsx`, `cost-breakdown-chart.tsx`, `usage-trend-chart.tsx` — hardcoded MOCK_* data, no props
+2. **Real (PascalCase):** `MetricsKpiCards.tsx`, `CostBreakdownChart.tsx`, `UsageChart.tsx` — accept data props, used by `metrics/client.tsx`
+
+The `metrics/client.tsx` already fetches from `GET /api/v1/admin/agents/metrics` and passes data as props. The `analytics/page.tsx` imports the mock versions.
+
+**Strategy:** Convert analytics page to a client component that fetches data (like metrics/client.tsx), use the real PascalCase components, delete mock kebab-case files.
+
+- [ ] **Step 1: Read all real components to understand their props**
+
+Read `MetricsKpiCards.tsx`, `CostBreakdownChart.tsx`, `UsageChart.tsx`, `TopAgentsTable.tsx` to confirm their prop interfaces.
+
+- [ ] **Step 2: Read metrics/client.tsx fully**
+
+Understand the fetch logic, date range handling, and data flow pattern.
+
+- [ ] **Step 3: Convert analytics/page.tsx to client component with data fetching**
+
+Rewrite `analytics/page.tsx` to:
+1. Add `'use client'` directive
+2. Import real components (PascalCase versions)
+3. Copy the fetch pattern from `metrics/client.tsx` (useQuery + fetchAgentMetrics)
+4. Add date range state (7d/30d/90d buttons already in UI)
+5. Pass fetched data as props to real components
+6. Handle loading/error states with existing Suspense skeletons
+
+Move metadata to a separate `layout.tsx` file since client components can't export metadata.
+
+- [ ] **Step 4: Delete mock component files**
+
+```bash
+rm apps/web/src/components/admin/agents/agent-kpi-cards.tsx
+rm apps/web/src/components/admin/agents/cost-breakdown-chart.tsx
+rm apps/web/src/components/admin/agents/usage-trend-chart.tsx
+```
+
+Verify no other files import from these paths:
+```bash
+grep -r "agent-kpi-cards\|cost-breakdown-chart\|usage-trend-chart" apps/web/src/ --include="*.tsx" --include="*.ts"
+```
+
+Also check `top-queries-table.tsx` — if it's mock, delete and use `TopAgentsTable.tsx`.
+
+- [ ] **Step 5: Verify no broken imports**
+
+```bash
+cd apps/web && pnpm tsc --noEmit 2>&1 | head -30
+```
+
+- [ ] **Step 6: Test manually**
+
+Navigate to `/admin/agents/analytics`, verify real data loads (or proper empty/error state if no metrics exist yet).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add -A apps/web/src/app/admin/\(dashboard\)/agents/analytics/
+git add -A apps/web/src/components/admin/agents/
+git commit -m "feat(admin): wire agent analytics to real metrics API, remove mock components"
+```
+
+---
+
+### Task 4: C1 — Wire Dashboard Upcoming Game Night
+
+**Files:**
+- Modify: `apps/web/src/app/(authenticated)/gaming-hub-client.tsx` (line 64)
+- Reference: `apps/web/src/hooks/queries/useGameNights.ts` (`useUpcomingGameNights()` hook already exists!)
+
+**Context:** `upcomingGameNight: null` with TODO. The hook `useUpcomingGameNights()` already exists and calls `gameNightsClient.getUpcoming()`.
+
+- [ ] **Step 1: Read gaming-hub-client.tsx and useGameNights.ts**
+
+Understand the `useDashboardContext()` call and confirm `useUpcomingGameNights()` return shape.
+
+- [ ] **Step 2: Use the existing hook**
+
+```tsx
+import { useUpcomingGameNights } from '@/hooks/queries/useGameNights';
+
+// Add in component:
+const { data: upcomingNights } = useUpcomingGameNights();
+const upcomingGameNight = upcomingNights?.[0] ?? null;
+```
+
+- [ ] **Step 3: Replace the hardcoded null**
+
+```tsx
+// Replace:
+upcomingGameNight: null, // TODO: wire to real API
+
+// With:
+upcomingGameNight,
+```
+
+- [ ] **Step 4: Test manually**
+
+Dashboard should show upcoming game night if one exists, or behave as before (null) if none.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add apps/web/src/app/\(authenticated\)/gaming-hub-client.tsx
+git commit -m "feat(dashboard): wire upcoming game night to real API"
+```
+
+---
+
+### Task 5: C3 — Wire Session History
+
+**Files:**
+- Modify: `apps/web/src/app/(authenticated)/toolkit/history/page.tsx` (line 36)
+- Reference: `apps/web/src/lib/api/clients/sessionsClient.ts` (`getHistory(filters)` exists)
+
+**Context:** `useState<Session[]>([])` with MVP comment. `sessionsClient.getHistory()` returns `PaginatedSessionsResponse` with filters for `gameId`, `startDate`, `endDate`, `limit`, `offset`.
+
+- [ ] **Step 1: Read history page and sessionsClient**
+
+Understand the Session type expected and the filter UI already built (gameFilter, startDate, endDate at lines 41-43).
+
+- [ ] **Step 2: Replace useState with useQuery**
+
+```tsx
+import { useQuery } from '@tanstack/react-query';
+import { api } from '@/lib/api';
+
+const { data: sessionsData, isLoading } = useQuery({
+  queryKey: ['session-history', gameFilter, startDate, endDate],
+  queryFn: () => api.sessions.getHistory({
+    gameId: gameFilter || undefined,
+    startDate: startDate || undefined,
+    endDate: endDate || undefined,
+    limit: 20,
+  }),
+  retry: false,
+});
+
+const sessions = sessionsData?.items ?? [];
+```
+
+- [ ] **Step 3: Remove the old useState**
+
+Delete: `const [sessions] = useState<Session[]>([]);`
+
+- [ ] **Step 4: Add loading state**
+
+Show a spinner/skeleton while `isLoading` is true.
+
+- [ ] **Step 5: Test manually**
+
+Page should show real session history or proper empty state.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/web/src/app/\(authenticated\)/toolkit/history/page.tsx
+git commit -m "feat(toolkit): wire session history to real API"
+```
+
+---
+
+## Chunk 2: Phase 2 — Backend + Frontend
+
+### Task 6: A3 — Contact Form Endpoint
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/Administration/Application/Commands/Contact/SendContactMessageCommand.cs`
+- Create: `apps/api/src/Api/BoundedContexts/Administration/Application/Commands/Contact/SendContactMessageCommandHandler.cs`
+- Create: `apps/api/src/Api/BoundedContexts/Administration/Application/Commands/Contact/SendContactMessageCommandValidator.cs`
+- Modify: `apps/api/src/Api/Routing/` — add contact endpoint (find appropriate routing file or create new)
+- Create: `apps/web/src/lib/api/clients/contactClient.ts` (if not exists)
+- Modify: `apps/web/src/app/(public)/contact/page.tsx` (line 61-62)
+
+**Context:** No contact endpoint exists in backend. Frontend has `setTimeout(1500)` placeholder. Place in Administration bounded context since it's admin-facing (contact messages go to admin).
+
+- [ ] **Step 1: Check existing patterns for simple command endpoints**
+
+Read an existing simple command (e.g., a notification or alert creation) to follow the same CQRS pattern.
+
+- [ ] **Step 2: Create the command**
+
+```csharp
+// SendContactMessageCommand.cs
+internal record SendContactMessageCommand(
+    string Name,
+    string Email,
+    string Subject,
+    string Message
+) : ICommand<Guid>;
+```
+
+- [ ] **Step 3: Create the validator**
+
+```csharp
+// SendContactMessageCommandValidator.cs
+internal class SendContactMessageCommandValidator : AbstractValidator<SendContactMessageCommand>
+{
+    public SendContactMessageCommandValidator()
+    {
+        RuleFor(x => x.Name).NotEmpty().MaximumLength(100);
+        RuleFor(x => x.Email).NotEmpty().EmailAddress().MaximumLength(255);
+        RuleFor(x => x.Subject).NotEmpty().MaximumLength(200);
+        RuleFor(x => x.Message).NotEmpty().MaximumLength(5000);
+    }
+}
+```
+
+- [ ] **Step 4: Create the handler**
+
+Handler should store the message (or send email). Follow existing patterns — check if there's an email service or just persist to DB.
+
+- [ ] **Step 5: Add the endpoint**
+
+```csharp
+app.MapPost("/api/v1/contact", async (SendContactMessageCommand cmd, IMediator mediator) =>
+    Results.Ok(await mediator.Send(cmd)))
+    .AllowAnonymous()
+    .WithTags("Contact");
+```
+
+- [ ] **Step 6: Create frontend client (if needed)**
+
+```typescript
+// contactClient.ts
+export function createContactClient(http: HttpClient) {
+  return {
+    send: (data: { name: string; email: string; subject: string; message: string }) =>
+      http.post('/api/v1/contact', data),
+  };
+}
+```
+
+Register in `apps/web/src/lib/api/index.ts`.
+
+- [ ] **Step 7: Wire contact page**
+
+Replace setTimeout with real API call:
+
+```tsx
+// Replace:
+await new Promise((resolve) => setTimeout(resolve, 1500));
+
+// With:
+await api.contact.send({ name, email, subject, message });
+```
+
+- [ ] **Step 8: Test**
+
+Run backend tests: `dotnet test --filter "Contact"`
+Manual: submit form, verify 200 response.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/Administration/Application/Commands/Contact/
+git add apps/api/src/Api/Routing/
+git add apps/web/src/lib/api/clients/contactClient.ts
+git add apps/web/src/lib/api/index.ts
+git add apps/web/src/app/\(public\)/contact/page.tsx
+git commit -m "feat(contact): add contact form endpoint and wire frontend"
+```
+
+---
+
+### Task 7: A4 — Privacy Settings Endpoint
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/Authentication/Domain/Entities/User.cs` (add privacy fields)
+- Create: EF migration for new columns
+- Modify: `apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/UserProfile/UpdatePreferencesCommand.cs`
+- Modify: `apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/UserProfile/UpdatePreferencesCommandHandler.cs`
+- Modify: `apps/api/src/Api/Routing/UserProfileEndpoints.cs` (~line 246)
+- Modify: `apps/web/src/app/(public)/settings/page.tsx` (~line 393-396)
+
+**Context:** `PUT /api/v1/users/preferences` exists with fields: `Language, Theme, EmailNotifications, DataRetentionDays`. Missing: privacy fields. The User entity does NOT have privacy columns — this requires a DB migration. Use PUT (not PATCH) for consistency with existing endpoint pattern.
+
+- [ ] **Step 1: Read User.cs entity and UpdatePreferencesCommand.cs**
+
+Understand current domain model fields and DB mapping.
+
+- [ ] **Step 2: Add privacy fields to User entity**
+
+```csharp
+// Add to User entity:
+public bool ShowProfile { get; private set; } = true;
+public bool ShowActivity { get; private set; } = true;
+public bool ShowLibrary { get; private set; } = true;
+
+public void UpdatePrivacySettings(bool showProfile, bool showActivity, bool showLibrary)
+{
+    ShowProfile = showProfile;
+    ShowActivity = showActivity;
+    ShowLibrary = showLibrary;
+}
+```
+
+- [ ] **Step 3: Create EF migration**
+
+```bash
+cd apps/api/src/Api
+dotnet ef migrations add AddUserPrivacySettings
+```
+
+Review the generated SQL — should add 3 boolean columns with defaults.
+
+- [ ] **Step 4: Add privacy fields to UpdatePreferencesCommand**
+
+```csharp
+// Add to existing UpdatePreferencesCommand:
+public bool ShowProfile { get; init; } = true;
+public bool ShowActivity { get; init; } = true;
+public bool ShowLibrary { get; init; } = true;
+```
+
+- [ ] **Step 5: Update handler to persist privacy fields**
+
+Call `user.UpdatePrivacySettings(...)` in the existing handler.
+
+- [ ] **Step 6: Update GET endpoint to return privacy fields**
+
+Ensure `GET /api/v1/users/preferences` includes the new privacy booleans in its response object.
+
+- [ ] **Step 7: Wire frontend**
+
+Replace localStorage-only handler with API mutation using `PUT /api/v1/users/preferences`:
+
+```tsx
+const handleUpdatePrivacy = async (privacyData: PrivacyPreferences) => {
+  await api.auth.updatePreferences({
+    ...currentPreferences,
+    showProfile: privacyData.showProfile,
+    showActivity: privacyData.showActivity,
+    showLibrary: privacyData.showLibrary,
+  });
+};
+```
+
+- [ ] **Step 8: Test**
+
+Backend: `dotnet test --filter "Preferences"`
+Manual: toggle privacy settings, reload, verify persistence.
+DB: verify migration applied, columns exist.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/Authentication/
+git add apps/api/src/Api/Routing/UserProfileEndpoints.cs
+git add apps/api/src/Api/Migrations/
+git add apps/web/src/app/\(public\)/settings/page.tsx
+git commit -m "feat(settings): add privacy preferences with DB migration and wire frontend"
+```
+
+---
+
+### Task 8: B4 — Collection Stats Granular Breakdown
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/UserLibrary/Application/DTOs/UserLibraryStatsDto.cs`
+- Modify: `apps/api/src/Api/BoundedContexts/UserLibrary/Application/Queries/GetLibraryStatsQueryHandler.cs`
+- Modify: `apps/web/src/components/collection/CollectionDashboard.tsx` (lines 629-631)
+
+**Context:** Current `UserLibraryStatsDto` has: `TotalGames, FavoriteGames, PrivatePdfs, OldestAddedAt, NewestAddedAt`. Missing: breakdown by game state (nuovo, inPrestito, wishlist).
+
+- [ ] **Step 1: Read the current DTO, handler, and library entry entity**
+
+Understand what game states exist in the domain model. Check for a `GameState` enum or similar.
+
+- [ ] **Step 2: Add state counts to DTO**
+
+```csharp
+internal record UserLibraryStatsDto(
+    int TotalGames,
+    int FavoriteGames,
+    int PrivatePdfs,
+    DateTime? OldestAddedAt,
+    DateTime? NewestAddedAt,
+    // New fields:
+    int NewCount,
+    int LentCount,
+    int WishlistCount,
+    int OwnedCount
+);
+```
+
+- [ ] **Step 3: Update query handler to compute state counts**
+
+Add GroupBy on game state in the query handler.
+
+- [ ] **Step 4: Wire frontend**
+
+Replace hardcoded zeros in `CollectionDashboard.tsx`:
+
+```tsx
+// Replace lines 629-631:
+// nuovo: 0, // TODO
+// inPrestito: 0, // TODO
+// wishlist: 0, // TODO
+
+// With:
+nuovo: statsData.newCount ?? 0,
+inPrestito: statsData.lentCount ?? 0,
+wishlist: statsData.wishlistCount ?? 0,
+```
+
+- [ ] **Step 5: Update frontend Zod schema**
+
+Modify `apps/web/src/lib/api/schemas/library.schemas.ts` — add `newCount`, `lentCount`, `wishlistCount`, `ownedCount` to `UserLibraryStatsSchema`.
+
+- [ ] **Step 6: Test**
+
+Backend: `dotnet test --filter "LibraryStats"`
+Manual: verify collection dashboard shows real counts.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add apps/api/src/Api/BoundedContexts/UserLibrary/
+git add apps/web/src/lib/api/schemas/library.schemas.ts
+git add apps/web/src/components/collection/CollectionDashboard.tsx
+git commit -m "feat(library): add game state breakdown to collection stats"
+```
+
+---
+
+### Task 9: C2 — Library Server-Side Search
+
+**Files:**
+- Modify: `apps/api/src/Api/Routing/UserLibraryEndpoints.cs` (~line 105-145)
+- Modify: `apps/web/src/app/(authenticated)/library/CollectionPageClient.tsx` (~line 142)
+
+**Context:** The backend `GetUserLibraryQuery` already has a `Search` parameter but the endpoint doesn't pass it. Just need to wire the query parameter through.
+
+- [ ] **Step 1: Read UserLibraryEndpoints.cs GET library endpoint**
+
+Find the exact parameter binding.
+
+- [ ] **Step 2: Add search parameter to endpoint**
+
+```csharp
+// Add [FromQuery] string? search to the GET /api/v1/library handler parameters
+// Pass it to the query: new GetUserLibraryQuery(userId, Search: search, ...)
+```
+
+- [ ] **Step 3: Wire frontend search**
+
+In `CollectionPageClient.tsx`, pass search term to the API query with debounce:
+
+```tsx
+const [debouncedSearch] = useDebounce(searchTerm, 300);
+
+const { data } = useQuery({
+  queryKey: ['library', debouncedSearch, ...otherFilters],
+  queryFn: () => api.library.getLibrary({ search: debouncedSearch, ...otherFilters }),
+});
+```
+
+Check if `useDebounce` exists in the codebase or use `useDeferredValue`.
+
+- [ ] **Step 4: Remove client-side filtering comment**
+
+Delete the TODO comment about backend search integration.
+
+- [ ] **Step 5: Test**
+
+Manual: type in search box, verify results come from server (network tab shows query param).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add apps/api/src/Api/Routing/UserLibraryEndpoints.cs
+git add apps/web/src/app/\(authenticated\)/library/CollectionPageClient.tsx
+git commit -m "feat(library): wire server-side search to existing backend query param"
+```
+
+---
+
+### Task 10: C4 — Command Center Dashboard (DEFERRED)
+
+**Status:** Deferred pending monitoring stack decision. The `CommandCenterDashboard.tsx` has extensive mock data for service status, system metrics, and alerts. Implementation requires:
+1. Decision on monitoring data source (Prometheus, custom endpoints, etc.)
+2. Backend endpoints to expose system health
+3. Frontend wiring
+
+**Action:** Create a tracking issue for this task. Do not implement until monitoring architecture is decided.
+
+---
+
+## Execution Order
+
+**Parallel Group 1 (Tasks 1-5):** All Phase 1 tasks are independent — execute in parallel.
+
+**Sequential Group 2 (Tasks 6-9):** Phase 2 tasks can also run in parallel since they touch different bounded contexts:
+- Task 6 (Contact) — Administration BC
+- Task 7 (Privacy) — Authentication BC
+- Task 8 (Collection Stats) — UserLibrary BC
+- Task 9 (Library Search) — UserLibrary BC (same BC as Task 8, so run after it)
+
+**Deferred:** Task 10 (C4)
+
+## Definition of Done
+
+- [ ] Zero `MOCK_*` constants in production components (demo pages excluded)
+- [ ] Zero `// TODO: Replace with API` or `// TODO: wire to real API` comments in modified files
+- [ ] All modified components handle loading, error, and empty states
+- [ ] Backend tests pass: `dotnet test`
+- [ ] Frontend type-checks: `cd apps/web && pnpm tsc --noEmit`
+- [ ] No mock kebab-case component files remaining in `components/admin/agents/`

--- a/docs/superpowers/specs/2026-03-17-dashboard-search-chat-flow-design.md
+++ b/docs/superpowers/specs/2026-03-17-dashboard-search-chat-flow-design.md
@@ -1,0 +1,288 @@
+# Dashboard Search → Add Game → Chat Flow
+
+**Date**: 2026-03-17
+**Status**: Approved
+**Approach**: Hybrid — extend existing components + new isolated components
+
+## Scenario
+
+A new user logs in. Friends visit and ask about a board game. The game exists in the shared game library and has KB cards. The user needs to find the game, add it to their library, and chat with the AI about it — all with minimal friction, without leaving the dashboard.
+
+## User Flow
+
+1. New user logs in → sees dashboard with enhanced empty state
+2. HeroZone shows: "Hai una domanda su un gioco? Cerca nella community e chiedi all'AI!" + CTA button
+3. User clicks "Cerca un gioco" (or 🔍 in SmartFAB) → SearchExpander opens
+4. Types game name → debounced search against shared game library → results with dual actions
+5. Clicks "Chiedi" on a game not in library → AddToLibraryModal opens
+6. Clicks "Aggiungi e Chiedi" → game added to library + chat thread created
+7. Modal closes → chat card appears in dashboard "Active Chats" → ExtraMeepleCardDrawer opens
+8. EmbeddedChatView in drawer with agent greeting + KB context → user asks question
+
+## Architecture
+
+### Approach: Hybrid
+
+- **Extend**: SmartFAB (add SearchExpander child), ExtraMeepleCardDrawer (modify existing `chatSession` branch to use EmbeddedChatView)
+- **Create new**: SearchExpander, EmbeddedChatView, AddToLibraryModal
+- **Modify**: HeroZone (enhanced empty state for new users)
+
+> **Note on HeroZone**: Two versions exist — `components/dashboard/zones/HeroZone.tsx` and `components/dashboard-v2/hero-zone.tsx`. Verify which is active in GamingHubClient before modifying. If v2 is active, modify v2.
+
+## Component Design
+
+### 1. SearchExpander
+
+**Location**: `apps/web/src/components/dashboard/SearchExpander.tsx`
+**Parent**: SmartFAB (`apps/web/src/components/layout/SmartFAB/SmartFAB.tsx`) — child component
+
+**Behavior**:
+- Triggered by clicking 🔍 icon in SmartFAB or CTA button in HeroZone
+- Expands from pill into a search bar with glassmorphism styling
+- Debounced search (300ms) against `GET /api/v1/shared-games?search={query}` (returns `PagedResult<SharedGameDto>`, use first page with `pageSize=5`)
+- Results dropdown: max 5 results from first page, ordered by relevance
+
+**Each result shows**:
+- Game thumbnail + name
+- "Shared Library" label + KB card count (requires supplementary query: `GET /api/v1/knowledge-base/games/{gameId}/documents/count` or include count in `SharedGameDto` — verify at implementation time; if not available, omit KB count from search results and show only in AddToLibraryModal after fetching)
+- "✓ In libreria" badge if game is already in user's library
+- Dual action buttons:
+  - **"Vedi"** (blue): navigates to `/shared-games/{id}`
+  - **"Chiedi"** (purple if not in library, green if in library): triggers add flow or direct chat
+
+**Interaction**:
+- Close: ESC key or click outside
+- Keyboard navigation: ↑↓ arrows + Enter
+- Focus management: auto-focus input on open
+
+**Props**:
+```typescript
+interface SearchExpanderProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onViewGame: (gameId: string) => void;
+  onAskAboutGame: (game: SharedGameSearchResult) => void;
+}
+```
+
+### 2. AddToLibraryModal
+
+**Location**: `apps/web/src/components/dashboard/AddToLibraryModal.tsx`
+
+**Trigger**: User clicks "Chiedi" on a game not in their library.
+
+**Content**:
+- Game preview: thumbnail, name, publisher, player count
+- KB card count: "📄 3 KB cards disponibili"
+- Message: "Per chattare con l'AI su questo gioco, aggiungilo alla tua libreria."
+- Actions: "Annulla" (secondary) + "Aggiungi e Chiedi 🤖" (primary, gradient purple)
+
+**Orchestration on "Aggiungi e Chiedi"**:
+1. `POST /api/v1/user-library/games` — add shared game to user library
+2. `POST /api/v1/chat-threads` — create thread with `gameId` + default agent
+3. Close modal → invalidate dashboard queries (both `hooks/useDashboardData.ts` and `hooks/queries/useDashboardData.ts` — verify which is active in GamingHubClient)
+4. Callback `onSuccess({ gameId, threadId, agentId })` → parent opens drawer
+
+**Error handling**:
+- If step 1 fails: show error in modal, no side effects
+- If step 2 fails: game stays in library (no rollback), show error with "Riprova" option
+- Loading state: skeleton + disabled button during operations
+
+**Props**:
+```typescript
+interface AddToLibraryModalProps {
+  game: SharedGameSearchResult;
+  isOpen: boolean;
+  onClose: () => void;
+  onSuccess: (result: { gameId: string; threadId: string; agentId: string }) => void;
+}
+```
+
+### 3. EmbeddedChatView
+
+**Location**: `apps/web/src/components/chat-unified/EmbeddedChatView.tsx`
+
+**Purpose**: Compact version of ChatThreadView for use inside drawers. Messages + input only, no side info panel.
+
+**Reuses**:
+- `useAgentChatStream` hook for SSE streaming
+- Existing message rendering components (user/assistant messages, citations)
+- Existing input component (text input + send button)
+
+**Excludes** (compared to full ChatThreadView):
+- Right info panel (ChatInfoPanel)
+- Debug panel
+- Voice input/output (TTS)
+- Thread header with agent selector
+
+**Props**:
+```typescript
+interface EmbeddedChatViewProps {
+  threadId: string;
+  agentId: string;
+  gameId: string;
+}
+```
+
+**Behavior**:
+- On mount: loads thread history (if any) + connects SSE
+- Agent sends welcome message with KB context on first interaction
+- Citations rendered inline in assistant messages
+- Scroll-to-bottom on new messages
+
+### 4. ExtraMeepleCardDrawer Modification
+
+**Location**: Existing `apps/web/src/components/ui/data-display/extra-meeple-card/`
+
+**Change**: The `chatSession` entity type already exists in the drawer (line ~238), currently rendering `ChatDrawerContent` → `ChatExtraMeepleCard` (a detail/info card using `useChatDetail(entityId)`). Modify this existing branch to render `EmbeddedChatView` instead when opened from the dashboard search flow. Use a variant prop or a `mode` discriminator to distinguish between "detail view" (existing) and "live chat" (new).
+
+**When type is `chatSession` and mode is `liveChat`**:
+- Header: chat icon + "Chat — {Game Name}" + KB source count + close button
+- Body: renders `EmbeddedChatView` with `threadId`, `agentId`, `gameId`
+- Width: same as existing drawer (matches current Sheet component)
+
+**Data passed via drawer**:
+```typescript
+interface ChatSessionDrawerData {
+  threadId: string;
+  agentId: string;
+  gameId: string;
+  gameName: string;
+  kbCardCount: number;
+}
+```
+
+### 5. HeroZone Enhanced Empty State
+
+**Location**: Existing `apps/web/src/components/dashboard/zones/HeroZone.tsx`
+
+**Change**: Modify the `isNewUser` branch (when `libraryCount === 0`).
+
+**Current**: "Aggiungi il tuo primo gioco alla libreria" + feature icons
+**New**:
+- Greeting: "Buonasera, {name}!"
+- Message: "Hai una domanda su un gioco da tavolo? Cerca nella community e chiedi all'AI!"
+- CTA button: "🔍 Cerca un gioco" — triggers SearchExpander open
+- Subtle pointer: "oppure usa la barra in basso" + ↓ arrow
+
+**Transition**: When `libraryCount > 0` after adding first game, HeroZone switches to standard version with stats. Happens automatically via `useDashboardData` query invalidation.
+
+**Props addition**:
+```typescript
+// Add to HeroZone props
+onOpenSearch: () => void;  // Triggers SearchExpander in SmartFAB
+```
+
+### 6. SmartFAB Extension
+
+**Location**: Existing `apps/web/src/components/layout/SmartFAB/SmartFAB.tsx`
+
+**Change**: Add 🔍 search icon to the pill with highlighted styling (gradient blue-purple, subtle glow).
+
+**State management**:
+- New state: `isSearchOpen` — controls SearchExpander visibility
+- Exposed via callback: `onOpenSearch` passed up to dashboard for HeroZone to trigger
+- When search is open: pill icons dim, SearchExpander renders above the pill
+
+**Cross-component communication**: HeroZone and SmartFAB are separate component trees. Use a shared context (`DashboardSearchContext`) or a Zustand slice to coordinate `openSearch()` trigger from HeroZone to SmartFAB without prop drilling through the layout hierarchy.
+
+## Data Flow
+
+```
+HeroZone CTA click ──┐
+                      ├──→ SmartFAB.openSearch() (via DashboardSearchContext)
+🔍 icon click ────────┘          │
+                                 ▼
+                         SearchExpander opens
+                                 │
+                    debounced GET /shared-games?search={q}
+                                 │
+                      ┌──────────┴──────────┐
+                      ▼                      ▼
+               "Vedi" click            "Chiedi" click
+                      │                      │
+               navigate to            ┌──────┴──────┐
+             /shared-games/{id}       ▼              ▼
+                                 In library?    Not in library?
+                                      │              │
+                                      │     AddToLibraryModal
+                                      │              │
+                                      │    POST /user-library/games
+                                      │    POST /chat-threads
+                                      │              │
+                                      └──────┬───────┘
+                                             ▼
+                                  invalidate dashboard queries
+                                  chat card in "Active Chats"
+                                  open ExtraMeepleCardDrawer
+                                             │
+                                             ▼
+                                    EmbeddedChatView
+                                    SSE streaming + KB RAG
+```
+
+## API Dependencies
+
+All endpoints already exist:
+
+| Endpoint | Method | Purpose |
+|----------|--------|---------|
+| `/api/v1/shared-games?search={query}` | GET | Search shared game catalog (returns `PagedResult<SharedGameDto>`) |
+| `/api/v1/user-library/games` | POST | Add game to user library |
+| `/api/v1/chat-threads` | POST | Create new chat thread |
+| `/api/v1/agents/{id}/chat` | POST | SSE streaming chat |
+| `/api/v1/dashboard` | GET | Dashboard data (invalidate after add) |
+
+**Note**: KB card count may not be included in `SharedGameDto`. At implementation time, verify the DTO shape. If not available, either add a count field to the DTO or fetch KB document count separately. The `POST /api/v1/user-library/games` endpoint accepts an `AddGameToLibraryRequest` body — verify required fields at implementation time.
+
+**No new backend endpoints required** (KB count may need a supplementary query or DTO extension — evaluate during implementation).
+
+## Files to Create
+
+| File | Type | Description |
+|------|------|-------------|
+| `components/dashboard/SearchExpander.tsx` | New | Search widget for SmartFAB |
+| `components/dashboard/AddToLibraryModal.tsx` | New | Confirmation modal for add + chat |
+| `components/chat-unified/EmbeddedChatView.tsx` | New | Compact chat view for drawer |
+
+## Files to Modify
+
+| File | Change |
+|------|--------|
+| `SmartFAB.tsx` | Add 🔍 icon + `isSearchOpen` state + SearchExpander mount |
+| `ExtraMeepleCardDrawer` | Modify existing `chatSession` branch: add `liveChat` mode rendering EmbeddedChatView |
+| `HeroZone.tsx` | Enhanced empty state with CTA + `onOpenSearch` prop |
+| `DashboardRenderer.tsx` / `GamingHubClient` | Add `DashboardSearchContext` provider for HeroZone ↔ SmartFAB communication |
+
+## Testing Strategy
+
+### Unit Tests
+- SearchExpander: search debounce, result rendering, dual action callbacks, keyboard nav
+- AddToLibraryModal: success flow, error states, loading state, rollback behavior
+- EmbeddedChatView: message rendering, SSE connection, scroll behavior
+- HeroZone: empty state rendering, CTA click callback
+
+### Integration Tests
+- Full flow: search → click "Chiedi" → modal → add → drawer opens → chat works
+- Edge cases: game already in library (skip modal), search with no results, network errors
+
+### E2E Tests (Playwright)
+- New user login → dashboard → search game → add → chat → receive AI response
+- Verify drawer opens/closes correctly
+- Verify dashboard updates (chat card appears, stats update)
+
+## Scope Boundaries
+
+**In scope**:
+- SearchExpander in SmartFAB
+- AddToLibraryModal with add + create thread orchestration
+- EmbeddedChatView in ExtraMeepleCardDrawer
+- HeroZone enhanced empty state
+- Dashboard query invalidation after add
+
+**Out of scope**:
+- Changes to shared game page (`/shared-games/{id}`)
+- Changes to full chat page (`/chat/[threadId]`)
+- New backend endpoints
+- Onboarding tooltips or guided tours
+- "Recent Games" / "Active Chats" section redesign

--- a/docs/superpowers/specs/2026-03-17-replace-mocked-data-design.md
+++ b/docs/superpowers/specs/2026-03-17-replace-mocked-data-design.md
@@ -1,0 +1,121 @@
+# Replace Mocked Data with Real API Calls
+
+**Date:** 2026-03-17
+**Status:** Approved
+**Scope:** 12 tasks across frontend (7 wiring-only) + backend (5 new/modified endpoints)
+
+## Problem
+
+Frontend audit revealed 12 areas using hardcoded/mocked data instead of real API calls. This includes fake 2FA recovery codes, mock admin metrics, hardcoded zeros in collection stats, and unimplemented form submissions.
+
+## Execution Strategy
+
+**Phase 1 (Quick Wins):** 7 tasks requiring only frontend wiring — backend endpoints already exist.
+**Phase 2 (Backend + Frontend):** 5 tasks requiring new or modified backend endpoints.
+
+---
+
+## Phase 1: Frontend Wiring Only
+
+### A1: 2FA Status + Recovery Codes
+- **File:** `apps/web/src/app/(authenticated)/settings/security/page.tsx`
+- **Current:** Hardcoded `false` for 2FA status, fake recovery codes `ABCD-1234-EFGH`
+- **Fix:** Uncomment/create `useQuery` for 2FA status via `authClient`. Recovery codes come from `setup2FA()` response — show only after setup, not statically.
+- **Backend:** `POST /api/v1/auth/2fa/setup`, `POST /api/v1/auth/2fa/enable`, `POST /api/v1/auth/2fa/disable` already exist.
+
+### A2: Avatar Upload
+- **File:** `apps/web/src/app/(public)/settings/page.tsx`
+- **Current:** `api.auth.uploadAvatar(file)` commented out (line ~770)
+- **Fix:** Uncomment, wrap in `useMutation`, handle loading/error states, refresh user profile on success.
+- **Backend:** `POST /api/v1/auth/avatar` already exists.
+
+### B1: Agent KPI Cards
+- **File:** `apps/web/src/components/admin/agents/agent-kpi-cards.tsx`
+- **Current:** `MOCK_KPIS` array with hardcoded 14,832 queries, $247.50, etc.
+- **Fix:** Accept metrics data as props from parent `client.tsx` which already calls `fetchAgentMetrics()`. Remove `MOCK_KPIS` constant.
+- **Interface:** `AgentKPICardsProps { metrics: AgentMetricsData }` or loading/error states.
+
+### B2: Cost Breakdown Chart
+- **File:** `apps/web/src/components/admin/agents/cost-breakdown-chart.tsx`
+- **Current:** `MOCK_COST_DATA` with hardcoded model costs.
+- **Fix:** Accept cost breakdown data as props from parent. Remove `MOCK_COST_DATA`.
+- **Interface:** `CostBreakdownChartProps { data: CostBreakdownEntry[] }` with loading state.
+
+### B3: Usage Trend Chart
+- **File:** `apps/web/src/components/admin/agents/usage-trend-chart.tsx`
+- **Current:** `MOCK_USAGE_DATA` with hardcoded 7-day trend.
+- **Fix:** Accept usage trend data as props from parent. Remove `MOCK_USAGE_DATA`.
+- **Interface:** `UsageTrendChartProps { data: UsageTrendEntry[] }` with loading state.
+
+### C1: Dashboard Upcoming Game Night
+- **File:** `apps/web/src/app/(authenticated)/gaming-hub-client.tsx`
+- **Current:** `upcomingGameNight: null` with TODO comment.
+- **Fix:** Use `gameNightsClient.getGameNights()` with future date filter, take first result.
+- **Pattern:** `useQuery(['upcoming-game-night'], ...)` with `startDate > new Date()`.
+
+### C3: Session History
+- **File:** `apps/web/src/app/(authenticated)/toolkit/history/page.tsx`
+- **Current:** `useState<Session[]>([])` — empty MVP placeholder.
+- **Fix:** Replace with `useQuery` calling `sessionsClient.getHistory()`.
+- **Pattern:** Paginated query with loading/empty states.
+
+---
+
+## Phase 2: Backend + Frontend
+
+### A3: Contact Form Endpoint
+- **Frontend file:** `apps/web/src/app/(public)/contact/page.tsx`
+- **Current:** `setTimeout(1500)` simulating API call.
+- **Backend (new):** `POST /api/v1/contact` in a new or existing bounded context.
+  - Command: `SendContactMessageCommand { Name, Email, Subject, Message }`
+  - Handler: Send email notification to admin or store in DB.
+  - Validation: FluentValidation for required fields, email format.
+- **Frontend fix:** Replace setTimeout with `api.contact.send(formData)` mutation.
+
+### A4: Privacy Settings Endpoint
+- **Frontend file:** `apps/web/src/app/(public)/settings/page.tsx`
+- **Current:** Privacy preferences saved to localStorage only.
+- **Backend (new):** `PATCH /api/v1/auth/preferences/privacy` — extend existing UserPreferences.
+  - Command: `UpdatePrivacyPreferencesCommand { ShowProfile, ShowActivity, ShowLibrary }`
+  - Handler: Update user preferences in DB.
+- **Frontend fix:** Replace localStorage with `useMutation` → backend persist.
+
+### B4: Collection Stats Granular Breakdown
+- **Frontend file:** `apps/web/src/components/collection/CollectionDashboard.tsx`
+- **Current:** `nuovo: 0, inPrestito: 0, wishlist: 0` hardcoded.
+- **Backend (modify):** Extend `GET /api/v1/users/{id}/library/stats` response to include game state counts.
+  - Add to response DTO: `NewCount`, `LentCount`, `WishlistCount`.
+  - Query handler: Group by game state in library entries.
+- **Frontend fix:** Use new fields from stats API response.
+
+### C2: Library Server-Side Search
+- **Frontend file:** `apps/web/src/app/(authenticated)/library/CollectionPageClient.tsx`
+- **Current:** Client-side filtering only.
+- **Backend (verify):** Check if `GET /api/v1/users/{id}/library?search=term` already supports search param.
+- **Frontend fix:** Add `searchTerm` to query params with debounce (300ms), pass to API call.
+
+### C4: Command Center Dashboard — DEFERRED
+- **File:** `apps/web/src/components/admin/command-center/CommandCenterDashboard.tsx`
+- **Current:** Mock services, metrics, alerts.
+- **Status:** Deferred — requires architectural decision on monitoring stack (HyperDX removed, replacement TBD).
+- **Will address separately** once monitoring strategy is defined.
+
+---
+
+## Non-Goals
+
+- Demo pages (`/toolkit-demo`, `/demo/entity-list-*`) keep mock data — intentional.
+- No new UI design — use existing component patterns.
+- No refactoring beyond what's needed for the wiring.
+
+## Testing
+
+- Each wired component: verify loading, success, and error states render correctly.
+- Phase 2 backend: unit tests for new commands/handlers, integration tests for endpoints.
+- Update existing tests that assert on mock data (e.g., `AdminGameImportWizard.test.tsx` pattern).
+
+## Success Criteria
+
+- Zero `MOCK_*` constants in production components (demo pages excluded).
+- Zero `// TODO: Replace with API` comments in affected files.
+- All 11 tasks (C4 deferred) showing real data from backend.


### PR DESCRIPTION
## Summary

Replace all mocked/hardcoded data in the frontend with real API calls. 11 tasks across 2 phases:

### Phase 1: Frontend Wiring (backend already existed)
- **2FA Settings**: Wire status query + setup/enable/disable mutations, remove fake recovery codes
- **Avatar Upload**: Uncomment existing `api.auth.uploadAvatar()` call
- **Agent Analytics**: Delete 4 mock component files, convert analytics page to use real `MetricsKpiCards`/`CostBreakdownChart`/`UsageChart` with API data
- **Dashboard Game Night**: Use existing `useUpcomingGameNights()` hook
- **Session History**: Replace empty `useState` with `sessionsClient.getHistory()` query

### Phase 2: Backend + Frontend
- **Contact Form**: New `POST /api/v1/contact` endpoint (Administration BC, CQRS) + frontend client
- **Privacy Settings**: Add `ShowProfile/ShowActivity/ShowLibrary` to User entity + extend `PUT /api/v1/users/preferences`
- **Collection Stats**: Extend `UserLibraryStatsDto` with game state breakdown counts (nuovo/inPrestito/wishlist/owned)
- **Library Search**: Wire existing `Search` param in `GetUserLibraryQuery` to HTTP endpoint + frontend debounced search

### Also fixes
- Broken `/auth/signin` link → `/login` in admin import wizard

### Deferred
- Command Center Dashboard (C4): mock monitoring data — requires monitoring stack decision

## Stats
- 36 files changed, +860 / -426 lines
- 4 dead mock component files deleted (256 lines)
- 10 commits

## Test plan
- [ ] Verify 2FA settings page loads real status, setup wizard shows real QR/codes
- [ ] Verify avatar upload persists after page reload
- [ ] Verify `/admin/agents/analytics` shows real metrics (or proper empty state)
- [ ] Verify dashboard shows upcoming game night when one exists
- [ ] Verify toolkit history shows real session data
- [ ] Verify contact form submits to backend (check API logs)
- [ ] Verify privacy settings persist across page reloads
- [ ] Verify collection dashboard shows real state counts
- [ ] Verify library search filters server-side (check network tab)
- [ ] Backend builds: `dotnet build` (0 errors)
- [ ] Frontend builds: `pnpm build` (0 errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
