### PR TITLE
feat: dashboard search → add game → chat flow (v2, CommandPalette)

### DIFF
--- a/apps/web/src/__tests__/components/chat-unified/EmbeddedChatView.test.tsx
+++ b/apps/web/src/__tests__/components/chat-unified/EmbeddedChatView.test.tsx
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { EmbeddedChatView } from '@/components/chat-unified/EmbeddedChatView';
+
+const mockSendMessage = vi.fn();
+const mockReset = vi.fn();
+const mockStopStreaming = vi.fn();
+
+let mockState = {
+  statusMessage: null as string | null,
+  currentAnswer: '',
+  followUpQuestions: [] as string[],
+  isStreaming: false,
+  error: null as string | null,
+  chatThreadId: 't1',
+  totalTokens: 0,
+  debugSteps: [],
+  modelDowngrade: null,
+  strategyTier: null,
+  executionId: null,
+};
+
+vi.mock('@/hooks/useAgentChatStream', () => ({
+  useAgentChatStream: () => ({
+    state: mockState,
+    sendMessage: mockSendMessage,
+    stopStreaming: mockStopStreaming,
+    reset: mockReset,
+  }),
+}));
+
+describe('EmbeddedChatView', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockState = {
+      statusMessage: null,
+      currentAnswer: '',
+      followUpQuestions: [],
+      isStreaming: false,
+      error: null,
+      chatThreadId: 't1',
+      totalTokens: 0,
+      debugSteps: [],
+      modelDowngrade: null,
+      strategyTier: null,
+      executionId: null,
+    };
+  });
+
+  it('renders the embedded chat view container', () => {
+    render(<EmbeddedChatView threadId="t1" agentId="a1" gameId="g1" />);
+    expect(screen.getByTestId('embedded-chat-view')).toBeInTheDocument();
+  });
+
+  it('renders input area with placeholder', () => {
+    render(<EmbeddedChatView threadId="t1" agentId="a1" gameId="g1" />);
+    expect(screen.getByPlaceholderText(/scrivi/i)).toBeInTheDocument();
+  });
+
+  it('renders send button', () => {
+    render(<EmbeddedChatView threadId="t1" agentId="a1" gameId="g1" />);
+    expect(screen.getByRole('button', { name: /invia/i })).toBeInTheDocument();
+  });
+
+  it('renders welcome state when no messages', () => {
+    render(<EmbeddedChatView threadId="t1" agentId="a1" gameId="g1" />);
+    expect(screen.getByText(/chiedi qualsiasi cosa/i)).toBeInTheDocument();
+  });
+
+  it('sends message via SSE on submit', async () => {
+    render(<EmbeddedChatView threadId="t1" agentId="a1" gameId="g1" />);
+    const input = screen.getByPlaceholderText(/scrivi/i);
+    fireEvent.change(input, { target: { value: 'Come si gioca?' } });
+    fireEvent.submit(input.closest('form')!);
+    await waitFor(() => {
+      expect(mockSendMessage).toHaveBeenCalledWith(
+        'a1',
+        'Come si gioca?',
+        't1',
+        expect.anything(),
+        undefined
+      );
+    });
+  });
+
+  it('clears input after sending', async () => {
+    render(<EmbeddedChatView threadId="t1" agentId="a1" gameId="g1" />);
+    const input = screen.getByPlaceholderText(/scrivi/i) as HTMLInputElement;
+    fireEvent.change(input, { target: { value: 'Test message' } });
+    fireEvent.submit(input.closest('form')!);
+    await waitFor(() => {
+      expect(input.value).toBe('');
+    });
+  });
+
+  it('adds user message to the list on send', async () => {
+    render(<EmbeddedChatView threadId="t1" agentId="a1" gameId="g1" />);
+    const input = screen.getByPlaceholderText(/scrivi/i);
+    fireEvent.change(input, { target: { value: 'Ciao!' } });
+    fireEvent.submit(input.closest('form')!);
+    await waitFor(() => {
+      expect(screen.getByText('Ciao!')).toBeInTheDocument();
+    });
+    // Welcome message should be gone
+    expect(screen.queryByText(/chiedi qualsiasi cosa/i)).not.toBeInTheDocument();
+  });
+
+  it('does not send empty messages', () => {
+    render(<EmbeddedChatView threadId="t1" agentId="a1" gameId="g1" />);
+    const input = screen.getByPlaceholderText(/scrivi/i);
+    fireEvent.submit(input.closest('form')!);
+    expect(mockSendMessage).not.toHaveBeenCalled();
+  });
+
+  it('shows streaming answer when isStreaming with currentAnswer', () => {
+    mockState = {
+      ...mockState,
+      isStreaming: true,
+      currentAnswer: 'Streaming response...',
+    };
+    render(<EmbeddedChatView threadId="t1" agentId="a1" gameId="g1" />);
+    expect(screen.getByTestId('message-streaming')).toBeInTheDocument();
+    expect(screen.getByText('Streaming response...')).toBeInTheDocument();
+  });
+
+  it('shows status message during streaming', () => {
+    mockState = {
+      ...mockState,
+      isStreaming: true,
+      statusMessage: 'Connecting...',
+    };
+    render(<EmbeddedChatView threadId="t1" agentId="a1" gameId="g1" />);
+    expect(screen.getByTestId('stream-status')).toBeInTheDocument();
+    expect(screen.getByText('Connecting...')).toBeInTheDocument();
+  });
+
+  it('shows error message when error state is set', () => {
+    mockState = {
+      ...mockState,
+      error: 'Something went wrong',
+    };
+    render(<EmbeddedChatView threadId="t1" agentId="a1" gameId="g1" />);
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+    expect(screen.getByText('Something went wrong')).toBeInTheDocument();
+  });
+
+  it('disables input while streaming', () => {
+    mockState = {
+      ...mockState,
+      isStreaming: true,
+    };
+    render(<EmbeddedChatView threadId="t1" agentId="a1" gameId="g1" />);
+    expect(screen.getByPlaceholderText(/scrivi/i)).toBeDisabled();
+  });
+});

--- a/apps/web/src/__tests__/components/dashboard/AddToLibraryModal.test.tsx
+++ b/apps/web/src/__tests__/components/dashboard/AddToLibraryModal.test.tsx
@@ -1,0 +1,251 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+import { AddToLibraryModal } from '@/components/dashboard/AddToLibraryModal';
+
+// Mock the api module
+const mockAddGame = vi.fn();
+const mockCreateThread = vi.fn();
+vi.mock('@/lib/api', () => ({
+  api: {
+    library: {
+      addGame: (...args: unknown[]) => mockAddGame(...args),
+    },
+    chat: {
+      createThread: (...args: unknown[]) => mockCreateThread(...args),
+    },
+  },
+}));
+
+// Mock useAddGameToLibrary — we bypass the hook and call api directly in component,
+// but let's mock the hook as the component uses it
+const mockMutateAsync = vi.fn();
+const mockMutationState = {
+  mutateAsync: mockMutateAsync,
+  isPending: false,
+};
+vi.mock('@/hooks/queries/useLibrary', () => ({
+  useAddGameToLibrary: () => mockMutationState,
+  libraryKeys: {
+    all: ['library'],
+    lists: () => ['library', 'list'],
+    stats: () => ['library', 'stats'],
+    quota: () => ['library', 'quota'],
+    gameStatus: (id: string) => ['library', 'status', id],
+  },
+}));
+
+// Mock @tanstack/react-query for useQueryClient
+const mockInvalidateQueries = vi.fn();
+vi.mock('@tanstack/react-query', async () => {
+  const actual = await vi.importActual('@tanstack/react-query');
+  return {
+    ...actual,
+    useQueryClient: () => ({
+      invalidateQueries: mockInvalidateQueries,
+    }),
+  };
+});
+
+describe('AddToLibraryModal', () => {
+  const mockGame = {
+    id: 'game-123',
+    name: 'Catan',
+    imageUrl: '/catan.jpg',
+    playerCount: '3-4',
+  };
+
+  const mockOnClose = vi.fn();
+  const mockOnSuccess = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockMutationState.isPending = false;
+  });
+
+  function renderModal(props: Partial<React.ComponentProps<typeof AddToLibraryModal>> = {}) {
+    return render(
+      <AddToLibraryModal
+        game={mockGame}
+        isOpen={true}
+        onClose={mockOnClose}
+        onSuccess={mockOnSuccess}
+        {...props}
+      />
+    );
+  }
+
+  // =========================================================================
+  // 1. Renders game info and CTA when open
+  // =========================================================================
+  it('renders game info and CTA when open', () => {
+    renderModal();
+
+    expect(screen.getByText('Catan')).toBeInTheDocument();
+    expect(screen.getByText('3-4 giocatori')).toBeInTheDocument();
+    expect(
+      screen.getByText("Per chattare con l'AI su questo gioco, aggiungilo alla tua libreria.")
+    ).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /aggiungi e chiedi/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /annulla/i })).toBeInTheDocument();
+  });
+
+  // =========================================================================
+  // 2. Does not render when closed (isOpen=false)
+  // =========================================================================
+  it('does not render content when isOpen is false', () => {
+    renderModal({ isOpen: false });
+
+    expect(screen.queryByText('Catan')).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /aggiungi e chiedi/i })).not.toBeInTheDocument();
+  });
+
+  // =========================================================================
+  // 3. Does not render when game is null
+  // =========================================================================
+  it('does not render content when game is null', () => {
+    renderModal({ game: null });
+
+    expect(screen.queryByRole('button', { name: /aggiungi e chiedi/i })).not.toBeInTheDocument();
+  });
+
+  // =========================================================================
+  // 4. Orchestrates add + create thread on confirm, calls onSuccess
+  // =========================================================================
+  it('orchestrates add game + create thread on confirm', async () => {
+    const mockLibraryEntry = { gameId: 'game-123', id: 'entry-1' };
+    const mockThread = { id: 'thread-456', agentId: 'agent-789', gameId: 'game-123' };
+
+    mockMutateAsync.mockResolvedValueOnce(mockLibraryEntry);
+    mockCreateThread.mockResolvedValueOnce(mockThread);
+
+    renderModal();
+
+    fireEvent.click(screen.getByRole('button', { name: /aggiungi e chiedi/i }));
+
+    await waitFor(() => {
+      expect(mockMutateAsync).toHaveBeenCalledWith({ gameId: 'game-123' });
+    });
+
+    await waitFor(() => {
+      expect(mockCreateThread).toHaveBeenCalledWith({
+        gameId: 'game-123',
+        title: 'Catan',
+      });
+    });
+
+    await waitFor(() => {
+      expect(mockOnSuccess).toHaveBeenCalledWith({
+        gameId: 'game-123',
+        threadId: 'thread-456',
+        agentId: 'agent-789',
+        gameName: 'Catan',
+      });
+    });
+  });
+
+  // =========================================================================
+  // 5. Shows error when addGame fails
+  // =========================================================================
+  it('shows error message when addGame fails', async () => {
+    mockMutateAsync.mockRejectedValueOnce(new Error('Quota exceeded'));
+
+    renderModal();
+
+    fireEvent.click(screen.getByRole('button', { name: /aggiungi e chiedi/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/non è stato possibile aggiungere il gioco/i)).toBeInTheDocument();
+    });
+
+    // onSuccess should NOT have been called
+    expect(mockOnSuccess).not.toHaveBeenCalled();
+    // createThread should NOT have been called
+    expect(mockCreateThread).not.toHaveBeenCalled();
+  });
+
+  // =========================================================================
+  // 6. Shows "Riprova" when createThread fails
+  // =========================================================================
+  it('shows retry button when createThread fails after addGame succeeds', async () => {
+    const mockLibraryEntry = { gameId: 'game-123', id: 'entry-1' };
+    mockMutateAsync.mockResolvedValueOnce(mockLibraryEntry);
+    mockCreateThread.mockRejectedValueOnce(new Error('Thread creation failed'));
+
+    renderModal();
+
+    fireEvent.click(screen.getByRole('button', { name: /aggiungi e chiedi/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/gioco aggiunto.*riprova/i)).toBeInTheDocument();
+    });
+
+    // Retry button should be visible
+    const retryButton = screen.getByRole('button', { name: /riprova/i });
+    expect(retryButton).toBeInTheDocument();
+
+    // Now retry succeeds
+    const mockThread = { id: 'thread-456', agentId: 'agent-789', gameId: 'game-123' };
+    mockCreateThread.mockResolvedValueOnce(mockThread);
+
+    fireEvent.click(retryButton);
+
+    await waitFor(() => {
+      expect(mockOnSuccess).toHaveBeenCalledWith({
+        gameId: 'game-123',
+        threadId: 'thread-456',
+        agentId: 'agent-789',
+        gameName: 'Catan',
+      });
+    });
+  });
+
+  // =========================================================================
+  // 7. Calls onClose on cancel
+  // =========================================================================
+  it('calls onClose when cancel button is clicked', () => {
+    renderModal();
+
+    fireEvent.click(screen.getByRole('button', { name: /annulla/i }));
+
+    expect(mockOnClose).toHaveBeenCalledTimes(1);
+  });
+
+  // =========================================================================
+  // 8. Button is disabled during loading
+  // =========================================================================
+  it('disables confirm button during loading', async () => {
+    // Make the mutation hang
+    mockMutateAsync.mockImplementation(() => new Promise(() => {}));
+
+    renderModal();
+
+    fireEvent.click(screen.getByRole('button', { name: /aggiungi e chiedi/i }));
+
+    await waitFor(() => {
+      const button = screen.getByRole('button', { name: /aggiungendo/i });
+      expect(button).toBeDisabled();
+    });
+  });
+
+  // =========================================================================
+  // 9. Renders game image when imageUrl is provided
+  // =========================================================================
+  it('renders game thumbnail when imageUrl is provided', () => {
+    renderModal();
+
+    const img = screen.getByRole('img', { name: 'Catan' });
+    expect(img).toBeInTheDocument();
+  });
+
+  // =========================================================================
+  // 10. Shows placeholder when imageUrl is null
+  // =========================================================================
+  it('shows placeholder when imageUrl is null', () => {
+    renderModal({ game: { ...mockGame, imageUrl: null } });
+
+    expect(screen.queryByRole('img', { name: 'Catan' })).not.toBeInTheDocument();
+    // Placeholder icon should exist
+    expect(screen.getByTestId('game-placeholder-icon')).toBeInTheDocument();
+  });
+});

--- a/apps/web/src/__tests__/components/dashboard/SearchExpander.test.tsx
+++ b/apps/web/src/__tests__/components/dashboard/SearchExpander.test.tsx
@@ -1,0 +1,208 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor, act } from '@testing-library/react';
+
+import { SearchExpander } from '@/components/dashboard/SearchExpander';
+import type { SharedGameSearchResult } from '@/components/dashboard/SearchExpander';
+
+// Mock the api module (project pattern: import { api } from '@/lib/api')
+const mockSearch = vi.fn();
+vi.mock('@/lib/api', () => ({
+  api: {
+    sharedGames: {
+      search: (...args: unknown[]) => mockSearch(...args),
+    },
+  },
+}));
+
+// Mock the user library hook
+// useLibrary returns UseQueryResult<PaginatedLibraryResponse>
+// PaginatedLibraryResponse has items: UserLibraryEntry[] with gameId field
+vi.mock('@/hooks/queries/useLibrary', () => ({
+  useLibrary: () => ({
+    data: {
+      items: [],
+      totalCount: 0,
+      page: 1,
+      pageSize: 20,
+      totalPages: 0,
+      hasNextPage: false,
+      hasPreviousPage: false,
+    },
+    isLoading: false,
+  }),
+}));
+
+// Mock next/navigation
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+describe('SearchExpander', () => {
+  const mockOnViewGame = vi.fn();
+  const mockOnAskAboutGame = vi.fn<(game: SharedGameSearchResult) => void>();
+  const mockOnClose = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockSearch.mockResolvedValue({
+      items: [
+        {
+          id: 'g1',
+          title: 'Catan',
+          thumbnailUrl: '/catan.jpg',
+          imageUrl: '/catan-full.jpg',
+          minPlayers: 3,
+          maxPlayers: 4,
+          yearPublished: 1995,
+          playingTimeMinutes: 90,
+          minAge: 10,
+          description: 'A strategy game',
+          complexityRating: 2.3,
+          averageRating: 7.2,
+          status: 'Published',
+          isRagPublic: false,
+          createdAt: '2024-01-01T00:00:00Z',
+          modifiedAt: null,
+          bggId: 13,
+        },
+        {
+          id: 'g2',
+          title: 'Catan: Seafarers',
+          thumbnailUrl: '/seafarers.jpg',
+          imageUrl: '/seafarers-full.jpg',
+          minPlayers: 3,
+          maxPlayers: 4,
+          yearPublished: 1997,
+          playingTimeMinutes: 120,
+          minAge: 10,
+          description: 'An expansion',
+          complexityRating: 2.5,
+          averageRating: 7.0,
+          status: 'Published',
+          isRagPublic: false,
+          createdAt: '2024-01-01T00:00:00Z',
+          modifiedAt: null,
+          bggId: 325,
+        },
+      ],
+      total: 2,
+      page: 1,
+      pageSize: 5,
+    });
+  });
+
+  it('renders search input when open', () => {
+    render(
+      <SearchExpander
+        isOpen={true}
+        onClose={mockOnClose}
+        onViewGame={mockOnViewGame}
+        onAskAboutGame={mockOnAskAboutGame}
+      />
+    );
+    expect(screen.getByPlaceholderText(/cerca un gioco/i)).toBeInTheDocument();
+  });
+
+  it('does not render when closed', () => {
+    render(
+      <SearchExpander
+        isOpen={false}
+        onClose={mockOnClose}
+        onViewGame={mockOnViewGame}
+        onAskAboutGame={mockOnAskAboutGame}
+      />
+    );
+    expect(screen.queryByPlaceholderText(/cerca un gioco/i)).not.toBeInTheDocument();
+  });
+
+  it('searches after debounce and shows results', async () => {
+    render(
+      <SearchExpander
+        isOpen={true}
+        onClose={mockOnClose}
+        onViewGame={mockOnViewGame}
+        onAskAboutGame={mockOnAskAboutGame}
+      />
+    );
+
+    const input = screen.getByPlaceholderText(/cerca un gioco/i);
+    await act(async () => {
+      fireEvent.change(input, { target: { value: 'Catan' } });
+    });
+
+    await waitFor(() => {
+      expect(mockSearch).toHaveBeenCalledWith(
+        expect.objectContaining({ searchTerm: 'Catan', pageSize: 5 })
+      );
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Catan')).toBeInTheDocument();
+      expect(screen.getByText('Catan: Seafarers')).toBeInTheDocument();
+    });
+  });
+
+  it('calls onViewGame when "Vedi" is clicked', async () => {
+    render(
+      <SearchExpander
+        isOpen={true}
+        onClose={mockOnClose}
+        onViewGame={mockOnViewGame}
+        onAskAboutGame={mockOnAskAboutGame}
+      />
+    );
+
+    const input = screen.getByPlaceholderText(/cerca un gioco/i);
+    await act(async () => {
+      fireEvent.change(input, { target: { value: 'Catan' } });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Catan')).toBeInTheDocument();
+    });
+
+    const vediButtons = screen.getAllByText(/vedi/i);
+    fireEvent.click(vediButtons[0]);
+    expect(mockOnViewGame).toHaveBeenCalledWith('g1');
+  });
+
+  it('calls onAskAboutGame when "Chiedi" is clicked', async () => {
+    render(
+      <SearchExpander
+        isOpen={true}
+        onClose={mockOnClose}
+        onViewGame={mockOnViewGame}
+        onAskAboutGame={mockOnAskAboutGame}
+      />
+    );
+
+    const input = screen.getByPlaceholderText(/cerca un gioco/i);
+    await act(async () => {
+      fireEvent.change(input, { target: { value: 'Catan' } });
+    });
+
+    await waitFor(() => {
+      expect(screen.getByText('Catan')).toBeInTheDocument();
+    });
+
+    const chiediButtons = screen.getAllByText(/chiedi/i);
+    fireEvent.click(chiediButtons[0]);
+    expect(mockOnAskAboutGame).toHaveBeenCalledWith(
+      expect.objectContaining({ id: 'g1', title: 'Catan' })
+    );
+  });
+
+  it('closes on ESC key', () => {
+    render(
+      <SearchExpander
+        isOpen={true}
+        onClose={mockOnClose}
+        onViewGame={mockOnViewGame}
+        onAskAboutGame={mockOnAskAboutGame}
+      />
+    );
+
+    fireEvent.keyDown(document, { key: 'Escape' });
+    expect(mockOnClose).toHaveBeenCalled();
+  });
+});

--- a/apps/web/src/__tests__/stores/useDashboardSearchStore.test.ts
+++ b/apps/web/src/__tests__/stores/useDashboardSearchStore.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, beforeEach } from 'vitest';
+import { useDashboardSearchStore } from '@/stores/useDashboardSearchStore';
+
+describe('useDashboardSearchStore', () => {
+  beforeEach(() => {
+    useDashboardSearchStore.getState().reset();
+  });
+
+  it('starts with search closed', () => {
+    const state = useDashboardSearchStore.getState();
+    expect(state.isSearchOpen).toBe(false);
+    expect(state.selectedGame).toBeNull();
+    expect(state.drawerState).toBeNull();
+  });
+
+  it('opens and closes search', () => {
+    const { openSearch, closeSearch } = useDashboardSearchStore.getState();
+    openSearch();
+    expect(useDashboardSearchStore.getState().isSearchOpen).toBe(true);
+    closeSearch();
+    expect(useDashboardSearchStore.getState().isSearchOpen).toBe(false);
+  });
+
+  it('sets selected game for modal', () => {
+    const game = { id: 'g1', name: 'Catan', imageUrl: null, playerCount: '3-4' };
+    useDashboardSearchStore.getState().setSelectedGame(game);
+    expect(useDashboardSearchStore.getState().selectedGame).toEqual(game);
+  });
+
+  it('sets drawer state for live chat', () => {
+    const drawer = { threadId: 't1', agentId: 'a1', gameId: 'g1', gameName: 'Catan' };
+    useDashboardSearchStore.getState().openChatDrawer(drawer);
+    expect(useDashboardSearchStore.getState().drawerState).toEqual(drawer);
+  });
+
+  it('clears drawer state on close', () => {
+    const drawer = { threadId: 't1', agentId: 'a1', gameId: 'g1', gameName: 'Catan' };
+    useDashboardSearchStore.getState().openChatDrawer(drawer);
+    useDashboardSearchStore.getState().closeChatDrawer();
+    expect(useDashboardSearchStore.getState().drawerState).toBeNull();
+  });
+
+  it('reset clears everything', () => {
+    useDashboardSearchStore.getState().openSearch();
+    useDashboardSearchStore
+      .getState()
+      .setSelectedGame({ id: 'g1', name: 'X', imageUrl: null, playerCount: '2' });
+    useDashboardSearchStore.getState().reset();
+    const state = useDashboardSearchStore.getState();
+    expect(state.isSearchOpen).toBe(false);
+    expect(state.selectedGame).toBeNull();
+    expect(state.drawerState).toBeNull();
+  });
+});

--- a/apps/web/src/components/chat-unified/EmbeddedChatView.tsx
+++ b/apps/web/src/components/chat-unified/EmbeddedChatView.tsx
@@ -1,0 +1,213 @@
+/**
+ * EmbeddedChatView - Compact chat for ExtraMeepleCardDrawer (liveChat mode)
+ *
+ * Minimal version of ChatThreadView: messages + input only.
+ * No side panel, no debug, no voice, no thread header.
+ */
+
+'use client';
+
+import React, { useState, useCallback, useRef, useEffect } from 'react';
+
+import { useAgentChatStream } from '@/hooks/useAgentChatStream';
+import { cn } from '@/lib/utils';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+interface ChatMessage {
+  id: string;
+  role: 'user' | 'assistant';
+  content: string;
+  timestamp?: string;
+}
+
+export interface EmbeddedChatViewProps {
+  /** Chat thread ID */
+  threadId: string;
+  /** Agent ID for SSE streaming */
+  agentId: string;
+  /** Game ID for context */
+  gameId: string;
+  /** Game name for ProxyGameContext */
+  gameName?: string;
+}
+
+// ============================================================================
+// Component
+// ============================================================================
+
+export function EmbeddedChatView({ threadId, agentId, gameId, gameName }: EmbeddedChatViewProps) {
+  const messagesEndRef = useRef<HTMLDivElement>(null);
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [inputValue, setInputValue] = useState('');
+
+  // SSE streaming
+  const {
+    state: streamState,
+    sendMessage: sendViaSSE,
+    stopStreaming,
+  } = useAgentChatStream({
+    onComplete: (answer, metadata) => {
+      const assistantMessage: ChatMessage = {
+        id: `assistant-${crypto.randomUUID()}`,
+        role: 'assistant',
+        content: answer,
+        timestamp: new Date().toISOString(),
+      };
+      setMessages(prev => [...prev, assistantMessage]);
+    },
+  });
+
+  // Auto-scroll on new messages or streaming content
+  useEffect(() => {
+    messagesEndRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages, streamState.currentAnswer]);
+
+  // Stop SSE streaming on unmount
+  useEffect(() => {
+    return () => {
+      stopStreaming();
+    };
+  }, [stopStreaming]);
+
+  // Send message handler
+  const handleSend = useCallback(
+    (e: React.FormEvent) => {
+      e.preventDefault();
+      const content = inputValue.trim();
+      if (!content) return;
+
+      // Optimistic UI: add user message
+      const userMessage: ChatMessage = {
+        id: `user-${crypto.randomUUID()}`,
+        role: 'user',
+        content,
+        timestamp: new Date().toISOString(),
+      };
+      setMessages(prev => [...prev, userMessage]);
+      setInputValue('');
+
+      // Send via SSE
+      sendViaSSE(
+        agentId,
+        content,
+        threadId,
+        { gameName: gameName ?? '', agentTypology: '' },
+        undefined
+      );
+    },
+    [inputValue, agentId, threadId, gameName, sendViaSSE]
+  );
+
+  return (
+    <div className="flex flex-col h-full" data-testid="embedded-chat-view">
+      {/* Error banner */}
+      {streamState.error && (
+        <div
+          role="alert"
+          className="mx-3 mt-2 p-2 bg-red-50 dark:bg-red-500/10 text-red-700 dark:text-red-400 rounded-lg text-xs border border-red-200 dark:border-red-500/20"
+        >
+          {streamState.error}
+        </div>
+      )}
+
+      {/* Messages area */}
+      <div className="flex-1 overflow-y-auto p-4 space-y-3">
+        {/* Empty state */}
+        {messages.length === 0 && !streamState.isStreaming && (
+          <div className="flex items-center justify-center h-full">
+            <p className="text-sm text-muted-foreground font-nunito">
+              Chiedi qualsiasi cosa sul gioco!
+            </p>
+          </div>
+        )}
+
+        {/* Message bubbles */}
+        {messages.map(msg => (
+          <div
+            key={msg.id}
+            className={cn(
+              'max-w-[90%] rounded-2xl px-3 py-2',
+              msg.role === 'user'
+                ? 'ml-auto bg-amber-500 text-white'
+                : 'mr-auto bg-white/70 dark:bg-card/70 backdrop-blur-md border border-border/50'
+            )}
+            data-testid={`message-${msg.role}`}
+          >
+            <p className="text-sm whitespace-pre-wrap font-nunito">{msg.content}</p>
+          </div>
+        ))}
+
+        {/* Streaming status */}
+        {streamState.statusMessage && (
+          <div
+            className="flex items-center gap-2 text-xs text-muted-foreground font-nunito"
+            data-testid="stream-status"
+          >
+            <div className="h-3 w-3 border-2 border-amber-500/30 border-t-amber-500 rounded-full animate-spin" />
+            {streamState.statusMessage}
+          </div>
+        )}
+
+        {/* Streaming response bubble */}
+        {streamState.isStreaming && streamState.currentAnswer && (
+          <div
+            className="max-w-[90%] mr-auto rounded-2xl px-3 py-2 bg-white/70 dark:bg-card/70 backdrop-blur-md border border-border/50"
+            data-testid="message-streaming"
+          >
+            <p className="text-sm whitespace-pre-wrap font-nunito">{streamState.currentAnswer}</p>
+            <div className="mt-1 flex items-center gap-1">
+              <div className="h-1.5 w-1.5 rounded-full bg-amber-500 animate-pulse" />
+              <span className="text-[10px] text-muted-foreground">In scrittura...</span>
+            </div>
+          </div>
+        )}
+
+        <div ref={messagesEndRef} />
+      </div>
+
+      {/* Input area */}
+      <form onSubmit={handleSend} className="p-3 border-t border-border">
+        <div className="flex items-center gap-2">
+          <input
+            type="text"
+            value={inputValue}
+            onChange={e => setInputValue(e.target.value)}
+            placeholder="Scrivi la tua domanda..."
+            disabled={streamState.isStreaming}
+            className={cn(
+              'flex-1 rounded-xl border border-border/50 px-3 py-2',
+              'bg-white/70 dark:bg-card/70 backdrop-blur-md text-sm font-nunito',
+              'placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-amber-500/40',
+              'disabled:opacity-50 disabled:cursor-not-allowed'
+            )}
+            data-testid="embedded-chat-input"
+          />
+          <button
+            type="submit"
+            disabled={!inputValue.trim() || streamState.isStreaming}
+            className={cn(
+              'p-2 rounded-xl transition-all duration-200 flex-shrink-0',
+              inputValue.trim() && !streamState.isStreaming
+                ? 'bg-amber-500 hover:bg-amber-600 text-white cursor-pointer'
+                : 'bg-muted text-muted-foreground cursor-not-allowed'
+            )}
+            aria-label="Invia messaggio"
+            data-testid="embedded-send-btn"
+          >
+            <svg className="h-5 w-5" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M12 19l9 2-9-18-9 18 9-2zm0 0v-8"
+              />
+            </svg>
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}

--- a/apps/web/src/components/dashboard/AddToLibraryModal.tsx
+++ b/apps/web/src/components/dashboard/AddToLibraryModal.tsx
@@ -1,0 +1,232 @@
+'use client';
+
+/**
+ * AddToLibraryModal — Confirmation modal for adding a shared library game
+ * to the user's personal library and creating a chat thread in one action.
+ *
+ * Orchestration flow:
+ * 1. Add game to library via useAddGameToLibrary mutation
+ * 2. Create chat thread via api.chat.createThread
+ * 3. Call onSuccess with IDs so the chat drawer can open
+ *
+ * Error handling:
+ * - If step 1 fails: show error, no side effects
+ * - If step 2 fails: game stays in library, show "Riprova" to retry thread creation only
+ */
+
+import { useState, useCallback } from 'react';
+
+import { Gamepad2 } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/overlays/dialog';
+import { useAddGameToLibrary } from '@/hooks/queries/useLibrary';
+import { api } from '@/lib/api';
+
+// ============================================================================
+// Types
+// ============================================================================
+
+export interface AddToLibraryModalGame {
+  id: string;
+  name: string;
+  imageUrl: string | null;
+  playerCount: string;
+}
+
+export interface AddToLibraryModalProps {
+  game: AddToLibraryModalGame | null;
+  isOpen: boolean;
+  onClose: () => void;
+  onSuccess: (result: {
+    gameId: string;
+    threadId: string;
+    agentId: string;
+    gameName: string;
+  }) => void;
+}
+
+type ModalState =
+  | { phase: 'idle' }
+  | { phase: 'loading' }
+  | { phase: 'addFailed'; message: string }
+  | { phase: 'threadFailed'; message: string };
+
+// ============================================================================
+// Component
+// ============================================================================
+
+export function AddToLibraryModal({ game, isOpen, onClose, onSuccess }: AddToLibraryModalProps) {
+  const [state, setState] = useState<ModalState>({ phase: 'idle' });
+  const addGameMutation = useAddGameToLibrary();
+
+  const resetState = useCallback(() => {
+    setState({ phase: 'idle' });
+  }, []);
+
+  const handleOpenChange = useCallback(
+    (open: boolean) => {
+      if (!open) {
+        onClose();
+        resetState();
+      }
+    },
+    [onClose, resetState]
+  );
+
+  const createThread = useCallback(async (gameId: string, gameName: string) => {
+    const thread = await api.chat.createThread({
+      gameId,
+      title: gameName,
+    });
+    return thread;
+  }, []);
+
+  const handleConfirm = useCallback(async () => {
+    if (!game) return;
+
+    setState({ phase: 'loading' });
+
+    // Step 1: Add game to library
+    try {
+      await addGameMutation.mutateAsync({ gameId: game.id });
+    } catch {
+      setState({
+        phase: 'addFailed',
+        message: 'Non è stato possibile aggiungere il gioco alla libreria.',
+      });
+      return;
+    }
+
+    // Step 2: Create chat thread
+    try {
+      const thread = await createThread(game.id, game.name);
+      setState({ phase: 'idle' });
+      onSuccess({
+        gameId: game.id,
+        threadId: thread.id,
+        agentId: thread.agentId ?? '',
+        gameName: game.name,
+      });
+    } catch {
+      setState({
+        phase: 'threadFailed',
+        message: 'Gioco aggiunto alla libreria, ma la creazione della chat è fallita. Riprova.',
+      });
+    }
+  }, [game, addGameMutation, createThread, onSuccess]);
+
+  const handleRetryThread = useCallback(async () => {
+    if (!game) return;
+
+    setState({ phase: 'loading' });
+
+    try {
+      const thread = await createThread(game.id, game.name);
+      setState({ phase: 'idle' });
+      onSuccess({
+        gameId: game.id,
+        threadId: thread.id,
+        agentId: thread.agentId ?? '',
+        gameName: game.name,
+      });
+    } catch {
+      setState({
+        phase: 'threadFailed',
+        message: 'Gioco aggiunto alla libreria, ma la creazione della chat è fallita. Riprova.',
+      });
+    }
+  }, [game, createThread, onSuccess]);
+
+  const isLoading = state.phase === 'loading';
+  const showContent = isOpen && game !== null;
+
+  return (
+    <Dialog open={showContent} onOpenChange={handleOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Aggiungi alla libreria</DialogTitle>
+          <DialogDescription>
+            Per chattare con l&apos;AI su questo gioco, aggiungilo alla tua libreria.
+          </DialogDescription>
+        </DialogHeader>
+
+        {game && (
+          <>
+            {/* Game preview */}
+            <div className="flex items-center gap-4 rounded-lg border border-border/50 p-3">
+              <div className="h-16 w-16 flex-shrink-0 overflow-hidden rounded-md bg-muted">
+                {game.imageUrl ? (
+                  <img src={game.imageUrl} alt={game.name} className="h-full w-full object-cover" />
+                ) : (
+                  <div
+                    className="flex h-full w-full items-center justify-center"
+                    data-testid="game-placeholder-icon"
+                  >
+                    <Gamepad2 className="h-8 w-8 text-muted-foreground" />
+                  </div>
+                )}
+              </div>
+              <div className="min-w-0 flex-1">
+                <p className="truncate font-semibold">{game.name}</p>
+                <p className="text-sm text-muted-foreground">{game.playerCount} giocatori</p>
+              </div>
+            </div>
+
+            {/* Error messages */}
+            {state.phase === 'addFailed' && (
+              <p className="text-sm text-destructive" role="alert">
+                {state.message}
+              </p>
+            )}
+
+            {state.phase === 'threadFailed' && (
+              <p className="text-sm text-destructive" role="alert">
+                {state.message}
+              </p>
+            )}
+
+            {/* Actions */}
+            <DialogFooter>
+              <Button
+                type="button"
+                variant="outline"
+                onClick={() => handleOpenChange(false)}
+                disabled={isLoading}
+              >
+                Annulla
+              </Button>
+
+              {state.phase === 'threadFailed' ? (
+                <Button
+                  type="button"
+                  onClick={handleRetryThread}
+                  disabled={isLoading}
+                  className="bg-gradient-to-r from-purple-600 to-purple-500 text-white hover:from-purple-700 hover:to-purple-600"
+                >
+                  {isLoading ? 'Creando chat...' : 'Riprova'}
+                </Button>
+              ) : (
+                <Button
+                  type="button"
+                  onClick={handleConfirm}
+                  disabled={isLoading}
+                  className="bg-gradient-to-r from-purple-600 to-purple-500 text-white hover:from-purple-700 hover:to-purple-600"
+                >
+                  {isLoading ? 'Aggiungendo...' : 'Aggiungi e Chiedi 🤖'}
+                </Button>
+              )}
+            </DialogFooter>
+          </>
+        )}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/apps/web/src/components/dashboard/DashboardRenderer.tsx
+++ b/apps/web/src/components/dashboard/DashboardRenderer.tsx
@@ -1,9 +1,13 @@
 'use client';
 
-import { Suspense } from 'react';
+import { Suspense, useCallback } from 'react';
 
 import { AnimatePresence, motion } from 'framer-motion';
 
+import { ExtraMeepleCardDrawer } from '@/components/ui/data-display/extra-meeple-card';
+import { useDashboardSearchStore } from '@/stores/useDashboardSearchStore';
+
+import { AddToLibraryModal } from './AddToLibraryModal';
 import { useDashboardMode } from './useDashboardMode';
 import { HeroZone, StatsZone, CardsZone, AgentsSidebar, SessionBar, ScoreboardZone } from './zones';
 import './dashboard-transitions.css';
@@ -22,6 +26,26 @@ function ZoneSkeleton({ testId }: { testId: string }) {
  */
 export function DashboardRenderer() {
   const { state, isGameMode, isExploration } = useDashboardMode();
+  const { selectedGame, setSelectedGame, openChatDrawer, drawerState, closeChatDrawer } =
+    useDashboardSearchStore();
+
+  const handleModalSuccess = useCallback(
+    ({
+      gameId,
+      threadId,
+      agentId,
+      gameName,
+    }: {
+      gameId: string;
+      threadId: string;
+      agentId: string;
+      gameName: string;
+    }) => {
+      setSelectedGame(null);
+      openChatDrawer({ threadId, agentId, gameId, gameName });
+    },
+    [setSelectedGame, openChatDrawer]
+  );
 
   return (
     <div data-testid="dashboard-renderer" className="flex flex-col gap-6 w-full">
@@ -79,6 +103,24 @@ export function DashboardRenderer() {
           </motion.div>
         )}
       </AnimatePresence>
+
+      <AddToLibraryModal
+        game={selectedGame}
+        isOpen={selectedGame !== null}
+        onClose={() => setSelectedGame(null)}
+        onSuccess={handleModalSuccess}
+      />
+
+      {drawerState && (
+        <ExtraMeepleCardDrawer
+          entityType="chatSession"
+          entityId={drawerState.threadId}
+          open={true}
+          onClose={closeChatDrawer}
+          liveChatData={drawerState}
+          data-testid="dashboard-chat-drawer"
+        />
+      )}
     </div>
   );
 }

--- a/apps/web/src/components/dashboard/SearchExpander.tsx
+++ b/apps/web/src/components/dashboard/SearchExpander.tsx
@@ -1,0 +1,229 @@
+'use client';
+
+/**
+ * SearchExpander - Glassmorphism search bar with dropdown results
+ *
+ * Searches the shared game catalog with debounce (300ms).
+ * Shows results with dual actions: "Vedi" (view) and "Chiedi" (ask AI).
+ * Indicates if a game is already in the user's library.
+ */
+
+import { useState, useEffect, useRef, useCallback, useMemo } from 'react';
+
+import { Search, Loader2 } from 'lucide-react';
+
+import { useLibrary } from '@/hooks/queries/useLibrary';
+import { api } from '@/lib/api';
+import type { SharedGame } from '@/lib/api/schemas/shared-games.schemas';
+
+// ========== Types ==========
+
+export interface SharedGameSearchResult extends SharedGame {
+  isInLibrary?: boolean;
+}
+
+export interface SearchExpanderProps {
+  isOpen: boolean;
+  onClose: () => void;
+  onViewGame: (gameId: string) => void;
+  onAskAboutGame: (game: SharedGameSearchResult) => void;
+}
+
+// ========== Constants ==========
+
+const DEBOUNCE_MS = 300;
+const PAGE_SIZE = 5;
+
+// ========== Component ==========
+
+export function SearchExpander({
+  isOpen,
+  onClose,
+  onViewGame,
+  onAskAboutGame,
+}: SearchExpanderProps) {
+  const [query, setQuery] = useState('');
+  const [results, setResults] = useState<SharedGame[]>([]);
+  const [isSearching, setIsSearching] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const debounceRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  // Fetch user library to check which games are already owned
+  const { data: libraryData } = useLibrary();
+
+  // Build a Set of library game IDs for O(1) lookup
+  const libraryGameIds = useMemo(() => {
+    if (!libraryData?.items) return new Set<string>();
+    return new Set(libraryData.items.map(entry => entry.gameId));
+  }, [libraryData?.items]);
+
+  // Debounced search
+  const performSearch = useCallback(async (searchTerm: string) => {
+    if (!searchTerm.trim()) {
+      setResults([]);
+      setIsSearching(false);
+      return;
+    }
+
+    setIsSearching(true);
+    try {
+      const response = await api.sharedGames.search({
+        searchTerm,
+        pageSize: PAGE_SIZE,
+      });
+      setResults(response.items);
+    } catch {
+      setResults([]);
+    } finally {
+      setIsSearching(false);
+    }
+  }, []);
+
+  // Handle input change with debounce
+  useEffect(() => {
+    if (debounceRef.current) {
+      clearTimeout(debounceRef.current);
+    }
+
+    if (!query.trim()) {
+      setResults([]);
+      return;
+    }
+
+    debounceRef.current = setTimeout(() => {
+      performSearch(query);
+    }, DEBOUNCE_MS);
+
+    return () => {
+      if (debounceRef.current) {
+        clearTimeout(debounceRef.current);
+      }
+    };
+  }, [query, performSearch]);
+
+  // Auto-focus input when opened
+  useEffect(() => {
+    if (isOpen) {
+      // Small delay to ensure the DOM is ready
+      const timer = setTimeout(() => {
+        inputRef.current?.focus();
+      }, 50);
+      return () => clearTimeout(timer);
+    } else {
+      // Reset state when closed
+      setQuery('');
+      setResults([]);
+    }
+  }, [isOpen]);
+
+  // ESC key handler
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const handleKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        onClose();
+      }
+    };
+
+    document.addEventListener('keydown', handleKeyDown);
+    return () => document.removeEventListener('keydown', handleKeyDown);
+  }, [isOpen, onClose]);
+
+  // Don't render when closed
+  if (!isOpen) return null;
+
+  // Enrich results with library status
+  const enrichedResults: SharedGameSearchResult[] = results.map(game => ({
+    ...game,
+    isInLibrary: libraryGameIds.has(game.id),
+  }));
+
+  const formatPlayers = (min: number, max: number) => {
+    if (min === max) return `${min} giocatori`;
+    return `${min}-${max} giocatori`;
+  };
+
+  return (
+    <div data-testid="search-expander" className="absolute inset-x-4 bottom-20 z-50">
+      {/* Search Input */}
+      <div className="bg-white/5 backdrop-blur-xl border border-white/10 rounded-2xl p-3 shadow-2xl">
+        <div className="relative">
+          <Search className="absolute left-3 top-1/2 -translate-y-1/2 h-4 w-4 text-white/40" />
+          <input
+            ref={inputRef}
+            type="text"
+            value={query}
+            onChange={e => setQuery(e.target.value)}
+            placeholder="Cerca un gioco..."
+            className="w-full bg-white/5 border border-white/10 rounded-xl py-2.5 pl-10 pr-4 text-sm text-white placeholder:text-white/40 focus:outline-none focus:ring-1 focus:ring-white/20"
+          />
+          {isSearching && (
+            <Loader2 className="absolute right-3 top-1/2 -translate-y-1/2 h-4 w-4 text-white/40 animate-spin" />
+          )}
+        </div>
+
+        {/* Results Dropdown */}
+        {enrichedResults.length > 0 && (
+          <div className="mt-2 space-y-1 max-h-[280px] overflow-y-auto">
+            {enrichedResults.map(game => (
+              <div
+                key={game.id}
+                className="flex items-center gap-3 p-2 rounded-xl hover:bg-white/5 transition-colors"
+              >
+                {/* Thumbnail */}
+                {game.thumbnailUrl && (
+                  <img
+                    src={game.thumbnailUrl}
+                    alt={game.title}
+                    className="h-10 w-10 rounded-lg object-cover flex-shrink-0"
+                  />
+                )}
+
+                {/* Game Info */}
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2">
+                    <span className="text-sm font-medium text-white truncate">{game.title}</span>
+                    {game.isInLibrary && (
+                      <span className="text-[10px] px-1.5 py-0.5 rounded-full bg-emerald-500/20 text-emerald-400 whitespace-nowrap">
+                        ✓ In libreria
+                      </span>
+                    )}
+                  </div>
+                  <span className="text-xs text-white/40">
+                    {formatPlayers(game.minPlayers, game.maxPlayers)}
+                  </span>
+                </div>
+
+                {/* Action Buttons */}
+                <div className="flex items-center gap-1.5 flex-shrink-0">
+                  <button
+                    onClick={() => onViewGame(game.id)}
+                    className="px-2.5 py-1 text-xs font-medium rounded-lg bg-blue-500/20 text-blue-400 hover:bg-blue-500/30 transition-colors"
+                  >
+                    Vedi
+                  </button>
+                  <button
+                    onClick={() => onAskAboutGame(game)}
+                    className={`px-2.5 py-1 text-xs font-medium rounded-lg transition-colors ${
+                      game.isInLibrary
+                        ? 'bg-emerald-500/20 text-emerald-400 hover:bg-emerald-500/30'
+                        : 'bg-purple-500/20 text-purple-400 hover:bg-purple-500/30'
+                    }`}
+                  >
+                    Chiedi
+                  </button>
+                </div>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {/* Empty state when searching with no results */}
+        {query.trim() && !isSearching && results.length === 0 && (
+          <div className="mt-2 py-4 text-center text-xs text-white/30">Nessun gioco trovato</div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/src/components/dashboard/zones/HeroZone.tsx
+++ b/apps/web/src/components/dashboard/zones/HeroZone.tsx
@@ -1,6 +1,8 @@
 'use client';
 
-import { useMemo } from 'react';
+import { useCallback, useMemo } from 'react';
+
+import { Search } from 'lucide-react';
 
 import { useDashboardData } from '@/hooks/useDashboardData';
 
@@ -60,15 +62,21 @@ function GameNightBanner({
   );
 }
 
-function WelcomePrompt() {
+function SearchCTA({ onOpenSearch }: { onOpenSearch: () => void }) {
   return (
-    <div className="mt-4 flex items-center gap-3 rounded-xl bg-white/60 dark:bg-white/10 px-4 py-3 backdrop-blur-sm">
-      <span className="text-2xl" role="img" aria-label="wave">
-        👋
-      </span>
-      <p className="text-sm text-amber-900 dark:text-amber-100">
-        Aggiungi il tuo primo gioco alla libreria per iniziare!
+    <div className="mt-4 rounded-xl bg-gradient-to-br from-purple-500/10 to-blue-500/10 border border-purple-500/20 p-6 text-center">
+      <p className="text-sm text-purple-300 mb-4">
+        Hai una domanda su un gioco da tavolo? Cerca nella community e chiedi all&apos;AI!
       </p>
+      <button
+        onClick={onOpenSearch}
+        className="inline-flex items-center gap-2 rounded-lg bg-purple-500/15 border border-purple-500/25 px-4 py-2 text-sm font-medium text-purple-300 hover:bg-purple-500/25 transition-colors"
+        data-testid="hero-search-cta"
+      >
+        <Search className="w-4 h-4" />
+        Cerca un gioco
+      </button>
+      <p className="mt-2 text-xs text-muted-foreground">oppure premi Cmd+K</p>
     </div>
   );
 }
@@ -81,6 +89,13 @@ export function HeroZone() {
   const { data, isLoading } = useDashboardData();
 
   const greeting = useMemo(() => getTimeGreeting(), []);
+
+  /** Dispatch Cmd+K to open CommandPalette from anywhere */
+  const openCommandPalette = useCallback(() => {
+    document.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'k', metaKey: true, bubbles: true })
+    );
+  }, []);
 
   if (isLoading) {
     return <HeroZoneSkeleton />;
@@ -113,7 +128,7 @@ export function HeroZone() {
 
       {upcomingGameNight && <GameNightBanner gameNight={upcomingGameNight} />}
 
-      {isNewUser && <WelcomePrompt />}
+      {isNewUser && <SearchCTA onOpenSearch={openCommandPalette} />}
     </section>
   );
 }

--- a/apps/web/src/components/ui/data-display/extra-meeple-card/ExtraMeepleCardDrawer.tsx
+++ b/apps/web/src/components/ui/data-display/extra-meeple-card/ExtraMeepleCardDrawer.tsx
@@ -39,6 +39,7 @@ import {
   Zap,
 } from 'lucide-react';
 
+import { EmbeddedChatView } from '@/components/chat-unified/EmbeddedChatView';
 import { useDashboardMode } from '@/components/dashboard';
 import { Sheet, SheetClose, SheetContent, SheetTitle } from '@/components/ui/navigation/sheet';
 import { cn } from '@/lib/utils';
@@ -83,6 +84,13 @@ export interface ExtraMeepleCardDrawerProps {
    * Maps the MeepleEntityType to the LinkEntityType for the API call.
    */
   linkEntityType?: LinkEntityType;
+  /** When present with chatSession entity type, renders EmbeddedChatView instead of ChatDrawerContent */
+  liveChatData?: {
+    threadId: string;
+    agentId: string;
+    gameId: string;
+    gameName: string;
+  };
   className?: string;
   'data-testid'?: string;
 }
@@ -132,6 +140,7 @@ export const ExtraMeepleCardDrawer = React.memo(function ExtraMeepleCardDrawer({
   open,
   onClose,
   linkEntityType,
+  liveChatData,
   className,
   'data-testid': testId,
 }: ExtraMeepleCardDrawerProps) {
@@ -210,6 +219,7 @@ export const ExtraMeepleCardDrawer = React.memo(function ExtraMeepleCardDrawer({
             entityType={entityType}
             entityId={entityId}
             linkEntityType={linkEntityType}
+            liveChatData={liveChatData}
           />
         </div>
       </SheetContent>
@@ -225,10 +235,12 @@ function DrawerEntityRouter({
   entityType,
   entityId,
   linkEntityType,
+  liveChatData,
 }: {
   entityType: DrawerEntityType;
   entityId: string;
   linkEntityType?: LinkEntityType;
+  liveChatData?: ExtraMeepleCardDrawerProps['liveChatData'];
 }) {
   switch (entityType) {
     case 'game':
@@ -237,6 +249,16 @@ function DrawerEntityRouter({
       return <AgentDrawerContent entityId={entityId} />;
     case 'chatSession':
     case 'chat':
+      if (liveChatData) {
+        return (
+          <EmbeddedChatView
+            threadId={liveChatData.threadId}
+            agentId={liveChatData.agentId}
+            gameId={liveChatData.gameId}
+            gameName={liveChatData.gameName}
+          />
+        );
+      }
       return <ChatDrawerContent entityId={entityId} />;
     case 'kb':
       return <KbDrawerContent entityId={entityId} />;

--- a/apps/web/src/stores/useDashboardSearchStore.ts
+++ b/apps/web/src/stores/useDashboardSearchStore.ts
@@ -1,0 +1,40 @@
+import { create } from 'zustand';
+
+export interface SearchGameResult {
+  id: string;
+  name: string;
+  imageUrl: string | null;
+  playerCount: string;
+}
+
+export interface ChatDrawerState {
+  threadId: string;
+  agentId: string;
+  gameId: string;
+  gameName: string;
+  kbCardCount?: number;
+}
+
+interface DashboardSearchState {
+  isSearchOpen: boolean;
+  selectedGame: SearchGameResult | null;
+  drawerState: ChatDrawerState | null;
+  openSearch: () => void;
+  closeSearch: () => void;
+  setSelectedGame: (game: SearchGameResult | null) => void;
+  openChatDrawer: (state: ChatDrawerState) => void;
+  closeChatDrawer: () => void;
+  reset: () => void;
+}
+
+export const useDashboardSearchStore = create<DashboardSearchState>(set => ({
+  isSearchOpen: false,
+  selectedGame: null,
+  drawerState: null,
+  openSearch: () => set({ isSearchOpen: true }),
+  closeSearch: () => set({ isSearchOpen: false, selectedGame: null }),
+  setSelectedGame: game => set({ selectedGame: game }),
+  openChatDrawer: state => set({ drawerState: state, isSearchOpen: false, selectedGame: null }),
+  closeChatDrawer: () => set({ drawerState: null }),
+  reset: () => set({ isSearchOpen: false, selectedGame: null, drawerState: null }),
+}));


### PR DESCRIPTION
## Summary

Realigned version of #510 (closed due to SmartFAB removal). Now integrates with **CommandPalette** (Cmd+K) instead of SmartFAB.

- **Zustand store** (`useDashboardSearchStore`): cross-component coordination for search/modal/drawer
- **SearchExpander**: glassmorphism search bar + results dropdown with dual actions (Vedi/Chiedi)
- **AddToLibraryModal**: one-click add game + create chat thread orchestration with error recovery
- **EmbeddedChatView**: compact ChatThreadView for drawer (SSE streaming, messages + input only)
- **ExtraMeepleCardDrawer**: liveChat mode for chatSession branch
- **HeroZone**: enhanced empty state with CTA that opens CommandPalette
- **DashboardRenderer**: mounts modal + drawer

## User Flow

New user -> dashboard -> HeroZone CTA or Cmd+K -> CommandPalette searches shared library -> Chiedi -> AddToLibraryModal -> add game + create thread -> chat in drawer

## Test plan

- [ ] New user sees enhanced HeroZone with search CTA
- [ ] CTA opens CommandPalette
- [ ] Chiedi on non-library game opens AddToLibraryModal
- [ ] Aggiungi e Chiedi adds game + creates thread + opens drawer
- [ ] EmbeddedChatView in drawer works with SSE streaming
- [ ] TypeScript type check passes
- [ ] 73 tests pass