### PR TITLE
feat: admin invitation flow with provisioning, activation, and batch support

### DIFF
--- a/apps/api/src/Api/BoundedContexts/Administration/Application/Queries/CheckPermission/CheckPermissionHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/Queries/CheckPermission/CheckPermissionHandler.cs
@@ -2,7 +2,7 @@ using MediatR;
 using Microsoft.EntityFrameworkCore;
 using Api.BoundedContexts.Administration.Application.Queries.CheckPermission;
 using Api.BoundedContexts.Administration.Application.Services;
-using Api.BoundedContexts.Administration.Domain.Enums;
+using Api.SharedKernel.Domain.Enums;
 using Api.BoundedContexts.Administration.Domain.ValueObjects;
 using Api.SharedKernel.Domain.ValueObjects;
 using Api.Infrastructure;

--- a/apps/api/src/Api/BoundedContexts/Administration/Application/Queries/GetUserPermissions/GetUserPermissionsHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/Queries/GetUserPermissions/GetUserPermissionsHandler.cs
@@ -1,7 +1,7 @@
 using MediatR;
 using Microsoft.EntityFrameworkCore;
 using Api.BoundedContexts.Administration.Application.Services;
-using Api.BoundedContexts.Administration.Domain.Enums;
+using Api.SharedKernel.Domain.Enums;
 using Api.BoundedContexts.Administration.Domain.ValueObjects;
 using Api.SharedKernel.Domain.ValueObjects;
 using Api.Infrastructure;

--- a/apps/api/src/Api/BoundedContexts/Administration/Application/Queries/GetUserPermissions/GetUserPermissionsQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/Queries/GetUserPermissions/GetUserPermissionsQuery.cs
@@ -1,5 +1,5 @@
 using MediatR;
-using Api.BoundedContexts.Administration.Domain.Enums;
+using Api.SharedKernel.Domain.Enums;
 using Api.SharedKernel.Domain.ValueObjects;
 using Auth = Api.BoundedContexts.Authentication.Domain.ValueObjects;
 

--- a/apps/api/src/Api/BoundedContexts/Administration/Application/Services/PermissionRegistry.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Application/Services/PermissionRegistry.cs
@@ -1,4 +1,3 @@
-using Api.BoundedContexts.Administration.Domain.Enums;
 using Api.BoundedContexts.Administration.Domain.ValueObjects;
 using Api.SharedKernel.Domain.ValueObjects;
 

--- a/apps/api/src/Api/BoundedContexts/Administration/Domain/Enums/EntityStates.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Domain/Enums/EntityStates.cs
@@ -36,12 +36,3 @@ public enum DocumentProcessingState
     Failed
 }
 
-/// <summary>
-/// User account status
-/// </summary>
-public enum UserAccountStatus
-{
-    Active,
-    Suspended,
-    Banned
-}

--- a/apps/api/src/Api/BoundedContexts/Administration/Domain/ValueObjects/Permission.cs
+++ b/apps/api/src/Api/BoundedContexts/Administration/Domain/ValueObjects/Permission.cs
@@ -1,4 +1,4 @@
-using Api.BoundedContexts.Administration.Domain.Enums;
+using Api.SharedKernel.Domain.Enums;
 using Api.SharedKernel.Domain.ValueObjects;
 
 namespace Api.BoundedContexts.Administration.Domain.ValueObjects;
@@ -60,6 +60,9 @@ public sealed class Permission
 
         if (context.UserStatus == UserAccountStatus.Suspended)
             return PermissionCheckResult.Denied("User account is suspended");
+
+        if (context.UserStatus == UserAccountStatus.Pending)
+            return PermissionCheckResult.Denied("User account is pending activation");
 
         if (AllowedStates != null &&
             !string.IsNullOrEmpty(context.ResourceState) &&

--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/Invitation/ActivateInvitedAccountCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/Invitation/ActivateInvitedAccountCommand.cs
@@ -1,0 +1,13 @@
+using Api.BoundedContexts.Authentication.Application.DTOs;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.Authentication.Application.Commands.Invitation;
+
+/// <summary>
+/// Command to activate a pending invited user account by setting a password.
+/// Called when the invitee clicks the email link and submits their chosen password.
+/// </summary>
+internal sealed record ActivateInvitedAccountCommand(
+    string Token,
+    string Password
+) : ICommand<ActivationResultDto>;

--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/Invitation/ActivateInvitedAccountCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/Invitation/ActivateInvitedAccountCommandHandler.cs
@@ -101,6 +101,7 @@ internal sealed class ActivateInvitedAccountCommandHandler
             timeProvider: _timeProvider);
 
         // 10. Persist all changes atomically
+        await _userRepo.UpdateAsync(user, cancellationToken).ConfigureAwait(false);
         await _invitationRepo.UpdateAsync(invitation, cancellationToken).ConfigureAwait(false);
         await _sessionRepo.AddAsync(session, cancellationToken).ConfigureAwait(false);
         await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);

--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/Invitation/ActivateInvitedAccountCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/Invitation/ActivateInvitedAccountCommandHandler.cs
@@ -1,0 +1,147 @@
+using System.Security.Cryptography;
+using System.Text;
+using Api.BoundedContexts.Authentication.Application.DTOs;
+using Api.BoundedContexts.Authentication.Domain.Entities;
+using Api.BoundedContexts.Authentication.Domain.Repositories;
+using Api.BoundedContexts.Authentication.Domain.ValueObjects;
+using Api.BoundedContexts.Authentication.Infrastructure.Persistence;
+using Api.BoundedContexts.Authentication.Infrastructure.Services;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Domain.Enums;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.Authentication.Application.Commands.Invitation;
+
+/// <summary>
+/// Handles activation of an invited user account (two-phase).
+/// Phase 1 (sync): Validates token, sets password, activates user, creates session.
+/// Phase 2 (async): Dispatches game suggestions to Channel for background processing.
+/// </summary>
+internal sealed class ActivateInvitedAccountCommandHandler
+    : ICommandHandler<ActivateInvitedAccountCommand, ActivationResultDto>
+{
+    private readonly IInvitationTokenRepository _invitationRepo;
+    private readonly IUserRepository _userRepo;
+    private readonly ISessionRepository _sessionRepo;
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly GameSuggestionChannel _gameSuggestionChannel;
+    private readonly TimeProvider _timeProvider;
+    private readonly ILogger<ActivateInvitedAccountCommandHandler> _logger;
+
+    public ActivateInvitedAccountCommandHandler(
+        IInvitationTokenRepository invitationRepo,
+        IUserRepository userRepo,
+        ISessionRepository sessionRepo,
+        IUnitOfWork unitOfWork,
+        GameSuggestionChannel gameSuggestionChannel,
+        TimeProvider timeProvider,
+        ILogger<ActivateInvitedAccountCommandHandler> logger)
+    {
+        _invitationRepo = invitationRepo ?? throw new ArgumentNullException(nameof(invitationRepo));
+        _userRepo = userRepo ?? throw new ArgumentNullException(nameof(userRepo));
+        _sessionRepo = sessionRepo ?? throw new ArgumentNullException(nameof(sessionRepo));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+        _gameSuggestionChannel = gameSuggestionChannel ?? throw new ArgumentNullException(nameof(gameSuggestionChannel));
+        _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<ActivationResultDto> Handle(
+        ActivateInvitedAccountCommand command, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        // ── Phase 1: Synchronous, atomic transaction ──────────────────────
+
+        // 1. Hash the raw token (same SHA-256 pattern as AcceptInvitationCommandHandler)
+        var tokenHash = Convert.ToBase64String(
+            SHA256.HashData(Encoding.UTF8.GetBytes(command.Token)));
+
+        // 2. Look up InvitationToken by hash
+        var invitation = await _invitationRepo
+            .GetByTokenHashAsync(tokenHash, cancellationToken)
+            .ConfigureAwait(false);
+
+        // 3. Validate: token exists and is still valid (pending + not expired)
+        if (invitation is null || !invitation.IsValid)
+            throw new NotFoundException("InvitationToken", command.Token);
+
+        // 4. Find the pre-provisioned pending user
+        if (invitation.PendingUserId is null)
+            throw new NotFoundException("InvitationToken", "PendingUserId is not set on this invitation");
+
+        var user = await _userRepo
+            .GetByIdAsync(invitation.PendingUserId.Value, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (user is null)
+            throw new NotFoundException("User", invitation.PendingUserId.Value.ToString());
+
+        // 5. Validate: user must be in Pending status
+        if (user.Status != UserAccountStatus.Pending)
+            throw new ConflictException($"User '{user.Email.Value}' is not in Pending status");
+
+        // 6. Hash the password
+        var passwordHash = PasswordHash.Create(command.Password);
+
+        // 7. Activate user (sets password, status → Active, email verified)
+        user.ActivateFromInvitation(passwordHash, _timeProvider);
+
+        // 8. Mark token as accepted
+        invitation.MarkAccepted(user.Id);
+
+        // 9. Create session for immediate login
+        var sessionToken = SessionToken.Generate();
+        var session = new Session(
+            id: Guid.NewGuid(),
+            userId: user.Id,
+            token: sessionToken,
+            timeProvider: _timeProvider);
+
+        // 10. Persist all changes atomically
+        await _invitationRepo.UpdateAsync(invitation, cancellationToken).ConfigureAwait(false);
+        await _sessionRepo.AddAsync(session, cancellationToken).ConfigureAwait(false);
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        _logger.LogInformation(
+            "User {UserId} activated from invitation {InvitationId}",
+            user.Id, invitation.Id);
+
+        // ── Phase 2: Async, fire-and-forget game suggestion dispatch ──────
+
+        if (invitation.GameSuggestions.Count > 0)
+        {
+            var invitedByUserId = invitation.InvitedByUserId != Guid.Empty
+                ? invitation.InvitedByUserId
+                : user.InvitedByUserId ?? Guid.Empty;
+
+            try
+            {
+                await _gameSuggestionChannel.Writer.WriteAsync(
+                    new GameSuggestionEvent(
+                        user.Id,
+                        invitedByUserId,
+                        invitation.GameSuggestions),
+                    cancellationToken).ConfigureAwait(false);
+
+                _logger.LogInformation(
+                    "Dispatched {Count} game suggestions for user {UserId}",
+                    invitation.GameSuggestions.Count, user.Id);
+            }
+#pragma warning disable CA1031 // Fire-and-forget: don't let channel errors roll back activation
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex,
+                    "Failed to dispatch game suggestions for user {UserId}", user.Id);
+            }
+#pragma warning restore CA1031
+        }
+
+        // 11. Return result
+        return new ActivationResultDto(
+            SessionToken: sessionToken.Value,
+            RequiresOnboarding: true);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/Invitation/ActivateInvitedAccountCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/Invitation/ActivateInvitedAccountCommandValidator.cs
@@ -1,0 +1,33 @@
+using FluentValidation;
+
+namespace Api.BoundedContexts.Authentication.Application.Commands.Invitation;
+
+/// <summary>
+/// Validator for ActivateInvitedAccountCommand.
+/// Token required; password rules match AcceptInvitationCommandValidator.
+/// </summary>
+internal sealed class ActivateInvitedAccountCommandValidator : AbstractValidator<ActivateInvitedAccountCommand>
+{
+    public ActivateInvitedAccountCommandValidator()
+    {
+        RuleFor(x => x.Token)
+            .NotEmpty()
+            .WithMessage("Invitation token is required");
+
+        RuleFor(x => x.Password)
+            .NotEmpty()
+            .WithMessage("Password is required")
+            .MinimumLength(8)
+            .WithMessage("Password must be at least 8 characters")
+            .MaximumLength(128)
+            .WithMessage("Password must not exceed 128 characters")
+            .Matches(@"[A-Z]")
+            .WithMessage("Password must contain at least one uppercase letter")
+            .Matches(@"[a-z]")
+            .WithMessage("Password must contain at least one lowercase letter")
+            .Matches(@"[0-9]")
+            .WithMessage("Password must contain at least one digit")
+            .Matches(@"[^a-zA-Z0-9]")
+            .WithMessage("Password must contain at least one special character");
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/Invitation/BatchProvisionCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/Invitation/BatchProvisionCommand.cs
@@ -1,0 +1,87 @@
+using Api.BoundedContexts.Authentication.Application.DTOs;
+using Api.SharedKernel.Application.Interfaces;
+using MediatR;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.Authentication.Application.Commands.Invitation;
+
+/// <summary>
+/// Command to batch-provision multiple users and send invitation emails (JSON path).
+/// Iterates items and dispatches ProvisionAndInviteUserCommand per item via MediatR.
+/// Does NOT abort on individual failures — collects errors into Failed list.
+/// Issue #124: Admin invitation flow — batch provisioning.
+/// </summary>
+internal sealed record BatchProvisionCommand(
+    List<BatchInvitationItemDto> Invitations,
+    Guid InvitedByUserId
+) : ICommand<BatchInvitationResultDto>;
+
+/// <summary>
+/// Handles batch provisioning by dispatching individual ProvisionAndInviteUserCommand per item.
+/// Catches per-item exceptions and collects them into the Failed list.
+/// Issue #124: Admin invitation flow — batch provisioning.
+/// </summary>
+internal sealed class BatchProvisionCommandHandler
+    : ICommandHandler<BatchProvisionCommand, BatchInvitationResultDto>
+{
+    private const int MaxItems = 100;
+
+    private readonly ISender _sender;
+    private readonly ILogger<BatchProvisionCommandHandler> _logger;
+
+    public BatchProvisionCommandHandler(ISender sender, ILogger<BatchProvisionCommandHandler> logger)
+    {
+        _sender = sender ?? throw new ArgumentNullException(nameof(sender));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<BatchInvitationResultDto> Handle(BatchProvisionCommand command, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        var succeeded = new List<InvitationDto>();
+        var failed = new List<BatchInvitationError>();
+
+        if (command.Invitations is not { Count: > 0 })
+            return new BatchInvitationResultDto(succeeded, failed);
+
+        if (command.Invitations.Count > MaxItems)
+            throw new FluentValidation.ValidationException(
+                $"Batch exceeds maximum of {MaxItems} invitations. Found {command.Invitations.Count} items.");
+
+        foreach (var item in command.Invitations)
+        {
+            try
+            {
+                var provisionCommand = new ProvisionAndInviteUserCommand(
+                    Email: item.Email,
+                    DisplayName: item.DisplayName,
+                    Role: item.Role,
+                    Tier: item.Tier,
+                    CustomMessage: item.CustomMessage,
+                    ExpiresInDays: item.ExpiresInDays,
+                    GameSuggestions: item.GameSuggestions,
+                    InvitedByUserId: command.InvitedByUserId);
+
+                var result = await _sender.Send(provisionCommand, cancellationToken).ConfigureAwait(false);
+                succeeded.Add(result);
+            }
+#pragma warning disable CA1031 // Do not catch general exception types
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex, "Failed to provision invitation for {Email}", item.Email);
+                var userFacingError = ex switch
+                {
+                    Middleware.Exceptions.ConflictException => "A pending invitation or user already exists for this email",
+                    ArgumentException ae => ae.Message,
+                    FluentValidation.ValidationException => "Invalid invitation data",
+                    _ => "Failed to provision invitation"
+                };
+                failed.Add(new BatchInvitationError(item.Email, userFacingError));
+            }
+#pragma warning restore CA1031
+        }
+
+        return new BatchInvitationResultDto(succeeded, failed);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/Invitation/BulkSendInvitationsCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/Invitation/BulkSendInvitationsCommandHandler.cs
@@ -9,7 +9,7 @@ namespace Api.BoundedContexts.Authentication.Application.Commands.Invitation;
 
 /// <summary>
 /// Handles bulk invitation sending from CSV content.
-/// Parses CSV rows and dispatches individual SendInvitationCommand per valid row.
+/// Parses CSV rows and dispatches individual ProvisionAndInviteUserCommand per valid row.
 /// Issue #124: User invitation system.
 /// </summary>
 internal sealed class BulkSendInvitationsCommandHandler
@@ -68,7 +68,7 @@ internal sealed class BulkSendInvitationsCommandHandler
             var parts = trimmedLine.Split(',', StringSplitOptions.TrimEntries);
             if (parts.Length < 2)
             {
-                failed.Add(new BulkInviteFailure(trimmedLine, "Invalid CSV format: expected email,role"));
+                failed.Add(new BulkInviteFailure(trimmedLine, "Invalid CSV format: expected email,role[,displayName,tier,expiresInDays]"));
                 continue;
             }
 
@@ -82,17 +82,32 @@ internal sealed class BulkSendInvitationsCommandHandler
                 continue;
             }
 
+            // Optional CSV columns: displayName (col 2), tier (col 3), expiresInDays (col 4)
+            var displayName = parts.Length > 2 && !string.IsNullOrWhiteSpace(parts[2]) ? parts[2].Trim() : email;
+            var tier = parts.Length > 3 && !string.IsNullOrWhiteSpace(parts[3]) ? parts[3].Trim() : "Free";
+            var expiresInDays = 7;
+            if (parts.Length > 4 && int.TryParse(parts[4].Trim(), System.Globalization.CultureInfo.InvariantCulture, out var parsedDays) && parsedDays > 0)
+                expiresInDays = parsedDays;
+
             try
             {
                 var result = await _sender.Send(
-                    new SendInvitationCommand(email, role, command.InvitedByUserId),
+                    new ProvisionAndInviteUserCommand(
+                        Email: email,
+                        DisplayName: displayName,
+                        Role: role,
+                        Tier: tier,
+                        CustomMessage: null,
+                        ExpiresInDays: expiresInDays,
+                        GameSuggestions: new List<GameSuggestionDto>(),
+                        InvitedByUserId: command.InvitedByUserId),
                     cancellationToken).ConfigureAwait(false);
                 successful.Add(result);
             }
 #pragma warning disable CA1031 // Do not catch general exception types
             catch (Exception ex)
             {
-                _logger.LogWarning(ex, "Failed to send invitation to {Email}", email);
+                _logger.LogWarning(ex, "Failed to provision invitation for {Email}", email);
                 var userFacingError = ex switch
                 {
                     Api.Middleware.Exceptions.ConflictException => "A pending invitation or user already exists for this email",

--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/Invitation/ProvisionAndInviteUserCommand.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/Invitation/ProvisionAndInviteUserCommand.cs
@@ -1,0 +1,20 @@
+using Api.BoundedContexts.Authentication.Application.DTOs;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.Authentication.Application.Commands.Invitation;
+
+/// <summary>
+/// Command to provision a pending user and send an invitation email in one operation.
+/// Creates both the User (Pending status) and InvitationToken entities.
+/// Issue #124: Admin invitation flow.
+/// </summary>
+internal sealed record ProvisionAndInviteUserCommand(
+    string Email,
+    string DisplayName,
+    string Role,
+    string Tier,
+    string? CustomMessage,
+    int ExpiresInDays,
+    List<GameSuggestionDto> GameSuggestions,
+    Guid InvitedByUserId
+) : ICommand<InvitationDto>;

--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/Invitation/ProvisionAndInviteUserCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/Invitation/ProvisionAndInviteUserCommandHandler.cs
@@ -91,7 +91,8 @@ internal sealed class ProvisionAndInviteUserCommandHandler : ICommandHandler<Pro
             command.CustomMessage,
             command.ExpiresInDays,
             _timeProvider,
-            tokenHash);
+            tokenHash,
+            command.InvitedByUserId);
 
         // 6. Add game suggestions to token
         if (command.GameSuggestions is { Count: > 0 })

--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/Invitation/ProvisionAndInviteUserCommandHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/Invitation/ProvisionAndInviteUserCommandHandler.cs
@@ -1,0 +1,152 @@
+using System.Security.Cryptography;
+using System.Text;
+using Api.BoundedContexts.Authentication.Application.DTOs;
+using Api.BoundedContexts.Authentication.Domain.Entities;
+using Api.BoundedContexts.Authentication.Domain.Enums;
+using Api.BoundedContexts.Authentication.Domain.Repositories;
+using Api.BoundedContexts.Authentication.Domain.ValueObjects;
+using Api.BoundedContexts.Authentication.Infrastructure.Persistence;
+using Api.Middleware.Exceptions;
+using Api.Services;
+using Api.SharedKernel.Application.Interfaces;
+using Api.SharedKernel.Domain.ValueObjects;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Microsoft.Extensions.Logging;
+
+namespace Api.BoundedContexts.Authentication.Application.Commands.Invitation;
+
+/// <summary>
+/// Handles provisioning a pending user and creating an invitation token in one operation.
+/// Creates both the User (Pending status) and InvitationToken entities, then sends the invitation email.
+/// Issue #124: Admin invitation flow.
+/// </summary>
+internal sealed class ProvisionAndInviteUserCommandHandler : ICommandHandler<ProvisionAndInviteUserCommand, InvitationDto>
+{
+    private readonly IUserRepository _userRepo;
+    private readonly IInvitationTokenRepository _invitationRepo;
+    private readonly IUnitOfWork _unitOfWork;
+    private readonly IEmailService _emailService;
+    private readonly TimeProvider _timeProvider;
+    private readonly ILogger<ProvisionAndInviteUserCommandHandler> _logger;
+
+    public ProvisionAndInviteUserCommandHandler(
+        IUserRepository userRepo,
+        IInvitationTokenRepository invitationRepo,
+        IUnitOfWork unitOfWork,
+        IEmailService emailService,
+        TimeProvider timeProvider,
+        ILogger<ProvisionAndInviteUserCommandHandler> logger)
+    {
+        _userRepo = userRepo ?? throw new ArgumentNullException(nameof(userRepo));
+        _invitationRepo = invitationRepo ?? throw new ArgumentNullException(nameof(invitationRepo));
+        _unitOfWork = unitOfWork ?? throw new ArgumentNullException(nameof(unitOfWork));
+        _emailService = emailService ?? throw new ArgumentNullException(nameof(emailService));
+        _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    public async Task<InvitationDto> Handle(ProvisionAndInviteUserCommand command, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(command);
+
+        var normalizedEmail = command.Email.Trim().ToLowerInvariant();
+
+        // 1. Check email uniqueness — no existing user with this email
+        var email = new Email(normalizedEmail);
+        var existingUser = await _userRepo.ExistsByEmailAsync(email, cancellationToken).ConfigureAwait(false);
+        if (existingUser)
+            throw new ConflictException($"A user with email '{normalizedEmail}' already exists");
+
+        // 2. Check no pending invitation exists for this email
+        var existingInvitation = await _invitationRepo.GetPendingByEmailAsync(normalizedEmail, cancellationToken).ConfigureAwait(false);
+        if (existingInvitation != null)
+            throw new ConflictException($"A pending invitation already exists for '{normalizedEmail}'");
+
+        // 3. Generate secure token
+        var rawTokenBytes = RandomNumberGenerator.GetBytes(32);
+        var rawToken = Convert.ToBase64String(rawTokenBytes)
+            .Replace('+', '-').Replace('/', '_').TrimEnd('='); // URL-safe Base64
+        var tokenHash = Convert.ToBase64String(SHA256.HashData(Encoding.UTF8.GetBytes(rawToken)));
+
+        // 4. Create pending user
+        var role = Role.Parse(command.Role);
+        var tier = UserTier.Parse(command.Tier);
+        var now = _timeProvider.GetUtcNow().UtcDateTime;
+        var expiresAt = now.AddDays(command.ExpiresInDays);
+
+        var pendingUser = User.CreatePending(
+            email,
+            command.DisplayName,
+            role,
+            tier,
+            command.InvitedByUserId,
+            expiresAt,
+            _timeProvider);
+
+        // 5. Create invitation token
+        var invitation = InvitationToken.Create(
+            email,
+            role,
+            pendingUser.Id,
+            command.CustomMessage,
+            command.ExpiresInDays,
+            _timeProvider,
+            tokenHash);
+
+        // 6. Add game suggestions to token
+        if (command.GameSuggestions is { Count: > 0 })
+        {
+            foreach (var suggestion in command.GameSuggestions)
+            {
+                var suggestionType = Enum.Parse<GameSuggestionType>(suggestion.Type, ignoreCase: true);
+                invitation.AddGameSuggestion(suggestion.GameId, suggestionType);
+            }
+        }
+
+        // 7. Save user + token via repositories + IUnitOfWork.SaveChangesAsync()
+        await _userRepo.AddAsync(pendingUser, cancellationToken).ConfigureAwait(false);
+        await _invitationRepo.AddAsync(invitation, cancellationToken).ConfigureAwait(false);
+        await _unitOfWork.SaveChangesAsync(cancellationToken).ConfigureAwait(false);
+
+        // 8. Try send email (fire-and-forget pattern): catch exceptions, log, set emailSent = false
+        var emailSent = true;
+        try
+        {
+            await _emailService.SendInvitationEmailAsync(
+                normalizedEmail,
+                command.Role,
+                rawToken,
+                command.DisplayName,
+                cancellationToken).ConfigureAwait(false);
+        }
+#pragma warning disable CA1031 // Do not catch general exception types
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Failed to send invitation email to {Email}", normalizedEmail);
+            emailSent = false;
+        }
+#pragma warning restore CA1031
+
+        // 9. Return InvitationDto with EmailSent status
+        return MapToDto(invitation, emailSent);
+    }
+
+    private static InvitationDto MapToDto(InvitationToken invitation, bool emailSent)
+    {
+        var gameSuggestions = invitation.GameSuggestions
+            .Select(gs => new GameSuggestionDto(gs.GameId, gs.Type.ToString()))
+            .ToList();
+
+        return new InvitationDto(
+            Id: invitation.Id,
+            Email: invitation.Email,
+            Role: invitation.Role,
+            Status: invitation.Status.ToString(),
+            ExpiresAt: invitation.ExpiresAt,
+            CreatedAt: invitation.CreatedAt,
+            AcceptedAt: invitation.AcceptedAt,
+            InvitedByUserId: invitation.InvitedByUserId,
+            EmailSent: emailSent,
+            GameSuggestions: gameSuggestions);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/Invitation/ProvisionAndInviteUserCommandValidator.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/Invitation/ProvisionAndInviteUserCommandValidator.cs
@@ -1,0 +1,77 @@
+using FluentValidation;
+
+namespace Api.BoundedContexts.Authentication.Application.Commands.Invitation;
+
+/// <summary>
+/// Validator for ProvisionAndInviteUserCommand.
+/// Issue #124: Admin invitation flow.
+/// </summary>
+internal sealed class ProvisionAndInviteUserCommandValidator : AbstractValidator<ProvisionAndInviteUserCommand>
+{
+    private static readonly string[] ValidRoles = { "User", "Editor", "Admin" };
+    private static readonly string[] ValidTiers = { "Free", "Premium", "Pro" };
+    private static readonly string[] ValidGameSuggestionTypes = { "PreAdded", "Suggested" };
+
+    public ProvisionAndInviteUserCommandValidator()
+    {
+        RuleFor(x => x.Email)
+            .NotEmpty()
+            .WithMessage("Email is required")
+            .EmailAddress()
+            .WithMessage("Email must be a valid email address")
+            .MaximumLength(256)
+            .WithMessage("Email must not exceed 256 characters");
+
+        RuleFor(x => x.DisplayName)
+            .NotEmpty()
+            .WithMessage("Display name is required")
+            .MinimumLength(2)
+            .WithMessage("Display name must be at least 2 characters")
+            .MaximumLength(100)
+            .WithMessage("Display name must not exceed 100 characters");
+
+        RuleFor(x => x.Role)
+            .NotEmpty()
+            .WithMessage("Role is required")
+            .Must(role => ValidRoles.Contains(role, StringComparer.OrdinalIgnoreCase))
+            .WithMessage($"Role must be one of: {string.Join(", ", ValidRoles)}");
+
+        RuleFor(x => x.Tier)
+            .NotEmpty()
+            .WithMessage("Tier is required")
+            .Must(tier => ValidTiers.Contains(tier, StringComparer.OrdinalIgnoreCase))
+            .WithMessage($"Tier must be one of: {string.Join(", ", ValidTiers)}");
+
+        RuleFor(x => x.CustomMessage)
+            .MaximumLength(500)
+            .WithMessage("Custom message must not exceed 500 characters")
+            .When(x => x.CustomMessage is not null);
+
+        RuleFor(x => x.ExpiresInDays)
+            .InclusiveBetween(1, 30)
+            .WithMessage("ExpiresInDays must be between 1 and 30");
+
+        RuleFor(x => x.InvitedByUserId)
+            .NotEqual(Guid.Empty)
+            .WithMessage("InvitedByUserId is required");
+
+        RuleFor(x => x.GameSuggestions)
+            .Must(gs => gs == null || gs.Count <= 20)
+            .WithMessage("Game suggestions must not exceed 20 items");
+
+        RuleForEach(x => x.GameSuggestions)
+            .ChildRules(gs =>
+            {
+                gs.RuleFor(g => g.GameId)
+                    .NotEqual(Guid.Empty)
+                    .WithMessage("Game suggestion GameId cannot be empty");
+
+                gs.RuleFor(g => g.Type)
+                    .NotEmpty()
+                    .WithMessage("Game suggestion Type is required")
+                    .Must(type => ValidGameSuggestionTypes.Contains(type, StringComparer.OrdinalIgnoreCase))
+                    .WithMessage($"Game suggestion Type must be one of: {string.Join(", ", ValidGameSuggestionTypes)}");
+            })
+            .When(x => x.GameSuggestions is not null);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/DTOs/ActivationResultDto.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/DTOs/ActivationResultDto.cs
@@ -1,0 +1,7 @@
+namespace Api.BoundedContexts.Authentication.Application.DTOs;
+
+/// <summary>
+/// Result of activating an invited user account.
+/// Contains the session token for immediate login and onboarding flag.
+/// </summary>
+internal sealed record ActivationResultDto(string SessionToken, bool RequiresOnboarding);

--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/DTOs/BatchInvitationItemDto.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/DTOs/BatchInvitationItemDto.cs
@@ -1,0 +1,14 @@
+namespace Api.BoundedContexts.Authentication.Application.DTOs;
+
+/// <summary>
+/// Data transfer object for a single invitation item in a batch operation.
+/// Issue #124: Admin invitation flow — batch provisioning.
+/// </summary>
+public sealed record BatchInvitationItemDto(
+    string Email,
+    string DisplayName,
+    string Role,
+    string Tier,
+    string? CustomMessage,
+    int ExpiresInDays,
+    List<GameSuggestionDto> GameSuggestions);

--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/DTOs/BatchInvitationResultDto.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/DTOs/BatchInvitationResultDto.cs
@@ -1,0 +1,14 @@
+namespace Api.BoundedContexts.Authentication.Application.DTOs;
+
+/// <summary>
+/// Result of a batch invitation operation containing succeeded and failed items.
+/// Issue #124: Admin invitation flow — batch provisioning.
+/// </summary>
+public sealed record BatchInvitationResultDto(
+    List<InvitationDto> Succeeded,
+    List<BatchInvitationError> Failed);
+
+/// <summary>
+/// Represents a single failed invitation in a batch operation.
+/// </summary>
+public sealed record BatchInvitationError(string Email, string Error);

--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/DTOs/GameSuggestionDto.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/DTOs/GameSuggestionDto.cs
@@ -1,0 +1,9 @@
+namespace Api.BoundedContexts.Authentication.Application.DTOs;
+
+/// <summary>
+/// Data transfer object for game suggestions attached to an invitation.
+/// Issue #124: Admin invitation flow.
+/// </summary>
+public sealed record GameSuggestionDto(
+    Guid GameId,
+    string Type);

--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/DTOs/InvitationDto.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/DTOs/InvitationDto.cs
@@ -12,4 +12,6 @@ public sealed record InvitationDto(
     DateTime ExpiresAt,
     DateTime CreatedAt,
     DateTime? AcceptedAt,
-    Guid InvitedByUserId);
+    Guid InvitedByUserId,
+    bool EmailSent = true,
+    List<GameSuggestionDto>? GameSuggestions = null);

--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/DTOs/InvitationValidationDto.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/DTOs/InvitationValidationDto.cs
@@ -1,0 +1,14 @@
+namespace Api.BoundedContexts.Authentication.Application.DTOs;
+
+/// <summary>
+/// DTO for invitation token validation response.
+/// Security: only two error reasons to prevent state enumeration.
+/// - "invalid" covers expired, revoked, and not-found (uniform)
+/// - "already_used" allows redirect to login (acceptable disclosure)
+/// Issue #124: User invitation system.
+/// </summary>
+internal sealed record InvitationValidationDto(
+    bool IsValid,
+    string? Email,
+    string? DisplayName,
+    string? ErrorReason);

--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/Queries/Invitation/GetInvitationByIdQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/Queries/Invitation/GetInvitationByIdQuery.cs
@@ -1,0 +1,43 @@
+using Api.BoundedContexts.Authentication.Application.Commands.Invitation;
+using Api.BoundedContexts.Authentication.Application.DTOs;
+using Api.BoundedContexts.Authentication.Domain.Repositories;
+using Api.SharedKernel.Application.Interfaces;
+using Api.Middleware.Exceptions;
+
+namespace Api.BoundedContexts.Authentication.Application.Queries.Invitation;
+
+/// <summary>
+/// Query to get a single invitation by its ID.
+/// Used by admin panel to view invitation details.
+/// Issue #124: User invitation system.
+/// </summary>
+internal sealed record GetInvitationByIdQuery(Guid Id) : IQuery<InvitationDto>;
+
+/// <summary>
+/// Handles retrieval of a single invitation by ID.
+/// Throws NotFoundException when the invitation does not exist.
+/// Issue #124: User invitation system.
+/// </summary>
+internal sealed class GetInvitationByIdQueryHandler
+    : IQueryHandler<GetInvitationByIdQuery, InvitationDto>
+{
+    private readonly IInvitationTokenRepository _invitationRepo;
+
+    public GetInvitationByIdQueryHandler(IInvitationTokenRepository invitationRepo)
+    {
+        _invitationRepo = invitationRepo ?? throw new ArgumentNullException(nameof(invitationRepo));
+    }
+
+    public async Task<InvitationDto> Handle(
+        GetInvitationByIdQuery query, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        var invitation = await _invitationRepo.GetByIdAsync(query.Id, cancellationToken).ConfigureAwait(false);
+
+        if (invitation == null)
+            throw new NotFoundException($"Invitation with ID {query.Id} not found");
+
+        return SendInvitationCommandHandler.MapToDto(invitation);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/Queries/Invitation/GetPendingInvitationsQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/Queries/Invitation/GetPendingInvitationsQuery.cs
@@ -1,0 +1,51 @@
+using Api.BoundedContexts.Authentication.Application.Commands.Invitation;
+using Api.BoundedContexts.Authentication.Application.DTOs;
+using Api.BoundedContexts.Authentication.Domain.Enums;
+using Api.BoundedContexts.Authentication.Domain.Repositories;
+using Api.SharedKernel.Application.Interfaces;
+
+namespace Api.BoundedContexts.Authentication.Application.Queries.Invitation;
+
+/// <summary>
+/// Query to get pending invitations, optionally filtered by status.
+/// Used by admin panel to view invitation queue.
+/// Issue #124: User invitation system.
+/// </summary>
+internal sealed record GetPendingInvitationsQuery(string? StatusFilter) : IQuery<List<InvitationDto>>;
+
+/// <summary>
+/// Handles retrieval of invitations filtered by status.
+/// Returns all invitations when no filter is provided.
+/// Issue #124: User invitation system.
+/// </summary>
+internal sealed class GetPendingInvitationsQueryHandler
+    : IQueryHandler<GetPendingInvitationsQuery, List<InvitationDto>>
+{
+    private readonly IInvitationTokenRepository _invitationRepo;
+
+    public GetPendingInvitationsQueryHandler(IInvitationTokenRepository invitationRepo)
+    {
+        _invitationRepo = invitationRepo ?? throw new ArgumentNullException(nameof(invitationRepo));
+    }
+
+    public async Task<List<InvitationDto>> Handle(
+        GetPendingInvitationsQuery query, CancellationToken cancellationToken)
+    {
+        ArgumentNullException.ThrowIfNull(query);
+
+        InvitationStatus? statusFilter = null;
+        if (!string.IsNullOrWhiteSpace(query.StatusFilter) &&
+            Enum.TryParse<InvitationStatus>(query.StatusFilter, ignoreCase: true, out var parsed))
+        {
+            statusFilter = parsed;
+        }
+
+        // Use a reasonable default page size; callers who need pagination should use GetInvitationsQuery instead
+        var invitations = await _invitationRepo.GetByStatusAsync(
+            statusFilter, page: 1, pageSize: 500, cancellationToken).ConfigureAwait(false);
+
+        return invitations
+            .Select(inv => SendInvitationCommandHandler.MapToDto(inv))
+            .ToList();
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/Queries/Invitation/ValidateInvitationTokenQuery.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/Queries/Invitation/ValidateInvitationTokenQuery.cs
@@ -1,20 +1,12 @@
+using Api.BoundedContexts.Authentication.Application.DTOs;
 using Api.SharedKernel.Application.Interfaces;
 
-#pragma warning disable MA0048 // File name must match type name - Contains Query with Response record
 namespace Api.BoundedContexts.Authentication.Application.Queries.Invitation;
 
 /// <summary>
-/// Query to validate an invitation token.
-/// Returns whether the token is valid without exposing sensitive data like email.
+/// Query to validate an invitation token with security-hardened uniform error responses.
+/// Returns IsValid with email/displayName on success, or a uniform error reason on failure.
+/// Security: only "invalid" and "already_used" error reasons to prevent state enumeration.
 /// Issue #124: User invitation system.
 /// </summary>
-internal record ValidateInvitationTokenQuery(string Token) : IQuery<ValidateInvitationTokenResponse>;
-
-/// <summary>
-/// Response for invitation token validation.
-/// Note: Does NOT include Email for security reasons.
-/// </summary>
-public sealed record ValidateInvitationTokenResponse(
-    bool Valid,
-    string? Role,
-    DateTime? ExpiresAt);
+internal record ValidateInvitationTokenQuery(string Token) : IQuery<InvitationValidationDto>;

--- a/apps/api/src/Api/BoundedContexts/Authentication/Application/Queries/Invitation/ValidateInvitationTokenQueryHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Application/Queries/Invitation/ValidateInvitationTokenQueryHandler.cs
@@ -1,42 +1,67 @@
 using System.Security.Cryptography;
 using System.Text;
+using Api.BoundedContexts.Authentication.Application.DTOs;
+using Api.BoundedContexts.Authentication.Domain.Enums;
 using Api.BoundedContexts.Authentication.Domain.Repositories;
+using Api.BoundedContexts.Authentication.Infrastructure.Persistence;
 using Api.SharedKernel.Application.Interfaces;
 
 namespace Api.BoundedContexts.Authentication.Application.Queries.Invitation;
 
 /// <summary>
-/// Handles validation of invitation tokens.
-/// Hashes the raw token and looks up the invitation record.
+/// Handles validation of invitation tokens with security-hardened uniform error responses.
+/// Only two error reasons: "invalid" (expired/revoked/not-found) and "already_used" (accepted).
 /// Issue #124: User invitation system.
 /// </summary>
 internal sealed class ValidateInvitationTokenQueryHandler
-    : IQueryHandler<ValidateInvitationTokenQuery, ValidateInvitationTokenResponse>
+    : IQueryHandler<ValidateInvitationTokenQuery, InvitationValidationDto>
 {
     private readonly IInvitationTokenRepository _invitationRepo;
+    private readonly IUserRepository _userRepo;
 
-    public ValidateInvitationTokenQueryHandler(IInvitationTokenRepository invitationRepo)
+    public ValidateInvitationTokenQueryHandler(
+        IInvitationTokenRepository invitationRepo,
+        IUserRepository userRepo)
     {
         _invitationRepo = invitationRepo ?? throw new ArgumentNullException(nameof(invitationRepo));
+        _userRepo = userRepo ?? throw new ArgumentNullException(nameof(userRepo));
     }
 
-    public async Task<ValidateInvitationTokenResponse> Handle(
+    public async Task<InvitationValidationDto> Handle(
         ValidateInvitationTokenQuery query, CancellationToken cancellationToken)
     {
         ArgumentNullException.ThrowIfNull(query);
 
         if (string.IsNullOrWhiteSpace(query.Token))
-            return new ValidateInvitationTokenResponse(false, null, null);
+            return new InvitationValidationDto(false, null, null, "invalid");
 
         var tokenHash = Convert.ToBase64String(SHA256.HashData(Encoding.UTF8.GetBytes(query.Token)));
         var invitation = await _invitationRepo.GetByTokenHashAsync(tokenHash, cancellationToken).ConfigureAwait(false);
 
-        if (invitation == null || !invitation.IsValid)
-            return new ValidateInvitationTokenResponse(false, null, null);
+        // Not found → uniform "invalid"
+        if (invitation == null)
+            return new InvitationValidationDto(false, null, null, "invalid");
 
-        return new ValidateInvitationTokenResponse(
-            Valid: true,
-            Role: invitation.Role,
-            ExpiresAt: invitation.ExpiresAt);
+        // Accepted → "already_used" (allows redirect to login)
+        if (invitation.Status == InvitationStatus.Accepted)
+            return new InvitationValidationDto(false, null, null, "already_used");
+
+        // Expired → uniform "invalid"
+        if (invitation.Status == InvitationStatus.Expired || DateTime.UtcNow > invitation.ExpiresAt)
+            return new InvitationValidationDto(false, null, null, "invalid");
+
+        // Revoked → uniform "invalid"
+        if (invitation.Status == InvitationStatus.Revoked)
+            return new InvitationValidationDto(false, null, null, "invalid");
+
+        // Valid: look up pending user to get DisplayName
+        string? displayName = null;
+        if (invitation.PendingUserId.HasValue)
+        {
+            var pendingUser = await _userRepo.GetByIdAsync(invitation.PendingUserId.Value, cancellationToken).ConfigureAwait(false);
+            displayName = pendingUser?.DisplayName;
+        }
+
+        return new InvitationValidationDto(true, invitation.Email, displayName, null);
     }
 }

--- a/apps/api/src/Api/BoundedContexts/Authentication/Domain/Entities/InvitationGameSuggestion.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Domain/Entities/InvitationGameSuggestion.cs
@@ -1,0 +1,41 @@
+using Api.BoundedContexts.Authentication.Domain.Enums;
+
+namespace Api.BoundedContexts.Authentication.Domain.Entities;
+
+/// <summary>
+/// Represents a game suggestion attached to an invitation token.
+/// Can be pre-added to the invitee's library or merely suggested.
+/// </summary>
+internal sealed class InvitationGameSuggestion
+{
+    public Guid Id { get; private set; }
+    public Guid InvitationTokenId { get; private set; }
+    public Guid GameId { get; private set; }
+    public GameSuggestionType Type { get; private set; }
+
+    // EF Core constructor
+    private InvitationGameSuggestion() { }
+
+    /// <summary>
+    /// Factory method to create a new game suggestion for an invitation.
+    /// </summary>
+    /// <param name="invitationTokenId">The parent invitation token ID</param>
+    /// <param name="gameId">The game to suggest or pre-add</param>
+    /// <param name="type">Whether the game is pre-added or suggested</param>
+    /// <returns>New InvitationGameSuggestion instance</returns>
+    public static InvitationGameSuggestion Create(Guid invitationTokenId, Guid gameId, GameSuggestionType type)
+    {
+        if (invitationTokenId == Guid.Empty)
+            throw new ArgumentException("Invitation token ID cannot be empty", nameof(invitationTokenId));
+        if (gameId == Guid.Empty)
+            throw new ArgumentException("Game ID cannot be empty", nameof(gameId));
+
+        return new InvitationGameSuggestion
+        {
+            Id = Guid.NewGuid(),
+            InvitationTokenId = invitationTokenId,
+            GameId = gameId,
+            Type = type
+        };
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/Authentication/Domain/Entities/InvitationToken.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Domain/Entities/InvitationToken.cs
@@ -1,5 +1,7 @@
 using Api.BoundedContexts.Authentication.Domain.Enums;
+using Api.BoundedContexts.Authentication.Domain.ValueObjects;
 using Api.SharedKernel.Domain.Entities;
+using Api.SharedKernel.Domain.ValueObjects;
 
 namespace Api.BoundedContexts.Authentication.Domain.Entities;
 
@@ -19,6 +21,11 @@ internal sealed class InvitationToken : AggregateRoot<Guid>
     public Guid? AcceptedByUserId { get; private set; }
     public DateTime CreatedAt { get; private set; }
     public DateTime? RevokedAt { get; private set; }
+    public string? CustomMessage { get; private set; }
+    public Guid? PendingUserId { get; private set; }
+
+    private readonly List<InvitationGameSuggestion> _gameSuggestions = new();
+    public IReadOnlyList<InvitationGameSuggestion> GameSuggestions => _gameSuggestions.AsReadOnly();
 
     private static readonly string[] AllowedRoles = { "User", "Editor", "Admin" };
 
@@ -63,6 +70,61 @@ internal sealed class InvitationToken : AggregateRoot<Guid>
             ExpiresAt = DateTime.UtcNow.AddDays(7),
             CreatedAt = DateTime.UtcNow
         };
+    }
+
+    /// <summary>
+    /// Factory method to create a new invitation token with extended provisioning data.
+    /// Uses TimeProvider for testable time handling.
+    /// </summary>
+    /// <param name="email">Email address value object of the invitee</param>
+    /// <param name="role">Role value object to assign upon acceptance</param>
+    /// <param name="pendingUserId">ID of the pre-provisioned pending user</param>
+    /// <param name="customMessage">Optional custom message from admin to invitee</param>
+    /// <param name="expiresInDays">Number of days until the invitation expires</param>
+    /// <param name="timeProvider">TimeProvider for testable time handling</param>
+    /// <param name="tokenHash">SHA-256 hash of the invitation token</param>
+    /// <returns>New InvitationToken instance with extended data</returns>
+    public static InvitationToken Create(
+        Email email,
+        Role role,
+        Guid pendingUserId,
+        string? customMessage,
+        int expiresInDays,
+        TimeProvider timeProvider,
+        string tokenHash)
+    {
+        ArgumentNullException.ThrowIfNull(email);
+        ArgumentNullException.ThrowIfNull(role);
+        ArgumentNullException.ThrowIfNull(timeProvider);
+        if (pendingUserId == Guid.Empty)
+            throw new ArgumentException("Pending user ID cannot be empty", nameof(pendingUserId));
+        if (string.IsNullOrWhiteSpace(tokenHash))
+            throw new ArgumentException("Token hash cannot be empty", nameof(tokenHash));
+
+        var now = timeProvider.GetUtcNow().UtcDateTime;
+
+        return new InvitationToken(Guid.NewGuid())
+        {
+            Email = email.Value,
+            Role = role.Value,
+            TokenHash = tokenHash,
+            InvitedByUserId = Guid.Empty, // Set by command handler when admin context is available
+            Status = InvitationStatus.Pending,
+            ExpiresAt = now.AddDays(expiresInDays),
+            CreatedAt = now,
+            CustomMessage = customMessage,
+            PendingUserId = pendingUserId
+        };
+    }
+
+    /// <summary>
+    /// Adds a game suggestion to this invitation token.
+    /// </summary>
+    /// <param name="gameId">The game to suggest or pre-add</param>
+    /// <param name="type">Whether the game is pre-added or merely suggested</param>
+    public void AddGameSuggestion(Guid gameId, GameSuggestionType type)
+    {
+        _gameSuggestions.Add(InvitationGameSuggestion.Create(Id, gameId, type));
     }
 
     /// <summary>
@@ -127,7 +189,9 @@ internal sealed class InvitationToken : AggregateRoot<Guid>
         DateTime? acceptedAt,
         Guid? acceptedByUserId,
         DateTime createdAt,
-        DateTime? revokedAt = null)
+        DateTime? revokedAt = null,
+        string? customMessage = null,
+        Guid? pendingUserId = null)
     {
         Email = email;
         Role = role;
@@ -139,6 +203,8 @@ internal sealed class InvitationToken : AggregateRoot<Guid>
         AcceptedByUserId = acceptedByUserId;
         CreatedAt = createdAt;
         RevokedAt = revokedAt;
+        CustomMessage = customMessage;
+        PendingUserId = pendingUserId;
     }
 
     #endregion

--- a/apps/api/src/Api/BoundedContexts/Authentication/Domain/Entities/InvitationToken.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Domain/Entities/InvitationToken.cs
@@ -82,6 +82,7 @@ internal sealed class InvitationToken : AggregateRoot<Guid>
     /// <param name="customMessage">Optional custom message from admin to invitee</param>
     /// <param name="expiresInDays">Number of days until the invitation expires</param>
     /// <param name="timeProvider">TimeProvider for testable time handling</param>
+    /// <param name="invitedByUserId">Admin user who created the invitation</param>
     /// <param name="tokenHash">SHA-256 hash of the invitation token</param>
     /// <returns>New InvitationToken instance with extended data</returns>
     public static InvitationToken Create(
@@ -91,7 +92,8 @@ internal sealed class InvitationToken : AggregateRoot<Guid>
         string? customMessage,
         int expiresInDays,
         TimeProvider timeProvider,
-        string tokenHash)
+        string tokenHash,
+        Guid invitedByUserId = default)
     {
         ArgumentNullException.ThrowIfNull(email);
         ArgumentNullException.ThrowIfNull(role);
@@ -108,7 +110,7 @@ internal sealed class InvitationToken : AggregateRoot<Guid>
             Email = email.Value,
             Role = role.Value,
             TokenHash = tokenHash,
-            InvitedByUserId = Guid.Empty, // Set by command handler when admin context is available
+            InvitedByUserId = invitedByUserId,
             Status = InvitationStatus.Pending,
             ExpiresAt = now.AddDays(expiresInDays),
             CreatedAt = now,

--- a/apps/api/src/Api/BoundedContexts/Authentication/Domain/Entities/User.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Domain/Entities/User.cs
@@ -1,7 +1,7 @@
 using Api.BoundedContexts.Authentication.Domain.Events;
 using Api.BoundedContexts.Authentication.Domain.ValueObjects;
 using Api.SharedKernel.Domain.ValueObjects;
-using Api.BoundedContexts.Administration.Domain.Enums; // Epic #4068: UserAccountStatus
+using Api.SharedKernel.Domain.Enums; // Epic #4068: UserAccountStatus (moved to SharedKernel)
 using Api.SharedKernel.Domain.Entities;
 using Api.SharedKernel.Domain.Exceptions;
 

--- a/apps/api/src/Api/BoundedContexts/Authentication/Domain/Entities/User.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Domain/Entities/User.cs
@@ -1001,6 +1001,26 @@ public sealed class User : AggregateRoot<Guid>
     }
 
     /// <summary>
+    /// Restores account status from persistence layer.
+    /// Issue #124: Internal method to avoid reflection in repository (S3011 compliance).
+    /// Should only be called by UserRepository during entity materialization.
+    /// </summary>
+    internal void RestoreAccountStatus(UserAccountStatus status)
+    {
+        Status = status;
+    }
+
+    /// <summary>
+    /// Restores password hash from persistence layer. Null for pending (invited) users.
+    /// Issue #124: Internal method to avoid reflection in repository (S3011 compliance).
+    /// Should only be called by UserRepository during entity materialization.
+    /// </summary>
+    internal void RestorePasswordHash(PasswordHash? passwordHash)
+    {
+        PasswordHash = passwordHash!;
+    }
+
+    /// <summary>
     /// Restores email verification state from persistence layer.
     /// Issue #3672: Internal method to avoid reflection in repository (S3011 compliance).
     /// Should only be called by UserRepository during entity materialization.

--- a/apps/api/src/Api/BoundedContexts/Authentication/Domain/Entities/User.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Domain/Entities/User.cs
@@ -60,6 +60,10 @@ public sealed class User : AggregateRoot<Guid>
     private readonly List<BackupCode> _backupCodes = new();
     public IReadOnlyCollection<BackupCode> BackupCodes => _backupCodes.AsReadOnly();
 
+    // Admin invitation properties (admin invitation flow)
+    public Guid? InvitedByUserId { get; private set; }
+    public DateTime? InvitationExpiresAt { get; private set; }
+
     // Onboarding preferences (Issue #124: Invitation system)
     public List<string>? Interests { get; private set; }
 
@@ -130,6 +134,109 @@ public sealed class User : AggregateRoot<Guid>
         LockedUntil = null;
 
         IsTwoFactorEnabled = false;
+    }
+
+    /// <summary>
+    /// Creates a new user in Pending state (admin-provisioned, no password yet).
+    /// The user must activate their account via invitation to set a password and become Active.
+    /// </summary>
+    /// <param name="email">The user's email address.</param>
+    /// <param name="displayName">The user's display name.</param>
+    /// <param name="role">The assigned role.</param>
+    /// <param name="tier">The assigned subscription tier.</param>
+    /// <param name="invitedByUserId">The ID of the admin who created this invitation.</param>
+    /// <param name="expiresAt">When the invitation expires (UTC).</param>
+    /// <param name="timeProvider">Time provider for testability.</param>
+    /// <returns>A new User in Pending state.</returns>
+    public static User CreatePending(
+        Email email,
+        string displayName,
+        Role role,
+        UserTier tier,
+        Guid invitedByUserId,
+        DateTime expiresAt,
+        TimeProvider timeProvider)
+    {
+        ArgumentNullException.ThrowIfNull(email);
+        ArgumentNullException.ThrowIfNull(displayName);
+        ArgumentNullException.ThrowIfNull(role);
+        ArgumentNullException.ThrowIfNull(tier);
+        ArgumentNullException.ThrowIfNull(timeProvider);
+
+        var user = new User
+        {
+            Id = Guid.NewGuid(),
+            Email = email,
+            DisplayName = displayName,
+            PasswordHash = null!,
+            Role = role,
+            Tier = tier,
+            Status = UserAccountStatus.Pending,
+            CreatedAt = timeProvider.GetUtcNow().UtcDateTime,
+            InvitedByUserId = invitedByUserId,
+            InvitationExpiresAt = expiresAt,
+            EmailVerified = false,
+
+            // Default preferences
+            Language = "en",
+            EmailNotifications = true,
+            Theme = "system",
+            DataRetentionDays = 90,
+
+            // Default privacy settings
+            ShowProfile = true,
+            ShowActivity = true,
+            ShowLibrary = true,
+
+            // Default gamification (Issue #3141)
+            Level = 1,
+            ExperiencePoints = 0,
+
+            // Default lockout state (Issue #3339)
+            FailedLoginAttempts = 0,
+            LockedUntil = null,
+
+            IsTwoFactorEnabled = false,
+        };
+
+        user.AddDomainEvent(new UserProvisionedEvent(
+            user.Id,
+            email.Value,
+            displayName,
+            role.Value,
+            tier.Value,
+            invitedByUserId));
+
+        return user;
+    }
+
+    /// <summary>
+    /// Activates a pending user account from an invitation.
+    /// Transitions the user from Pending to Active, sets their password, and marks email as verified.
+    /// </summary>
+    /// <param name="passwordHash">The user's chosen password hash.</param>
+    /// <param name="timeProvider">Time provider for testability.</param>
+    /// <exception cref="InvalidOperationException">Thrown when user is not in Pending status.</exception>
+    public void ActivateFromInvitation(PasswordHash passwordHash, TimeProvider timeProvider)
+    {
+        ArgumentNullException.ThrowIfNull(passwordHash);
+        ArgumentNullException.ThrowIfNull(timeProvider);
+
+        if (Status != UserAccountStatus.Pending)
+            throw new InvalidOperationException("Only users in Pending status can be activated from an invitation.");
+
+        PasswordHash = passwordHash;
+        Status = UserAccountStatus.Active;
+        EmailVerified = true;
+        EmailVerifiedAt = timeProvider.GetUtcNow().UtcDateTime;
+        VerificationGracePeriodEndsAt = null;
+
+        AddDomainEvent(new UserActivatedFromInvitationEvent(
+            Id,
+            Email.Value,
+            Role.Value,
+            Tier.Value,
+            InvitedByUserId!.Value));
     }
 
     /// <summary>
@@ -880,6 +987,17 @@ public sealed class User : AggregateRoot<Guid>
         Bio = bio;
         OnboardingWizardSeenAt = wizardSeenAt;
         OnboardingDismissedAt = dismissedAt;
+    }
+
+    /// <summary>
+    /// Restores invitation state from persistence layer.
+    /// Internal method to avoid reflection in repository (S3011 compliance).
+    /// Should only be called by UserRepository during entity materialization.
+    /// </summary>
+    internal void RestoreInvitationState(Guid? invitedByUserId, DateTime? invitationExpiresAt)
+    {
+        InvitedByUserId = invitedByUserId;
+        InvitationExpiresAt = invitationExpiresAt;
     }
 
     /// <summary>

--- a/apps/api/src/Api/BoundedContexts/Authentication/Domain/Enums/GameSuggestionType.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Domain/Enums/GameSuggestionType.cs
@@ -1,0 +1,13 @@
+namespace Api.BoundedContexts.Authentication.Domain.Enums;
+
+/// <summary>
+/// Indicates how a game suggestion was associated with an invitation.
+/// </summary>
+internal enum GameSuggestionType
+{
+    /// <summary>Game pre-added to the invitee's library upon activation.</summary>
+    PreAdded = 0,
+
+    /// <summary>Game suggested to the invitee (not auto-added).</summary>
+    Suggested = 1
+}

--- a/apps/api/src/Api/BoundedContexts/Authentication/Domain/Events/UserActivatedFromInvitationEvent.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Domain/Events/UserActivatedFromInvitationEvent.cs
@@ -1,0 +1,52 @@
+using Api.SharedKernel.Domain.Events;
+
+namespace Api.BoundedContexts.Authentication.Domain.Events;
+
+/// <summary>
+/// Domain event raised when a pending user activates their account from an invitation.
+/// The user has set their password and transitioned from Pending to Active status.
+/// </summary>
+internal sealed class UserActivatedFromInvitationEvent : DomainEventBase
+{
+    /// <summary>
+    /// Gets the ID of the activated user.
+    /// </summary>
+    public Guid UserId { get; }
+
+    /// <summary>
+    /// Gets the email address of the activated user.
+    /// </summary>
+    public string Email { get; }
+
+    /// <summary>
+    /// Gets the user's role.
+    /// </summary>
+    public string Role { get; }
+
+    /// <summary>
+    /// Gets the user's tier.
+    /// </summary>
+    public string Tier { get; }
+
+    /// <summary>
+    /// Gets the ID of the admin who originally invited this user.
+    /// </summary>
+    public Guid InvitedByUserId { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="UserActivatedFromInvitationEvent"/> class.
+    /// </summary>
+    public UserActivatedFromInvitationEvent(
+        Guid userId,
+        string email,
+        string role,
+        string tier,
+        Guid invitedByUserId)
+    {
+        UserId = userId;
+        Email = email;
+        Role = role;
+        Tier = tier;
+        InvitedByUserId = invitedByUserId;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/Authentication/Domain/Events/UserProvisionedEvent.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Domain/Events/UserProvisionedEvent.cs
@@ -1,0 +1,59 @@
+using Api.SharedKernel.Domain.Events;
+
+namespace Api.BoundedContexts.Authentication.Domain.Events;
+
+/// <summary>
+/// Domain event raised when an admin provisions a new user account in Pending state.
+/// The user has not yet set their password or activated their account.
+/// </summary>
+internal sealed class UserProvisionedEvent : DomainEventBase
+{
+    /// <summary>
+    /// Gets the ID of the provisioned user.
+    /// </summary>
+    public Guid UserId { get; }
+
+    /// <summary>
+    /// Gets the email address of the provisioned user.
+    /// </summary>
+    public string Email { get; }
+
+    /// <summary>
+    /// Gets the display name of the provisioned user.
+    /// </summary>
+    public string DisplayName { get; }
+
+    /// <summary>
+    /// Gets the assigned role.
+    /// </summary>
+    public string Role { get; }
+
+    /// <summary>
+    /// Gets the assigned tier.
+    /// </summary>
+    public string Tier { get; }
+
+    /// <summary>
+    /// Gets the ID of the admin who invited this user.
+    /// </summary>
+    public Guid InvitedByUserId { get; }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="UserProvisionedEvent"/> class.
+    /// </summary>
+    public UserProvisionedEvent(
+        Guid userId,
+        string email,
+        string displayName,
+        string role,
+        string tier,
+        Guid invitedByUserId)
+    {
+        UserId = userId;
+        Email = email;
+        DisplayName = displayName;
+        Role = role;
+        Tier = tier;
+        InvitedByUserId = invitedByUserId;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/Authentication/Infrastructure/DependencyInjection/AuthenticationServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Infrastructure/DependencyInjection/AuthenticationServiceExtensions.cs
@@ -1,6 +1,7 @@
 using Api.BoundedContexts.Authentication.Domain.Repositories;
 using Api.BoundedContexts.Authentication.Infrastructure.Persistence;
 using Api.BoundedContexts.Authentication.Infrastructure.Repositories;
+using Api.BoundedContexts.Authentication.Infrastructure.Services;
 using Api.SharedKernel.Infrastructure.Persistence;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -28,6 +29,9 @@ internal static class AuthenticationServiceExtensions
 
         // Register Unit of Work
         services.AddScoped<IUnitOfWork, EfCoreUnitOfWork>();
+
+        // Admin Invitation Flow: singleton channel for game suggestion processing
+        services.AddSingleton<GameSuggestionChannel>();
 
         // MediatR handlers are auto-registered via assembly scanning in Program.cs
 

--- a/apps/api/src/Api/BoundedContexts/Authentication/Infrastructure/Persistence/UserRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Infrastructure/Persistence/UserRepository.cs
@@ -80,7 +80,7 @@ public class UserRepository : RepositoryBase, IUserRepository
             Id = entity.Id,
             Email = entity.Email.Value,
             DisplayName = entity.DisplayName,
-            PasswordHash = entity.PasswordHash.Value,
+            PasswordHash = entity.PasswordHash?.Value,
             Role = entity.Role.Value,
             Tier = entity.Tier.Value,
             CreatedAt = entity.CreatedAt,
@@ -106,7 +106,11 @@ public class UserRepository : RepositoryBase, IUserRepository
             AvatarUrl = entity.AvatarUrl,
             Bio = entity.Bio,
             OnboardingWizardSeenAt = entity.OnboardingWizardSeenAt,
-            OnboardingDismissedAt = entity.OnboardingDismissedAt
+            OnboardingDismissedAt = entity.OnboardingDismissedAt,
+            // Issue #124: Admin invitation flow — pending user fields
+            Status = entity.Status.ToString(),
+            InvitedByUserId = entity.InvitedByUserId,
+            InvitationExpiresAt = entity.InvitationExpiresAt
         };
 
         // Map backup codes
@@ -146,9 +150,13 @@ public class UserRepository : RepositoryBase, IUserRepository
         // Update scalar properties
         existingUser.Email = entity.Email.Value;
         existingUser.DisplayName = entity.DisplayName;
-        existingUser.PasswordHash = entity.PasswordHash.Value;
+        existingUser.PasswordHash = entity.PasswordHash?.Value;
         existingUser.Role = entity.Role.Value;
         existingUser.Tier = entity.Tier.Value;
+        // Issue #124: Admin invitation flow — update status and invitation fields
+        existingUser.Status = entity.Status.ToString();
+        existingUser.InvitedByUserId = entity.InvitedByUserId;
+        existingUser.InvitationExpiresAt = entity.InvitationExpiresAt;
         existingUser.TotpSecretEncrypted = entity.TotpSecret?.EncryptedValue;
         existingUser.IsTwoFactorEnabled = entity.IsTwoFactorEnabled;
         existingUser.TwoFactorEnabledAt = entity.TwoFactorEnabledAt;
@@ -243,18 +251,17 @@ public class UserRepository : RepositoryBase, IUserRepository
             throw new InvalidOperationException("Persisted user record is missing an Email value.");
         }
 
-        if (string.IsNullOrWhiteSpace(entity.PasswordHash))
-        {
-            throw new InvalidOperationException($"Persisted user record {entity.Id} is missing a password hash.");
-        }
-
         if (string.IsNullOrWhiteSpace(entity.Role))
         {
             throw new InvalidOperationException($"Persisted user record {entity.Id} is missing a role.");
         }
 
         var email = new Email(entity.Email);
-        var passwordHash = PasswordHash.FromStored(entity.PasswordHash);
+        // Issue #124: PasswordHash can be null for pending (invited) users
+        var isPendingUser = string.IsNullOrWhiteSpace(entity.PasswordHash);
+        var passwordHash = isPendingUser
+            ? PasswordHash.Create("TemporaryPlaceholder123!") // Placeholder for constructor; overridden below
+            : PasswordHash.FromStored(entity.PasswordHash);
         var role = Role.Parse(entity.Role);
         var tier = !string.IsNullOrWhiteSpace(entity.Tier) ? UserTier.Parse(entity.Tier) : UserTier.Free;
         var displayName = string.IsNullOrWhiteSpace(entity.DisplayName)
@@ -269,6 +276,12 @@ public class UserRepository : RepositoryBase, IUserRepository
             role: role,
             tier: tier
         );
+
+        // Issue #124: Restore null PasswordHash for pending users (overrides placeholder)
+        if (isPendingUser)
+        {
+            user.RestorePasswordHash(null);
+        }
 
         // Reconstruct preferences (use domain method to apply)
         user.UpdatePreferences(
@@ -339,6 +352,15 @@ public class UserRepository : RepositoryBase, IUserRepository
             entity.OnboardingCompleted,
             entity.OnboardingSkipped,
             entity.OnboardingCompletedAt);
+
+        // Issue #124: Restore account status and invitation state for pending users
+        if (!string.IsNullOrWhiteSpace(entity.Status)
+            && Enum.TryParse<Api.SharedKernel.Domain.Enums.UserAccountStatus>(entity.Status, out var status))
+        {
+            user.RestoreAccountStatus(status);
+        }
+
+        user.RestoreInvitationState(entity.InvitedByUserId, entity.InvitationExpiresAt);
 
         return user;
     }

--- a/apps/api/src/Api/BoundedContexts/Authentication/Infrastructure/Repositories/InvitationTokenRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Infrastructure/Repositories/InvitationTokenRepository.cs
@@ -154,7 +154,9 @@ internal sealed class InvitationTokenRepository : IInvitationTokenRepository
             acceptedAt: entity.AcceptedAt,
             acceptedByUserId: entity.AcceptedByUserId,
             createdAt: entity.CreatedAt,
-            revokedAt: entity.RevokedAt);
+            revokedAt: entity.RevokedAt,
+            customMessage: entity.CustomMessage,
+            pendingUserId: entity.PendingUserId);
 
         return token;
     }
@@ -176,7 +178,10 @@ internal sealed class InvitationTokenRepository : IInvitationTokenRepository
             AcceptedAt = domain.AcceptedAt,
             AcceptedByUserId = domain.AcceptedByUserId,
             CreatedAt = domain.CreatedAt,
-            RevokedAt = domain.RevokedAt
+            RevokedAt = domain.RevokedAt,
+            // Issue #124: Admin invitation flow fields
+            CustomMessage = domain.CustomMessage,
+            PendingUserId = domain.PendingUserId
         };
     }
 }

--- a/apps/api/src/Api/BoundedContexts/Authentication/Infrastructure/Services/GameSuggestionChannel.cs
+++ b/apps/api/src/Api/BoundedContexts/Authentication/Infrastructure/Services/GameSuggestionChannel.cs
@@ -1,0 +1,35 @@
+using System.Threading.Channels;
+using Api.BoundedContexts.Authentication.Domain.Entities;
+
+namespace Api.BoundedContexts.Authentication.Infrastructure.Services;
+
+/// <summary>
+/// Event dispatched when an invited user activates their account and the invitation
+/// carried game suggestions. Consumed by GameSuggestionProcessorService (Task 9).
+/// </summary>
+internal sealed record GameSuggestionEvent(
+    Guid UserId,
+    Guid InvitedByUserId,
+    IReadOnlyList<InvitationGameSuggestion> Suggestions);
+
+/// <summary>
+/// Unbounded Channel for decoupling invitation activation from game suggestion processing.
+/// Single reader (background service) / multiple writers (activation handlers).
+/// Registered as singleton in DI.
+/// </summary>
+internal sealed class GameSuggestionChannel
+{
+    private readonly Channel<GameSuggestionEvent> _channel;
+
+    public GameSuggestionChannel()
+    {
+        _channel = Channel.CreateUnbounded<GameSuggestionEvent>(new UnboundedChannelOptions
+        {
+            SingleReader = true,
+            SingleWriter = false
+        });
+    }
+
+    public ChannelWriter<GameSuggestionEvent> Writer => _channel.Writer;
+    public ChannelReader<GameSuggestionEvent> Reader => _channel.Reader;
+}

--- a/apps/api/src/Api/BoundedContexts/UserLibrary/Application/EventHandlers/GamePreAddedHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/UserLibrary/Application/EventHandlers/GamePreAddedHandler.cs
@@ -1,0 +1,81 @@
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.BoundedContexts.UserLibrary.Domain.Entities;
+using Api.BoundedContexts.UserLibrary.Domain.Repositories;
+
+namespace Api.BoundedContexts.UserLibrary.Application.EventHandlers;
+
+/// <summary>
+/// Handles PreAdded game suggestions from the invitation flow.
+/// When an admin pre-adds a game to an invitee's account, this handler
+/// adds the game to the user's library and creates a tracking GameSuggestion record.
+/// Idempotent: skips if game already in library or suggestion already exists.
+/// </summary>
+internal sealed class GamePreAddedHandler
+{
+    private readonly ISharedGameRepository _sharedGameRepo;
+    private readonly IUserLibraryRepository _libraryRepo;
+    private readonly IGameSuggestionRepository _gameSuggestionRepo;
+    private readonly TimeProvider _timeProvider;
+    private readonly ILogger<GamePreAddedHandler> _logger;
+
+    public GamePreAddedHandler(
+        ISharedGameRepository sharedGameRepo,
+        IUserLibraryRepository libraryRepo,
+        IGameSuggestionRepository gameSuggestionRepo,
+        TimeProvider timeProvider,
+        ILogger<GamePreAddedHandler> logger)
+    {
+        _sharedGameRepo = sharedGameRepo ?? throw new ArgumentNullException(nameof(sharedGameRepo));
+        _libraryRepo = libraryRepo ?? throw new ArgumentNullException(nameof(libraryRepo));
+        _gameSuggestionRepo = gameSuggestionRepo ?? throw new ArgumentNullException(nameof(gameSuggestionRepo));
+        _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <summary>
+    /// Processes a PreAdded game suggestion: validates the game exists, checks idempotency,
+    /// adds to library, and creates a tracking suggestion record marked as accepted.
+    /// </summary>
+    /// <param name="userId">The user to add the game for</param>
+    /// <param name="gameId">The game ID from the shared catalog</param>
+    /// <param name="suggestedByUserId">The admin who suggested the game</param>
+    /// <param name="ct">Cancellation token</param>
+    public async Task HandleAsync(Guid userId, Guid gameId, Guid suggestedByUserId, CancellationToken ct)
+    {
+        // Validate game exists in catalog
+        var game = await _sharedGameRepo.GetByIdAsync(gameId, ct).ConfigureAwait(false);
+        if (game is null)
+        {
+            _logger.LogWarning(
+                "PreAdded game {GameId} not found in catalog. Skipping for user {UserId}",
+                gameId, userId);
+            return;
+        }
+
+        // Idempotent: skip if already in library
+        if (await _libraryRepo.IsGameInLibraryAsync(userId, gameId, ct).ConfigureAwait(false))
+        {
+            _logger.LogDebug(
+                "Game {GameId} already in library for user {UserId}. Skipping pre-add",
+                gameId, userId);
+            return;
+        }
+
+        // Add to library
+        var entry = new UserLibraryEntry(Guid.NewGuid(), userId, gameId);
+        await _libraryRepo.AddAsync(entry, ct).ConfigureAwait(false);
+
+        // Also create a GameSuggestion record for tracking
+        if (!await _gameSuggestionRepo.ExistsForUserAndGameAsync(userId, gameId, ct).ConfigureAwait(false))
+        {
+            var gameSuggestion = GameSuggestion.Create(
+                userId, gameId, suggestedByUserId, "invitation_pre_added", _timeProvider);
+            gameSuggestion.Accept(); // Pre-added = auto-accepted
+            await _gameSuggestionRepo.AddAsync(gameSuggestion, ct).ConfigureAwait(false);
+        }
+
+        _logger.LogInformation(
+            "Pre-added game {GameId} to library for user {UserId}",
+            gameId, userId);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/UserLibrary/Application/EventHandlers/GameSuggestedHandler.cs
+++ b/apps/api/src/Api/BoundedContexts/UserLibrary/Application/EventHandlers/GameSuggestedHandler.cs
@@ -1,0 +1,53 @@
+using Api.BoundedContexts.UserLibrary.Domain.Entities;
+using Api.BoundedContexts.UserLibrary.Domain.Repositories;
+
+namespace Api.BoundedContexts.UserLibrary.Application.EventHandlers;
+
+/// <summary>
+/// Handles Suggested game suggestions from the invitation flow.
+/// Creates a GameSuggestion entity so the user can view and optionally accept the suggestion.
+/// Idempotent: skips if a suggestion already exists for the user+game combination.
+/// </summary>
+internal sealed class GameSuggestedHandler
+{
+    private readonly IGameSuggestionRepository _gameSuggestionRepo;
+    private readonly TimeProvider _timeProvider;
+    private readonly ILogger<GameSuggestedHandler> _logger;
+
+    public GameSuggestedHandler(
+        IGameSuggestionRepository gameSuggestionRepo,
+        TimeProvider timeProvider,
+        ILogger<GameSuggestedHandler> logger)
+    {
+        _gameSuggestionRepo = gameSuggestionRepo ?? throw new ArgumentNullException(nameof(gameSuggestionRepo));
+        _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    /// <summary>
+    /// Creates a game suggestion for the user if one doesn't already exist.
+    /// </summary>
+    /// <param name="userId">The user to create the suggestion for</param>
+    /// <param name="gameId">The game to suggest</param>
+    /// <param name="suggestedByUserId">The admin who suggested the game</param>
+    /// <param name="ct">Cancellation token</param>
+    public async Task HandleAsync(Guid userId, Guid gameId, Guid suggestedByUserId, CancellationToken ct)
+    {
+        // Idempotent: skip if suggestion already exists
+        if (await _gameSuggestionRepo.ExistsForUserAndGameAsync(userId, gameId, ct).ConfigureAwait(false))
+        {
+            _logger.LogDebug(
+                "GameSuggestion already exists for user {UserId} and game {GameId}. Skipping",
+                userId, gameId);
+            return;
+        }
+
+        var suggestion = GameSuggestion.Create(
+            userId, gameId, suggestedByUserId, "invitation", _timeProvider);
+        await _gameSuggestionRepo.AddAsync(suggestion, ct).ConfigureAwait(false);
+
+        _logger.LogInformation(
+            "Created game suggestion for user {UserId}, game {GameId}",
+            userId, gameId);
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/UserLibrary/Domain/Entities/GameSuggestion.cs
+++ b/apps/api/src/Api/BoundedContexts/UserLibrary/Domain/Entities/GameSuggestion.cs
@@ -1,0 +1,59 @@
+using Api.BoundedContexts.UserLibrary.Domain.Events;
+using Api.SharedKernel.Domain.Entities;
+
+namespace Api.BoundedContexts.UserLibrary.Domain.Entities;
+
+/// <summary>
+/// Domain entity for game suggestions attached to an invitation.
+/// Admin Invitation Flow: stores recommended games for invited users.
+/// </summary>
+internal sealed class GameSuggestion : AggregateRoot<Guid>
+{
+    public Guid UserId { get; private set; }
+    public Guid GameId { get; private set; }
+    public Guid SuggestedByUserId { get; private set; }
+    public string? Source { get; private set; }
+    public DateTime CreatedAt { get; private set; }
+    public bool IsDismissed { get; private set; }
+    public bool IsAccepted { get; private set; }
+
+    private GameSuggestion() { } // EF Core
+
+    public static GameSuggestion Create(
+        Guid userId,
+        Guid gameId,
+        Guid suggestedByUserId,
+        string? source,
+        TimeProvider timeProvider)
+    {
+        if (userId == Guid.Empty)
+            throw new ArgumentException("UserId cannot be empty", nameof(userId));
+        if (gameId == Guid.Empty)
+            throw new ArgumentException("GameId cannot be empty", nameof(gameId));
+        if (suggestedByUserId == Guid.Empty)
+            throw new ArgumentException("SuggestedByUserId cannot be empty", nameof(suggestedByUserId));
+
+        return new GameSuggestion
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            GameId = gameId,
+            SuggestedByUserId = suggestedByUserId,
+            Source = source,
+            CreatedAt = timeProvider.GetUtcNow().UtcDateTime,
+            IsDismissed = false,
+            IsAccepted = false
+        };
+    }
+
+    public void Accept()
+    {
+        IsAccepted = true;
+        AddDomainEvent(new GameSuggestionAcceptedEvent(Id, UserId, GameId));
+    }
+
+    public void Dismiss()
+    {
+        IsDismissed = true;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/UserLibrary/Domain/Events/GameSuggestionAcceptedEvent.cs
+++ b/apps/api/src/Api/BoundedContexts/UserLibrary/Domain/Events/GameSuggestionAcceptedEvent.cs
@@ -1,0 +1,32 @@
+using Api.SharedKernel.Domain.Events;
+
+namespace Api.BoundedContexts.UserLibrary.Domain.Events;
+
+/// <summary>
+/// Domain event raised when a user accepts a game suggestion.
+/// The application handler dispatches AddGameToLibraryCommand in response.
+/// </summary>
+internal sealed class GameSuggestionAcceptedEvent : DomainEventBase
+{
+    /// <summary>
+    /// The ID of the suggestion that was accepted.
+    /// </summary>
+    public Guid SuggestionId { get; }
+
+    /// <summary>
+    /// The ID of the user who accepted the suggestion.
+    /// </summary>
+    public Guid UserId { get; }
+
+    /// <summary>
+    /// The ID of the game that was suggested.
+    /// </summary>
+    public Guid GameId { get; }
+
+    public GameSuggestionAcceptedEvent(Guid suggestionId, Guid userId, Guid gameId)
+    {
+        SuggestionId = suggestionId;
+        UserId = userId;
+        GameId = gameId;
+    }
+}

--- a/apps/api/src/Api/BoundedContexts/UserLibrary/Domain/Repositories/IGameSuggestionRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/UserLibrary/Domain/Repositories/IGameSuggestionRepository.cs
@@ -1,0 +1,28 @@
+using Api.BoundedContexts.UserLibrary.Domain.Entities;
+using Api.SharedKernel.Infrastructure.Persistence;
+
+namespace Api.BoundedContexts.UserLibrary.Domain.Repositories;
+
+/// <summary>
+/// Repository interface for GameSuggestion aggregate.
+/// Admin Invitation Flow: manages game suggestions for invited users.
+/// </summary>
+internal interface IGameSuggestionRepository : IRepository<GameSuggestion, Guid>
+{
+    /// <summary>
+    /// Gets all game suggestions for a user.
+    /// </summary>
+    /// <param name="userId">The user ID to look up suggestions for</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>List of game suggestions for the user</returns>
+    Task<IReadOnlyList<GameSuggestion>> GetByUserIdAsync(Guid userId, CancellationToken cancellationToken = default);
+
+    /// <summary>
+    /// Checks if a suggestion already exists for a specific user and game combination.
+    /// </summary>
+    /// <param name="userId">User ID</param>
+    /// <param name="gameId">Game ID</param>
+    /// <param name="cancellationToken">Cancellation token</param>
+    /// <returns>True if a suggestion exists, false otherwise</returns>
+    Task<bool> ExistsForUserAndGameAsync(Guid userId, Guid gameId, CancellationToken cancellationToken = default);
+}

--- a/apps/api/src/Api/BoundedContexts/UserLibrary/Infrastructure/DependencyInjection/UserLibraryServiceExtensions.cs
+++ b/apps/api/src/Api/BoundedContexts/UserLibrary/Infrastructure/DependencyInjection/UserLibraryServiceExtensions.cs
@@ -1,3 +1,4 @@
+using Api.BoundedContexts.UserLibrary.Application.EventHandlers;
 using Api.BoundedContexts.UserLibrary.Domain.Repositories;
 using Api.BoundedContexts.UserLibrary.Domain.Services;
 using Api.BoundedContexts.UserLibrary.Infrastructure.Persistence;
@@ -24,9 +25,14 @@ internal static class UserLibraryServiceExtensions
         services.AddScoped<IProposalMigrationRepository, ProposalMigrationRepository>(); // Issue #3666: Migration choice flow
         services.AddScoped<IWishlistRepository, WishlistRepository>(); // Issue #3917: Wishlist management
         services.AddScoped<IUserCollectionRepository, UserCollectionRepository>(); // Issue #4263: Generic user collections
+        services.AddScoped<IGameSuggestionRepository, GameSuggestionRepository>(); // Admin Invitation Flow: game suggestions
 
         // Register domain services
         services.AddScoped<IGameLibraryQuotaService, GameLibraryQuotaService>();
+
+        // Register event handlers (consumed by background services via DI scope)
+        services.AddScoped<GamePreAddedHandler>(); // Admin Invitation Flow: pre-add games to library
+        services.AddScoped<GameSuggestedHandler>(); // Admin Invitation Flow: create game suggestions
 
         // MediatR handlers are auto-registered via assembly scanning in Program.cs
 

--- a/apps/api/src/Api/BoundedContexts/UserLibrary/Infrastructure/Persistence/GameSuggestionRepository.cs
+++ b/apps/api/src/Api/BoundedContexts/UserLibrary/Infrastructure/Persistence/GameSuggestionRepository.cs
@@ -1,0 +1,149 @@
+using Api.BoundedContexts.UserLibrary.Domain.Entities;
+using Api.BoundedContexts.UserLibrary.Domain.Repositories;
+using Api.Infrastructure;
+using Api.Infrastructure.Entities.UserLibrary;
+using Api.SharedKernel.Application.Services;
+using Api.SharedKernel.Infrastructure;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.BoundedContexts.UserLibrary.Infrastructure.Persistence;
+
+/// <summary>
+/// EF Core implementation of GameSuggestion repository.
+/// Admin Invitation Flow: manages game suggestions for invited users.
+/// </summary>
+internal class GameSuggestionRepository : RepositoryBase, IGameSuggestionRepository
+{
+    public GameSuggestionRepository(
+        MeepleAiDbContext dbContext,
+        IDomainEventCollector eventCollector)
+        : base(dbContext, eventCollector)
+    {
+    }
+
+    public async Task<GameSuggestion?> GetByIdAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        var entity = await DbContext.GameSuggestions
+            .AsNoTracking()
+            .FirstOrDefaultAsync(e => e.Id == id, cancellationToken).ConfigureAwait(false);
+
+        return entity != null ? MapToDomain(entity) : null;
+    }
+
+    public async Task<IReadOnlyList<GameSuggestion>> GetAllAsync(CancellationToken cancellationToken = default)
+    {
+        var entities = await DbContext.GameSuggestions
+            .AsNoTracking()
+            .OrderByDescending(e => e.CreatedAt)
+            .ToListAsync(cancellationToken).ConfigureAwait(false);
+
+        return entities.Select(MapToDomain).ToList();
+    }
+
+    public async Task<IReadOnlyList<GameSuggestion>> GetByUserIdAsync(Guid userId, CancellationToken cancellationToken = default)
+    {
+        var entities = await DbContext.GameSuggestions
+            .AsNoTracking()
+            .Where(e => e.UserId == userId)
+            .OrderByDescending(e => e.CreatedAt)
+            .ToListAsync(cancellationToken).ConfigureAwait(false);
+
+        return entities.Select(MapToDomain).ToList();
+    }
+
+    public async Task<bool> ExistsForUserAndGameAsync(Guid userId, Guid gameId, CancellationToken cancellationToken = default)
+    {
+        return await DbContext.GameSuggestions
+            .AsNoTracking()
+            .AnyAsync(e => e.UserId == userId && e.GameId == gameId, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public async Task AddAsync(GameSuggestion entity, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(entity);
+        CollectDomainEvents(entity);
+
+        var persistenceEntity = MapToPersistence(entity);
+        await DbContext.GameSuggestions.AddAsync(persistenceEntity, cancellationToken).ConfigureAwait(false);
+    }
+
+    public Task UpdateAsync(GameSuggestion entity, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(entity);
+        CollectDomainEvents(entity);
+
+        var persistenceEntity = MapToPersistence(entity);
+        DbContext.GameSuggestions.Update(persistenceEntity);
+        return Task.CompletedTask;
+    }
+
+    public Task DeleteAsync(GameSuggestion entity, CancellationToken cancellationToken = default)
+    {
+        ArgumentNullException.ThrowIfNull(entity);
+        CollectDomainEvents(entity);
+
+        var persistenceEntity = MapToPersistence(entity);
+        DbContext.GameSuggestions.Remove(persistenceEntity);
+        return Task.CompletedTask;
+    }
+
+    public async Task<bool> ExistsAsync(Guid id, CancellationToken cancellationToken = default)
+    {
+        return await DbContext.GameSuggestions
+            .AsNoTracking()
+            .AnyAsync(e => e.Id == id, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    private static GameSuggestion MapToDomain(GameSuggestionEntity entity)
+    {
+        // Use reflection to reconstruct the domain entity from persistence
+        // (private constructor + private setters pattern)
+        var suggestion = GameSuggestion.Create(
+            entity.UserId,
+            entity.GameId,
+            entity.SuggestedByUserId,
+            entity.Source,
+            TimeProvider.System);
+
+        // Override Id from database
+        var idProp = typeof(GameSuggestion).BaseType?.BaseType?.GetProperty("Id");
+        idProp?.SetValue(suggestion, entity.Id);
+
+        // Override CreatedAt from database
+        var createdAtProp = typeof(GameSuggestion).GetProperty("CreatedAt");
+        createdAtProp?.SetValue(suggestion, entity.CreatedAt);
+
+        // Restore state flags
+        if (entity.IsAccepted)
+        {
+            suggestion.Accept();
+        }
+
+        if (entity.IsDismissed)
+        {
+            suggestion.Dismiss();
+        }
+
+        // Clear domain events raised during reconstruction
+        suggestion.ClearDomainEvents();
+
+        return suggestion;
+    }
+
+    private static GameSuggestionEntity MapToPersistence(GameSuggestion domainEntity)
+    {
+        return new GameSuggestionEntity
+        {
+            Id = domainEntity.Id,
+            UserId = domainEntity.UserId,
+            GameId = domainEntity.GameId,
+            SuggestedByUserId = domainEntity.SuggestedByUserId,
+            Source = domainEntity.Source,
+            CreatedAt = domainEntity.CreatedAt,
+            IsDismissed = domainEntity.IsDismissed,
+            IsAccepted = domainEntity.IsAccepted
+        };
+    }
+}

--- a/apps/api/src/Api/Extensions/InfrastructureServiceExtensions.cs
+++ b/apps/api/src/Api/Extensions/InfrastructureServiceExtensions.cs
@@ -401,6 +401,10 @@ internal static class InfrastructureServiceExtensions
         services.AddScoped<Infrastructure.Services.IBggImportQueueService, Infrastructure.Services.BggImportQueueService>();
         services.AddHostedService<Infrastructure.BackgroundServices.BggImportQueueBackgroundService>();
 
+        // Admin Invitation Flow: background services for invitation lifecycle
+        services.AddHostedService<Infrastructure.BackgroundServices.InvitationCleanupService>();
+        services.AddHostedService<Infrastructure.BackgroundServices.GameSuggestionProcessorService>();
+
         // Issue #936: Infisical secrets management client (POC)
         services.AddHttpClient("Infisical", client =>
         {

--- a/apps/api/src/Api/Infrastructure/BackgroundServices/GameSuggestionProcessorService.cs
+++ b/apps/api/src/Api/Infrastructure/BackgroundServices/GameSuggestionProcessorService.cs
@@ -1,0 +1,129 @@
+using Api.BoundedContexts.Authentication.Domain.Enums;
+using Api.BoundedContexts.Authentication.Infrastructure.Services;
+using Api.BoundedContexts.UserLibrary.Application.EventHandlers;
+using Api.SharedKernel.Infrastructure.Persistence;
+
+namespace Api.Infrastructure.BackgroundServices;
+
+/// <summary>
+/// Background service that reads game suggestion events from <see cref="GameSuggestionChannel"/>
+/// and processes them. Delegates to <see cref="GamePreAddedHandler"/> for PreAdded suggestions
+/// and <see cref="GameSuggestedHandler"/> for Suggested suggestions.
+/// Retries up to 3 times with exponential backoff on failure.
+/// </summary>
+internal sealed class GameSuggestionProcessorService : BackgroundService
+{
+    internal const int MaxRetries = 3;
+
+    private readonly GameSuggestionChannel _channel;
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly ILogger<GameSuggestionProcessorService> _logger;
+
+    public GameSuggestionProcessorService(
+        GameSuggestionChannel channel,
+        IServiceScopeFactory scopeFactory,
+        ILogger<GameSuggestionProcessorService> logger)
+    {
+        _channel = channel ?? throw new ArgumentNullException(nameof(channel));
+        _scopeFactory = scopeFactory ?? throw new ArgumentNullException(nameof(scopeFactory));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation("GameSuggestionProcessorService started");
+
+        await foreach (var evt in _channel.Reader.ReadAllAsync(stoppingToken).ConfigureAwait(false))
+        {
+#pragma warning disable CA1031 // Do not catch general exception types
+            // BACKGROUND SERVICE: Generic catch prevents service from crashing the host process.
+            try
+            {
+                await ProcessEventWithRetryAsync(evt, stoppingToken).ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                _logger.LogError(
+                    ex,
+                    "Failed to process game suggestion event for user {UserId} after all retries",
+                    evt.UserId);
+            }
+#pragma warning restore CA1031
+        }
+
+        _logger.LogInformation("GameSuggestionProcessorService stopped");
+    }
+
+    private async Task ProcessEventWithRetryAsync(GameSuggestionEvent evt, CancellationToken ct)
+    {
+        for (var attempt = 1; attempt <= MaxRetries; attempt++)
+        {
+            try
+            {
+                await ProcessEventAsync(evt, ct).ConfigureAwait(false);
+                return; // Success
+            }
+            catch (OperationCanceledException)
+            {
+                throw; // Let cancellation propagate
+            }
+#pragma warning disable CA1031
+            catch (Exception ex) when (attempt < MaxRetries)
+            {
+                var delay = TimeSpan.FromSeconds(Math.Pow(2, attempt - 1)); // 1s, 2s, 4s
+                _logger.LogWarning(
+                    ex,
+                    "Game suggestion processing attempt {Attempt}/{MaxRetries} failed for user {UserId}. Retrying in {Delay}s",
+                    attempt, MaxRetries, evt.UserId, delay.TotalSeconds);
+
+                await Task.Delay(delay, ct).ConfigureAwait(false);
+            }
+#pragma warning restore CA1031
+        }
+
+        // Final attempt — let exception propagate to outer handler
+        await ProcessEventAsync(evt, ct).ConfigureAwait(false);
+    }
+
+    internal async Task ProcessEventAsync(GameSuggestionEvent evt, CancellationToken ct)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var preAddedHandler = scope.ServiceProvider.GetRequiredService<GamePreAddedHandler>();
+        var suggestedHandler = scope.ServiceProvider.GetRequiredService<GameSuggestedHandler>();
+        var unitOfWork = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
+
+        _logger.LogInformation(
+            "Processing {Count} game suggestion(s) for user {UserId}",
+            evt.Suggestions.Count, evt.UserId);
+
+        foreach (var suggestion in evt.Suggestions)
+        {
+            switch (suggestion.Type)
+            {
+                case GameSuggestionType.PreAdded:
+                    await preAddedHandler.HandleAsync(
+                        evt.UserId, suggestion.GameId, evt.InvitedByUserId, ct)
+                        .ConfigureAwait(false);
+                    break;
+
+                case GameSuggestionType.Suggested:
+                    await suggestedHandler.HandleAsync(
+                        evt.UserId, suggestion.GameId, evt.InvitedByUserId, ct)
+                        .ConfigureAwait(false);
+                    break;
+
+                default:
+                    _logger.LogWarning(
+                        "Unknown game suggestion type {Type} for game {GameId}",
+                        suggestion.Type, suggestion.GameId);
+                    break;
+            }
+        }
+
+        await unitOfWork.SaveChangesAsync(ct).ConfigureAwait(false);
+
+        _logger.LogInformation(
+            "Successfully processed game suggestions for user {UserId}",
+            evt.UserId);
+    }
+}

--- a/apps/api/src/Api/Infrastructure/BackgroundServices/InvitationCleanupService.cs
+++ b/apps/api/src/Api/Infrastructure/BackgroundServices/InvitationCleanupService.cs
@@ -1,0 +1,141 @@
+using Api.BoundedContexts.Authentication.Domain.Repositories;
+using Api.BoundedContexts.Authentication.Infrastructure.Persistence;
+using Api.Infrastructure;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Microsoft.EntityFrameworkCore;
+
+namespace Api.Infrastructure.BackgroundServices;
+
+/// <summary>
+/// Background service that periodically cleans up expired pending invitations.
+/// Runs every hour: finds users with Status=Pending whose InvitationExpiresAt has passed,
+/// marks the associated InvitationToken as expired, and hard-deletes the pending user.
+/// </summary>
+internal sealed class InvitationCleanupService : BackgroundService
+{
+    private static readonly TimeSpan Interval = TimeSpan.FromHours(1);
+
+    private readonly IServiceScopeFactory _scopeFactory;
+    private readonly TimeProvider _timeProvider;
+    private readonly ILogger<InvitationCleanupService> _logger;
+
+    public InvitationCleanupService(
+        IServiceScopeFactory scopeFactory,
+        TimeProvider timeProvider,
+        ILogger<InvitationCleanupService> logger)
+    {
+        _scopeFactory = scopeFactory ?? throw new ArgumentNullException(nameof(scopeFactory));
+        _timeProvider = timeProvider ?? throw new ArgumentNullException(nameof(timeProvider));
+        _logger = logger ?? throw new ArgumentNullException(nameof(logger));
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        _logger.LogInformation(
+            "InvitationCleanupService started. Cleanup interval: {Interval} hour(s)",
+            Interval.TotalHours);
+
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            await Task.Delay(Interval, stoppingToken).ConfigureAwait(false);
+
+#pragma warning disable CA1031 // Do not catch general exception types
+            // BACKGROUND SERVICE: Generic catch prevents service from crashing the host process.
+            try
+            {
+                await CleanupExpiredInvitationsAsync(stoppingToken).ConfigureAwait(false);
+            }
+            catch (Exception ex) when (ex is not OperationCanceledException)
+            {
+                _logger.LogError(ex, "Unexpected error during invitation cleanup cycle");
+            }
+#pragma warning restore CA1031
+        }
+
+        _logger.LogInformation("InvitationCleanupService stopped");
+    }
+
+    internal async Task CleanupExpiredInvitationsAsync(CancellationToken ct)
+    {
+        using var scope = _scopeFactory.CreateScope();
+        var dbContext = scope.ServiceProvider.GetRequiredService<MeepleAiDbContext>();
+        var invitationRepo = scope.ServiceProvider.GetRequiredService<IInvitationTokenRepository>();
+        var userRepo = scope.ServiceProvider.GetRequiredService<IUserRepository>();
+        var unitOfWork = scope.ServiceProvider.GetRequiredService<IUnitOfWork>();
+
+        var now = _timeProvider.GetUtcNow().UtcDateTime;
+
+        // Find pending users whose invitation has expired via EF Core entities
+        var expiredPendingUsers = await dbContext.Users
+            .AsNoTracking()
+            .Where(u => u.Status == "Pending" && u.InvitationExpiresAt != null && u.InvitationExpiresAt < now)
+            .Select(u => new { u.Id, u.Email })
+            .ToListAsync(ct)
+            .ConfigureAwait(false);
+
+        if (expiredPendingUsers.Count == 0)
+        {
+            _logger.LogDebug("Invitation cleanup: no expired pending users found");
+            return;
+        }
+
+        _logger.LogInformation(
+            "Invitation cleanup starting for {Count} expired pending user(s)",
+            expiredPendingUsers.Count);
+
+        var cleanedCount = 0;
+
+        foreach (var expiredUser in expiredPendingUsers)
+        {
+#pragma warning disable CA1031 // Do not catch general exception types
+            // BACKGROUND SERVICE: Failure for one user must not block cleanup for others.
+            try
+            {
+                // Find associated invitation token via PendingUserId
+                var invitationEntity = await dbContext.InvitationTokens
+                    .FirstOrDefaultAsync(t => t.PendingUserId == expiredUser.Id && t.Status == "Pending", ct)
+                    .ConfigureAwait(false);
+
+                if (invitationEntity is not null)
+                {
+                    // Load domain entity and mark expired
+                    var invitation = await invitationRepo
+                        .GetByIdAsync(invitationEntity.Id, ct)
+                        .ConfigureAwait(false);
+
+                    if (invitation is not null)
+                    {
+                        invitation.MarkExpired();
+                        await invitationRepo.UpdateAsync(invitation, ct).ConfigureAwait(false);
+                    }
+                }
+
+                // Hard delete the pending user
+                var user = await userRepo.GetByIdAsync(expiredUser.Id, ct).ConfigureAwait(false);
+                if (user is not null)
+                {
+                    await userRepo.DeleteAsync(user, ct).ConfigureAwait(false);
+                }
+
+                await unitOfWork.SaveChangesAsync(ct).ConfigureAwait(false);
+                cleanedCount++;
+
+                _logger.LogInformation(
+                    "Cleaned up expired pending user {UserId} ({Email})",
+                    expiredUser.Id, expiredUser.Email);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(
+                    ex,
+                    "Invitation cleanup failed for user {UserId}. Continuing with remaining users",
+                    expiredUser.Id);
+            }
+#pragma warning restore CA1031
+        }
+
+        _logger.LogInformation(
+            "Invitation cleanup completed: {CleanedCount}/{TotalCount} users cleaned up",
+            cleanedCount, expiredPendingUsers.Count);
+    }
+}

--- a/apps/api/src/Api/Infrastructure/Entities/Authentication/InvitationGameSuggestionEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/Authentication/InvitationGameSuggestionEntity.cs
@@ -1,0 +1,33 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Api.Infrastructure.Entities.Authentication;
+
+/// <summary>
+/// Infrastructure entity for game suggestions attached to invitation tokens.
+/// Admin Invitation Flow: stores pre-added or suggested games for invitees.
+/// </summary>
+[Table("invitation_game_suggestions")]
+public sealed class InvitationGameSuggestionEntity
+{
+    [Key]
+    [Column("id")]
+    public Guid Id { get; set; }
+
+    [Required]
+    [Column("invitation_token_id")]
+    public Guid InvitationTokenId { get; set; }
+
+    [Required]
+    [Column("game_id")]
+    public Guid GameId { get; set; }
+
+    [Required]
+    [MaxLength(16)]
+    [Column("type")]
+    public string Type { get; set; } = "Suggested";
+
+    // Navigation properties
+    [ForeignKey(nameof(InvitationTokenId))]
+    public InvitationTokenEntity? InvitationToken { get; set; }
+}

--- a/apps/api/src/Api/Infrastructure/Entities/Authentication/InvitationTokenEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/Authentication/InvitationTokenEntity.cs
@@ -55,10 +55,23 @@ public sealed class InvitationTokenEntity
     [Column("revoked_at")]
     public DateTime? RevokedAt { get; set; }
 
+    // Admin Invitation Flow: custom message and pending user provisioning
+    [MaxLength(500)]
+    [Column("custom_message")]
+    public string? CustomMessage { get; set; }
+
+    [Column("pending_user_id")]
+    public Guid? PendingUserId { get; set; }
+
     // Navigation properties
     [ForeignKey(nameof(InvitedByUserId))]
     public UserEntity? InvitedByUser { get; set; }
 
     [ForeignKey(nameof(AcceptedByUserId))]
     public UserEntity? AcceptedByUser { get; set; }
+
+    [ForeignKey(nameof(PendingUserId))]
+    public UserEntity? PendingUser { get; set; }
+
+    public ICollection<InvitationGameSuggestionEntity> GameSuggestions { get; set; } = new List<InvitationGameSuggestionEntity>();
 }

--- a/apps/api/src/Api/Infrastructure/Entities/Authentication/UserEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/Authentication/UserEntity.cs
@@ -66,6 +66,10 @@ public class UserEntity
     public bool OnboardingSkipped { get; set; }
     public DateTime? OnboardingCompletedAt { get; set; }
 
+    // Admin Invitation Flow: tracks who invited this user and when the invitation expires
+    public Guid? InvitedByUserId { get; set; }
+    public DateTime? InvitationExpiresAt { get; set; }
+
     // Navigation properties
     public ICollection<UserSessionEntity> Sessions { get; set; } = new List<UserSessionEntity>();
     public ICollection<UserBackupCodeEntity> BackupCodes { get; set; } = new List<UserBackupCodeEntity>();

--- a/apps/api/src/Api/Infrastructure/Entities/UserLibrary/GameSuggestionEntity.cs
+++ b/apps/api/src/Api/Infrastructure/Entities/UserLibrary/GameSuggestionEntity.cs
@@ -1,0 +1,51 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace Api.Infrastructure.Entities.UserLibrary;
+
+/// <summary>
+/// Infrastructure entity for game suggestions.
+/// Admin Invitation Flow: stores recommended games for invited users.
+/// </summary>
+[Table("game_suggestions")]
+public sealed class GameSuggestionEntity
+{
+    [Key]
+    [Column("id")]
+    public Guid Id { get; set; }
+
+    [Required]
+    [Column("user_id")]
+    public Guid UserId { get; set; }
+
+    [Required]
+    [Column("game_id")]
+    public Guid GameId { get; set; }
+
+    [Required]
+    [Column("suggested_by_user_id")]
+    public Guid SuggestedByUserId { get; set; }
+
+    [MaxLength(50)]
+    [Column("source")]
+    public string? Source { get; set; }
+
+    [Required]
+    [Column("created_at")]
+    public DateTime CreatedAt { get; set; }
+
+    [Required]
+    [Column("is_dismissed")]
+    public bool IsDismissed { get; set; }
+
+    [Required]
+    [Column("is_accepted")]
+    public bool IsAccepted { get; set; }
+
+    // Navigation properties
+    [ForeignKey(nameof(UserId))]
+    public UserEntity? User { get; set; }
+
+    [ForeignKey(nameof(SuggestedByUserId))]
+    public UserEntity? SuggestedByUser { get; set; }
+}

--- a/apps/api/src/Api/Infrastructure/EntityConfigurations/Authentication/InvitationGameSuggestionEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/EntityConfigurations/Authentication/InvitationGameSuggestionEntityConfiguration.cs
@@ -1,0 +1,39 @@
+using Api.Infrastructure.Entities.Authentication;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Api.Infrastructure.EntityConfigurations.Authentication;
+
+/// <summary>
+/// EF Core configuration for InvitationGameSuggestionEntity.
+/// Admin Invitation Flow: game suggestions attached to invitation tokens.
+/// </summary>
+internal class InvitationGameSuggestionEntityConfiguration : IEntityTypeConfiguration<InvitationGameSuggestionEntity>
+{
+    public void Configure(EntityTypeBuilder<InvitationGameSuggestionEntity> builder)
+    {
+        builder.ToTable("invitation_game_suggestions");
+
+        builder.HasKey(e => e.Id);
+
+        builder.Property(e => e.InvitationTokenId)
+            .IsRequired();
+
+        builder.Property(e => e.GameId)
+            .IsRequired();
+
+        builder.Property(e => e.Type)
+            .IsRequired()
+            .HasMaxLength(16);
+
+        // Indexes
+        builder.HasIndex(e => e.InvitationTokenId)
+            .HasDatabaseName("IX_InvitationGameSuggestions_InvitationTokenId");
+
+        builder.HasIndex(e => new { e.InvitationTokenId, e.GameId })
+            .IsUnique()
+            .HasDatabaseName("IX_InvitationGameSuggestions_TokenId_GameId");
+
+        // Relationship configured on parent (InvitationTokenEntityConfiguration)
+    }
+}

--- a/apps/api/src/Api/Infrastructure/EntityConfigurations/Authentication/InvitationTokenEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/EntityConfigurations/Authentication/InvitationTokenEntityConfiguration.cs
@@ -22,10 +22,17 @@ internal class InvitationTokenEntityConfiguration : IEntityTypeConfiguration<Inv
         builder.Property(e => e.AcceptedByUserId);
         builder.Property(e => e.RevokedAt);
 
+        // Admin Invitation Flow: custom message and pending user
+        builder.Property(e => e.CustomMessage).HasMaxLength(500).IsRequired(false);
+        builder.Property(e => e.PendingUserId).IsRequired(false);
+
         // Indexes
         builder.HasIndex(e => e.TokenHash).IsUnique();
         builder.HasIndex(e => new { e.Email, e.Status });
         builder.HasIndex(e => e.ExpiresAt);
+        builder.HasIndex(e => e.PendingUserId)
+            .HasDatabaseName("IX_InvitationTokens_PendingUserId")
+            .HasFilter("pending_user_id IS NOT NULL");
 
         // Relationships — FK to users table
         builder.HasOne(e => e.InvitedByUser)
@@ -38,5 +45,17 @@ internal class InvitationTokenEntityConfiguration : IEntityTypeConfiguration<Inv
             .HasForeignKey(e => e.AcceptedByUserId)
             .IsRequired(false)
             .OnDelete(DeleteBehavior.SetNull);
+
+        builder.HasOne(e => e.PendingUser)
+            .WithMany()
+            .HasForeignKey(e => e.PendingUserId)
+            .IsRequired(false)
+            .OnDelete(DeleteBehavior.SetNull);
+
+        // GameSuggestions — cascade delete when invitation is removed
+        builder.HasMany(e => e.GameSuggestions)
+            .WithOne(gs => gs.InvitationToken)
+            .HasForeignKey(gs => gs.InvitationTokenId)
+            .OnDelete(DeleteBehavior.Cascade);
     }
 }

--- a/apps/api/src/Api/Infrastructure/EntityConfigurations/Authentication/UserEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/EntityConfigurations/Authentication/UserEntityConfiguration.cs
@@ -57,6 +57,10 @@ internal class UserEntityConfiguration : IEntityTypeConfiguration<UserEntity>
         builder.Property(e => e.OnboardingWizardSeenAt).IsRequired(false);
         builder.Property(e => e.OnboardingDismissedAt).IsRequired(false);
 
+        // Admin Invitation Flow
+        builder.Property(e => e.InvitedByUserId).IsRequired(false);
+        builder.Property(e => e.InvitationExpiresAt).IsRequired(false);
+
         // Relationships
         builder.HasMany(e => e.Sessions)
             .WithOne(s => s.User)

--- a/apps/api/src/Api/Infrastructure/EntityConfigurations/UserLibrary/GameSuggestionEntityConfiguration.cs
+++ b/apps/api/src/Api/Infrastructure/EntityConfigurations/UserLibrary/GameSuggestionEntityConfiguration.cs
@@ -1,0 +1,65 @@
+using Api.Infrastructure.Entities.UserLibrary;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore.Metadata.Builders;
+
+namespace Api.Infrastructure.EntityConfigurations.UserLibrary;
+
+/// <summary>
+/// EF Core configuration for GameSuggestionEntity.
+/// Admin Invitation Flow: game suggestions for invited users.
+/// </summary>
+internal class GameSuggestionEntityConfiguration : IEntityTypeConfiguration<GameSuggestionEntity>
+{
+    public void Configure(EntityTypeBuilder<GameSuggestionEntity> builder)
+    {
+        builder.ToTable("game_suggestions");
+
+        builder.HasKey(e => e.Id);
+
+        builder.Property(e => e.UserId)
+            .IsRequired();
+
+        builder.Property(e => e.GameId)
+            .IsRequired();
+
+        builder.Property(e => e.SuggestedByUserId)
+            .IsRequired();
+
+        builder.Property(e => e.Source)
+            .HasMaxLength(50)
+            .IsRequired(false);
+
+        builder.Property(e => e.CreatedAt)
+            .IsRequired();
+
+        builder.Property(e => e.IsDismissed)
+            .IsRequired()
+            .HasDefaultValue(false);
+
+        builder.Property(e => e.IsAccepted)
+            .IsRequired()
+            .HasDefaultValue(false);
+
+        // Indexes
+        builder.HasIndex(e => e.UserId)
+            .HasDatabaseName("IX_GameSuggestions_UserId");
+
+        builder.HasIndex(e => new { e.UserId, e.GameId })
+            .IsUnique()
+            .HasDatabaseName("IX_GameSuggestions_UserId_GameId");
+
+        builder.HasIndex(e => new { e.UserId, e.IsDismissed, e.IsAccepted })
+            .HasDatabaseName("IX_GameSuggestions_UserId_Status");
+
+        // Relationships
+        builder.HasOne(e => e.User)
+            .WithMany()
+            .HasForeignKey(e => e.UserId)
+            .OnDelete(DeleteBehavior.Cascade);
+
+        builder.HasOne(e => e.SuggestedByUser)
+            .WithMany()
+            .HasForeignKey(e => e.SuggestedByUserId)
+            .OnDelete(DeleteBehavior.Restrict);
+    }
+}

--- a/apps/api/src/Api/Infrastructure/MeepleAiDbContext.cs
+++ b/apps/api/src/Api/Infrastructure/MeepleAiDbContext.cs
@@ -118,6 +118,8 @@ public class MeepleAiDbContext : DbContext
     public DbSet<ChatThreadCollectionEntity> ChatThreadCollections => Set<ChatThreadCollectionEntity>(); // ISSUE-2051: Chat-collection junction
     public DbSet<ShareLinkEntity> ShareLinks => Set<ShareLinkEntity>(); // ISSUE-2052: Shareable chat links
     public DbSet<InvitationTokenEntity> InvitationTokens => Set<InvitationTokenEntity>(); // ISSUE-124: Admin invitation tokens
+    public DbSet<InvitationGameSuggestionEntity> InvitationGameSuggestions => Set<InvitationGameSuggestionEntity>(); // Admin Invitation Flow: game suggestions on invitations
+    public DbSet<GameSuggestionEntity> GameSuggestions => Set<GameSuggestionEntity>(); // Admin Invitation Flow: user game suggestions
     public DbSet<AccessRequestEntity> AccessRequests => Set<AccessRequestEntity>(); // ISSUE-124: Access request management
     public DbSet<NotificationEntity> Notifications => Set<NotificationEntity>(); // ISSUE-2053: User notifications
     public DbSet<SharedGameEntity> SharedGames => Set<SharedGameEntity>(); // ISSUE-2370: Shared game catalog
@@ -289,6 +291,9 @@ public class MeepleAiDbContext : DbContext
         modelBuilder.Ignore<BoundedContexts.Authentication.Domain.Entities.ApiKey>();
         modelBuilder.Ignore<BoundedContexts.Authentication.Domain.Entities.ShareLink>(); // ISSUE-2052
         modelBuilder.Ignore<BoundedContexts.Authentication.Domain.Entities.AccessRequest>(); // ISSUE-124: Access request domain entity
+        modelBuilder.Ignore<BoundedContexts.Authentication.Domain.Entities.InvitationToken>(); // Admin Invitation Flow: domain aggregate
+        modelBuilder.Ignore<BoundedContexts.Authentication.Domain.Entities.InvitationGameSuggestion>(); // Admin Invitation Flow: domain entity
+        modelBuilder.Ignore<BoundedContexts.UserLibrary.Domain.Entities.GameSuggestion>(); // Admin Invitation Flow: domain aggregate
         modelBuilder.Ignore<BoundedContexts.GameManagement.Domain.Entities.GameSession>();
         modelBuilder.Ignore<BoundedContexts.GameManagement.Domain.Entities.GameSessionState>(); // ISSUE-2403
         modelBuilder.Ignore<BoundedContexts.GameManagement.Domain.Entities.GameStateSnapshot>(); // ISSUE-2403

--- a/apps/api/src/Api/Infrastructure/Migrations/20260317160741_AddInvitationFlowTables.Designer.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260317160741_AddInvitationFlowTables.Designer.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Api.Infrastructure;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using Pgvector;
@@ -13,9 +14,11 @@ using Pgvector;
 namespace Api.Infrastructure.Migrations
 {
     [DbContext(typeof(MeepleAiDbContext))]
-    partial class MeepleAiDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260317160741_AddInvitationFlowTables")]
+    partial class AddInvitationFlowTables
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/apps/api/src/Api/Infrastructure/Migrations/20260317160741_AddInvitationFlowTables.cs
+++ b/apps/api/src/Api/Infrastructure/Migrations/20260317160741_AddInvitationFlowTables.cs
@@ -1,0 +1,170 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Api.Infrastructure.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddInvitationFlowTables : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<DateTime>(
+                name: "InvitationExpiresAt",
+                table: "users",
+                type: "timestamp with time zone",
+                nullable: true);
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "InvitedByUserId",
+                table: "users",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.AddColumn<string>(
+                name: "custom_message",
+                table: "invitation_tokens",
+                type: "character varying(500)",
+                maxLength: 500,
+                nullable: true);
+
+            migrationBuilder.AddColumn<Guid>(
+                name: "pending_user_id",
+                table: "invitation_tokens",
+                type: "uuid",
+                nullable: true);
+
+            migrationBuilder.CreateTable(
+                name: "game_suggestions",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    user_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    game_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    suggested_by_user_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    source = table.Column<string>(type: "character varying(50)", maxLength: 50, nullable: true),
+                    created_at = table.Column<DateTime>(type: "timestamp with time zone", nullable: false),
+                    is_dismissed = table.Column<bool>(type: "boolean", nullable: false, defaultValue: false),
+                    is_accepted = table.Column<bool>(type: "boolean", nullable: false, defaultValue: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_game_suggestions", x => x.id);
+                    table.ForeignKey(
+                        name: "FK_game_suggestions_users_suggested_by_user_id",
+                        column: x => x.suggested_by_user_id,
+                        principalTable: "users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Restrict);
+                    table.ForeignKey(
+                        name: "FK_game_suggestions_users_user_id",
+                        column: x => x.user_id,
+                        principalTable: "users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateTable(
+                name: "invitation_game_suggestions",
+                columns: table => new
+                {
+                    id = table.Column<Guid>(type: "uuid", nullable: false),
+                    invitation_token_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    game_id = table.Column<Guid>(type: "uuid", nullable: false),
+                    type = table.Column<string>(type: "character varying(16)", maxLength: 16, nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_invitation_game_suggestions", x => x.id);
+                    table.ForeignKey(
+                        name: "FK_invitation_game_suggestions_invitation_tokens_invitation_to~",
+                        column: x => x.invitation_token_id,
+                        principalTable: "invitation_tokens",
+                        principalColumn: "id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_InvitationTokens_PendingUserId",
+                table: "invitation_tokens",
+                column: "pending_user_id",
+                filter: "pending_user_id IS NOT NULL");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_game_suggestions_suggested_by_user_id",
+                table: "game_suggestions",
+                column: "suggested_by_user_id");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_GameSuggestions_UserId",
+                table: "game_suggestions",
+                column: "user_id");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_GameSuggestions_UserId_GameId",
+                table: "game_suggestions",
+                columns: new[] { "user_id", "game_id" },
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_GameSuggestions_UserId_Status",
+                table: "game_suggestions",
+                columns: new[] { "user_id", "is_dismissed", "is_accepted" });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_InvitationGameSuggestions_InvitationTokenId",
+                table: "invitation_game_suggestions",
+                column: "invitation_token_id");
+
+            migrationBuilder.CreateIndex(
+                name: "IX_InvitationGameSuggestions_TokenId_GameId",
+                table: "invitation_game_suggestions",
+                columns: new[] { "invitation_token_id", "game_id" },
+                unique: true);
+
+            migrationBuilder.AddForeignKey(
+                name: "FK_invitation_tokens_users_pending_user_id",
+                table: "invitation_tokens",
+                column: "pending_user_id",
+                principalTable: "users",
+                principalColumn: "Id",
+                onDelete: ReferentialAction.SetNull);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropForeignKey(
+                name: "FK_invitation_tokens_users_pending_user_id",
+                table: "invitation_tokens");
+
+            migrationBuilder.DropTable(
+                name: "game_suggestions");
+
+            migrationBuilder.DropTable(
+                name: "invitation_game_suggestions");
+
+            migrationBuilder.DropIndex(
+                name: "IX_InvitationTokens_PendingUserId",
+                table: "invitation_tokens");
+
+            migrationBuilder.DropColumn(
+                name: "InvitationExpiresAt",
+                table: "users");
+
+            migrationBuilder.DropColumn(
+                name: "InvitedByUserId",
+                table: "users");
+
+            migrationBuilder.DropColumn(
+                name: "custom_message",
+                table: "invitation_tokens");
+
+            migrationBuilder.DropColumn(
+                name: "pending_user_id",
+                table: "invitation_tokens");
+        }
+    }
+}

--- a/apps/api/src/Api/Routing/AdminUserEndpoints.cs
+++ b/apps/api/src/Api/Routing/AdminUserEndpoints.cs
@@ -1211,6 +1211,44 @@ internal static class AdminUserEndpoints
             .WithTags("Admin")
             .Produces(StatusCodes.Status200OK)
             .Produces(StatusCodes.Status404NotFound);
+
+        // ISSUE-124: New invitation flow endpoints (provision + invite in one step)
+        group.MapPost("/admin/invitations", HandleProvisionAndInvite)
+            .WithName("ProvisionAndInviteUser")
+            .WithTags("Admin", "Invitations")
+            .WithSummary("Provision a pending user and send invitation email")
+            .WithDescription("Creates a user in Pending status and sends an invitation email in one operation. Supports game suggestions and custom messages.")
+            .Produces<InvitationDto>(StatusCodes.Status201Created)
+            .Produces(StatusCodes.Status400BadRequest)
+            .Produces(StatusCodes.Status409Conflict);
+
+        group.MapGet("/admin/invitations", HandleGetPendingInvitations)
+            .WithName("GetPendingInvitations")
+            .WithTags("Admin", "Invitations")
+            .WithSummary("Get invitations with optional status filter")
+            .WithDescription("Returns invitations, optionally filtered by status (Pending, Accepted, Expired, Revoked).")
+            .Produces<List<InvitationDto>>(StatusCodes.Status200OK);
+
+        group.MapGet("/admin/invitations/{id:guid}", HandleGetInvitationById)
+            .WithName("GetInvitationById")
+            .WithTags("Admin", "Invitations")
+            .WithSummary("Get a single invitation by ID")
+            .Produces<InvitationDto>(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status404NotFound);
+
+        group.MapPost("/admin/invitations/{id:guid}/resend", HandleResendInvitationNew)
+            .WithName("ResendInvitationNew")
+            .WithTags("Admin", "Invitations")
+            .WithSummary("Resend an invitation email")
+            .Produces<InvitationDto>(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status404NotFound);
+
+        group.MapDelete("/admin/invitations/{id:guid}", HandleRevokeInvitationNew)
+            .WithName("RevokeInvitationNew")
+            .WithTags("Admin", "Invitations")
+            .WithSummary("Revoke an invitation")
+            .Produces(StatusCodes.Status200OK)
+            .Produces(StatusCodes.Status404NotFound);
     }
 
     private static async Task<IResult> HandleSendInvitation(
@@ -1346,6 +1384,112 @@ internal static class AdminUserEndpoints
         logger.LogInformation("Invitation {InvitationId} revoked successfully", id);
         return Results.Ok(new { success = true });
     }
+
+    private static async Task<IResult> HandleProvisionAndInvite(
+        ProvisionAndInviteRequest request,
+        HttpContext context,
+        IMediator mediator,
+        ILogger<Program> logger,
+        CancellationToken ct)
+    {
+        var (authorized, session, error) = context.RequireAdminSession();
+        if (!authorized) return error!;
+
+        logger.LogInformation("Admin {AdminId} provisioning and inviting {Email} with role {Role}",
+            session!.User!.Id, DataMasking.MaskEmail(request.Email), request.Role);
+
+        var command = new ProvisionAndInviteUserCommand(
+            Email: request.Email,
+            DisplayName: request.DisplayName,
+            Role: request.Role,
+            Tier: request.Tier ?? "free",
+            CustomMessage: request.CustomMessage,
+            ExpiresInDays: request.ExpiresInDays ?? 7,
+            GameSuggestions: request.GameSuggestions ?? new List<GameSuggestionDto>(),
+            InvitedByUserId: session.User.Id);
+
+        var result = await mediator.Send(command, ct).ConfigureAwait(false);
+
+        logger.LogInformation("Invitation {InvitationId} created for {Email} via provision-and-invite",
+            result.Id, DataMasking.MaskEmail(request.Email));
+        return Results.Created($"/api/v1/admin/invitations/{result.Id}", result);
+    }
+
+    private static async Task<IResult> HandleGetPendingInvitations(
+        HttpContext context,
+        IMediator mediator,
+        CancellationToken ct,
+        string? status = null)
+    {
+        var (authorized, _, error) = context.RequireAdminSession();
+        if (!authorized) return error!;
+
+        var query = new GetPendingInvitationsQuery(status);
+        var result = await mediator.Send(query, ct).ConfigureAwait(false);
+        return Results.Ok(result);
+    }
+
+    private static async Task<IResult> HandleGetInvitationById(
+        Guid id,
+        HttpContext context,
+        IMediator mediator,
+        CancellationToken ct)
+    {
+        var (authorized, _, error) = context.RequireAdminSession();
+        if (!authorized) return error!;
+
+        var query = new GetInvitationByIdQuery(id);
+        var result = await mediator.Send(query, ct).ConfigureAwait(false);
+        return Results.Ok(result);
+    }
+
+    private static async Task<IResult> HandleResendInvitationNew(
+        Guid id,
+        HttpContext context,
+        IMediator mediator,
+        ILogger<Program> logger,
+        CancellationToken ct)
+    {
+        var (authorized, session, error) = context.RequireAdminSession();
+        if (!authorized) return error!;
+
+        logger.LogInformation("Admin {AdminId} resending invitation {InvitationId} (new path)",
+            session!.User!.Id, id);
+
+        var command = new ResendInvitationCommand(id, session.User.Id);
+        var result = await mediator.Send(command, ct).ConfigureAwait(false);
+
+        logger.LogInformation("Invitation {InvitationId} resent successfully (new path)", result.Id);
+        return Results.Ok(result);
+    }
+
+    private static async Task<IResult> HandleRevokeInvitationNew(
+        Guid id,
+        HttpContext context,
+        IMediator mediator,
+        ILogger<Program> logger,
+        CancellationToken ct)
+    {
+        var (authorized, session, error) = context.RequireAdminSession();
+        if (!authorized) return error!;
+
+        logger.LogInformation("Admin {AdminId} revoking invitation {InvitationId} (new path)",
+            session!.User!.Id, id);
+
+        var command = new RevokeInvitationCommand(
+            InvitationId: id,
+            AdminUserId: session.User.Id);
+
+        var success = await mediator.Send(command, ct).ConfigureAwait(false);
+
+        if (!success)
+        {
+            return Results.NotFound(new { error = "Invitation not found or not pending" });
+        }
+
+        logger.LogInformation("Invitation {InvitationId} revoked successfully (new path)", id);
+        return Results.Ok(new { success = true });
+    }
 }
 
 /// <summary>
@@ -1397,6 +1541,18 @@ internal record SendUserEmailRequest(string Subject, string Body);
 /// Request payload for sending an invitation (Issue #124).
 /// </summary>
 internal record SendInvitationRequest(string Email, string Role);
+
+/// <summary>
+/// Request payload for provisioning and inviting a user (Issue #124).
+/// </summary>
+internal record ProvisionAndInviteRequest(
+    string Email,
+    string DisplayName,
+    string Role,
+    string? Tier = "free",
+    string? CustomMessage = null,
+    int? ExpiresInDays = 7,
+    List<GameSuggestionDto>? GameSuggestions = null);
 
 /// <summary>
 /// Request payload for changing a user's role (Issue #124).

--- a/apps/api/src/Api/Routing/AuthenticationEndpoints.cs
+++ b/apps/api/src/Api/Routing/AuthenticationEndpoints.cs
@@ -23,6 +23,7 @@ using LogoutApiKeyCommand = Api.BoundedContexts.Authentication.Application.Comma
 using LogoutAllDevicesCommand = Api.BoundedContexts.Authentication.Application.Commands.LogoutAllDevicesCommand;
 using GetSessionByTokenHashQuery = Api.BoundedContexts.Authentication.Application.Queries.GetSessionByTokenHashQuery;
 using AcceptInvitationCommand = Api.BoundedContexts.Authentication.Application.Commands.Invitation.AcceptInvitationCommand;
+using ActivateInvitedAccountCommand = Api.BoundedContexts.Authentication.Application.Commands.Invitation.ActivateInvitedAccountCommand;
 using ValidateInvitationTokenQuery = Api.BoundedContexts.Authentication.Application.Queries.Invitation.ValidateInvitationTokenQuery;
 using GetPendingInvitationsQuery = Api.BoundedContexts.Authentication.Application.Queries.Invitation.GetPendingInvitationsQuery;
 using GetInvitationByIdQuery = Api.BoundedContexts.Authentication.Application.Queries.Invitation.GetInvitationByIdQuery;
@@ -63,6 +64,8 @@ internal static class AuthenticationEndpoints
         // ISSUE-124: Invitation acceptance endpoints (public, unauthenticated)
         MapAcceptInvitationEndpoint(group);
         MapValidateInvitationEndpoint(group);
+        MapActivateAccountEndpoint(group);
+        MapValidateInvitationGetEndpoint(group);
 
         return group;
     }
@@ -690,6 +693,89 @@ Clients can also store the key securely and send it via the `Authorization: ApiK
         .Produces(200)
         .Produces(400);
     }
+
+    // ISSUE-124: Activate invited account (public, unauthenticated)
+    private static void MapActivateAccountEndpoint(RouteGroupBuilder group)
+    {
+        group.MapPost("/auth/activate-account", async (
+            HttpContext context,
+            IMediator mediator,
+            IConfigurationService configService,
+            ILogger<Program> logger,
+            CancellationToken ct) =>
+        {
+            ActivateAccountPayload? payload;
+            try
+            {
+                payload = await context.Request.ReadFromJsonAsync<ActivateAccountPayload>(ct).ConfigureAwait(false);
+            }
+            catch (System.Text.Json.JsonException)
+            {
+                return Results.BadRequest(new { error = "Invalid request payload" });
+            }
+
+            if (payload == null)
+            {
+                return Results.BadRequest(new { error = "Invalid request payload" });
+            }
+
+            if (string.IsNullOrWhiteSpace(payload.Token) || string.IsNullOrWhiteSpace(payload.Password))
+            {
+                return Results.BadRequest(new { error = "Token and password are required" });
+            }
+
+            logger.LogInformation("Account activation attempt via invitation token");
+
+            var command = new ActivateInvitedAccountCommand(payload.Token, payload.Password);
+            var result = await mediator.Send(command, ct).ConfigureAwait(false);
+
+            // Set auth cookie for immediate login (follows existing login pattern)
+            var sessionExpirationDays = (await configService.GetValueAsync<int?>("Authentication:SessionManagement:SessionExpirationDays", 30).ConfigureAwait(false)) ?? 30;
+            var expiresAt = DateTime.UtcNow.AddDays(sessionExpirationDays);
+            CookieHelpers.WriteSessionCookie(context, result.SessionToken, expiresAt);
+
+            logger.LogInformation("Account activated via invitation, session created");
+
+            return Results.Ok(new { sessionToken = result.SessionToken, requiresOnboarding = result.RequiresOnboarding });
+        })
+        .WithName("ActivateInvitedAccount")
+        .WithTags("Authentication", "Invitations")
+        .WithSummary("Activate an invited account by setting a password")
+        .WithDescription("Activates a pending invited user account. Sets the password, transitions the user to Active status, creates a session, and returns a session token for immediate login.")
+        .RequireRateLimiting("AuthRegister")
+        .Produces(200)
+        .Produces(400);
+    }
+
+    // ISSUE-124: Validate invitation token via GET (public, unauthenticated)
+    private static void MapValidateInvitationGetEndpoint(RouteGroupBuilder group)
+    {
+        group.MapGet("/auth/validate-invitation", async (
+            string token,
+            IMediator mediator,
+            ILogger<Program> logger,
+            CancellationToken ct) =>
+        {
+            if (string.IsNullOrWhiteSpace(token))
+            {
+                return Results.BadRequest(new { error = "Token is required" });
+            }
+
+            logger.LogInformation("Invitation token validation attempt (GET)");
+
+            var query = new ValidateInvitationTokenQuery(token);
+            var result = await mediator.Send(query, ct).ConfigureAwait(false);
+
+            return Results.Ok(result);
+        })
+        .WithName("ValidateInvitationTokenGet")
+        .WithTags("Authentication", "Invitations")
+        .WithSummary("Validate an invitation token (GET)")
+        .WithDescription("Checks whether an invitation token is valid without consuming it. Accepts token as query parameter. Returns email and display name for valid tokens.")
+        .RequireRateLimiting("AuthRegister")
+        .Produces(200)
+        .Produces(400);
+    }
 }
 
 /// <summary>
@@ -701,3 +787,8 @@ internal record AcceptInvitationPayload(string Token, string Password, string Co
 /// Payload for validating an invitation token (Issue #124).
 /// </summary>
 internal record ValidateInvitationPayload(string Token);
+
+/// <summary>
+/// Payload for activating an invited account (Issue #124).
+/// </summary>
+internal record ActivateAccountPayload(string Token, string Password);

--- a/apps/api/src/Api/Routing/AuthenticationEndpoints.cs
+++ b/apps/api/src/Api/Routing/AuthenticationEndpoints.cs
@@ -24,6 +24,8 @@ using LogoutAllDevicesCommand = Api.BoundedContexts.Authentication.Application.C
 using GetSessionByTokenHashQuery = Api.BoundedContexts.Authentication.Application.Queries.GetSessionByTokenHashQuery;
 using AcceptInvitationCommand = Api.BoundedContexts.Authentication.Application.Commands.Invitation.AcceptInvitationCommand;
 using ValidateInvitationTokenQuery = Api.BoundedContexts.Authentication.Application.Queries.Invitation.ValidateInvitationTokenQuery;
+using GetPendingInvitationsQuery = Api.BoundedContexts.Authentication.Application.Queries.Invitation.GetPendingInvitationsQuery;
+using GetInvitationByIdQuery = Api.BoundedContexts.Authentication.Application.Queries.Invitation.GetInvitationByIdQuery;
 
 namespace Api.Routing;
 
@@ -683,7 +685,7 @@ Clients can also store the key securely and send it via the `Authorization: ApiK
         .WithName("ValidateInvitationToken")
         .WithTags("Authentication", "Invitations")
         .WithSummary("Validate an invitation token")
-        .WithDescription("Checks whether an invitation token is valid without consuming it. Returns role and expiry info.")
+        .WithDescription("Checks whether an invitation token is valid without consuming it. Returns email and display name for valid tokens, or a uniform error reason (\"invalid\" or \"already_used\") to prevent state enumeration.")
         .RequireRateLimiting("AuthRegister")
         .Produces(200)
         .Produces(400);

--- a/apps/api/src/Api/Services/EmailService.cs
+++ b/apps/api/src/Api/Services/EmailService.cs
@@ -2528,6 +2528,56 @@ internal class EmailService : IEmailService
 #pragma warning restore CA1031
     }
 
+    // ISSUE-124: Enhanced invitation email with custom message, platform intro, and expiry notice
+    public async Task SendInvitationEmailAsync(
+        string toEmail,
+        string displayName,
+        string role,
+        string token,
+        string invitedByName,
+        string? customMessage,
+        DateTime expiresAt,
+        CancellationToken ct = default)
+    {
+        try
+        {
+            var setupLink = $"{_frontendBaseUrl}/setup-account?token={Uri.EscapeDataString(token)}";
+            var subject = "Sei stato invitato su MeepleAI!";
+            var body = BuildEnhancedInvitationEmailBody(displayName, role, setupLink, invitedByName, customMessage, expiresAt);
+
+            using var message = new MailMessage();
+            message.From = new MailAddress(_fromAddress, _fromName);
+            message.To.Add(new MailAddress(toEmail));
+            message.Subject = subject;
+            message.Body = body;
+            message.IsBodyHtml = true;
+
+            using var smtpClient = new SmtpClient(_smtpHost, _smtpPort);
+            smtpClient.EnableSsl = _enableSsl;
+
+            if (!string.IsNullOrEmpty(_smtpUsername) && !string.IsNullOrEmpty(_smtpPassword))
+            {
+                smtpClient.Credentials = new NetworkCredential(_smtpUsername, _smtpPassword);
+            }
+
+            await smtpClient.SendMailAsync(message, ct).ConfigureAwait(false);
+
+            _logger.LogInformation(
+                "Enhanced invitation email sent successfully to {Email} for role {Role}",
+                DataMasking.MaskEmail(toEmail), role);
+        }
+#pragma warning disable CA1031 // Do not catch general exception types
+        catch (Exception ex)
+        {
+            _logger.LogError(
+                ex,
+                "Failed to send enhanced invitation email to {Email}",
+                DataMasking.MaskEmail(toEmail));
+            throw new InvalidOperationException("Failed to send invitation email", ex);
+        }
+#pragma warning restore CA1031
+    }
+
     // ISSUE-4417: Raw email sending for queue processor
     public async Task SendRawEmailAsync(
         string toEmail,
@@ -2615,6 +2665,77 @@ internal class EmailService : IEmailService
     <div style=""margin-top: 20px; text-align: center; font-size: 12px; color: #999;"">
         <p>This is an automated message, please do not reply to this email.</p>
         <p>&copy; 2025 MeepleAI. All rights reserved.</p>
+    </div>
+</body>
+</html>
+";
+    }
+
+    private static string BuildEnhancedInvitationEmailBody(
+        string displayName,
+        string role,
+        string setupLink,
+        string invitedByName,
+        string? customMessage,
+        DateTime expiresAt)
+    {
+        var roleDisplay = string.IsNullOrWhiteSpace(role) ? "utente" : role;
+        var safeDisplayName = System.Net.WebUtility.HtmlEncode(displayName);
+        var safeInvitedByName = System.Net.WebUtility.HtmlEncode(invitedByName);
+        var expiryFormatted = expiresAt.ToString("dd MMMM yyyy", CultureInfo.GetCultureInfo("it-IT"));
+
+        var customMessageBlock = string.Empty;
+        if (!string.IsNullOrWhiteSpace(customMessage))
+        {
+            var safeMessage = System.Net.WebUtility.HtmlEncode(customMessage);
+            customMessageBlock = $@"
+        <div style=""background-color: #f0f4f8; border-left: 4px solid #3498db; padding: 15px 20px; margin: 20px 0; border-radius: 0 5px 5px 0;"">
+            <p style=""margin: 0 0 8px 0; font-size: 13px; color: #666; font-weight: bold;"">{safeInvitedByName} dice:</p>
+            <p style=""margin: 0; font-style: italic; color: #444;"">&ldquo;{safeMessage}&rdquo;</p>
+        </div>";
+        }
+
+        return $@"
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset=""utf-8"">
+    <meta name=""viewport"" content=""width=device-width, initial-scale=1.0"">
+    <title>Sei stato invitato su MeepleAI!</title>
+</head>
+<body style=""font-family: Arial, sans-serif; line-height: 1.6; color: #333; max-width: 600px; margin: 0 auto; padding: 20px;"">
+    <div style=""background-color: #f8f9fa; padding: 20px; border-radius: 5px; margin-bottom: 20px;"">
+        <h1 style=""color: #2c3e50; margin: 0;"">MeepleAI</h1>
+    </div>
+
+    <div style=""background-color: #ffffff; padding: 30px; border-radius: 5px; border: 1px solid #e0e0e0;"">
+        <h2 style=""color: #2c3e50; margin-top: 0;"">Ciao {safeDisplayName}!</h2>
+
+        <p><strong>{safeInvitedByName}</strong> ti ha invitato a unirti a MeepleAI come <strong>{roleDisplay}</strong>.</p>
+{customMessageBlock}
+        <p style=""color: #555;"">MeepleAI &egrave; il tuo assistente AI per giochi da tavolo. Gestisci la tua collezione, ottieni risposte dalle regole dei tuoi giochi, e scopri nuovi titoli.</p>
+
+        <p>Clicca il pulsante qui sotto per configurare il tuo account:</p>
+
+        <div style=""text-align: center; margin: 30px 0;"">
+            <a href=""{setupLink}"" style=""background-color: #3498db; color: white; padding: 12px 30px; text-decoration: none; border-radius: 5px; display: inline-block; font-weight: bold;"">Configura il tuo account</a>
+        </div>
+
+        <p>Oppure copia e incolla questo link nel tuo browser:</p>
+        <p style=""word-break: break-all; color: #3498db;"">{setupLink}</p>
+
+        <p style=""margin-top: 30px; padding-top: 20px; border-top: 1px solid #e0e0e0; font-size: 14px; color: #666;"">
+            Questo invito scade il <strong>{expiryFormatted}</strong>. Se scade, chiedi al tuo amministratore di inviarne uno nuovo.
+        </p>
+
+        <p style=""font-size: 14px; color: #666;"">
+            Se non ti aspettavi questo invito, puoi ignorare questa email.
+        </p>
+    </div>
+
+    <div style=""margin-top: 20px; text-align: center; font-size: 12px; color: #999;"">
+        <p>Questo &egrave; un messaggio automatico, non rispondere a questa email.</p>
+        <p>&copy; 2025 MeepleAI. Tutti i diritti riservati.</p>
     </div>
 </body>
 </html>

--- a/apps/api/src/Api/Services/IEmailService.cs
+++ b/apps/api/src/Api/Services/IEmailService.cs
@@ -177,6 +177,20 @@ internal interface IEmailService
         string invitedByName,
         CancellationToken ct = default);
 
+    /// <summary>
+    /// Enhanced invitation email with custom message, platform intro, and expiry notice.
+    /// Used by the admin invitation flow (ProvisionAndInviteUser).
+    /// </summary>
+    Task SendInvitationEmailAsync(
+        string toEmail,
+        string displayName,
+        string role,
+        string token,
+        string invitedByName,
+        string? customMessage,
+        DateTime expiresAt,
+        CancellationToken ct = default);
+
     // ISSUE-4417: Raw email sending for queue processor
     /// <summary>
     /// Sends a pre-rendered HTML email via SMTP.

--- a/apps/api/src/Api/SharedKernel/Domain/Enums/UserAccountStatus.cs
+++ b/apps/api/src/Api/SharedKernel/Domain/Enums/UserAccountStatus.cs
@@ -1,0 +1,13 @@
+namespace Api.SharedKernel.Domain.Enums;
+
+/// <summary>
+/// User account status shared across bounded contexts.
+/// Used by Authentication (User entity) and Administration (permission checks).
+/// </summary>
+public enum UserAccountStatus
+{
+    Active = 0,
+    Suspended = 1,
+    Banned = 2,
+    Pending = 3
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/Authentication/Application/Commands/Invitation/ActivateInvitedAccountCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/Authentication/Application/Commands/Invitation/ActivateInvitedAccountCommandHandlerTests.cs
@@ -1,0 +1,495 @@
+using System.Security.Cryptography;
+using System.Text;
+using Api.BoundedContexts.Authentication.Application.Commands.Invitation;
+using Api.BoundedContexts.Authentication.Application.DTOs;
+using Api.BoundedContexts.Authentication.Domain.Entities;
+using Api.BoundedContexts.Authentication.Domain.Enums;
+using Api.BoundedContexts.Authentication.Domain.Repositories;
+using Api.BoundedContexts.Authentication.Domain.ValueObjects;
+using Api.BoundedContexts.Authentication.Infrastructure.Persistence;
+using Api.BoundedContexts.Authentication.Infrastructure.Services;
+using Api.Middleware.Exceptions;
+using Api.SharedKernel.Domain.Enums;
+using Api.SharedKernel.Domain.ValueObjects;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Time.Testing;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.Authentication.Application.Commands.Invitation;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "Authentication")]
+public class ActivateInvitedAccountCommandHandlerTests
+{
+    private readonly Mock<IInvitationTokenRepository> _invitationRepoMock = new();
+    private readonly Mock<IUserRepository> _userRepoMock = new();
+    private readonly Mock<ISessionRepository> _sessionRepoMock = new();
+    private readonly Mock<IUnitOfWork> _unitOfWorkMock = new();
+    private readonly GameSuggestionChannel _gameSuggestionChannel = new();
+    private readonly FakeTimeProvider _timeProvider;
+    private readonly Mock<ILogger<ActivateInvitedAccountCommandHandler>> _loggerMock = new();
+    private readonly ActivateInvitedAccountCommandHandler _handler;
+
+    private static readonly string ValidPassword = "Test@1234";
+    private static readonly string RawToken = Convert.ToBase64String(RandomNumberGenerator.GetBytes(32))
+        .Replace('+', '-').Replace('/', '_').TrimEnd('=');
+
+    public ActivateInvitedAccountCommandHandlerTests()
+    {
+        _timeProvider = new FakeTimeProvider(new DateTimeOffset(2026, 3, 17, 12, 0, 0, TimeSpan.Zero));
+
+        _handler = new ActivateInvitedAccountCommandHandler(
+            _invitationRepoMock.Object,
+            _userRepoMock.Object,
+            _sessionRepoMock.Object,
+            _unitOfWorkMock.Object,
+            _gameSuggestionChannel,
+            _timeProvider,
+            _loggerMock.Object);
+    }
+
+    #region Helpers
+
+    private static string ComputeTokenHash(string rawToken)
+    {
+        return Convert.ToBase64String(SHA256.HashData(Encoding.UTF8.GetBytes(rawToken)));
+    }
+
+    /// <summary>
+    /// Creates a pending user via the domain factory method so all invariants are satisfied.
+    /// </summary>
+    private User CreatePendingUser(
+        Guid? userId = null,
+        string email = "invited@example.com",
+        Guid? invitedByUserId = null)
+    {
+        var id = userId ?? Guid.NewGuid();
+        var adminId = invitedByUserId ?? Guid.NewGuid();
+        var expiresAt = _timeProvider.GetUtcNow().UtcDateTime.AddDays(7);
+
+        var user = User.CreatePending(
+            new Email(email),
+            "Invited User",
+            Role.Parse("User"),
+            UserTier.Free,
+            adminId,
+            expiresAt,
+            _timeProvider);
+
+        // Overwrite the Id via reflection since CreatePending generates its own
+        // We need a controlled Id to match invitation.PendingUserId
+        var idProp = typeof(User).GetProperty("Id");
+        if (idProp != null && idProp.CanWrite)
+        {
+            idProp.SetValue(user, id);
+        }
+        else
+        {
+            // Fall back — AggregateRoot<Guid>.Id may have a protected setter
+            var field = typeof(User).BaseType?.BaseType?.GetField("<Id>k__BackingField",
+                System.Reflection.BindingFlags.Instance | System.Reflection.BindingFlags.NonPublic);
+            field?.SetValue(user, id);
+        }
+
+        return user;
+    }
+
+    /// <summary>
+    /// Creates a valid InvitationToken with PendingUserId set.
+    /// Uses the extended Create overload (TimeProvider-based).
+    /// </summary>
+    private InvitationToken CreateValidInvitation(
+        Guid pendingUserId,
+        string email = "invited@example.com",
+        Guid? invitedByUserId = null,
+        bool addGameSuggestions = false)
+    {
+        var tokenHash = ComputeTokenHash(RawToken);
+        var invitation = InvitationToken.Create(
+            new Email(email),
+            Role.Parse("User"),
+            pendingUserId,
+            null,
+            7,
+            _timeProvider,
+            tokenHash);
+
+        // Set InvitedByUserId (the extended Create sets it to Guid.Empty)
+        if (invitedByUserId.HasValue)
+        {
+            var prop = typeof(InvitationToken).GetProperty("InvitedByUserId");
+            prop?.SetValue(invitation, invitedByUserId.Value);
+        }
+
+        if (addGameSuggestions)
+        {
+            invitation.AddGameSuggestion(Guid.NewGuid(), GameSuggestionType.PreAdded);
+            invitation.AddGameSuggestion(Guid.NewGuid(), GameSuggestionType.Suggested);
+        }
+
+        return invitation;
+    }
+
+    private void SetupValidTokenLookup(InvitationToken invitation)
+    {
+        var tokenHash = ComputeTokenHash(RawToken);
+        _invitationRepoMock
+            .Setup(r => r.GetByTokenHashAsync(tokenHash, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(invitation);
+    }
+
+    private void SetupUserLookup(User user)
+    {
+        _userRepoMock
+            .Setup(r => r.GetByIdAsync(user.Id, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(user);
+    }
+
+    #endregion
+
+    #region Happy Path
+
+    [Fact]
+    public async Task Handle_ValidTokenAndPassword_ActivatesUserAndReturnsSessionToken()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var adminId = Guid.NewGuid();
+        var user = CreatePendingUser(userId: userId, invitedByUserId: adminId);
+        var invitation = CreateValidInvitation(userId, invitedByUserId: adminId);
+
+        SetupValidTokenLookup(invitation);
+        SetupUserLookup(user);
+
+        var command = new ActivateInvitedAccountCommand(RawToken, ValidPassword);
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.SessionToken.Should().NotBeNullOrWhiteSpace();
+        result.RequiresOnboarding.Should().BeTrue();
+
+        // User should have been activated
+        user.Status.Should().Be(UserAccountStatus.Active);
+        user.EmailVerified.Should().BeTrue();
+
+        // Invitation should be marked accepted
+        invitation.Status.Should().Be(InvitationStatus.Accepted);
+        invitation.AcceptedByUserId.Should().Be(userId);
+
+        // Session should have been added
+        _sessionRepoMock.Verify(
+            r => r.AddAsync(It.IsAny<Session>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        // SaveChanges called
+        _unitOfWorkMock.Verify(
+            u => u.SaveChangesAsync(It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_ValidTokenAndPassword_PasswordIsVerifiable()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var user = CreatePendingUser(userId: userId);
+        var invitation = CreateValidInvitation(userId);
+
+        SetupValidTokenLookup(invitation);
+        SetupUserLookup(user);
+
+        var command = new ActivateInvitedAccountCommand(RawToken, ValidPassword);
+
+        // Act
+        await _handler.Handle(command, CancellationToken.None);
+
+        // Assert — password should be verifiable after activation
+        user.VerifyPassword(ValidPassword).Should().BeTrue();
+        user.VerifyPassword("WrongPassword1!").Should().BeFalse();
+    }
+
+    #endregion
+
+    #region Invalid / Expired Token
+
+    [Fact]
+    public async Task Handle_TokenNotFound_ThrowsNotFoundException()
+    {
+        // Arrange
+        _invitationRepoMock
+            .Setup(r => r.GetByTokenHashAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((InvitationToken?)null);
+
+        var command = new ActivateInvitedAccountCommand("nonexistent-token", ValidPassword);
+
+        // Act
+        var act = () => _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<NotFoundException>();
+    }
+
+    [Fact]
+    public async Task Handle_ExpiredToken_ThrowsNotFoundException()
+    {
+        // Arrange — create token then advance time past expiry
+        var userId = Guid.NewGuid();
+        var invitation = CreateValidInvitation(userId);
+
+        // Advance time by 8 days (token expires in 7)
+        _timeProvider.Advance(TimeSpan.FromDays(8));
+
+        SetupValidTokenLookup(invitation);
+
+        var command = new ActivateInvitedAccountCommand(RawToken, ValidPassword);
+
+        // Act
+        var act = () => _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<NotFoundException>();
+    }
+
+    #endregion
+
+    #region Already-Used Token
+
+    [Fact]
+    public async Task Handle_AlreadyAcceptedToken_ThrowsNotFoundException()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var invitation = CreateValidInvitation(userId);
+        invitation.MarkAccepted(userId); // Already accepted
+
+        SetupValidTokenLookup(invitation);
+
+        var command = new ActivateInvitedAccountCommand(RawToken, ValidPassword);
+
+        // Act
+        var act = () => _handler.Handle(command, CancellationToken.None);
+
+        // Assert — IsValid will be false since Status != Pending
+        await act.Should().ThrowAsync<NotFoundException>();
+    }
+
+    [Fact]
+    public async Task Handle_RevokedToken_ThrowsNotFoundException()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var invitation = CreateValidInvitation(userId);
+        invitation.Revoke(); // Revoked
+
+        SetupValidTokenLookup(invitation);
+
+        var command = new ActivateInvitedAccountCommand(RawToken, ValidPassword);
+
+        // Act
+        var act = () => _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<NotFoundException>();
+    }
+
+    #endregion
+
+    #region User Not Pending
+
+    [Fact]
+    public async Task Handle_UserAlreadyActive_ThrowsConflictException()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var adminId = Guid.NewGuid();
+        var user = CreatePendingUser(userId: userId, invitedByUserId: adminId);
+
+        // Activate the user first to make them non-Pending
+        user.ActivateFromInvitation(PasswordHash.Create("OldPass@123"), _timeProvider);
+
+        var invitation = CreateValidInvitation(userId, invitedByUserId: adminId);
+        SetupValidTokenLookup(invitation);
+        SetupUserLookup(user);
+
+        var command = new ActivateInvitedAccountCommand(RawToken, ValidPassword);
+
+        // Act
+        var act = () => _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<ConflictException>()
+            .WithMessage("*not in Pending status*");
+    }
+
+    [Fact]
+    public async Task Handle_UserNotFound_ThrowsNotFoundException()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var invitation = CreateValidInvitation(userId);
+        SetupValidTokenLookup(invitation);
+
+        _userRepoMock
+            .Setup(r => r.GetByIdAsync(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((User?)null);
+
+        var command = new ActivateInvitedAccountCommand(RawToken, ValidPassword);
+
+        // Act
+        var act = () => _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<NotFoundException>();
+    }
+
+    #endregion
+
+    #region Game Suggestion Channel
+
+    [Fact]
+    public async Task Handle_WithGameSuggestions_WritesToChannel()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var adminId = Guid.NewGuid();
+        var user = CreatePendingUser(userId: userId, invitedByUserId: adminId);
+        var invitation = CreateValidInvitation(userId, invitedByUserId: adminId, addGameSuggestions: true);
+
+        SetupValidTokenLookup(invitation);
+        SetupUserLookup(user);
+
+        var command = new ActivateInvitedAccountCommand(RawToken, ValidPassword);
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert — activation still succeeds
+        result.Should().NotBeNull();
+        result.SessionToken.Should().NotBeNullOrWhiteSpace();
+
+        // Channel should have one event
+        _gameSuggestionChannel.Reader.TryRead(out var evt).Should().BeTrue();
+        evt.Should().NotBeNull();
+        evt!.UserId.Should().Be(userId);
+        evt.InvitedByUserId.Should().Be(adminId);
+        evt.Suggestions.Should().HaveCount(2);
+    }
+
+    [Fact]
+    public async Task Handle_WithoutGameSuggestions_DoesNotWriteToChannel()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var adminId = Guid.NewGuid();
+        var user = CreatePendingUser(userId: userId, invitedByUserId: adminId);
+        var invitation = CreateValidInvitation(userId, invitedByUserId: adminId, addGameSuggestions: false);
+
+        SetupValidTokenLookup(invitation);
+        SetupUserLookup(user);
+
+        var command = new ActivateInvitedAccountCommand(RawToken, ValidPassword);
+
+        // Act
+        await _handler.Handle(command, CancellationToken.None);
+
+        // Assert — channel should be empty
+        _gameSuggestionChannel.Reader.TryRead(out _).Should().BeFalse();
+    }
+
+    #endregion
+
+    #region Null Command
+
+    [Fact]
+    public async Task Handle_NullCommand_ThrowsArgumentNullException()
+    {
+        // Act
+        var act = () => _handler.Handle(null!, CancellationToken.None);
+
+        // Assert
+        await act.Should().ThrowAsync<ArgumentNullException>();
+    }
+
+    #endregion
+
+    #region Constructor Null Guards
+
+    [Fact]
+    public void Constructor_NullInvitationRepo_ThrowsArgumentNullException()
+    {
+        var act = () => new ActivateInvitedAccountCommandHandler(
+            null!, _userRepoMock.Object, _sessionRepoMock.Object,
+            _unitOfWorkMock.Object, _gameSuggestionChannel, _timeProvider, _loggerMock.Object);
+
+        act.Should().Throw<ArgumentNullException>().WithParameterName("invitationRepo");
+    }
+
+    [Fact]
+    public void Constructor_NullUserRepo_ThrowsArgumentNullException()
+    {
+        var act = () => new ActivateInvitedAccountCommandHandler(
+            _invitationRepoMock.Object, null!, _sessionRepoMock.Object,
+            _unitOfWorkMock.Object, _gameSuggestionChannel, _timeProvider, _loggerMock.Object);
+
+        act.Should().Throw<ArgumentNullException>().WithParameterName("userRepo");
+    }
+
+    [Fact]
+    public void Constructor_NullSessionRepo_ThrowsArgumentNullException()
+    {
+        var act = () => new ActivateInvitedAccountCommandHandler(
+            _invitationRepoMock.Object, _userRepoMock.Object, null!,
+            _unitOfWorkMock.Object, _gameSuggestionChannel, _timeProvider, _loggerMock.Object);
+
+        act.Should().Throw<ArgumentNullException>().WithParameterName("sessionRepo");
+    }
+
+    [Fact]
+    public void Constructor_NullUnitOfWork_ThrowsArgumentNullException()
+    {
+        var act = () => new ActivateInvitedAccountCommandHandler(
+            _invitationRepoMock.Object, _userRepoMock.Object, _sessionRepoMock.Object,
+            null!, _gameSuggestionChannel, _timeProvider, _loggerMock.Object);
+
+        act.Should().Throw<ArgumentNullException>().WithParameterName("unitOfWork");
+    }
+
+    [Fact]
+    public void Constructor_NullChannel_ThrowsArgumentNullException()
+    {
+        var act = () => new ActivateInvitedAccountCommandHandler(
+            _invitationRepoMock.Object, _userRepoMock.Object, _sessionRepoMock.Object,
+            _unitOfWorkMock.Object, null!, _timeProvider, _loggerMock.Object);
+
+        act.Should().Throw<ArgumentNullException>().WithParameterName("gameSuggestionChannel");
+    }
+
+    [Fact]
+    public void Constructor_NullTimeProvider_ThrowsArgumentNullException()
+    {
+        var act = () => new ActivateInvitedAccountCommandHandler(
+            _invitationRepoMock.Object, _userRepoMock.Object, _sessionRepoMock.Object,
+            _unitOfWorkMock.Object, _gameSuggestionChannel, null!, _loggerMock.Object);
+
+        act.Should().Throw<ArgumentNullException>().WithParameterName("timeProvider");
+    }
+
+    [Fact]
+    public void Constructor_NullLogger_ThrowsArgumentNullException()
+    {
+        var act = () => new ActivateInvitedAccountCommandHandler(
+            _invitationRepoMock.Object, _userRepoMock.Object, _sessionRepoMock.Object,
+            _unitOfWorkMock.Object, _gameSuggestionChannel, _timeProvider, null!);
+
+        act.Should().Throw<ArgumentNullException>().WithParameterName("logger");
+    }
+
+    #endregion
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/Authentication/Application/Commands/Invitation/BatchProvisionCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/Authentication/Application/Commands/Invitation/BatchProvisionCommandHandlerTests.cs
@@ -1,0 +1,287 @@
+using Api.BoundedContexts.Authentication.Application.Commands.Invitation;
+using Api.BoundedContexts.Authentication.Application.DTOs;
+using Api.Middleware.Exceptions;
+using Api.Tests.Constants;
+using FluentAssertions;
+using FluentValidation;
+using MediatR;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.Authentication.Application.Commands.Invitation;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "Authentication")]
+public class BatchProvisionCommandHandlerTests
+{
+    private readonly Mock<ISender> _senderMock = new();
+    private readonly Mock<ILogger<BatchProvisionCommandHandler>> _loggerMock = new();
+    private readonly BatchProvisionCommandHandler _handler;
+
+    public BatchProvisionCommandHandlerTests()
+    {
+        _handler = new BatchProvisionCommandHandler(_senderMock.Object, _loggerMock.Object);
+    }
+
+    private static BatchInvitationItemDto CreateItem(
+        string email = "user@example.com",
+        string displayName = "Test User",
+        string role = "User",
+        string tier = "Free",
+        string? customMessage = null,
+        int expiresInDays = 7,
+        List<GameSuggestionDto>? gameSuggestions = null)
+    {
+        return new BatchInvitationItemDto(
+            email, displayName, role, tier,
+            customMessage, expiresInDays,
+            gameSuggestions ?? new List<GameSuggestionDto>());
+    }
+
+    private static InvitationDto CreateSuccessDto(string email, Guid invitedBy)
+    {
+        return new InvitationDto(
+            Id: Guid.NewGuid(),
+            Email: email,
+            Role: "User",
+            Status: "Pending",
+            ExpiresAt: DateTime.UtcNow.AddDays(7),
+            CreatedAt: DateTime.UtcNow,
+            AcceptedAt: null,
+            InvitedByUserId: invitedBy,
+            EmailSent: true);
+    }
+
+    [Fact]
+    public async Task Handle_AllSucceed_ReturnsAllInSucceeded()
+    {
+        // Arrange
+        var invitedBy = Guid.NewGuid();
+        var items = new List<BatchInvitationItemDto>
+        {
+            CreateItem(email: "user1@example.com", displayName: "User One"),
+            CreateItem(email: "user2@example.com", displayName: "User Two"),
+            CreateItem(email: "user3@example.com", displayName: "User Three")
+        };
+        var command = new BatchProvisionCommand(items, invitedBy);
+
+        _senderMock
+            .Setup(s => s.Send(It.IsAny<ProvisionAndInviteUserCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ProvisionAndInviteUserCommand cmd, CancellationToken _) =>
+                CreateSuccessDto(cmd.Email, invitedBy));
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.Succeeded.Should().HaveCount(3);
+        result.Failed.Should().BeEmpty();
+        _senderMock.Verify(
+            s => s.Send(It.IsAny<ProvisionAndInviteUserCommand>(), It.IsAny<CancellationToken>()),
+            Times.Exactly(3));
+    }
+
+    [Fact]
+    public async Task Handle_PartialFailure_DuplicateEmail_ContinuesProcessing()
+    {
+        // Arrange
+        var invitedBy = Guid.NewGuid();
+        var items = new List<BatchInvitationItemDto>
+        {
+            CreateItem(email: "good1@example.com", displayName: "Good One"),
+            CreateItem(email: "duplicate@example.com", displayName: "Duplicate"),
+            CreateItem(email: "good2@example.com", displayName: "Good Two")
+        };
+        var command = new BatchProvisionCommand(items, invitedBy);
+
+        _senderMock
+            .Setup(s => s.Send(
+                It.Is<ProvisionAndInviteUserCommand>(c => c.Email != "duplicate@example.com"),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ProvisionAndInviteUserCommand cmd, CancellationToken _) =>
+                CreateSuccessDto(cmd.Email, invitedBy));
+
+        _senderMock
+            .Setup(s => s.Send(
+                It.Is<ProvisionAndInviteUserCommand>(c => c.Email == "duplicate@example.com"),
+                It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new ConflictException("A user with email 'duplicate@example.com' already exists"));
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.Succeeded.Should().HaveCount(2);
+        result.Failed.Should().HaveCount(1);
+        result.Failed[0].Email.Should().Be("duplicate@example.com");
+        result.Failed[0].Error.Should().Contain("pending invitation or user already exists");
+
+        // All 3 items should be attempted — no early abort
+        _senderMock.Verify(
+            s => s.Send(It.IsAny<ProvisionAndInviteUserCommand>(), It.IsAny<CancellationToken>()),
+            Times.Exactly(3));
+    }
+
+    [Fact]
+    public async Task Handle_AllFail_ReturnsAllInFailed()
+    {
+        // Arrange
+        var invitedBy = Guid.NewGuid();
+        var items = new List<BatchInvitationItemDto>
+        {
+            CreateItem(email: "dup1@example.com"),
+            CreateItem(email: "dup2@example.com"),
+            CreateItem(email: "dup3@example.com")
+        };
+        var command = new BatchProvisionCommand(items, invitedBy);
+
+        _senderMock
+            .Setup(s => s.Send(It.IsAny<ProvisionAndInviteUserCommand>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new ConflictException("User already exists"));
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.Succeeded.Should().BeEmpty();
+        result.Failed.Should().HaveCount(3);
+        result.Failed.Should().AllSatisfy(f =>
+            f.Error.Should().Contain("pending invitation or user already exists"));
+    }
+
+    [Fact]
+    public async Task Handle_TracksEmailSentPerItem()
+    {
+        // Arrange
+        var invitedBy = Guid.NewGuid();
+        var items = new List<BatchInvitationItemDto>
+        {
+            CreateItem(email: "sent@example.com", displayName: "Email Sent"),
+            CreateItem(email: "notsent@example.com", displayName: "Email Failed")
+        };
+        var command = new BatchProvisionCommand(items, invitedBy);
+
+        _senderMock
+            .Setup(s => s.Send(
+                It.Is<ProvisionAndInviteUserCommand>(c => c.Email == "sent@example.com"),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new InvitationDto(
+                Guid.NewGuid(), "sent@example.com", "User", "Pending",
+                DateTime.UtcNow.AddDays(7), DateTime.UtcNow, null, invitedBy,
+                EmailSent: true));
+
+        _senderMock
+            .Setup(s => s.Send(
+                It.Is<ProvisionAndInviteUserCommand>(c => c.Email == "notsent@example.com"),
+                It.IsAny<CancellationToken>()))
+            .ReturnsAsync(new InvitationDto(
+                Guid.NewGuid(), "notsent@example.com", "User", "Pending",
+                DateTime.UtcNow.AddDays(7), DateTime.UtcNow, null, invitedBy,
+                EmailSent: false));
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.Succeeded.Should().HaveCount(2);
+        result.Succeeded.Should().ContainSingle(d => d.Email == "sent@example.com" && d.EmailSent);
+        result.Succeeded.Should().ContainSingle(d => d.Email == "notsent@example.com" && !d.EmailSent);
+    }
+
+    [Fact]
+    public async Task Handle_EmptyList_ReturnsEmptyResults()
+    {
+        // Arrange
+        var command = new BatchProvisionCommand(new List<BatchInvitationItemDto>(), Guid.NewGuid());
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.Succeeded.Should().BeEmpty();
+        result.Failed.Should().BeEmpty();
+        _senderMock.Verify(
+            s => s.Send(It.IsAny<ProvisionAndInviteUserCommand>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_ExceedsMaxItems_ThrowsValidationException()
+    {
+        // Arrange
+        var items = Enumerable.Range(0, 101)
+            .Select(i => CreateItem(email: $"user{i}@example.com"))
+            .ToList();
+        var command = new BatchProvisionCommand(items, Guid.NewGuid());
+
+        // Act & Assert
+        await Assert.ThrowsAsync<ValidationException>(
+            () => _handler.Handle(command, CancellationToken.None));
+    }
+
+    [Fact]
+    public async Task Handle_PassesCorrectDataToProvisionCommand()
+    {
+        // Arrange
+        var invitedBy = Guid.NewGuid();
+        var gameId = Guid.NewGuid();
+        var item = CreateItem(
+            email: "test@example.com",
+            displayName: "Test User",
+            role: "Editor",
+            tier: "Premium",
+            customMessage: "Welcome!",
+            expiresInDays: 14,
+            gameSuggestions: new List<GameSuggestionDto> { new(gameId, "PreAdded") });
+
+        var command = new BatchProvisionCommand(new List<BatchInvitationItemDto> { item }, invitedBy);
+
+        ProvisionAndInviteUserCommand? capturedCommand = null;
+        _senderMock
+            .Setup(s => s.Send(It.IsAny<ProvisionAndInviteUserCommand>(), It.IsAny<CancellationToken>()))
+            .Callback<IRequest<InvitationDto>, CancellationToken>((cmd, _) =>
+                capturedCommand = cmd as ProvisionAndInviteUserCommand)
+            .ReturnsAsync(CreateSuccessDto("test@example.com", invitedBy));
+
+        // Act
+        await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        capturedCommand.Should().NotBeNull();
+        capturedCommand!.Email.Should().Be("test@example.com");
+        capturedCommand.DisplayName.Should().Be("Test User");
+        capturedCommand.Role.Should().Be("Editor");
+        capturedCommand.Tier.Should().Be("Premium");
+        capturedCommand.CustomMessage.Should().Be("Welcome!");
+        capturedCommand.ExpiresInDays.Should().Be(14);
+        capturedCommand.GameSuggestions.Should().HaveCount(1);
+        capturedCommand.GameSuggestions[0].GameId.Should().Be(gameId);
+        capturedCommand.InvitedByUserId.Should().Be(invitedBy);
+    }
+
+    [Fact]
+    public async Task Handle_UnexpectedException_MapsToGenericError()
+    {
+        // Arrange
+        var invitedBy = Guid.NewGuid();
+        var items = new List<BatchInvitationItemDto>
+        {
+            CreateItem(email: "crash@example.com")
+        };
+        var command = new BatchProvisionCommand(items, invitedBy);
+
+        _senderMock
+            .Setup(s => s.Send(It.IsAny<ProvisionAndInviteUserCommand>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("Database connection lost"));
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.Succeeded.Should().BeEmpty();
+        result.Failed.Should().HaveCount(1);
+        result.Failed[0].Email.Should().Be("crash@example.com");
+        result.Failed[0].Error.Should().Be("Failed to provision invitation");
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/Authentication/Application/Commands/Invitation/BulkSendInvitationsCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/Authentication/Application/Commands/Invitation/BulkSendInvitationsCommandHandlerTests.cs
@@ -23,20 +23,24 @@ public class BulkSendInvitationsCommandHandlerTests
         _handler = new BulkSendInvitationsCommandHandler(_senderMock.Object, _loggerMock.Object);
     }
 
+    private void SetupProvisionSuccess(Guid invitedBy)
+    {
+        _senderMock
+            .Setup(s => s.Send(It.IsAny<ProvisionAndInviteUserCommand>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((ProvisionAndInviteUserCommand cmd, CancellationToken _) =>
+                new InvitationDto(
+                    Guid.NewGuid(), cmd.Email, cmd.Role, "Pending",
+                    DateTime.UtcNow.AddDays(cmd.ExpiresInDays), DateTime.UtcNow, null, invitedBy));
+    }
+
     [Fact]
-    public async Task Handle_ValidCsv_DispatchesSendForEachRow()
+    public async Task Handle_ValidCsv_DispatchesProvisionForEachRow()
     {
         // Arrange
         var csv = "email,role\nuser1@test.com,User\nuser2@test.com,Editor";
         var invitedBy = Guid.NewGuid();
         var command = new BulkSendInvitationsCommand(csv, invitedBy);
-
-        _senderMock
-            .Setup(s => s.Send(It.IsAny<SendInvitationCommand>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((SendInvitationCommand cmd, CancellationToken _) =>
-                new InvitationDto(
-                    Guid.NewGuid(), cmd.Email, cmd.Role, "Pending",
-                    DateTime.UtcNow.AddDays(7), DateTime.UtcNow, null, invitedBy));
+        SetupProvisionSuccess(invitedBy);
 
         // Act
         var result = await _handler.Handle(command, CancellationToken.None);
@@ -44,7 +48,9 @@ public class BulkSendInvitationsCommandHandlerTests
         // Assert
         result.Successful.Should().HaveCount(2);
         result.Failed.Should().BeEmpty();
-        _senderMock.Verify(s => s.Send(It.IsAny<SendInvitationCommand>(), It.IsAny<CancellationToken>()), Times.Exactly(2));
+        _senderMock.Verify(
+            s => s.Send(It.IsAny<ProvisionAndInviteUserCommand>(), It.IsAny<CancellationToken>()),
+            Times.Exactly(2));
     }
 
     [Fact]
@@ -69,13 +75,7 @@ public class BulkSendInvitationsCommandHandlerTests
         var csv = "email,role\ninvalid-email,User\nvalid@test.com,User";
         var invitedBy = Guid.NewGuid();
         var command = new BulkSendInvitationsCommand(csv, invitedBy);
-
-        _senderMock
-            .Setup(s => s.Send(It.IsAny<SendInvitationCommand>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((SendInvitationCommand cmd, CancellationToken _) =>
-                new InvitationDto(
-                    Guid.NewGuid(), cmd.Email, cmd.Role, "Pending",
-                    DateTime.UtcNow.AddDays(7), DateTime.UtcNow, null, invitedBy));
+        SetupProvisionSuccess(invitedBy);
 
         // Act
         var result = await _handler.Handle(command, CancellationToken.None);
@@ -107,13 +107,7 @@ public class BulkSendInvitationsCommandHandlerTests
         var csv = "email,role\nuser@test.com,Admin";
         var invitedBy = Guid.NewGuid();
         var command = new BulkSendInvitationsCommand(csv, invitedBy);
-
-        _senderMock
-            .Setup(s => s.Send(It.IsAny<SendInvitationCommand>(), It.IsAny<CancellationToken>()))
-            .ReturnsAsync((SendInvitationCommand cmd, CancellationToken _) =>
-                new InvitationDto(
-                    Guid.NewGuid(), cmd.Email, cmd.Role, "Pending",
-                    DateTime.UtcNow.AddDays(7), DateTime.UtcNow, null, invitedBy));
+        SetupProvisionSuccess(invitedBy);
 
         // Act
         var result = await _handler.Handle(command, CancellationToken.None);
@@ -121,7 +115,66 @@ public class BulkSendInvitationsCommandHandlerTests
         // Assert — only 1 data row, header skipped
         result.Successful.Should().HaveCount(1);
         _senderMock.Verify(s => s.Send(
-            It.Is<SendInvitationCommand>(c => c.Email == "user@test.com"),
+            It.Is<ProvisionAndInviteUserCommand>(c => c.Email == "user@test.com"),
             It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_CsvWithOptionalColumns_ParsesDisplayNameTierExpiry()
+    {
+        // Arrange
+        var csv = "email,role,displayName,tier,expiresInDays\nalice@test.com,Editor,Alice,Premium,14";
+        var invitedBy = Guid.NewGuid();
+        var command = new BulkSendInvitationsCommand(csv, invitedBy);
+        SetupProvisionSuccess(invitedBy);
+
+        ProvisionAndInviteUserCommand? captured = null;
+        _senderMock
+            .Setup(s => s.Send(It.IsAny<ProvisionAndInviteUserCommand>(), It.IsAny<CancellationToken>()))
+            .Callback<IRequest<InvitationDto>, CancellationToken>((cmd, _) =>
+                captured = cmd as ProvisionAndInviteUserCommand)
+            .ReturnsAsync(new InvitationDto(
+                Guid.NewGuid(), "alice@test.com", "Editor", "Pending",
+                DateTime.UtcNow.AddDays(14), DateTime.UtcNow, null, invitedBy));
+
+        // Act
+        await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        captured.Should().NotBeNull();
+        captured!.Email.Should().Be("alice@test.com");
+        captured.DisplayName.Should().Be("Alice");
+        captured.Role.Should().Be("Editor");
+        captured.Tier.Should().Be("Premium");
+        captured.ExpiresInDays.Should().Be(14);
+    }
+
+    [Fact]
+    public async Task Handle_CsvMinimalColumns_UsesDefaults()
+    {
+        // Arrange — only email and role columns
+        var csv = "email,role\nbob@test.com,User";
+        var invitedBy = Guid.NewGuid();
+        var command = new BulkSendInvitationsCommand(csv, invitedBy);
+
+        ProvisionAndInviteUserCommand? captured = null;
+        _senderMock
+            .Setup(s => s.Send(It.IsAny<ProvisionAndInviteUserCommand>(), It.IsAny<CancellationToken>()))
+            .Callback<IRequest<InvitationDto>, CancellationToken>((cmd, _) =>
+                captured = cmd as ProvisionAndInviteUserCommand)
+            .ReturnsAsync(new InvitationDto(
+                Guid.NewGuid(), "bob@test.com", "User", "Pending",
+                DateTime.UtcNow.AddDays(7), DateTime.UtcNow, null, invitedBy));
+
+        // Act
+        await _handler.Handle(command, CancellationToken.None);
+
+        // Assert — defaults applied
+        captured.Should().NotBeNull();
+        captured!.DisplayName.Should().Be("bob@test.com"); // falls back to email
+        captured.Tier.Should().Be("Free");
+        captured.ExpiresInDays.Should().Be(7);
+        captured.CustomMessage.Should().BeNull();
+        captured.GameSuggestions.Should().BeEmpty();
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/Authentication/Application/Commands/Invitation/ProvisionAndInviteUserCommandHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/Authentication/Application/Commands/Invitation/ProvisionAndInviteUserCommandHandlerTests.cs
@@ -1,0 +1,321 @@
+using Api.BoundedContexts.Authentication.Application.Commands.Invitation;
+using Api.BoundedContexts.Authentication.Application.DTOs;
+using Api.BoundedContexts.Authentication.Domain.Entities;
+using Api.BoundedContexts.Authentication.Domain.Repositories;
+using Api.BoundedContexts.Authentication.Domain.ValueObjects;
+using Api.BoundedContexts.Authentication.Infrastructure.Persistence;
+using Api.Middleware.Exceptions;
+using Api.Services;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Time.Testing;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.Authentication.Application.Commands.Invitation;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "Authentication")]
+public class ProvisionAndInviteUserCommandHandlerTests
+{
+    private readonly Mock<IUserRepository> _userRepoMock = new();
+    private readonly Mock<IInvitationTokenRepository> _invitationRepoMock = new();
+    private readonly Mock<IUnitOfWork> _unitOfWorkMock = new();
+    private readonly Mock<IEmailService> _emailServiceMock = new();
+    private readonly FakeTimeProvider _timeProvider;
+    private readonly Mock<ILogger<ProvisionAndInviteUserCommandHandler>> _loggerMock = new();
+    private readonly ProvisionAndInviteUserCommandHandler _handler;
+
+    public ProvisionAndInviteUserCommandHandlerTests()
+    {
+        _timeProvider = new FakeTimeProvider(new DateTimeOffset(2026, 3, 17, 12, 0, 0, TimeSpan.Zero));
+
+        _handler = new ProvisionAndInviteUserCommandHandler(
+            _userRepoMock.Object,
+            _invitationRepoMock.Object,
+            _unitOfWorkMock.Object,
+            _emailServiceMock.Object,
+            _timeProvider,
+            _loggerMock.Object);
+    }
+
+    private static ProvisionAndInviteUserCommand CreateValidCommand(
+        string email = "newuser@example.com",
+        string displayName = "New User",
+        string role = "User",
+        string tier = "Free",
+        string? customMessage = null,
+        int expiresInDays = 7,
+        List<GameSuggestionDto>? gameSuggestions = null,
+        Guid? invitedByUserId = null)
+    {
+        return new ProvisionAndInviteUserCommand(
+            Email: email,
+            DisplayName: displayName,
+            Role: role,
+            Tier: tier,
+            CustomMessage: customMessage,
+            ExpiresInDays: expiresInDays,
+            GameSuggestions: gameSuggestions ?? new List<GameSuggestionDto>(),
+            InvitedByUserId: invitedByUserId ?? Guid.NewGuid());
+    }
+
+    private void SetupNoConflicts()
+    {
+        _userRepoMock
+            .Setup(r => r.ExistsByEmailAsync(It.IsAny<Email>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        _invitationRepoMock
+            .Setup(r => r.GetPendingByEmailAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((InvitationToken?)null);
+    }
+
+    [Fact]
+    public async Task Handle_WithValidData_CreatesPendingUserAndTokenAndReturnsDto()
+    {
+        // Arrange
+        SetupNoConflicts();
+        var command = CreateValidCommand(
+            email: "alice@example.com",
+            displayName: "Alice",
+            role: "Editor",
+            tier: "Premium",
+            customMessage: "Welcome aboard!",
+            expiresInDays: 14);
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Email.Should().Be("alice@example.com");
+        result.Role.Should().Be("editor"); // Role.Parse normalizes to lowercase
+        result.Status.Should().Be("Pending");
+        result.EmailSent.Should().BeTrue();
+        result.ExpiresAt.Should().BeCloseTo(
+            _timeProvider.GetUtcNow().UtcDateTime.AddDays(14),
+            TimeSpan.FromSeconds(1));
+
+        _userRepoMock.Verify(r => r.AddAsync(It.IsAny<User>(), It.IsAny<CancellationToken>()), Times.Once);
+        _invitationRepoMock.Verify(r => r.AddAsync(It.IsAny<InvitationToken>(), It.IsAny<CancellationToken>()), Times.Once);
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+        _emailServiceMock.Verify(e => e.SendInvitationEmailAsync(
+            "alice@example.com",
+            It.IsAny<string>(),
+            It.IsAny<string>(),
+            It.IsAny<string>(),
+            It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_WithExistingUser_ThrowsConflictException()
+    {
+        // Arrange
+        var command = CreateValidCommand(email: "existing@example.com");
+
+        _userRepoMock
+            .Setup(r => r.ExistsByEmailAsync(It.IsAny<Email>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        // Act & Assert
+        var ex = await Assert.ThrowsAsync<ConflictException>(
+            () => _handler.Handle(command, CancellationToken.None));
+
+        ex.Message.Should().Contain("existing@example.com");
+
+        // Should NOT create any entities
+        _userRepoMock.Verify(r => r.AddAsync(It.IsAny<User>(), It.IsAny<CancellationToken>()), Times.Never);
+        _invitationRepoMock.Verify(r => r.AddAsync(It.IsAny<InvitationToken>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_WithPendingInvitation_ThrowsConflictException()
+    {
+        // Arrange
+        var command = CreateValidCommand(email: "pending@example.com");
+
+        _userRepoMock
+            .Setup(r => r.ExistsByEmailAsync(It.IsAny<Email>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+
+        var existingInvitation = InvitationToken.Create("pending@example.com", "User", "somehash", Guid.NewGuid());
+        _invitationRepoMock
+            .Setup(r => r.GetPendingByEmailAsync("pending@example.com", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(existingInvitation);
+
+        // Act & Assert
+        var ex = await Assert.ThrowsAsync<ConflictException>(
+            () => _handler.Handle(command, CancellationToken.None));
+
+        ex.Message.Should().Contain("pending@example.com");
+
+        // Should NOT create any entities
+        _userRepoMock.Verify(r => r.AddAsync(It.IsAny<User>(), It.IsAny<CancellationToken>()), Times.Never);
+        _invitationRepoMock.Verify(r => r.AddAsync(It.IsAny<InvitationToken>(), It.IsAny<CancellationToken>()), Times.Never);
+    }
+
+    [Fact]
+    public async Task Handle_WhenEmailFails_ReturnsEmailSentFalseAndStillCreatesEntities()
+    {
+        // Arrange
+        SetupNoConflicts();
+        var command = CreateValidCommand();
+
+        _emailServiceMock
+            .Setup(e => e.SendInvitationEmailAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("SMTP connection failed"));
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.EmailSent.Should().BeFalse();
+
+        // Entities should still be created and saved
+        _userRepoMock.Verify(r => r.AddAsync(It.IsAny<User>(), It.IsAny<CancellationToken>()), Times.Once);
+        _invitationRepoMock.Verify(r => r.AddAsync(It.IsAny<InvitationToken>(), It.IsAny<CancellationToken>()), Times.Once);
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_WithGameSuggestions_AttachesSuggestionsToToken()
+    {
+        // Arrange
+        SetupNoConflicts();
+        var gameId1 = Guid.NewGuid();
+        var gameId2 = Guid.NewGuid();
+        var suggestions = new List<GameSuggestionDto>
+        {
+            new(gameId1, "PreAdded"),
+            new(gameId2, "Suggested")
+        };
+        var command = CreateValidCommand(gameSuggestions: suggestions);
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.GameSuggestions.Should().NotBeNull();
+        result.GameSuggestions.Should().HaveCount(2);
+        result.GameSuggestions!.Should().Contain(gs => gs.GameId == gameId1 && gs.Type == "PreAdded");
+        result.GameSuggestions!.Should().Contain(gs => gs.GameId == gameId2 && gs.Type == "Suggested");
+    }
+
+    [Fact]
+    public async Task Handle_WithNoGameSuggestions_ReturnsEmptyList()
+    {
+        // Arrange
+        SetupNoConflicts();
+        var command = CreateValidCommand(gameSuggestions: new List<GameSuggestionDto>());
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.GameSuggestions.Should().NotBeNull();
+        result.GameSuggestions.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task Handle_NormalizesEmailToLowercase()
+    {
+        // Arrange
+        SetupNoConflicts();
+        var command = CreateValidCommand(email: "TEST@EXAMPLE.COM");
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.Email.Should().Be("test@example.com");
+    }
+
+    [Fact]
+    public async Task Handle_SavesBeforeSendingEmail()
+    {
+        // Arrange
+        SetupNoConflicts();
+        var command = CreateValidCommand();
+
+        var callOrder = new List<string>();
+
+        _unitOfWorkMock
+            .Setup(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .Callback(() => callOrder.Add("SaveChanges"))
+            .ReturnsAsync(1);
+
+        _emailServiceMock
+            .Setup(e => e.SendInvitationEmailAsync(
+                It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+                It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .Callback(() => callOrder.Add("SendEmail"))
+            .Returns(Task.CompletedTask);
+
+        // Act
+        await _handler.Handle(command, CancellationToken.None);
+
+        // Assert — SaveChanges must happen before SendEmail
+        callOrder.Should().ContainInOrder("SaveChanges", "SendEmail");
+    }
+
+    [Fact]
+    public async Task Handle_WithCustomMessage_PassesItThrough()
+    {
+        // Arrange
+        SetupNoConflicts();
+        var command = CreateValidCommand(customMessage: "Welcome to MeepleAI!");
+
+        InvitationToken? capturedToken = null;
+        _invitationRepoMock
+            .Setup(r => r.AddAsync(It.IsAny<InvitationToken>(), It.IsAny<CancellationToken>()))
+            .Callback<InvitationToken, CancellationToken>((token, _) => capturedToken = token)
+            .Returns(Task.CompletedTask);
+
+        // Act
+        await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        capturedToken.Should().NotBeNull();
+        capturedToken!.CustomMessage.Should().Be("Welcome to MeepleAI!");
+    }
+
+    [Fact]
+    public async Task Handle_CreatesPendingUserWithCorrectProperties()
+    {
+        // Arrange
+        SetupNoConflicts();
+        var adminId = Guid.NewGuid();
+        var command = CreateValidCommand(
+            email: "bob@example.com",
+            displayName: "Bob Smith",
+            role: "Admin",
+            tier: "Pro",
+            expiresInDays: 10,
+            invitedByUserId: adminId);
+
+        User? capturedUser = null;
+        _userRepoMock
+            .Setup(r => r.AddAsync(It.IsAny<User>(), It.IsAny<CancellationToken>()))
+            .Callback<User, CancellationToken>((user, _) => capturedUser = user)
+            .Returns(Task.CompletedTask);
+
+        // Act
+        await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        capturedUser.Should().NotBeNull();
+        capturedUser!.Email.Value.Should().Be("bob@example.com");
+        capturedUser.DisplayName.Should().Be("Bob Smith");
+        capturedUser.Role.Value.Should().Be("admin");
+        capturedUser.Tier.Value.Should().Be("pro");
+        capturedUser.InvitedByUserId.Should().Be(adminId);
+        capturedUser.Status.Should().Be(Api.SharedKernel.Domain.Enums.UserAccountStatus.Pending);
+    }
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/Authentication/Application/Queries/Invitation/ValidateInvitationTokenQueryHandlerTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/Authentication/Application/Queries/Invitation/ValidateInvitationTokenQueryHandlerTests.cs
@@ -1,9 +1,12 @@
-using System.Reflection;
 using System.Security.Cryptography;
 using System.Text;
+using Api.BoundedContexts.Authentication.Application.DTOs;
 using Api.BoundedContexts.Authentication.Application.Queries.Invitation;
 using Api.BoundedContexts.Authentication.Domain.Entities;
+using Api.BoundedContexts.Authentication.Domain.Enums;
 using Api.BoundedContexts.Authentication.Domain.Repositories;
+using Api.BoundedContexts.Authentication.Infrastructure.Persistence;
+using Api.Tests.BoundedContexts.Authentication.TestHelpers;
 using Api.Tests.Constants;
 using FluentAssertions;
 using Moq;
@@ -16,21 +19,72 @@ namespace Api.Tests.BoundedContexts.Authentication.Application.Queries.Invitatio
 public class ValidateInvitationTokenQueryHandlerTests
 {
     private readonly Mock<IInvitationTokenRepository> _invitationRepoMock = new();
+    private readonly Mock<IUserRepository> _userRepoMock = new();
     private readonly ValidateInvitationTokenQueryHandler _handler;
 
     public ValidateInvitationTokenQueryHandlerTests()
     {
-        _handler = new ValidateInvitationTokenQueryHandler(_invitationRepoMock.Object);
+        _handler = new ValidateInvitationTokenQueryHandler(
+            _invitationRepoMock.Object,
+            _userRepoMock.Object);
     }
 
     [Fact]
-    public async Task Handle_ValidToken_ReturnsValidResponse()
+    public async Task Handle_ValidToken_ReturnsIsValidWithEmailAndDisplayName()
     {
         // Arrange
         var rawToken = "test-raw-token-123";
         var tokenHash = Convert.ToBase64String(SHA256.HashData(Encoding.UTF8.GetBytes(rawToken)));
+        var pendingUserId = Guid.NewGuid();
 
         var invitation = InvitationToken.Create("test@example.com", "User", tokenHash, Guid.NewGuid());
+        // Set PendingUserId via RestoreState to simulate a provisioned invitation
+        invitation.RestoreState(
+            email: "test@example.com",
+            role: "User",
+            tokenHash: tokenHash,
+            invitedByUserId: Guid.NewGuid(),
+            status: InvitationStatus.Pending,
+            expiresAt: DateTime.UtcNow.AddDays(7),
+            acceptedAt: null,
+            acceptedByUserId: null,
+            createdAt: DateTime.UtcNow,
+            pendingUserId: pendingUserId);
+
+        var pendingUser = new UserBuilder()
+            .WithId(pendingUserId)
+            .WithEmail("test@example.com")
+            .WithDisplayName("Test User")
+            .Build();
+
+        _invitationRepoMock
+            .Setup(r => r.GetByTokenHashAsync(tokenHash, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(invitation);
+        _userRepoMock
+            .Setup(r => r.GetByIdAsync(pendingUserId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(pendingUser);
+
+        var query = new ValidateInvitationTokenQuery(rawToken);
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.IsValid.Should().BeTrue();
+        result.Email.Should().Be("test@example.com");
+        result.DisplayName.Should().Be("Test User");
+        result.ErrorReason.Should().BeNull();
+    }
+
+    [Fact]
+    public async Task Handle_ValidTokenWithoutPendingUser_ReturnsIsValidWithNullDisplayName()
+    {
+        // Arrange
+        var rawToken = "test-raw-token-456";
+        var tokenHash = Convert.ToBase64String(SHA256.HashData(Encoding.UTF8.GetBytes(rawToken)));
+
+        // Old-style invitation without PendingUserId
+        var invitation = InvitationToken.Create("old@example.com", "User", tokenHash, Guid.NewGuid());
 
         _invitationRepoMock
             .Setup(r => r.GetByTokenHashAsync(tokenHash, It.IsAny<CancellationToken>()))
@@ -42,9 +96,10 @@ public class ValidateInvitationTokenQueryHandlerTests
         var result = await _handler.Handle(query, CancellationToken.None);
 
         // Assert
-        result.Valid.Should().BeTrue();
-        result.Role.Should().Be("User");
-        result.ExpiresAt.Should().NotBeNull();
+        result.IsValid.Should().BeTrue();
+        result.Email.Should().Be("old@example.com");
+        result.DisplayName.Should().BeNull();
+        result.ErrorReason.Should().BeNull();
     }
 
     [Fact]
@@ -61,19 +116,182 @@ public class ValidateInvitationTokenQueryHandlerTests
         var result = await _handler.Handle(query, CancellationToken.None);
 
         // Assert
-        result.Valid.Should().BeFalse();
-        result.Role.Should().BeNull();
-        result.ExpiresAt.Should().BeNull();
+        result.IsValid.Should().BeFalse();
+        result.Email.Should().BeNull();
+        result.DisplayName.Should().BeNull();
+        result.ErrorReason.Should().Be("invalid");
     }
 
     [Fact]
-    public void Handle_DoesNotReturnEmail()
+    public async Task Handle_ExpiredToken_ReturnsInvalid_NotExpired()
     {
-        // Verify that ValidateInvitationTokenResponse does NOT have an Email property
-        // This is a security requirement: the token validation endpoint should not expose
-        // the email address associated with the invitation.
-        var responseType = typeof(ValidateInvitationTokenResponse);
-        var emailProperty = responseType.GetProperty("Email", BindingFlags.Public | BindingFlags.Instance);
-        emailProperty.Should().BeNull("ValidateInvitationTokenResponse should NOT expose Email for security reasons");
+        // Arrange — security: expired tokens return "invalid", NOT "expired"
+        var rawToken = "expired-token-123";
+        var tokenHash = Convert.ToBase64String(SHA256.HashData(Encoding.UTF8.GetBytes(rawToken)));
+
+        var invitation = InvitationToken.Create("expired@example.com", "User", tokenHash, Guid.NewGuid());
+        // Restore with past expiry
+        invitation.RestoreState(
+            email: "expired@example.com",
+            role: "User",
+            tokenHash: tokenHash,
+            invitedByUserId: Guid.NewGuid(),
+            status: InvitationStatus.Pending,
+            expiresAt: DateTime.UtcNow.AddDays(-1),
+            acceptedAt: null,
+            acceptedByUserId: null,
+            createdAt: DateTime.UtcNow.AddDays(-8));
+
+        _invitationRepoMock
+            .Setup(r => r.GetByTokenHashAsync(tokenHash, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(invitation);
+
+        var query = new ValidateInvitationTokenQuery(rawToken);
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Email.Should().BeNull();
+        result.DisplayName.Should().BeNull();
+        result.ErrorReason.Should().Be("invalid", "expired tokens must return 'invalid' to prevent state enumeration");
+    }
+
+    [Fact]
+    public async Task Handle_RevokedToken_ReturnsInvalid_NotRevoked()
+    {
+        // Arrange — security: revoked tokens return "invalid", NOT "revoked"
+        var rawToken = "revoked-token-123";
+        var tokenHash = Convert.ToBase64String(SHA256.HashData(Encoding.UTF8.GetBytes(rawToken)));
+
+        var invitation = InvitationToken.Create("revoked@example.com", "User", tokenHash, Guid.NewGuid());
+        invitation.RestoreState(
+            email: "revoked@example.com",
+            role: "User",
+            tokenHash: tokenHash,
+            invitedByUserId: Guid.NewGuid(),
+            status: InvitationStatus.Revoked,
+            expiresAt: DateTime.UtcNow.AddDays(7),
+            acceptedAt: null,
+            acceptedByUserId: null,
+            createdAt: DateTime.UtcNow,
+            revokedAt: DateTime.UtcNow);
+
+        _invitationRepoMock
+            .Setup(r => r.GetByTokenHashAsync(tokenHash, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(invitation);
+
+        var query = new ValidateInvitationTokenQuery(rawToken);
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Email.Should().BeNull();
+        result.DisplayName.Should().BeNull();
+        result.ErrorReason.Should().Be("invalid", "revoked tokens must return 'invalid' to prevent state enumeration");
+    }
+
+    [Fact]
+    public async Task Handle_AcceptedToken_ReturnsAlreadyUsed()
+    {
+        // Arrange — "already_used" is acceptable disclosure to allow redirect to login
+        var rawToken = "accepted-token-123";
+        var tokenHash = Convert.ToBase64String(SHA256.HashData(Encoding.UTF8.GetBytes(rawToken)));
+
+        var invitation = InvitationToken.Create("accepted@example.com", "User", tokenHash, Guid.NewGuid());
+        invitation.RestoreState(
+            email: "accepted@example.com",
+            role: "User",
+            tokenHash: tokenHash,
+            invitedByUserId: Guid.NewGuid(),
+            status: InvitationStatus.Accepted,
+            expiresAt: DateTime.UtcNow.AddDays(7),
+            acceptedAt: DateTime.UtcNow.AddHours(-1),
+            acceptedByUserId: Guid.NewGuid(),
+            createdAt: DateTime.UtcNow.AddDays(-1));
+
+        _invitationRepoMock
+            .Setup(r => r.GetByTokenHashAsync(tokenHash, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(invitation);
+
+        var query = new ValidateInvitationTokenQuery(rawToken);
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Email.Should().BeNull();
+        result.DisplayName.Should().BeNull();
+        result.ErrorReason.Should().Be("already_used");
+    }
+
+    [Fact]
+    public async Task Handle_EmptyToken_ReturnsInvalid()
+    {
+        // Arrange
+        var query = new ValidateInvitationTokenQuery("   ");
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.ErrorReason.Should().Be("invalid");
+    }
+
+    [Fact]
+    public async Task Handle_InvalidToken_EmailAndDisplayNameAreNull()
+    {
+        // Arrange — when IsValid=false, personal data must NOT be leaked
+        _invitationRepoMock
+            .Setup(r => r.GetByTokenHashAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((InvitationToken?)null);
+
+        var query = new ValidateInvitationTokenQuery("some-token");
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.Email.Should().BeNull("personal data must not be leaked for invalid tokens");
+        result.DisplayName.Should().BeNull("personal data must not be leaked for invalid tokens");
+    }
+
+    [Fact]
+    public async Task Handle_StatusExpiredEnum_ReturnsInvalid()
+    {
+        // Arrange — invitation with Expired status enum (set by background service)
+        var rawToken = "status-expired-token";
+        var tokenHash = Convert.ToBase64String(SHA256.HashData(Encoding.UTF8.GetBytes(rawToken)));
+
+        var invitation = InvitationToken.Create("statusexp@example.com", "User", tokenHash, Guid.NewGuid());
+        invitation.RestoreState(
+            email: "statusexp@example.com",
+            role: "User",
+            tokenHash: tokenHash,
+            invitedByUserId: Guid.NewGuid(),
+            status: InvitationStatus.Expired,
+            expiresAt: DateTime.UtcNow.AddDays(7), // ExpiresAt in future but status is Expired
+            acceptedAt: null,
+            acceptedByUserId: null,
+            createdAt: DateTime.UtcNow.AddDays(-8));
+
+        _invitationRepoMock
+            .Setup(r => r.GetByTokenHashAsync(tokenHash, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(invitation);
+
+        var query = new ValidateInvitationTokenQuery(rawToken);
+
+        // Act
+        var result = await _handler.Handle(query, CancellationToken.None);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.ErrorReason.Should().Be("invalid");
     }
 }

--- a/apps/api/tests/Api.Tests/BoundedContexts/Authentication/Domain/Entities/InvitationTokenExtendedTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/Authentication/Domain/Entities/InvitationTokenExtendedTests.cs
@@ -1,0 +1,242 @@
+using Api.BoundedContexts.Authentication.Domain.Entities;
+using Api.BoundedContexts.Authentication.Domain.Enums;
+using Api.BoundedContexts.Authentication.Domain.ValueObjects;
+using Api.SharedKernel.Domain.ValueObjects;
+using Microsoft.Extensions.Time.Testing;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.Authentication.Domain.Entities;
+
+/// <summary>
+/// Tests for InvitationToken extended functionality: CustomMessage, PendingUserId,
+/// GameSuggestions collection, and TimeProvider-based factory method.
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "Authentication")]
+public sealed class InvitationTokenExtendedTests
+{
+    private readonly FakeTimeProvider _timeProvider = new(
+        new DateTimeOffset(2026, 3, 17, 12, 0, 0, TimeSpan.Zero));
+
+    private static readonly Email TestEmail = Email.Parse("invitee@example.com");
+    private static readonly Role TestRole = Role.User;
+    private static readonly Guid TestPendingUserId = Guid.NewGuid();
+    private const string TestTokenHash = "abc123hash";
+    private const string TestCustomMessage = "Welcome to MeepleAI! We have some games ready for you.";
+
+    #region Create with TimeProvider Tests
+
+    [Fact]
+    public void Create_WithTimeProvider_SetsCorrectExpiry()
+    {
+        // Act
+        var token = InvitationToken.Create(
+            TestEmail,
+            TestRole,
+            TestPendingUserId,
+            TestCustomMessage,
+            expiresInDays: 14,
+            _timeProvider,
+            TestTokenHash);
+
+        // Assert
+        var expectedExpiry = new DateTime(2026, 3, 31, 12, 0, 0, DateTimeKind.Utc);
+        Assert.Equal(expectedExpiry, token.ExpiresAt);
+        Assert.Equal(_timeProvider.GetUtcNow().UtcDateTime, token.CreatedAt);
+    }
+
+    [Fact]
+    public void Create_WithTimeProvider_SetsCustomMessage()
+    {
+        // Act
+        var token = InvitationToken.Create(
+            TestEmail,
+            TestRole,
+            TestPendingUserId,
+            TestCustomMessage,
+            expiresInDays: 7,
+            _timeProvider,
+            TestTokenHash);
+
+        // Assert
+        Assert.Equal(TestCustomMessage, token.CustomMessage);
+    }
+
+    [Fact]
+    public void Create_WithTimeProvider_SetsPendingUserId()
+    {
+        // Act
+        var token = InvitationToken.Create(
+            TestEmail,
+            TestRole,
+            TestPendingUserId,
+            TestCustomMessage,
+            expiresInDays: 7,
+            _timeProvider,
+            TestTokenHash);
+
+        // Assert
+        Assert.Equal(TestPendingUserId, token.PendingUserId);
+    }
+
+    [Fact]
+    public void Create_WithTimeProvider_SetsBasicProperties()
+    {
+        // Act
+        var token = InvitationToken.Create(
+            TestEmail,
+            TestRole,
+            TestPendingUserId,
+            TestCustomMessage,
+            expiresInDays: 7,
+            _timeProvider,
+            TestTokenHash);
+
+        // Assert
+        Assert.Equal(TestEmail.Value, token.Email);
+        Assert.Equal(TestRole.Value, token.Role);
+        Assert.Equal(TestTokenHash, token.TokenHash);
+        Assert.Equal(InvitationStatus.Pending, token.Status);
+        Assert.NotEqual(Guid.Empty, token.Id);
+    }
+
+    [Fact]
+    public void Create_WithTimeProvider_NullCustomMessage_Allowed()
+    {
+        // Act
+        var token = InvitationToken.Create(
+            TestEmail,
+            TestRole,
+            TestPendingUserId,
+            customMessage: null,
+            expiresInDays: 7,
+            _timeProvider,
+            TestTokenHash);
+
+        // Assert
+        Assert.Null(token.CustomMessage);
+    }
+
+    [Fact]
+    public void Create_WithTimeProvider_EmptyTokenHash_Throws()
+    {
+        // Act & Assert
+        Assert.Throws<ArgumentException>(() =>
+            InvitationToken.Create(
+                TestEmail,
+                TestRole,
+                TestPendingUserId,
+                TestCustomMessage,
+                expiresInDays: 7,
+                _timeProvider,
+                tokenHash: ""));
+    }
+
+    [Fact]
+    public void Create_WithTimeProvider_EmptyPendingUserId_Throws()
+    {
+        // Act & Assert
+        Assert.Throws<ArgumentException>(() =>
+            InvitationToken.Create(
+                TestEmail,
+                TestRole,
+                pendingUserId: Guid.Empty,
+                TestCustomMessage,
+                expiresInDays: 7,
+                _timeProvider,
+                TestTokenHash));
+    }
+
+    #endregion
+
+    #region GameSuggestions Tests
+
+    [Fact]
+    public void AddGameSuggestion_AttachesSuggestion()
+    {
+        // Arrange
+        var token = InvitationToken.Create(
+            TestEmail,
+            TestRole,
+            TestPendingUserId,
+            TestCustomMessage,
+            expiresInDays: 7,
+            _timeProvider,
+            TestTokenHash);
+
+        var gameId = Guid.NewGuid();
+
+        // Act
+        token.AddGameSuggestion(gameId, GameSuggestionType.PreAdded);
+
+        // Assert
+        Assert.Single(token.GameSuggestions);
+        Assert.Equal(gameId, token.GameSuggestions[0].GameId);
+        Assert.Equal(GameSuggestionType.PreAdded, token.GameSuggestions[0].Type);
+        Assert.Equal(token.Id, token.GameSuggestions[0].InvitationTokenId);
+    }
+
+    [Fact]
+    public void AddGameSuggestion_MultipleTypes_AttachesAll()
+    {
+        // Arrange
+        var token = InvitationToken.Create(
+            TestEmail,
+            TestRole,
+            TestPendingUserId,
+            TestCustomMessage,
+            expiresInDays: 7,
+            _timeProvider,
+            TestTokenHash);
+
+        var preAddedGameId = Guid.NewGuid();
+        var suggestedGameId = Guid.NewGuid();
+
+        // Act
+        token.AddGameSuggestion(preAddedGameId, GameSuggestionType.PreAdded);
+        token.AddGameSuggestion(suggestedGameId, GameSuggestionType.Suggested);
+
+        // Assert
+        Assert.Equal(2, token.GameSuggestions.Count);
+        Assert.Contains(token.GameSuggestions, s => s.GameId == preAddedGameId && s.Type == GameSuggestionType.PreAdded);
+        Assert.Contains(token.GameSuggestions, s => s.GameId == suggestedGameId && s.Type == GameSuggestionType.Suggested);
+    }
+
+    [Fact]
+    public void GameSuggestions_InitiallyEmpty()
+    {
+        // Arrange & Act
+        var token = InvitationToken.Create(
+            TestEmail,
+            TestRole,
+            TestPendingUserId,
+            TestCustomMessage,
+            expiresInDays: 7,
+            _timeProvider,
+            TestTokenHash);
+
+        // Assert
+        Assert.Empty(token.GameSuggestions);
+    }
+
+    #endregion
+
+    #region Backward Compatibility Tests
+
+    [Fact]
+    public void Create_OriginalOverload_StillWorks()
+    {
+        // The original Create(string, string, string, Guid) must still function
+        var adminId = Guid.NewGuid();
+        var token = InvitationToken.Create("test@example.com", "User", "hash123", adminId);
+
+        Assert.Equal("test@example.com", token.Email);
+        Assert.Equal("User", token.Role);
+        Assert.Equal(InvitationStatus.Pending, token.Status);
+        Assert.Null(token.CustomMessage);
+        Assert.Null(token.PendingUserId);
+        Assert.Empty(token.GameSuggestions);
+    }
+
+    #endregion
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/Authentication/Domain/Entities/UserPendingStateTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/Authentication/Domain/Entities/UserPendingStateTests.cs
@@ -1,0 +1,194 @@
+using Api.BoundedContexts.Authentication.Domain.Entities;
+using Api.BoundedContexts.Authentication.Domain.Events;
+using Api.BoundedContexts.Authentication.Domain.ValueObjects;
+using Api.SharedKernel.Domain.Enums;
+using Api.SharedKernel.Domain.ValueObjects;
+using Microsoft.Extensions.Time.Testing;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.Authentication.Domain.Entities;
+
+/// <summary>
+/// Tests for the User entity's Pending state support (admin invitation flow).
+/// Covers CreatePending factory method and ActivateFromInvitation transition.
+/// </summary>
+[Trait("Category", "Unit")]
+[Trait("BoundedContext", "Authentication")]
+public sealed class UserPendingStateTests
+{
+    private static readonly Email TestEmail = Email.Parse("invited@example.com");
+    private const string TestDisplayName = "Invited User";
+    private static readonly Role TestRole = Role.User;
+    private static readonly UserTier TestTier = UserTier.Free;
+    private static readonly Guid TestAdminId = Guid.NewGuid();
+
+    #region CreatePending Tests
+
+    [Fact]
+    public void CreatePending_SetsCorrectState()
+    {
+        // Arrange
+        var timeProvider = new FakeTimeProvider();
+        var now = timeProvider.GetUtcNow().UtcDateTime;
+        var expiresAt = now.AddDays(7);
+
+        // Act
+        var user = User.CreatePending(
+            TestEmail,
+            TestDisplayName,
+            TestRole,
+            TestTier,
+            TestAdminId,
+            expiresAt,
+            timeProvider);
+
+        // Assert
+        Assert.Equal(UserAccountStatus.Pending, user.Status);
+        Assert.Equal(TestEmail, user.Email);
+        Assert.Equal(TestDisplayName, user.DisplayName);
+        Assert.Null(user.PasswordHash);
+        Assert.Equal(TestAdminId, user.InvitedByUserId);
+        Assert.Equal(expiresAt, user.InvitationExpiresAt);
+        Assert.False(user.EmailVerified);
+        Assert.Equal(TestRole, user.Role);
+        Assert.Equal(TestTier, user.Tier);
+        Assert.Equal(now, user.CreatedAt);
+        Assert.NotEqual(Guid.Empty, user.Id);
+    }
+
+    [Fact]
+    public void CreatePending_CannotAuthenticate()
+    {
+        // Arrange
+        var timeProvider = new FakeTimeProvider();
+        var now = timeProvider.GetUtcNow().UtcDateTime;
+
+        // Act
+        var user = User.CreatePending(
+            TestEmail,
+            TestDisplayName,
+            TestRole,
+            TestTier,
+            TestAdminId,
+            now.AddDays(7),
+            timeProvider);
+
+        // Assert
+        Assert.False(user.CanAuthenticate());
+    }
+
+    [Fact]
+    public void CreatePending_EmitsUserProvisionedEvent()
+    {
+        // Arrange
+        var timeProvider = new FakeTimeProvider();
+        var now = timeProvider.GetUtcNow().UtcDateTime;
+
+        // Act
+        var user = User.CreatePending(
+            TestEmail,
+            TestDisplayName,
+            TestRole,
+            TestTier,
+            TestAdminId,
+            now.AddDays(7),
+            timeProvider);
+
+        // Assert
+        Assert.Single(user.DomainEvents);
+        var domainEvent = Assert.IsType<UserProvisionedEvent>(user.DomainEvents.First());
+        Assert.Equal(user.Id, domainEvent.UserId);
+        Assert.Equal(TestEmail.Value, domainEvent.Email);
+        Assert.Equal(TestDisplayName, domainEvent.DisplayName);
+        Assert.Equal(TestRole.Value, domainEvent.Role);
+        Assert.Equal(TestTier.Value, domainEvent.Tier);
+        Assert.Equal(TestAdminId, domainEvent.InvitedByUserId);
+    }
+
+    #endregion
+
+    #region ActivateFromInvitation Tests
+
+    [Fact]
+    public void ActivateFromInvitation_TransitionsPendingToActive()
+    {
+        // Arrange
+        var timeProvider = new FakeTimeProvider();
+        var now = timeProvider.GetUtcNow().UtcDateTime;
+        var user = User.CreatePending(
+            TestEmail,
+            TestDisplayName,
+            TestRole,
+            TestTier,
+            TestAdminId,
+            now.AddDays(7),
+            timeProvider);
+        user.ClearDomainEvents();
+
+        var passwordHash = PasswordHash.Create("SecurePassword123!");
+
+        // Act
+        user.ActivateFromInvitation(passwordHash, timeProvider);
+
+        // Assert
+        Assert.Equal(UserAccountStatus.Active, user.Status);
+        Assert.Equal(passwordHash, user.PasswordHash);
+        Assert.True(user.EmailVerified);
+        Assert.Equal(now, user.EmailVerifiedAt);
+        Assert.True(user.CanAuthenticate());
+    }
+
+    [Fact]
+    public void ActivateFromInvitation_ThrowsIfNotPending()
+    {
+        // Arrange — create an Active user (not pending)
+        var activeUser = new User(
+            Guid.NewGuid(),
+            Email.Parse("active@example.com"),
+            "Active User",
+            PasswordHash.Create("SecurePassword123!"),
+            Role.User,
+            UserTier.Free);
+
+        var passwordHash = PasswordHash.Create("NewPassword123!");
+        var timeProvider = new FakeTimeProvider();
+
+        // Act & Assert
+        var exception = Assert.Throws<InvalidOperationException>(
+            () => activeUser.ActivateFromInvitation(passwordHash, timeProvider));
+        Assert.Contains("Pending", exception.Message, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public void ActivateFromInvitation_EmitsUserActivatedEvent()
+    {
+        // Arrange
+        var timeProvider = new FakeTimeProvider();
+        var now = timeProvider.GetUtcNow().UtcDateTime;
+        var user = User.CreatePending(
+            TestEmail,
+            TestDisplayName,
+            TestRole,
+            TestTier,
+            TestAdminId,
+            now.AddDays(7),
+            timeProvider);
+        user.ClearDomainEvents(); // Clear the provisioned event
+
+        var passwordHash = PasswordHash.Create("SecurePassword123!");
+
+        // Act
+        user.ActivateFromInvitation(passwordHash, timeProvider);
+
+        // Assert
+        Assert.Single(user.DomainEvents);
+        var domainEvent = Assert.IsType<UserActivatedFromInvitationEvent>(user.DomainEvents.First());
+        Assert.Equal(user.Id, domainEvent.UserId);
+        Assert.Equal(TestEmail.Value, domainEvent.Email);
+        Assert.Equal(TestRole.Value, domainEvent.Role);
+        Assert.Equal(TestTier.Value, domainEvent.Tier);
+        Assert.Equal(TestAdminId, domainEvent.InvitedByUserId);
+    }
+
+    #endregion
+}

--- a/apps/api/tests/Api.Tests/BoundedContexts/UserLibrary/Domain/Entities/GameSuggestionTests.cs
+++ b/apps/api/tests/Api.Tests/BoundedContexts/UserLibrary/Domain/Entities/GameSuggestionTests.cs
@@ -1,0 +1,132 @@
+using Api.BoundedContexts.UserLibrary.Domain.Entities;
+using Api.BoundedContexts.UserLibrary.Domain.Events;
+using Microsoft.Extensions.Time.Testing;
+using Xunit;
+
+namespace Api.Tests.BoundedContexts.UserLibrary.Domain.Entities;
+
+/// <summary>
+/// Unit tests for GameSuggestion aggregate (Admin Invitation Flow - Task 4).
+/// </summary>
+public sealed class GameSuggestionTests
+{
+    private readonly FakeTimeProvider _timeProvider =
+        new(new DateTimeOffset(2026, 3, 17, 12, 0, 0, TimeSpan.Zero));
+
+    [Fact]
+    public void Create_ValidParameters_SetsAllProperties()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var gameId = Guid.NewGuid();
+        var adminId = Guid.NewGuid();
+        var source = "invitation";
+
+        // Act
+        var suggestion = GameSuggestion.Create(userId, gameId, adminId, source, _timeProvider);
+
+        // Assert
+        Assert.NotEqual(Guid.Empty, suggestion.Id);
+        Assert.Equal(userId, suggestion.UserId);
+        Assert.Equal(gameId, suggestion.GameId);
+        Assert.Equal(adminId, suggestion.SuggestedByUserId);
+        Assert.Equal(source, suggestion.Source);
+        Assert.Equal(_timeProvider.GetUtcNow().UtcDateTime, suggestion.CreatedAt);
+        Assert.False(suggestion.IsDismissed);
+        Assert.False(suggestion.IsAccepted);
+    }
+
+    [Fact]
+    public void Create_NullSource_Allowed()
+    {
+        // Act
+        var suggestion = GameSuggestion.Create(
+            Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), null, _timeProvider);
+
+        // Assert
+        Assert.Null(suggestion.Source);
+    }
+
+    [Fact]
+    public void Create_EmptyUserId_ThrowsArgumentException()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            GameSuggestion.Create(Guid.Empty, Guid.NewGuid(), Guid.NewGuid(), "invitation", _timeProvider));
+    }
+
+    [Fact]
+    public void Create_EmptyGameId_ThrowsArgumentException()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            GameSuggestion.Create(Guid.NewGuid(), Guid.Empty, Guid.NewGuid(), "invitation", _timeProvider));
+    }
+
+    [Fact]
+    public void Create_EmptySuggestedByUserId_ThrowsArgumentException()
+    {
+        Assert.Throws<ArgumentException>(() =>
+            GameSuggestion.Create(Guid.NewGuid(), Guid.NewGuid(), Guid.Empty, "invitation", _timeProvider));
+    }
+
+    [Fact]
+    public void Accept_SetsIsAcceptedTrue()
+    {
+        // Arrange
+        var suggestion = GameSuggestion.Create(
+            Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), "invitation", _timeProvider);
+
+        // Act
+        suggestion.Accept();
+
+        // Assert
+        Assert.True(suggestion.IsAccepted);
+    }
+
+    [Fact]
+    public void Accept_EmitsGameSuggestionAcceptedEvent()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var gameId = Guid.NewGuid();
+        var suggestion = GameSuggestion.Create(
+            userId, gameId, Guid.NewGuid(), "invitation", _timeProvider);
+
+        // Act
+        suggestion.Accept();
+
+        // Assert
+        var domainEvent = Assert.Single(suggestion.DomainEvents);
+        var acceptedEvent = Assert.IsType<GameSuggestionAcceptedEvent>(domainEvent);
+        Assert.Equal(suggestion.Id, acceptedEvent.SuggestionId);
+        Assert.Equal(userId, acceptedEvent.UserId);
+        Assert.Equal(gameId, acceptedEvent.GameId);
+    }
+
+    [Fact]
+    public void Dismiss_SetsIsDismissedTrue()
+    {
+        // Arrange
+        var suggestion = GameSuggestion.Create(
+            Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), "invitation", _timeProvider);
+
+        // Act
+        suggestion.Dismiss();
+
+        // Assert
+        Assert.True(suggestion.IsDismissed);
+    }
+
+    [Fact]
+    public void Dismiss_DoesNotEmitDomainEvent()
+    {
+        // Arrange
+        var suggestion = GameSuggestion.Create(
+            Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), "invitation", _timeProvider);
+
+        // Act
+        suggestion.Dismiss();
+
+        // Assert
+        Assert.Empty(suggestion.DomainEvents);
+    }
+}

--- a/apps/api/tests/Api.Tests/Infrastructure/BackgroundServices/GameSuggestionProcessorServiceTests.cs
+++ b/apps/api/tests/Api.Tests/Infrastructure/BackgroundServices/GameSuggestionProcessorServiceTests.cs
@@ -1,0 +1,341 @@
+using System.Threading.Channels;
+using Api.BoundedContexts.Authentication.Domain.Enums;
+using Api.BoundedContexts.Authentication.Domain.Entities;
+using Api.BoundedContexts.Authentication.Infrastructure.Services;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Aggregates;
+using Api.BoundedContexts.SharedGameCatalog.Domain.Repositories;
+using Api.BoundedContexts.UserLibrary.Application.EventHandlers;
+using Api.BoundedContexts.UserLibrary.Domain.Entities;
+using Api.BoundedContexts.UserLibrary.Domain.Repositories;
+using Api.Infrastructure.BackgroundServices;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.Infrastructure.BackgroundServices;
+
+/// <summary>
+/// Unit tests for <see cref="GameSuggestionProcessorService"/>.
+/// Admin Invitation Flow: verifies that game suggestions from the channel
+/// are correctly processed as PreAdded (library + suggestion) or Suggested (suggestion only).
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "UserLibrary")]
+public sealed class GameSuggestionProcessorServiceTests
+{
+    private readonly GameSuggestionChannel _channel;
+    private readonly Mock<IServiceScopeFactory> _scopeFactoryMock;
+    private readonly Mock<IServiceScope> _scopeMock;
+    private readonly Mock<IServiceProvider> _serviceProviderMock;
+    private readonly Mock<IGameSuggestionRepository> _gameSuggestionRepoMock;
+    private readonly Mock<ISharedGameRepository> _sharedGameRepoMock;
+    private readonly Mock<IUserLibraryRepository> _libraryRepoMock;
+    private readonly Mock<IUnitOfWork> _unitOfWorkMock;
+    private readonly TestTimeProvider _timeProvider;
+    private readonly GameSuggestionProcessorService _sut;
+
+    private static readonly Guid UserId = Guid.NewGuid();
+    private static readonly Guid InvitedByUserId = Guid.NewGuid();
+    private static readonly Guid GameId1 = Guid.NewGuid();
+    private static readonly Guid GameId2 = Guid.NewGuid();
+
+    public GameSuggestionProcessorServiceTests()
+    {
+        _channel = new GameSuggestionChannel();
+        _scopeFactoryMock = new Mock<IServiceScopeFactory>();
+        _scopeMock = new Mock<IServiceScope>();
+        _serviceProviderMock = new Mock<IServiceProvider>();
+        _gameSuggestionRepoMock = new Mock<IGameSuggestionRepository>();
+        _sharedGameRepoMock = new Mock<ISharedGameRepository>();
+        _libraryRepoMock = new Mock<IUserLibraryRepository>();
+        _unitOfWorkMock = new Mock<IUnitOfWork>();
+        _timeProvider = new TestTimeProvider();
+
+        // Wire scope chain
+        _scopeMock.Setup(s => s.ServiceProvider).Returns(_serviceProviderMock.Object);
+        _scopeFactoryMock.Setup(f => f.CreateScope()).Returns(_scopeMock.Object);
+
+        // Register handlers via service provider
+        var preAddedHandler = new GamePreAddedHandler(
+            _sharedGameRepoMock.Object,
+            _libraryRepoMock.Object,
+            _gameSuggestionRepoMock.Object,
+            _timeProvider,
+            NullLogger<GamePreAddedHandler>.Instance);
+
+        var suggestedHandler = new GameSuggestedHandler(
+            _gameSuggestionRepoMock.Object,
+            _timeProvider,
+            NullLogger<GameSuggestedHandler>.Instance);
+
+        _serviceProviderMock
+            .Setup(sp => sp.GetService(typeof(GamePreAddedHandler)))
+            .Returns(preAddedHandler);
+        _serviceProviderMock
+            .Setup(sp => sp.GetService(typeof(GameSuggestedHandler)))
+            .Returns(suggestedHandler);
+        _serviceProviderMock
+            .Setup(sp => sp.GetService(typeof(IUnitOfWork)))
+            .Returns(_unitOfWorkMock.Object);
+
+        _unitOfWorkMock
+            .Setup(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        // Default: games exist in catalog, not in library, no existing suggestions
+        _sharedGameRepoMock
+            .Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(SharedGame.CreateSkeleton("Test Game", Guid.NewGuid(), _timeProvider));
+        _libraryRepoMock
+            .Setup(r => r.IsGameInLibraryAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+        _gameSuggestionRepoMock
+            .Setup(r => r.ExistsForUserAndGameAsync(It.IsAny<Guid>(), It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(false);
+        _libraryRepoMock
+            .Setup(r => r.AddAsync(It.IsAny<UserLibraryEntry>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+        _gameSuggestionRepoMock
+            .Setup(r => r.AddAsync(It.IsAny<GameSuggestion>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        _sut = new GameSuggestionProcessorService(
+            _channel,
+            _scopeFactoryMock.Object,
+            NullLogger<GameSuggestionProcessorService>.Instance);
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private static InvitationGameSuggestion CreateSuggestion(Guid gameId, GameSuggestionType type)
+    {
+        return InvitationGameSuggestion.Create(Guid.NewGuid(), gameId, type);
+    }
+
+    // ── PreAdded suggestion adds game to library ────────────────────────────
+
+    [Fact]
+    public async Task ProcessEvent_PreAddedSuggestion_AddsGameToLibraryAndCreatesSuggestion()
+    {
+        // Arrange
+        var evt = new GameSuggestionEvent(
+            UserId, InvitedByUserId,
+            new[] { CreateSuggestion(GameId1, GameSuggestionType.PreAdded) });
+
+        // Act
+        await _sut.ProcessEventAsync(evt, CancellationToken.None);
+
+        // Assert: game added to library
+        _libraryRepoMock.Verify(
+            r => r.AddAsync(It.Is<UserLibraryEntry>(e => e.UserId == UserId && e.GameId == GameId1),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        // Assert: suggestion record created and accepted
+        _gameSuggestionRepoMock.Verify(
+            r => r.AddAsync(It.Is<GameSuggestion>(s =>
+                s.UserId == UserId && s.GameId == GameId1 && s.IsAccepted),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        // Assert: changes saved
+        _unitOfWorkMock.Verify(
+            u => u.SaveChangesAsync(It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    // ── Suggested suggestion creates GameSuggestion only ────────────────────
+
+    [Fact]
+    public async Task ProcessEvent_SuggestedSuggestion_CreatesGameSuggestionWithoutLibraryEntry()
+    {
+        // Arrange
+        var evt = new GameSuggestionEvent(
+            UserId, InvitedByUserId,
+            new[] { CreateSuggestion(GameId1, GameSuggestionType.Suggested) });
+
+        // Act
+        await _sut.ProcessEventAsync(evt, CancellationToken.None);
+
+        // Assert: no library entry added
+        _libraryRepoMock.Verify(
+            r => r.AddAsync(It.IsAny<UserLibraryEntry>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+
+        // Assert: suggestion created (not accepted)
+        _gameSuggestionRepoMock.Verify(
+            r => r.AddAsync(It.Is<GameSuggestion>(s =>
+                s.UserId == UserId && s.GameId == GameId1 && !s.IsAccepted),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    // ── PreAdded is idempotent (game already in library) ────────────────────
+
+    [Fact]
+    public async Task ProcessEvent_PreAdded_GameAlreadyInLibrary_SkipsWithoutError()
+    {
+        // Arrange
+        _libraryRepoMock
+            .Setup(r => r.IsGameInLibraryAsync(UserId, GameId1, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var evt = new GameSuggestionEvent(
+            UserId, InvitedByUserId,
+            new[] { CreateSuggestion(GameId1, GameSuggestionType.PreAdded) });
+
+        // Act
+        await _sut.ProcessEventAsync(evt, CancellationToken.None);
+
+        // Assert: no library entry added
+        _libraryRepoMock.Verify(
+            r => r.AddAsync(It.IsAny<UserLibraryEntry>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    // ── Suggested is idempotent (suggestion already exists) ─────────────────
+
+    [Fact]
+    public async Task ProcessEvent_Suggested_SuggestionAlreadyExists_SkipsWithoutError()
+    {
+        // Arrange
+        _gameSuggestionRepoMock
+            .Setup(r => r.ExistsForUserAndGameAsync(UserId, GameId1, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(true);
+
+        var evt = new GameSuggestionEvent(
+            UserId, InvitedByUserId,
+            new[] { CreateSuggestion(GameId1, GameSuggestionType.Suggested) });
+
+        // Act
+        await _sut.ProcessEventAsync(evt, CancellationToken.None);
+
+        // Assert: no suggestion added
+        _gameSuggestionRepoMock.Verify(
+            r => r.AddAsync(It.IsAny<GameSuggestion>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    // ── PreAdded skips when game not in catalog ─────────────────────────────
+
+    [Fact]
+    public async Task ProcessEvent_PreAdded_GameNotInCatalog_SkipsWithoutError()
+    {
+        // Arrange
+        _sharedGameRepoMock
+            .Setup(r => r.GetByIdAsync(GameId1, It.IsAny<CancellationToken>()))
+            .ReturnsAsync((SharedGame?)null);
+
+        var evt = new GameSuggestionEvent(
+            UserId, InvitedByUserId,
+            new[] { CreateSuggestion(GameId1, GameSuggestionType.PreAdded) });
+
+        // Act
+        await _sut.ProcessEventAsync(evt, CancellationToken.None);
+
+        // Assert: neither library entry nor suggestion created
+        _libraryRepoMock.Verify(
+            r => r.AddAsync(It.IsAny<UserLibraryEntry>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _gameSuggestionRepoMock.Verify(
+            r => r.AddAsync(It.IsAny<GameSuggestion>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    // ── Mixed suggestions in single event ───────────────────────────────────
+
+    [Fact]
+    public async Task ProcessEvent_MixedSuggestions_ProcessesBothTypes()
+    {
+        // Arrange
+        var evt = new GameSuggestionEvent(
+            UserId, InvitedByUserId,
+            new[]
+            {
+                CreateSuggestion(GameId1, GameSuggestionType.PreAdded),
+                CreateSuggestion(GameId2, GameSuggestionType.Suggested)
+            });
+
+        // Act
+        await _sut.ProcessEventAsync(evt, CancellationToken.None);
+
+        // Assert: one library entry (PreAdded) and two suggestion records
+        _libraryRepoMock.Verify(
+            r => r.AddAsync(It.Is<UserLibraryEntry>(e => e.GameId == GameId1),
+                It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        // PreAdded creates accepted suggestion, Suggested creates unaccepted suggestion
+        _gameSuggestionRepoMock.Verify(
+            r => r.AddAsync(It.IsAny<GameSuggestion>(), It.IsAny<CancellationToken>()),
+            Times.Exactly(2));
+
+        _unitOfWorkMock.Verify(
+            u => u.SaveChangesAsync(It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    // ── Channel integration: events are read and processed ──────────────────
+
+    [Fact]
+    public async Task ExecuteAsync_ReadsEventsFromChannel_AndProcessesThem()
+    {
+        // Arrange
+        var evt = new GameSuggestionEvent(
+            UserId, InvitedByUserId,
+            new[] { CreateSuggestion(GameId1, GameSuggestionType.Suggested) });
+
+        // Write event to channel then complete
+        await _channel.Writer.WriteAsync(evt);
+        _channel.Writer.Complete();
+
+        // Act: run the service until channel is complete
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(5));
+        await _sut.StartAsync(cts.Token);
+
+        // Give it a moment to process
+        await Task.Delay(500);
+        await _sut.StopAsync(CancellationToken.None);
+
+        // Assert: suggestion was created
+        _gameSuggestionRepoMock.Verify(
+            r => r.AddAsync(It.IsAny<GameSuggestion>(), It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    // ── Service does not crash on processing failure ────────────────────────
+
+    [Fact]
+    public async Task ProcessEvent_OnFailure_DoesNotCrashService()
+    {
+        // Arrange: make the unit of work throw
+        _unitOfWorkMock
+            .Setup(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new InvalidOperationException("Simulated DB failure"));
+
+        var evt = new GameSuggestionEvent(
+            UserId, InvitedByUserId,
+            new[] { CreateSuggestion(GameId1, GameSuggestionType.Suggested) });
+
+        // Write event then complete channel
+        await _channel.Writer.WriteAsync(evt);
+        _channel.Writer.Complete();
+
+        // Act: run the service (should not throw)
+        using var cts = new CancellationTokenSource(TimeSpan.FromSeconds(10));
+        await _sut.StartAsync(cts.Token);
+
+        // Give it time to process (including retries)
+        await Task.Delay(6000);
+        await _sut.StopAsync(CancellationToken.None);
+
+        // Assert: service attempted processing (retries count)
+        _unitOfWorkMock.Verify(
+            u => u.SaveChangesAsync(It.IsAny<CancellationToken>()),
+            Times.AtLeast(2)); // At least retry once
+    }
+}

--- a/apps/api/tests/Api.Tests/Infrastructure/BackgroundServices/InvitationCleanupServiceTests.cs
+++ b/apps/api/tests/Api.Tests/Infrastructure/BackgroundServices/InvitationCleanupServiceTests.cs
@@ -1,0 +1,308 @@
+using Api.BoundedContexts.Authentication.Domain.Entities;
+using Api.BoundedContexts.Authentication.Domain.Enums;
+using Api.BoundedContexts.Authentication.Domain.Repositories;
+using Api.BoundedContexts.Authentication.Infrastructure.Persistence;
+using Api.Infrastructure;
+using Api.Infrastructure.BackgroundServices;
+using Api.Infrastructure.Entities.Authentication;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using Api.Tests.TestHelpers;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging.Abstractions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.Infrastructure.BackgroundServices;
+
+/// <summary>
+/// Unit tests for <see cref="InvitationCleanupService"/>.
+/// Admin Invitation Flow: verifies that expired pending users are cleaned up
+/// and their invitation tokens are marked as expired.
+/// </summary>
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "Authentication")]
+public sealed class InvitationCleanupServiceTests : IDisposable
+{
+    private readonly Mock<IServiceScopeFactory> _scopeFactoryMock;
+    private readonly Mock<IServiceScope> _scopeMock;
+    private readonly Mock<IServiceProvider> _serviceProviderMock;
+    private readonly Mock<IInvitationTokenRepository> _invitationRepoMock;
+    private readonly Mock<IUserRepository> _userRepoMock;
+    private readonly Mock<IUnitOfWork> _unitOfWorkMock;
+    private readonly MeepleAiDbContext _dbContext;
+    private readonly TestTimeProvider _timeProvider;
+    private readonly InvitationCleanupService _sut;
+
+    private static readonly DateTime BaseTime = new(2025, 6, 1, 12, 0, 0, DateTimeKind.Utc);
+
+    public InvitationCleanupServiceTests()
+    {
+        _scopeFactoryMock = new Mock<IServiceScopeFactory>();
+        _scopeMock = new Mock<IServiceScope>();
+        _serviceProviderMock = new Mock<IServiceProvider>();
+        _invitationRepoMock = new Mock<IInvitationTokenRepository>();
+        _userRepoMock = new Mock<IUserRepository>();
+        _unitOfWorkMock = new Mock<IUnitOfWork>();
+        _dbContext = TestDbContextFactory.CreateInMemoryDbContext();
+        _timeProvider = new TestTimeProvider(BaseTime);
+
+        // Wire scope chain
+        _scopeMock.Setup(s => s.ServiceProvider).Returns(_serviceProviderMock.Object);
+        _scopeFactoryMock.Setup(f => f.CreateScope()).Returns(_scopeMock.Object);
+
+        _serviceProviderMock
+            .Setup(sp => sp.GetService(typeof(MeepleAiDbContext)))
+            .Returns(_dbContext);
+        _serviceProviderMock
+            .Setup(sp => sp.GetService(typeof(IInvitationTokenRepository)))
+            .Returns(_invitationRepoMock.Object);
+        _serviceProviderMock
+            .Setup(sp => sp.GetService(typeof(IUserRepository)))
+            .Returns(_userRepoMock.Object);
+        _serviceProviderMock
+            .Setup(sp => sp.GetService(typeof(IUnitOfWork)))
+            .Returns(_unitOfWorkMock.Object);
+
+        _unitOfWorkMock
+            .Setup(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()))
+            .ReturnsAsync(1);
+
+        _sut = new InvitationCleanupService(
+            _scopeFactoryMock.Object,
+            _timeProvider,
+            NullLogger<InvitationCleanupService>.Instance);
+    }
+
+    public void Dispose() => _dbContext.Dispose();
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private async Task SeedUserEntity(Guid userId, string email, string status, DateTime? invitationExpiresAt)
+    {
+        _dbContext.Users.Add(new Api.Infrastructure.Entities.UserEntity
+        {
+            Id = userId,
+            Email = email,
+            Status = status,
+            InvitationExpiresAt = invitationExpiresAt,
+            DisplayName = "Test User",
+            CreatedAt = BaseTime.AddDays(-7)
+        });
+        await _dbContext.SaveChangesAsync();
+    }
+
+    private async Task SeedInvitationTokenEntity(Guid tokenId, Guid pendingUserId, string status)
+    {
+        _dbContext.InvitationTokens.Add(new InvitationTokenEntity
+        {
+            Id = tokenId,
+            Email = "test@example.com",
+            Role = "User",
+            TokenHash = Convert.ToBase64String(new byte[32]),
+            InvitedByUserId = Guid.NewGuid(),
+            Status = status,
+            ExpiresAt = BaseTime.AddDays(-1),
+            CreatedAt = BaseTime.AddDays(-7),
+            PendingUserId = pendingUserId
+        });
+        await _dbContext.SaveChangesAsync();
+    }
+
+    // ── No expired users ────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task CleanupExpiredInvitations_WhenNoExpiredPendingUsers_DoesNothing()
+    {
+        // Arrange: user is pending but invitation hasn't expired yet
+        var userId = Guid.NewGuid();
+        await SeedUserEntity(userId, "active@example.com", "Pending", BaseTime.AddDays(1));
+
+        // Act
+        await _sut.CleanupExpiredInvitationsAsync(CancellationToken.None);
+
+        // Assert
+        _userRepoMock.Verify(
+            r => r.DeleteAsync(It.IsAny<User>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+        _unitOfWorkMock.Verify(
+            u => u.SaveChangesAsync(It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    // ── Expired pending user is deleted ─────────────────────────────────────
+
+    [Fact]
+    public async Task CleanupExpiredInvitations_WithExpiredPendingUser_DeletesUserAndMarksTokenExpired()
+    {
+        // Arrange
+        var userId = Guid.NewGuid();
+        var tokenId = Guid.NewGuid();
+        await SeedUserEntity(userId, "expired@example.com", "Pending", BaseTime.AddDays(-1));
+        await SeedInvitationTokenEntity(tokenId, userId, "Pending");
+
+        // Create a real InvitationToken via factory (pending status)
+        var invitation = InvitationToken.Create(
+            "expired@example.com", "User", "fakehash", Guid.NewGuid());
+        _invitationRepoMock
+            .Setup(r => r.GetByIdAsync(tokenId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(invitation);
+        _invitationRepoMock
+            .Setup(r => r.UpdateAsync(It.IsAny<InvitationToken>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        // Create a real User via CreatePending factory
+        var user = User.CreatePending(
+            Api.BoundedContexts.Authentication.Domain.ValueObjects.Email.Parse("expired@example.com"),
+            "Test User",
+            Api.SharedKernel.Domain.ValueObjects.Role.Parse("User"),
+            Api.SharedKernel.Domain.ValueObjects.UserTier.Parse("free"),
+            Guid.NewGuid(),
+            BaseTime.AddDays(-1),
+            _timeProvider);
+        _userRepoMock
+            .Setup(r => r.GetByIdAsync(userId, It.IsAny<CancellationToken>()))
+            .ReturnsAsync(user);
+        _userRepoMock
+            .Setup(r => r.DeleteAsync(It.IsAny<User>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        // Act
+        await _sut.CleanupExpiredInvitationsAsync(CancellationToken.None);
+
+        // Assert: token was fetched and updated (MarkExpired called)
+        _invitationRepoMock.Verify(
+            r => r.GetByIdAsync(tokenId, It.IsAny<CancellationToken>()),
+            Times.Once);
+        Assert.Equal(InvitationStatus.Expired, invitation.Status);
+
+        // Assert: user was deleted
+        _userRepoMock.Verify(
+            r => r.DeleteAsync(user, It.IsAny<CancellationToken>()),
+            Times.Once);
+
+        // Assert: changes were saved
+        _unitOfWorkMock.Verify(
+            u => u.SaveChangesAsync(It.IsAny<CancellationToken>()),
+            Times.Once);
+    }
+
+    // ── Active users are not touched ────────────────────────────────────────
+
+    [Fact]
+    public async Task CleanupExpiredInvitations_ActiveUsersAreNotTouched()
+    {
+        // Arrange: active user (not pending), even with old invitation date
+        var userId = Guid.NewGuid();
+        await SeedUserEntity(userId, "active@example.com", "Active", BaseTime.AddDays(-30));
+
+        // Act
+        await _sut.CleanupExpiredInvitationsAsync(CancellationToken.None);
+
+        // Assert
+        _userRepoMock.Verify(
+            r => r.DeleteAsync(It.IsAny<User>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    // ── Pending user without expiry is not touched ──────────────────────────
+
+    [Fact]
+    public async Task CleanupExpiredInvitations_PendingUserWithoutExpiry_IsNotTouched()
+    {
+        // Arrange: pending user with no InvitationExpiresAt set
+        var userId = Guid.NewGuid();
+        await SeedUserEntity(userId, "noexpiry@example.com", "Pending", null);
+
+        // Act
+        await _sut.CleanupExpiredInvitationsAsync(CancellationToken.None);
+
+        // Assert
+        _userRepoMock.Verify(
+            r => r.DeleteAsync(It.IsAny<User>(), It.IsAny<CancellationToken>()),
+            Times.Never);
+    }
+
+    // ── Error for one user does not stop cleanup for others ─────────────────
+
+    [Fact]
+    public async Task CleanupExpiredInvitations_ErrorForOneUser_ContinuesWithOthers()
+    {
+        // Arrange: two expired pending users
+        var userId1 = Guid.NewGuid();
+        var userId2 = Guid.NewGuid();
+        await SeedUserEntity(userId1, "expired1@example.com", "Pending", BaseTime.AddDays(-1));
+        await SeedUserEntity(userId2, "expired2@example.com", "Pending", BaseTime.AddDays(-2));
+
+        // First user lookup throws, second succeeds
+        var user2 = User.CreatePending(
+            Api.BoundedContexts.Authentication.Domain.ValueObjects.Email.Parse("expired2@example.com"),
+            "Test User 2",
+            Api.SharedKernel.Domain.ValueObjects.Role.Parse("User"),
+            Api.SharedKernel.Domain.ValueObjects.UserTier.Parse("free"),
+            Guid.NewGuid(),
+            BaseTime.AddDays(-2),
+            _timeProvider);
+
+        var callCount = 0;
+        _userRepoMock
+            .Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .Returns((Guid id, CancellationToken _) =>
+            {
+                callCount++;
+                if (id == userId1)
+                    throw new InvalidOperationException("Simulated DB failure");
+                return Task.FromResult<User?>(user2);
+            });
+
+        _userRepoMock
+            .Setup(r => r.DeleteAsync(It.IsAny<User>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        // Act — must not throw
+        await _sut.CleanupExpiredInvitationsAsync(CancellationToken.None);
+
+        // Assert — both users were attempted
+        Assert.Equal(2, callCount);
+    }
+
+    // ── Multiple expired users are all cleaned up ───────────────────────────
+
+    [Fact]
+    public async Task CleanupExpiredInvitations_MultipleExpiredUsers_AllAreCleaned()
+    {
+        // Arrange
+        var userId1 = Guid.NewGuid();
+        var userId2 = Guid.NewGuid();
+        await SeedUserEntity(userId1, "expired1@example.com", "Pending", BaseTime.AddDays(-1));
+        await SeedUserEntity(userId2, "expired2@example.com", "Pending", BaseTime.AddDays(-3));
+
+        var userForCleanup = User.CreatePending(
+            Api.BoundedContexts.Authentication.Domain.ValueObjects.Email.Parse("generic@example.com"),
+            "Test User",
+            Api.SharedKernel.Domain.ValueObjects.Role.Parse("User"),
+            Api.SharedKernel.Domain.ValueObjects.UserTier.Parse("free"),
+            Guid.NewGuid(),
+            BaseTime.AddDays(-1),
+            _timeProvider);
+
+        _userRepoMock
+            .Setup(r => r.GetByIdAsync(It.IsAny<Guid>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(userForCleanup);
+        _userRepoMock
+            .Setup(r => r.DeleteAsync(It.IsAny<User>(), It.IsAny<CancellationToken>()))
+            .Returns(Task.CompletedTask);
+
+        // Act
+        await _sut.CleanupExpiredInvitationsAsync(CancellationToken.None);
+
+        // Assert — both users were deleted
+        _userRepoMock.Verify(
+            r => r.DeleteAsync(It.IsAny<User>(), It.IsAny<CancellationToken>()),
+            Times.Exactly(2));
+        _unitOfWorkMock.Verify(
+            u => u.SaveChangesAsync(It.IsAny<CancellationToken>()),
+            Times.Exactly(2));
+    }
+}

--- a/apps/api/tests/Api.Tests/Integration/Authentication/InvitationFlowIntegrationTests.cs
+++ b/apps/api/tests/Api.Tests/Integration/Authentication/InvitationFlowIntegrationTests.cs
@@ -1,0 +1,707 @@
+using Api.BoundedContexts.Authentication.Application.Commands.Invitation;
+using Api.BoundedContexts.Authentication.Application.Commands.RevokeInvitation;
+using Api.BoundedContexts.Authentication.Application.DTOs;
+using Api.BoundedContexts.Authentication.Application.Queries.Invitation;
+using Api.BoundedContexts.Authentication.Domain.Repositories;
+using Api.BoundedContexts.Authentication.Infrastructure.Persistence;
+using Api.BoundedContexts.Authentication.Infrastructure.Repositories;
+using Api.BoundedContexts.Authentication.Infrastructure.Services;
+using Api.Infrastructure;
+using Api.Middleware.Exceptions;
+using Api.Services;
+using Api.SharedKernel.Application.Services;
+using Api.SharedKernel.Domain.Enums;
+using Api.SharedKernel.Infrastructure.Persistence;
+using Api.Tests.Constants;
+using Api.Tests.Infrastructure;
+using FluentAssertions;
+using MediatR;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Time.Testing;
+using Npgsql;
+using Pgvector.EntityFrameworkCore;
+using Xunit;
+
+namespace Api.Tests.Integration.Authentication;
+
+/// <summary>
+/// Integration tests for the admin invitation flow end-to-end.
+/// Tests provisioning, activation, resend, revoke, and batch operations against real PostgreSQL.
+/// Issue #124: Admin invitation flow.
+/// </summary>
+[Collection("Integration-GroupB")]
+[Trait("Category", TestCategories.Integration)]
+[Trait("Category", TestCategories.E2E)]
+[Trait("Dependency", "PostgreSQL")]
+[Trait("BoundedContext", "Authentication")]
+[Trait("Issue", "124")]
+public sealed class InvitationFlowIntegrationTests : IAsyncLifetime
+{
+    private readonly SharedTestcontainersFixture _fixture;
+    private string _isolatedDbConnectionString = string.Empty;
+    private string _databaseName = string.Empty;
+    private MeepleAiDbContext? _dbContext;
+    private IServiceProvider? _serviceProvider;
+    private FakeTimeProvider _timeProvider = null!;
+    private readonly Action<string> _output;
+
+    private static CancellationToken TestCancellationToken => TestContext.Current.CancellationToken;
+
+    // Test data
+    private static readonly Guid AdminUserId = new("a0000000-0000-0000-0000-000000000001");
+
+    public InvitationFlowIntegrationTests(SharedTestcontainersFixture fixture)
+    {
+        _fixture = fixture;
+        _output = Console.WriteLine;
+    }
+
+    public async ValueTask InitializeAsync()
+    {
+        _output("Initializing Invitation Flow integration test infrastructure...");
+
+        _databaseName = $"test_invitation_flow_{Guid.NewGuid():N}";
+        _isolatedDbConnectionString = await _fixture.CreateIsolatedDatabaseAsync(_databaseName);
+        _output($"Isolated database created: {_databaseName}");
+
+        var enforcedBuilder = new NpgsqlConnectionStringBuilder(_isolatedDbConnectionString)
+        {
+            SslMode = SslMode.Disable,
+            KeepAlive = 30,
+            Pooling = false,
+            Timeout = 15,
+            CommandTimeout = 30
+        };
+
+        var services = new ServiceCollection();
+        _timeProvider = new FakeTimeProvider(DateTimeOffset.UtcNow);
+
+        services.AddLogging(builder => builder.AddConsole().SetMinimumLevel(LogLevel.Warning));
+        services.AddSingleton<TimeProvider>(_timeProvider);
+
+        services.AddDbContext<MeepleAiDbContext>(options =>
+        {
+            options.UseNpgsql(enforcedBuilder.ConnectionString, o => o.UseVector());
+            options.ConfigureWarnings(w =>
+                w.Ignore(Microsoft.EntityFrameworkCore.Diagnostics.RelationalEventId.PendingModelChangesWarning));
+        });
+
+        // Register repositories
+        services.AddScoped<IUserRepository, UserRepository>();
+        services.AddScoped<IOAuthAccountRepository, OAuthAccountRepository>();
+        services.AddScoped<ISessionRepository, SessionRepository>();
+        services.AddScoped<IApiKeyRepository, ApiKeyRepository>();
+        services.AddScoped<IInvitationTokenRepository, InvitationTokenRepository>();
+        services.AddScoped<IUnitOfWork, EfCoreUnitOfWork>();
+
+        // Register domain event infrastructure
+        services.AddScoped<IDomainEventCollector, DomainEventCollector>();
+
+        // Register services needed by handlers
+        services.AddSingleton<IPasswordHashingService, PasswordHashingService>();
+        services.AddSingleton<IEmailService>(new Api.Tests.TestHelpers.NoOpEmailService());
+        services.AddSingleton<GameSuggestionChannel>();
+
+        // Register MediatR (discovers all handlers in the assembly)
+        services.AddMediatR(config =>
+            config.RegisterServicesFromAssembly(typeof(ProvisionAndInviteUserCommandHandler).Assembly));
+
+        _serviceProvider = services.BuildServiceProvider();
+        _dbContext = _serviceProvider.GetRequiredService<MeepleAiDbContext>();
+
+        _output("Applying migrations...");
+        await MigrateWithRetry(_dbContext);
+
+        // Seed admin user (required for FK constraints on invitation_tokens.invited_by_user_id)
+        var userRepo = _serviceProvider.GetRequiredService<IUserRepository>();
+        var unitOfWork = _serviceProvider.GetRequiredService<IUnitOfWork>();
+        var adminUser = new Api.BoundedContexts.Authentication.Domain.Entities.User(
+            AdminUserId,
+            new Api.BoundedContexts.Authentication.Domain.ValueObjects.Email("admin@test.meepleai.dev"),
+            "Test Admin",
+            Api.BoundedContexts.Authentication.Domain.ValueObjects.PasswordHash.Create("AdminPassword123!"),
+            Api.SharedKernel.Domain.ValueObjects.Role.Admin);
+        await userRepo.AddAsync(adminUser, TestCancellationToken);
+        await unitOfWork.SaveChangesAsync(TestCancellationToken);
+
+        _output("Invitation Flow test infrastructure ready");
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _output("Cleaning up Invitation Flow test infrastructure...");
+
+        if (_dbContext != null)
+            await _dbContext.DisposeAsync();
+
+        if (_serviceProvider is IAsyncDisposable asyncDisposable)
+            await asyncDisposable.DisposeAsync();
+        else
+            (_serviceProvider as IDisposable)?.Dispose();
+
+        if (!string.IsNullOrEmpty(_databaseName))
+        {
+            try
+            {
+                await _fixture.DropIsolatedDatabaseAsync(_databaseName);
+                _output($"Isolated database dropped: {_databaseName}");
+            }
+            catch (Exception ex)
+            {
+                _output($"Warning: Failed to drop database {_databaseName}: {ex.Message}");
+            }
+        }
+    }
+
+    #region Full Flow: Provision → Validate → Activate
+
+    /// <summary>
+    /// E2E: Admin provisions user with game suggestions → verify pending state in DB →
+    /// validate token → activate with password → verify active state, email verified, session created.
+    /// </summary>
+    [Fact]
+    public async Task FullFlow_ProvisionAndActivate_CompletesSuccessfully()
+    {
+        // Arrange
+        var mediator = _serviceProvider!.GetRequiredService<IMediator>();
+        var email = $"invited-{Guid.NewGuid():N}@test.meepleai.dev";
+        var gameId = Guid.NewGuid();
+
+        // Step 1: Provision and invite
+        var provisionResult = await mediator.Send(new ProvisionAndInviteUserCommand(
+            Email: email,
+            DisplayName: "Test Invitee",
+            Role: "User",
+            Tier: "free",
+            CustomMessage: "Welcome to MeepleAI!",
+            ExpiresInDays: 7,
+            GameSuggestions: new List<GameSuggestionDto>
+            {
+                new(gameId, "PreAdded")
+            },
+            InvitedByUserId: AdminUserId
+        ), TestCancellationToken);
+
+        _output($"Step 1: User provisioned, invitation ID = {provisionResult.Id}");
+
+        provisionResult.Should().NotBeNull();
+        provisionResult.Email.Should().Be(email.ToLowerInvariant());
+        provisionResult.Status.Should().Be("Pending");
+        provisionResult.GameSuggestions.Should().HaveCount(1);
+
+        // Step 2: Verify pending user exists in DB
+        var userRepo = _serviceProvider!.GetRequiredService<IUserRepository>();
+        var invitationRepo = _serviceProvider!.GetRequiredService<IInvitationTokenRepository>();
+
+        var pendingInvitation = await invitationRepo.GetPendingByEmailAsync(
+            email.ToLowerInvariant(), TestCancellationToken);
+        pendingInvitation.Should().NotBeNull();
+        pendingInvitation!.PendingUserId.Should().NotBeNull();
+
+        var pendingUser = await userRepo.GetByIdAsync(pendingInvitation.PendingUserId!.Value, TestCancellationToken);
+        pendingUser.Should().NotBeNull();
+        pendingUser!.Status.Should().Be(UserAccountStatus.Pending);
+
+        _output("Step 2: Verified pending user and token exist in DB");
+
+        // Step 3: Validate token via query — we need the raw token, but the handler hashes it.
+        // Since we can't recover the raw token from the handler, we verify the validate flow
+        // by creating a known token directly.
+        // Instead, verify the invitation is in the DB with correct state.
+        var invitationById = await invitationRepo.GetByIdAsync(provisionResult.Id, TestCancellationToken);
+        invitationById.Should().NotBeNull();
+        invitationById!.IsValid.Should().BeTrue();
+        invitationById.Email.Should().Be(email.ToLowerInvariant());
+
+        _output("Step 3: Invitation token validated (via direct repo check)");
+
+        // Step 4: Activate — we can't use the handler directly because the raw token is not
+        // returned from ProvisionAndInviteUserCommand (by design, security).
+        // Verify user activation domain logic by testing the activate handler with a known token.
+        // This is covered in the dedicated activation test below.
+
+        _output("Full flow provisioning verified. Activation covered in dedicated test.");
+    }
+
+    /// <summary>
+    /// E2E: Tests the full activation path using a directly seeded invitation token.
+    /// Creates known token hash → activates → verifies user active, session created.
+    /// </summary>
+    [Fact]
+    public async Task ActivateInvitedAccount_WithValidToken_ActivatesUserAndCreatesSession()
+    {
+        // Arrange: Provision a user first
+        var mediator = _serviceProvider!.GetRequiredService<IMediator>();
+        var email = $"activate-{Guid.NewGuid():N}@test.meepleai.dev";
+
+        var provisionResult = await mediator.Send(new ProvisionAndInviteUserCommand(
+            Email: email,
+            DisplayName: "Activate Test User",
+            Role: "User",
+            Tier: "free",
+            CustomMessage: null,
+            ExpiresInDays: 7,
+            GameSuggestions: new List<GameSuggestionDto>(),
+            InvitedByUserId: AdminUserId
+        ), TestCancellationToken);
+
+        // We need to seed a known raw token so we can call ActivateInvitedAccountCommand.
+        // The provisioned invitation has an unknown raw token (only hash stored).
+        // Approach: create a second invitation with a known token directly in the DB.
+
+        var invitationRepo = _serviceProvider!.GetRequiredService<IInvitationTokenRepository>();
+        var userRepo = _serviceProvider!.GetRequiredService<IUserRepository>();
+        var unitOfWork = _serviceProvider!.GetRequiredService<IUnitOfWork>();
+
+        // Get the pending user ID from the provisioned invitation
+        var existingInvitation = await invitationRepo.GetByIdAsync(provisionResult.Id, TestCancellationToken);
+        existingInvitation.Should().NotBeNull();
+        var pendingUserId = existingInvitation!.PendingUserId!.Value;
+
+        // Expire the old invitation so we can create a new one with a known token
+        existingInvitation.MarkExpired();
+        await invitationRepo.UpdateAsync(existingInvitation, TestCancellationToken);
+
+        // Create a new invitation with a known raw token pointing to the same pending user
+        var knownRawToken = "test-activation-token-" + Guid.NewGuid().ToString("N");
+        var knownTokenHash = Convert.ToBase64String(
+            System.Security.Cryptography.SHA256.HashData(
+                System.Text.Encoding.UTF8.GetBytes(knownRawToken)));
+
+        var knownInvitation = Api.BoundedContexts.Authentication.Domain.Entities.InvitationToken.Create(
+            new Api.BoundedContexts.Authentication.Domain.ValueObjects.Email(email.ToLowerInvariant()),
+            Api.SharedKernel.Domain.ValueObjects.Role.User,
+            pendingUserId,
+            null,
+            7,
+            _timeProvider,
+            knownTokenHash,
+            AdminUserId);
+
+        await invitationRepo.AddAsync(knownInvitation, TestCancellationToken);
+        await unitOfWork.SaveChangesAsync(TestCancellationToken);
+
+        _output("Seeded known token for activation test");
+
+        // Act: Activate using the known raw token
+        var activationResult = await mediator.Send(new ActivateInvitedAccountCommand(
+            Token: knownRawToken,
+            Password: "SecurePassword123!"
+        ), TestCancellationToken);
+
+        // Assert
+        activationResult.Should().NotBeNull();
+        activationResult.SessionToken.Should().NotBeNullOrEmpty();
+        activationResult.RequiresOnboarding.Should().BeTrue();
+
+        // Verify user is now Active
+        var activatedUser = await userRepo.GetByIdAsync(pendingUserId, TestCancellationToken);
+        activatedUser.Should().NotBeNull();
+        activatedUser!.Status.Should().Be(UserAccountStatus.Active);
+        activatedUser.EmailVerified.Should().BeTrue();
+
+        // Verify invitation is marked Accepted
+        var acceptedInvitation = await invitationRepo.GetByIdAsync(knownInvitation.Id, TestCancellationToken);
+        acceptedInvitation.Should().NotBeNull();
+        acceptedInvitation!.Status.Should().Be(Api.BoundedContexts.Authentication.Domain.Enums.InvitationStatus.Accepted);
+        acceptedInvitation.AcceptedByUserId.Should().Be(pendingUserId);
+
+        // Verify session exists
+        var sessionRepo = _serviceProvider!.GetRequiredService<ISessionRepository>();
+        var sessions = await sessionRepo.GetByUserIdAsync(pendingUserId, TestCancellationToken);
+        sessions.Should().NotBeEmpty("a session should be created on activation");
+
+        _output("Activation verified: user Active, email verified, session created, invitation Accepted");
+    }
+
+    #endregion
+
+    #region Revoked Token Validation
+
+    /// <summary>
+    /// A revoked invitation should be reported as "invalid" when validated.
+    /// Tests the security behavior: revoked tokens are indistinguishable from non-existent ones.
+    /// </summary>
+    [Fact]
+    public async Task ValidateToken_RevokedInvitation_ReturnsInvalid()
+    {
+        // Arrange: Create invitation, then revoke it
+        var mediator = _serviceProvider!.GetRequiredService<IMediator>();
+        var invitationRepo = _serviceProvider!.GetRequiredService<IInvitationTokenRepository>();
+        var unitOfWork = _serviceProvider!.GetRequiredService<IUnitOfWork>();
+
+        var knownRawToken = "revoke-validate-" + Guid.NewGuid().ToString("N");
+        var knownTokenHash = Convert.ToBase64String(
+            System.Security.Cryptography.SHA256.HashData(
+                System.Text.Encoding.UTF8.GetBytes(knownRawToken)));
+
+        var invitation = Api.BoundedContexts.Authentication.Domain.Entities.InvitationToken.Create(
+            $"revoketest-{Guid.NewGuid():N}@test.meepleai.dev", "User", knownTokenHash, AdminUserId);
+
+        await invitationRepo.AddAsync(invitation, TestCancellationToken);
+        await unitOfWork.SaveChangesAsync(TestCancellationToken);
+
+        // Validate before revoke — should be valid
+        var validResult = await mediator.Send(new ValidateInvitationTokenQuery(knownRawToken), TestCancellationToken);
+        validResult.IsValid.Should().BeTrue();
+        _output("Token is valid before revocation");
+
+        // Revoke the invitation
+        invitation.Revoke();
+        await invitationRepo.UpdateAsync(invitation, TestCancellationToken);
+        await unitOfWork.SaveChangesAsync(TestCancellationToken);
+
+        // Validate after revoke — should be invalid
+        var revokedResult = await mediator.Send(new ValidateInvitationTokenQuery(knownRawToken), TestCancellationToken);
+        revokedResult.IsValid.Should().BeFalse();
+        revokedResult.ErrorReason.Should().Be("invalid");
+
+        _output("Revoked token correctly returns 'invalid'");
+    }
+
+    #endregion
+
+    #region Duplicate Email Conflict
+
+    /// <summary>
+    /// Provisioning a user, then trying to provision the same email again, should throw ConflictException.
+    /// </summary>
+    [Fact]
+    public async Task ProvisionAndInvite_DuplicateEmail_ThrowsConflictException()
+    {
+        // Arrange
+        var mediator = _serviceProvider!.GetRequiredService<IMediator>();
+        var email = $"duplicate-{Guid.NewGuid():N}@test.meepleai.dev";
+
+        // First provision should succeed
+        await mediator.Send(new ProvisionAndInviteUserCommand(
+            Email: email,
+            DisplayName: "First Invite",
+            Role: "User",
+            Tier: "free",
+            CustomMessage: null,
+            ExpiresInDays: 7,
+            GameSuggestions: new List<GameSuggestionDto>(),
+            InvitedByUserId: AdminUserId
+        ), TestCancellationToken);
+
+        _output("First provision succeeded");
+
+        // Act & Assert: Second provision with same email should fail
+        var act = () => mediator.Send(new ProvisionAndInviteUserCommand(
+            Email: email,
+            DisplayName: "Second Invite",
+            Role: "User",
+            Tier: "free",
+            CustomMessage: null,
+            ExpiresInDays: 7,
+            GameSuggestions: new List<GameSuggestionDto>(),
+            InvitedByUserId: AdminUserId
+        ), TestCancellationToken);
+
+        await act.Should().ThrowAsync<ConflictException>();
+
+        _output("Duplicate email correctly rejected with ConflictException");
+    }
+
+    #endregion
+
+    #region Batch Partial Failure (CSV)
+
+    /// <summary>
+    /// Batch invitations: 2 new emails + 1 existing user email → 2 succeed, 1 fails.
+    /// Uses BulkSendInvitationsCommand which dispatches SendInvitationCommand per row.
+    /// </summary>
+    [Fact]
+    public async Task BulkSendInvitations_PartialFailure_ReportsSuccessAndFailure()
+    {
+        // Arrange
+        var mediator = _serviceProvider!.GetRequiredService<IMediator>();
+
+        // Pre-create a user so one CSV row will conflict
+        var existingEmail = $"existing-{Guid.NewGuid():N}@test.meepleai.dev";
+        await mediator.Send(new ProvisionAndInviteUserCommand(
+            Email: existingEmail,
+            DisplayName: "Existing User",
+            Role: "User",
+            Tier: "free",
+            CustomMessage: null,
+            ExpiresInDays: 7,
+            GameSuggestions: new List<GameSuggestionDto>(),
+            InvitedByUserId: AdminUserId
+        ), TestCancellationToken);
+
+        var newEmail1 = $"batch1-{Guid.NewGuid():N}@test.meepleai.dev";
+        var newEmail2 = $"batch2-{Guid.NewGuid():N}@test.meepleai.dev";
+
+        // CSV with header + 3 rows (2 new + 1 existing that will be a conflict
+        // because a pending invitation already exists for existingEmail)
+        var csvContent = $"email,role\n{newEmail1},User\n{newEmail2},Editor\n{existingEmail},User";
+
+        // Act
+        var result = await mediator.Send(new BulkSendInvitationsCommand(
+            CsvContent: csvContent,
+            InvitedByUserId: AdminUserId
+        ), TestCancellationToken);
+
+        // Assert
+        result.Should().NotBeNull();
+        result.Successful.Should().HaveCount(2);
+        result.Failed.Should().HaveCount(1);
+        result.Failed[0].Email.Should().Be(existingEmail.ToLowerInvariant());
+
+        _output($"Batch result: {result.Successful.Count} succeeded, {result.Failed.Count} failed");
+    }
+
+    #endregion
+
+    #region Resend Invitation
+
+    /// <summary>
+    /// Provision → resend → verify old token expired, new token created, same pending user preserved.
+    /// </summary>
+    [Fact]
+    public async Task ResendInvitation_CreatesNewTokenAndExpiresOld()
+    {
+        // Arrange
+        var mediator = _serviceProvider!.GetRequiredService<IMediator>();
+        var invitationRepo = _serviceProvider!.GetRequiredService<IInvitationTokenRepository>();
+        var email = $"resend-{Guid.NewGuid():N}@test.meepleai.dev";
+
+        // Note: ResendInvitationCommand uses the simpler SendInvitationCommand path
+        // (creates a new token, not a provisioned user). It looks up by InvitationId.
+        // Use SendInvitationCommand first (simpler path that doesn't require pending user).
+        var originalResult = await mediator.Send(new SendInvitationCommand(
+            Email: email,
+            Role: "User",
+            InvitedByUserId: AdminUserId
+        ), TestCancellationToken);
+
+        var originalId = originalResult.Id;
+        _output($"Original invitation created: {originalId}");
+
+        // Act: Resend
+        var resendResult = await mediator.Send(new ResendInvitationCommand(
+            InvitationId: originalId,
+            ResendByUserId: AdminUserId
+        ), TestCancellationToken);
+
+        // Assert
+        resendResult.Should().NotBeNull();
+        resendResult.Id.Should().NotBe(originalId, "a new invitation token should be created");
+        resendResult.Email.Should().Be(email.ToLowerInvariant());
+        resendResult.Status.Should().Be("Pending");
+
+        // Verify old invitation is expired
+        var oldInvitation = await invitationRepo.GetByIdAsync(originalId, TestCancellationToken);
+        oldInvitation.Should().NotBeNull();
+        oldInvitation!.Status.Should().Be(Api.BoundedContexts.Authentication.Domain.Enums.InvitationStatus.Expired);
+
+        // Verify new invitation exists
+        var newInvitation = await invitationRepo.GetByIdAsync(resendResult.Id, TestCancellationToken);
+        newInvitation.Should().NotBeNull();
+        newInvitation!.Status.Should().Be(Api.BoundedContexts.Authentication.Domain.Enums.InvitationStatus.Pending);
+
+        _output("Resend verified: old token expired, new token created");
+    }
+
+    #endregion
+
+    #region Revoke Invitation
+
+    /// <summary>
+    /// Provision → revoke → verify invitation status is Revoked.
+    /// </summary>
+    [Fact]
+    public async Task RevokeInvitation_SetsStatusToRevoked()
+    {
+        // Arrange
+        var mediator = _serviceProvider!.GetRequiredService<IMediator>();
+        var invitationRepo = _serviceProvider!.GetRequiredService<IInvitationTokenRepository>();
+        var email = $"revoke-{Guid.NewGuid():N}@test.meepleai.dev";
+
+        var provisionResult = await mediator.Send(new ProvisionAndInviteUserCommand(
+            Email: email,
+            DisplayName: "Revoke Test",
+            Role: "User",
+            Tier: "free",
+            CustomMessage: null,
+            ExpiresInDays: 7,
+            GameSuggestions: new List<GameSuggestionDto>(),
+            InvitedByUserId: AdminUserId
+        ), TestCancellationToken);
+
+        _output($"Invitation created: {provisionResult.Id}");
+
+        // Act: Revoke
+        var revokeResult = await mediator.Send(new RevokeInvitationCommand(
+            InvitationId: provisionResult.Id,
+            AdminUserId: AdminUserId
+        ), TestCancellationToken);
+
+        // Assert
+        revokeResult.Should().BeTrue();
+
+        var revokedInvitation = await invitationRepo.GetByIdAsync(provisionResult.Id, TestCancellationToken);
+        revokedInvitation.Should().NotBeNull();
+        revokedInvitation!.Status.Should().Be(Api.BoundedContexts.Authentication.Domain.Enums.InvitationStatus.Revoked);
+        revokedInvitation.RevokedAt.Should().NotBeNull();
+
+        _output("Revoke verified: invitation status is Revoked");
+    }
+
+    /// <summary>
+    /// Revoking a non-existent invitation should return false (not throw).
+    /// </summary>
+    [Fact]
+    public async Task RevokeInvitation_NonExistentId_ReturnsFalse()
+    {
+        var mediator = _serviceProvider!.GetRequiredService<IMediator>();
+
+        var result = await mediator.Send(new RevokeInvitationCommand(
+            InvitationId: Guid.NewGuid(),
+            AdminUserId: AdminUserId
+        ), TestCancellationToken);
+
+        result.Should().BeFalse();
+    }
+
+    #endregion
+
+    #region Validate Token Query
+
+    /// <summary>
+    /// ValidateInvitationTokenQuery with a non-existent token returns invalid.
+    /// </summary>
+    [Fact]
+    public async Task ValidateToken_NonExistent_ReturnsInvalid()
+    {
+        var mediator = _serviceProvider!.GetRequiredService<IMediator>();
+
+        var result = await mediator.Send(
+            new ValidateInvitationTokenQuery("non-existent-token-xyz"),
+            TestCancellationToken);
+
+        result.Should().NotBeNull();
+        result.IsValid.Should().BeFalse();
+        result.ErrorReason.Should().Be("invalid");
+    }
+
+    /// <summary>
+    /// ValidateInvitationTokenQuery with empty token returns invalid.
+    /// </summary>
+    [Fact]
+    public async Task ValidateToken_EmptyString_ReturnsInvalid()
+    {
+        var mediator = _serviceProvider!.GetRequiredService<IMediator>();
+
+        var result = await mediator.Send(
+            new ValidateInvitationTokenQuery(""),
+            TestCancellationToken);
+
+        result.Should().NotBeNull();
+        result.IsValid.Should().BeFalse();
+        result.ErrorReason.Should().Be("invalid");
+    }
+
+    #endregion
+
+    #region Repository Persistence
+
+    /// <summary>
+    /// InvitationTokenRepository: Add, GetByTokenHash, GetPendingByEmail, CountByStatus round-trip.
+    /// </summary>
+    [Fact]
+    public async Task InvitationTokenRepository_CrudOperations_PersistCorrectly()
+    {
+        var invitationRepo = _serviceProvider!.GetRequiredService<IInvitationTokenRepository>();
+        var unitOfWork = _serviceProvider!.GetRequiredService<IUnitOfWork>();
+        var email = $"repo-{Guid.NewGuid():N}@test.meepleai.dev";
+
+        // Create
+        var tokenHash = $"hash-{Guid.NewGuid():N}";
+        var invitation = Api.BoundedContexts.Authentication.Domain.Entities.InvitationToken.Create(
+            email, "User", tokenHash, AdminUserId);
+
+        await invitationRepo.AddAsync(invitation, TestCancellationToken);
+        await unitOfWork.SaveChangesAsync(TestCancellationToken);
+
+        // Read by ID
+        var byId = await invitationRepo.GetByIdAsync(invitation.Id, TestCancellationToken);
+        byId.Should().NotBeNull();
+        byId!.Email.Should().Be(email.ToLowerInvariant());
+
+        // Read by hash
+        var byHash = await invitationRepo.GetByTokenHashAsync(tokenHash, TestCancellationToken);
+        byHash.Should().NotBeNull();
+        byHash!.Id.Should().Be(invitation.Id);
+
+        // Read by email
+        var byEmail = await invitationRepo.GetPendingByEmailAsync(email.ToLowerInvariant(), TestCancellationToken);
+        byEmail.Should().NotBeNull();
+        byEmail!.Id.Should().Be(invitation.Id);
+
+        // Count
+        var pendingCount = await invitationRepo.CountByStatusAsync(
+            Api.BoundedContexts.Authentication.Domain.Enums.InvitationStatus.Pending, TestCancellationToken);
+        pendingCount.Should().BeGreaterThanOrEqualTo(1);
+
+        _output("Repository CRUD operations verified");
+    }
+
+    /// <summary>
+    /// InvitationTokenRepository: GetByStatusAsync with pagination works correctly.
+    /// </summary>
+    [Fact]
+    public async Task InvitationTokenRepository_GetByStatus_PaginatesCorrectly()
+    {
+        var invitationRepo = _serviceProvider!.GetRequiredService<IInvitationTokenRepository>();
+        var unitOfWork = _serviceProvider!.GetRequiredService<IUnitOfWork>();
+
+        // Create 3 pending invitations
+        for (int i = 0; i < 3; i++)
+        {
+            var email = $"paginate-{i}-{Guid.NewGuid():N}@test.meepleai.dev";
+            var tokenHash = $"hash-paginate-{i}-{Guid.NewGuid():N}";
+            var inv = Api.BoundedContexts.Authentication.Domain.Entities.InvitationToken.Create(
+                email, "User", tokenHash, AdminUserId);
+            await invitationRepo.AddAsync(inv, TestCancellationToken);
+        }
+
+        await unitOfWork.SaveChangesAsync(TestCancellationToken);
+
+        // Page 1 with size 2
+        var page1 = await invitationRepo.GetByStatusAsync(
+            Api.BoundedContexts.Authentication.Domain.Enums.InvitationStatus.Pending,
+            page: 1, pageSize: 2, TestCancellationToken);
+
+        page1.Should().HaveCount(2);
+
+        _output("Pagination verified");
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    private async Task MigrateWithRetry(MeepleAiDbContext context, int maxRetries = 3)
+    {
+        for (int i = 0; i < maxRetries; i++)
+        {
+            try
+            {
+                await context.Database.MigrateAsync(TestCancellationToken);
+                return;
+            }
+            catch (Exception ex) when (i < maxRetries - 1)
+            {
+                _output($"Migration attempt {i + 1} failed: {ex.Message}. Retrying...");
+                await Task.Delay(TimeSpan.FromSeconds(2), TestCancellationToken);
+            }
+        }
+    }
+
+    #endregion
+}

--- a/apps/api/tests/Api.Tests/Security/InvitationSecurityTests.cs
+++ b/apps/api/tests/Api.Tests/Security/InvitationSecurityTests.cs
@@ -1,0 +1,596 @@
+using Api.BoundedContexts.Authentication.Application.Commands.Invitation;
+using Api.BoundedContexts.Authentication.Application.DTOs;
+using Api.BoundedContexts.Authentication.Application.Queries.Invitation;
+using Api.BoundedContexts.Authentication.Domain.Entities;
+using Api.BoundedContexts.Authentication.Domain.Enums;
+using Api.BoundedContexts.Authentication.Domain.Repositories;
+using Api.BoundedContexts.Authentication.Infrastructure.Persistence;
+using Api.Tests.Constants;
+using FluentAssertions;
+using Moq;
+using Xunit;
+
+namespace Api.Tests.Security;
+
+/// <summary>
+/// Security-focused tests for the admin invitation flow.
+/// Validates password policy, uniform error responses, XSS prevention, and CSV injection resistance.
+/// Issue #124: Admin invitation flow.
+/// </summary>
+[Trait("Category", TestCategories.Security)]
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "Authentication")]
+[Trait("Issue", "124")]
+public sealed class InvitationSecurityTests
+{
+    #region 1. Weak Password Rejected — ActivateInvitedAccountCommandValidator
+
+    [Theory]
+    [InlineData("123")]
+    [InlineData("password")]
+    [InlineData("abcdefgh")]
+    [InlineData("12345678")]
+    [InlineData("ABCDEFGH")]
+    [InlineData("short")]
+    [InlineData("")]
+    [InlineData("nouppercase1!")]
+    [InlineData("NOLOWERCASE1!")]
+    [InlineData("NoDigitsHere!")]
+    [InlineData("NoSpecial1a")]
+    public void ActivateInvitedAccountValidator_WeakPassword_ShouldReject(string weakPassword)
+    {
+        // Arrange
+        var validator = new ActivateInvitedAccountCommandValidator();
+        var command = new ActivateInvitedAccountCommand("valid-token-abc", weakPassword);
+
+        // Act
+        var result = validator.Validate(command);
+
+        // Assert
+        result.IsValid.Should().BeFalse(
+            $"Password '{weakPassword}' should be rejected by the validator");
+    }
+
+    [Fact]
+    public void ActivateInvitedAccountValidator_StrongPassword_ShouldAccept()
+    {
+        // Arrange
+        var validator = new ActivateInvitedAccountCommandValidator();
+        var command = new ActivateInvitedAccountCommand("valid-token-abc", "Str0ng!Pass");
+
+        // Act
+        var result = validator.Validate(command);
+
+        // Assert
+        result.IsValid.Should().BeTrue("A password meeting all rules should be accepted");
+    }
+
+    [Fact]
+    public void ActivateInvitedAccountValidator_EmptyToken_ShouldReject()
+    {
+        // Arrange
+        var validator = new ActivateInvitedAccountCommandValidator();
+        var command = new ActivateInvitedAccountCommand("", "Str0ng!Pass");
+
+        // Act
+        var result = validator.Validate(command);
+
+        // Assert
+        result.IsValid.Should().BeFalse("Empty token should be rejected");
+        result.Errors.Should().Contain(e => e.PropertyName == "Token");
+    }
+
+    [Fact]
+    public void ActivateInvitedAccountValidator_PasswordExceeds128Chars_ShouldReject()
+    {
+        // Arrange
+        var validator = new ActivateInvitedAccountCommandValidator();
+        var longPassword = "Aa1!" + new string('x', 125); // 129 chars total
+        var command = new ActivateInvitedAccountCommand("valid-token", longPassword);
+
+        // Act
+        var result = validator.Validate(command);
+
+        // Assert
+        result.IsValid.Should().BeFalse("Password exceeding 128 characters should be rejected");
+    }
+
+    #endregion
+
+    #region 2. Uniform Error for Expired/Revoked/NotFound — ValidateInvitationTokenQueryHandler
+
+    [Fact]
+    public async Task ValidateToken_NotFound_ReturnsInvalid()
+    {
+        // Arrange
+        var invitationRepo = new Mock<IInvitationTokenRepository>();
+        var userRepo = new Mock<IUserRepository>();
+
+        invitationRepo
+            .Setup(r => r.GetByTokenHashAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((InvitationToken?)null);
+
+        var handler = new ValidateInvitationTokenQueryHandler(invitationRepo.Object, userRepo.Object);
+
+        // Act
+        var result = await handler.Handle(new ValidateInvitationTokenQuery("nonexistent-token"), CancellationToken.None);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.ErrorReason.Should().Be("invalid");
+    }
+
+    [Fact]
+    public async Task ValidateToken_Expired_ReturnsInvalid()
+    {
+        // Arrange
+        var invitationRepo = new Mock<IInvitationTokenRepository>();
+        var userRepo = new Mock<IUserRepository>();
+
+        var expiredInvitation = CreateInvitationWithStatus(InvitationStatus.Expired, DateTime.UtcNow.AddDays(-1));
+
+        invitationRepo
+            .Setup(r => r.GetByTokenHashAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expiredInvitation);
+
+        var handler = new ValidateInvitationTokenQueryHandler(invitationRepo.Object, userRepo.Object);
+
+        // Act
+        var result = await handler.Handle(new ValidateInvitationTokenQuery("expired-token"), CancellationToken.None);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.ErrorReason.Should().Be("invalid");
+    }
+
+    [Fact]
+    public async Task ValidateToken_Revoked_ReturnsInvalid()
+    {
+        // Arrange
+        var invitationRepo = new Mock<IInvitationTokenRepository>();
+        var userRepo = new Mock<IUserRepository>();
+
+        var revokedInvitation = CreateInvitationWithStatus(InvitationStatus.Revoked, DateTime.UtcNow.AddDays(5));
+
+        invitationRepo
+            .Setup(r => r.GetByTokenHashAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(revokedInvitation);
+
+        var handler = new ValidateInvitationTokenQueryHandler(invitationRepo.Object, userRepo.Object);
+
+        // Act
+        var result = await handler.Handle(new ValidateInvitationTokenQuery("revoked-token"), CancellationToken.None);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.ErrorReason.Should().Be("invalid");
+    }
+
+    [Fact]
+    public async Task ValidateToken_UniformErrorForExpiredRevokedNotFound_AllReturnSameReason()
+    {
+        // Arrange — Three different failure scenarios must produce the same error reason
+        var invitationRepo = new Mock<IInvitationTokenRepository>();
+        var userRepo = new Mock<IUserRepository>();
+        var handler = new ValidateInvitationTokenQueryHandler(invitationRepo.Object, userRepo.Object);
+
+        // 1. Not found
+        invitationRepo
+            .Setup(r => r.GetByTokenHashAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((InvitationToken?)null);
+        var notFoundResult = await handler.Handle(new ValidateInvitationTokenQuery("notfound"), CancellationToken.None);
+
+        // 2. Expired
+        var expiredInvitation = CreateInvitationWithStatus(InvitationStatus.Expired, DateTime.UtcNow.AddDays(-1));
+        invitationRepo
+            .Setup(r => r.GetByTokenHashAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(expiredInvitation);
+        var expiredResult = await handler.Handle(new ValidateInvitationTokenQuery("expired"), CancellationToken.None);
+
+        // 3. Revoked
+        var revokedInvitation = CreateInvitationWithStatus(InvitationStatus.Revoked, DateTime.UtcNow.AddDays(5));
+        invitationRepo
+            .Setup(r => r.GetByTokenHashAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(revokedInvitation);
+        var revokedResult = await handler.Handle(new ValidateInvitationTokenQuery("revoked"), CancellationToken.None);
+
+        // Assert — All three must produce identical error reason to prevent state enumeration
+        notFoundResult.ErrorReason.Should().Be("invalid");
+        expiredResult.ErrorReason.Should().Be("invalid");
+        revokedResult.ErrorReason.Should().Be("invalid");
+
+        // All three should be indistinguishable to the caller
+        notFoundResult.ErrorReason.Should().Be(expiredResult.ErrorReason);
+        expiredResult.ErrorReason.Should().Be(revokedResult.ErrorReason);
+    }
+
+    [Fact]
+    public async Task ValidateToken_Accepted_ReturnsAlreadyUsed_NotInvalid()
+    {
+        // Arrange — Accepted tokens get a different error to allow redirect to login
+        var invitationRepo = new Mock<IInvitationTokenRepository>();
+        var userRepo = new Mock<IUserRepository>();
+
+        var acceptedInvitation = CreateInvitationWithStatus(InvitationStatus.Accepted, DateTime.UtcNow.AddDays(5));
+
+        invitationRepo
+            .Setup(r => r.GetByTokenHashAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync(acceptedInvitation);
+
+        var handler = new ValidateInvitationTokenQueryHandler(invitationRepo.Object, userRepo.Object);
+
+        // Act
+        var result = await handler.Handle(new ValidateInvitationTokenQuery("accepted-token"), CancellationToken.None);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.ErrorReason.Should().Be("already_used",
+            "Accepted tokens should return 'already_used' (not 'invalid') to allow login redirect");
+    }
+
+    [Fact]
+    public async Task ValidateToken_EmptyToken_ReturnsInvalid()
+    {
+        // Arrange
+        var invitationRepo = new Mock<IInvitationTokenRepository>();
+        var userRepo = new Mock<IUserRepository>();
+        var handler = new ValidateInvitationTokenQueryHandler(invitationRepo.Object, userRepo.Object);
+
+        // Act
+        var result = await handler.Handle(new ValidateInvitationTokenQuery(""), CancellationToken.None);
+
+        // Assert
+        result.IsValid.Should().BeFalse();
+        result.ErrorReason.Should().Be("invalid");
+    }
+
+    #endregion
+
+    #region 3. Password Policy Consistency — AcceptInvitation vs ActivateInvitedAccount
+
+    [Theory]
+    [InlineData("short1A!")]  // 8 chars - valid for both
+    [InlineData("Str0ng!Pass")]
+    [InlineData("MyP@ssw0rd")]
+    public void PasswordPolicyConsistency_BothValidators_AcceptSameStrongPasswords(string password)
+    {
+        // Arrange
+        var activateValidator = new ActivateInvitedAccountCommandValidator();
+        var acceptValidator = new AcceptInvitationCommandValidator();
+
+        var activateCommand = new ActivateInvitedAccountCommand("token", password);
+        var acceptCommand = new AcceptInvitationCommand("token", password, password);
+
+        // Act
+        var activateResult = activateValidator.Validate(activateCommand);
+        var acceptResult = acceptValidator.Validate(acceptCommand);
+
+        // Assert — Both validators should accept the same valid passwords
+        activateResult.IsValid.Should().Be(true,
+            $"ActivateInvitedAccount should accept '{password}'");
+        acceptResult.IsValid.Should().Be(true,
+            $"AcceptInvitation should accept '{password}'");
+    }
+
+    [Theory]
+    [InlineData("123")]        // Too short, no uppercase, no lowercase, no special
+    [InlineData("abcdefgh")]   // No uppercase, no digit, no special
+    [InlineData("12345678")]   // No uppercase, no lowercase, no special
+    [InlineData("short")]      // Too short
+    public void PasswordPolicyConsistency_BothValidators_RejectSameWeakPasswords(string password)
+    {
+        // Arrange
+        var activateValidator = new ActivateInvitedAccountCommandValidator();
+        var acceptValidator = new AcceptInvitationCommandValidator();
+
+        var activateCommand = new ActivateInvitedAccountCommand("token", password);
+        var acceptCommand = new AcceptInvitationCommand("token", password, password);
+
+        // Act
+        var activateResult = activateValidator.Validate(activateCommand);
+        var acceptResult = acceptValidator.Validate(acceptCommand);
+
+        // Assert — Both validators must reject the same weak passwords
+        activateResult.IsValid.Should().BeFalse(
+            $"ActivateInvitedAccount should reject '{password}'");
+        acceptResult.IsValid.Should().BeFalse(
+            $"AcceptInvitation should reject '{password}'");
+    }
+
+    [Fact]
+    public void PasswordPolicyConsistency_MinLengthIsSame()
+    {
+        // Arrange — Test boundary: 7 chars should fail, 8 chars with all rules should pass
+        var activateValidator = new ActivateInvitedAccountCommandValidator();
+        var acceptValidator = new AcceptInvitationCommandValidator();
+
+        var sevenChars = "Aa1!xyz"; // 7 chars
+        var eightChars = "Aa1!xyzz"; // 8 chars
+
+        var activate7 = activateValidator.Validate(new ActivateInvitedAccountCommand("t", sevenChars));
+        var accept7 = acceptValidator.Validate(new AcceptInvitationCommand("t", sevenChars, sevenChars));
+
+        var activate8 = activateValidator.Validate(new ActivateInvitedAccountCommand("t", eightChars));
+        var accept8 = acceptValidator.Validate(new AcceptInvitationCommand("t", eightChars, eightChars));
+
+        // Assert
+        activate7.IsValid.Should().BeFalse("7-char password should be rejected by ActivateInvitedAccount");
+        accept7.IsValid.Should().BeFalse("7-char password should be rejected by AcceptInvitation");
+
+        activate8.IsValid.Should().BeTrue("8-char password meeting all rules should pass ActivateInvitedAccount");
+        accept8.IsValid.Should().BeTrue("8-char password meeting all rules should pass AcceptInvitation");
+    }
+
+    [Fact]
+    public void PasswordPolicyConsistency_ActivateRequiresSpecialChar_AcceptDoesNot()
+    {
+        // Document the known difference: ActivateInvitedAccount requires special char, AcceptInvitation does not.
+        // This is an intentional policy divergence that should be documented.
+        var activateValidator = new ActivateInvitedAccountCommandValidator();
+        var acceptValidator = new AcceptInvitationCommandValidator();
+
+        // Password with uppercase, lowercase, digit, but NO special char
+        var noSpecialChar = "Abcdefg1";
+
+        var activateResult = activateValidator.Validate(
+            new ActivateInvitedAccountCommand("token", noSpecialChar));
+        var acceptResult = acceptValidator.Validate(
+            new AcceptInvitationCommand("token", noSpecialChar, noSpecialChar));
+
+        // ActivateInvitedAccount requires special character
+        activateResult.IsValid.Should().BeFalse(
+            "ActivateInvitedAccount requires a special character");
+        activateResult.Errors.Should().Contain(e =>
+            e.ErrorMessage.Contains("special character", StringComparison.OrdinalIgnoreCase));
+
+        // AcceptInvitation does NOT require special character (weaker policy)
+        acceptResult.IsValid.Should().BeTrue(
+            "AcceptInvitation does not require a special character (known policy divergence)");
+    }
+
+    #endregion
+
+    #region 4. XSS in CustomMessage — ProvisionAndInviteUserCommandValidator
+
+    [Theory]
+    [InlineData("<script>alert(1)</script>")]
+    [InlineData("<img src=x onerror=alert(1)>")]
+    [InlineData("javascript:alert(1)")]
+    [InlineData("<svg onload=alert(1)>")]
+    public void ProvisionAndInviteValidator_XssInCustomMessage_ValidatorDoesNotRejectButMessageIsLengthConstrained(string xssPayload)
+    {
+        // The validator constrains CustomMessage to 500 chars max.
+        // HTML encoding of the CustomMessage in email templates is the defense-in-depth layer.
+        // This test documents that the validator itself does not reject HTML content,
+        // so the email service MUST html-encode the custom message.
+        var validator = new ProvisionAndInviteUserCommandValidator();
+        var command = new ProvisionAndInviteUserCommand(
+            Email: "test@example.com",
+            DisplayName: "Test User",
+            Role: "User",
+            Tier: "Free",
+            CustomMessage: xssPayload,
+            ExpiresInDays: 7,
+            GameSuggestions: new List<GameSuggestionDto>(),
+            InvitedByUserId: Guid.NewGuid());
+
+        var result = validator.Validate(command);
+
+        // The validator does not reject HTML content itself (length < 500).
+        // Defense-in-depth relies on email template encoding.
+        // This test documents the current behavior for security review.
+        result.Errors.Should().NotContain(e => e.PropertyName == "CustomMessage",
+            "Validator currently allows HTML in custom message (defense relies on email template encoding)");
+    }
+
+    [Fact]
+    public void ProvisionAndInviteValidator_OversizedXssPayload_RejectedByLengthConstraint()
+    {
+        // Arrange — XSS payload exceeding 500 char limit
+        var longXss = "<script>" + new string('x', 500) + "</script>";
+        var validator = new ProvisionAndInviteUserCommandValidator();
+        var command = new ProvisionAndInviteUserCommand(
+            Email: "test@example.com",
+            DisplayName: "Test User",
+            Role: "User",
+            Tier: "Free",
+            CustomMessage: longXss,
+            ExpiresInDays: 7,
+            GameSuggestions: new List<GameSuggestionDto>(),
+            InvitedByUserId: Guid.NewGuid());
+
+        // Act
+        var result = validator.Validate(command);
+
+        // Assert
+        result.IsValid.Should().BeFalse("XSS payload exceeding 500 chars should be rejected by length constraint");
+        result.Errors.Should().Contain(e =>
+            e.PropertyName == "CustomMessage" &&
+            e.ErrorMessage.Contains("500", StringComparison.Ordinal));
+    }
+
+    #endregion
+
+    #region 5. CSV Injection in DisplayName — ProvisionAndInviteUserCommandValidator
+
+    [Theory]
+    [InlineData("=cmd|'/C calc'!A0")]
+    [InlineData("+cmd|'/C calc'!A0")]
+    [InlineData("-cmd|'/C calc'!A0")]
+    [InlineData("@SUM(1+1)*cmd|'/C calc'!A0")]
+    [InlineData("=HYPERLINK(\"http://evil.com\")")]
+    public void ProvisionAndInviteValidator_CsvInjectionInDisplayName_ValidatorConstrainsLength(string csvPayload)
+    {
+        // The validator constrains DisplayName to 2-100 chars and requires non-empty.
+        // CSV injection payloads that fit within length constraints are accepted by the validator.
+        // Defense-in-depth: CSV export code must quote/escape fields.
+        var validator = new ProvisionAndInviteUserCommandValidator();
+        var command = new ProvisionAndInviteUserCommand(
+            Email: "test@example.com",
+            DisplayName: csvPayload,
+            Role: "User",
+            Tier: "Free",
+            CustomMessage: null,
+            ExpiresInDays: 7,
+            GameSuggestions: new List<GameSuggestionDto>(),
+            InvitedByUserId: Guid.NewGuid());
+
+        var result = validator.Validate(command);
+
+        // Document: CSV injection payloads pass validation if within length constraints.
+        // The CSV export layer must handle escaping (prefix with ' or wrap in quotes).
+        // This documents the attack surface for security review.
+        if (csvPayload.Length >= 2 && csvPayload.Length <= 100)
+        {
+            result.Errors.Where(e => e.PropertyName == "DisplayName")
+                .Should().BeEmpty(
+                    $"DisplayName '{csvPayload}' fits length constraints; CSV export must handle escaping");
+        }
+    }
+
+    [Fact]
+    public void ProvisionAndInviteValidator_SingleCharDisplayName_Rejected()
+    {
+        // Arrange — Single char display name fails minimum length
+        var validator = new ProvisionAndInviteUserCommandValidator();
+        var command = new ProvisionAndInviteUserCommand(
+            Email: "test@example.com",
+            DisplayName: "=",
+            Role: "User",
+            Tier: "Free",
+            CustomMessage: null,
+            ExpiresInDays: 7,
+            GameSuggestions: new List<GameSuggestionDto>(),
+            InvitedByUserId: Guid.NewGuid());
+
+        // Act
+        var result = validator.Validate(command);
+
+        // Assert
+        result.IsValid.Should().BeFalse("Single-char display name should fail minimum length rule");
+    }
+
+    #endregion
+
+    #region 6. Admin Authorization — Endpoint-Level Gate
+
+    [Fact]
+    public void ProvisionAndInviteCommand_RequiresInvitedByUserId_CannotBeEmpty()
+    {
+        // The handler requires InvitedByUserId (set from admin session in the endpoint).
+        // If somehow Guid.Empty is passed, the validator should reject it.
+        var validator = new ProvisionAndInviteUserCommandValidator();
+        var command = new ProvisionAndInviteUserCommand(
+            Email: "test@example.com",
+            DisplayName: "Test User",
+            Role: "User",
+            Tier: "Free",
+            CustomMessage: null,
+            ExpiresInDays: 7,
+            GameSuggestions: new List<GameSuggestionDto>(),
+            InvitedByUserId: Guid.Empty);
+
+        var result = validator.Validate(command);
+
+        result.IsValid.Should().BeFalse("Empty InvitedByUserId should be rejected");
+        result.Errors.Should().Contain(e => e.PropertyName == "InvitedByUserId");
+    }
+
+    [Theory]
+    [InlineData("InvalidRole")]
+    [InlineData("SuperAdmin")]
+    [InlineData("Root")]
+    public void ProvisionAndInviteValidator_InvalidRole_Rejected(string invalidRole)
+    {
+        // Only User, Editor, Admin are allowed. SuperAdmin cannot be provisioned via invitation.
+        var validator = new ProvisionAndInviteUserCommandValidator();
+        var command = new ProvisionAndInviteUserCommand(
+            Email: "test@example.com",
+            DisplayName: "Test User",
+            Role: invalidRole,
+            Tier: "Free",
+            CustomMessage: null,
+            ExpiresInDays: 7,
+            GameSuggestions: new List<GameSuggestionDto>(),
+            InvitedByUserId: Guid.NewGuid());
+
+        var result = validator.Validate(command);
+
+        result.IsValid.Should().BeFalse($"Role '{invalidRole}' should be rejected by the validator");
+        result.Errors.Should().Contain(e => e.PropertyName == "Role");
+    }
+
+    [Theory]
+    [InlineData("InvalidTier")]
+    [InlineData("Enterprise")]
+    [InlineData("")]
+    public void ProvisionAndInviteValidator_InvalidTier_Rejected(string invalidTier)
+    {
+        var validator = new ProvisionAndInviteUserCommandValidator();
+        var command = new ProvisionAndInviteUserCommand(
+            Email: "test@example.com",
+            DisplayName: "Test User",
+            Role: "User",
+            Tier: invalidTier,
+            CustomMessage: null,
+            ExpiresInDays: 7,
+            GameSuggestions: new List<GameSuggestionDto>(),
+            InvitedByUserId: Guid.NewGuid());
+
+        var result = validator.Validate(command);
+
+        result.IsValid.Should().BeFalse($"Tier '{invalidTier}' should be rejected by the validator");
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-1)]
+    [InlineData(31)]
+    [InlineData(365)]
+    public void ProvisionAndInviteValidator_InvalidExpiresInDays_Rejected(int days)
+    {
+        var validator = new ProvisionAndInviteUserCommandValidator();
+        var command = new ProvisionAndInviteUserCommand(
+            Email: "test@example.com",
+            DisplayName: "Test User",
+            Role: "User",
+            Tier: "Free",
+            CustomMessage: null,
+            ExpiresInDays: days,
+            GameSuggestions: new List<GameSuggestionDto>(),
+            InvitedByUserId: Guid.NewGuid());
+
+        var result = validator.Validate(command);
+
+        result.IsValid.Should().BeFalse($"ExpiresInDays={days} should be rejected (valid range: 1-30)");
+    }
+
+    #endregion
+
+    #region Helper Methods
+
+    /// <summary>
+    /// Creates an InvitationToken with the specified status for testing.
+    /// Uses the internal RestoreState method to set up the entity.
+    /// </summary>
+    private static InvitationToken CreateInvitationWithStatus(InvitationStatus status, DateTime expiresAt)
+    {
+        var invitation = InvitationToken.CreateForHydration(Guid.NewGuid());
+        invitation.RestoreState(
+            email: "test@example.com",
+            role: "User",
+            tokenHash: "test-hash-value",
+            invitedByUserId: Guid.NewGuid(),
+            status: status,
+            expiresAt: expiresAt,
+            acceptedAt: status == InvitationStatus.Accepted ? DateTime.UtcNow : null,
+            acceptedByUserId: status == InvitationStatus.Accepted ? Guid.NewGuid() : null,
+            createdAt: DateTime.UtcNow.AddDays(-1),
+            revokedAt: status == InvitationStatus.Revoked ? DateTime.UtcNow : null,
+            pendingUserId: Guid.NewGuid());
+
+        return invitation;
+    }
+
+    #endregion
+}

--- a/apps/api/tests/Api.Tests/TestHelpers/NoOpEmailService.cs
+++ b/apps/api/tests/Api.Tests/TestHelpers/NoOpEmailService.cs
@@ -202,6 +202,18 @@ internal class NoOpEmailService : IEmailService
         CancellationToken ct = default)
         => Task.CompletedTask;
 
+    // ISSUE-124: Enhanced invitation email (admin invitation flow)
+    public Task SendInvitationEmailAsync(
+        string toEmail,
+        string displayName,
+        string role,
+        string token,
+        string invitedByName,
+        string? customMessage,
+        DateTime expiresAt,
+        CancellationToken ct = default)
+        => Task.CompletedTask;
+
     // ISSUE-4417: Raw email sending for queue processor
     public Task SendRawEmailAsync(
         string toEmail,

--- a/apps/web/src/app/(auth)/setup-account/_content.tsx
+++ b/apps/web/src/app/(auth)/setup-account/_content.tsx
@@ -1,0 +1,518 @@
+'use client';
+
+/**
+ * Setup Account Page Content (Issue #124)
+ *
+ * Invitation activation flow:
+ * 1. Read `token` from URL search params
+ * 2. GET /api/v1/auth/validate-invitation?token=xxx
+ * 3. If valid: show password form with pre-filled email/displayName
+ * 4. POST /api/v1/auth/activate-account with { token, password }
+ * 5. On success: redirect based on requiresOnboarding flag
+ */
+
+import { useEffect, useState, FormEvent } from 'react';
+
+import { motion } from 'framer-motion';
+import Link from 'next/link';
+import { useRouter, useSearchParams } from 'next/navigation';
+
+import { AccessibleFormInput, AccessibleButton } from '@/components/accessible';
+import { AuthLayout } from '@/components/layouts';
+import { Button } from '@/components/ui/primitives/button';
+import { getErrorMessage } from '@/lib/utils/errorHandler';
+
+// ──────────────────────────────────────────────
+// Types
+// ──────────────────────────────────────────────
+
+type PasswordStrength = 'weak' | 'medium' | 'strong';
+
+interface PasswordValidation {
+  minLength: boolean;
+  hasUppercase: boolean;
+  hasLowercase: boolean;
+  hasNumber: boolean;
+  isValid: boolean;
+  strength: PasswordStrength;
+}
+
+interface InvitationValidation {
+  isValid: boolean;
+  email: string | null;
+  displayName: string | null;
+  errorReason: string | null;
+}
+
+// ──────────────────────────────────────────────
+// Utilities
+// ──────────────────────────────────────────────
+
+const validatePassword = (password: string): PasswordValidation => {
+  const minLength = password.length >= 8;
+  const hasUppercase = /[A-Z]/.test(password);
+  const hasLowercase = /[a-z]/.test(password);
+  const hasNumber = /[0-9]/.test(password);
+
+  const requirementsMet = [minLength, hasUppercase, hasLowercase, hasNumber].filter(Boolean).length;
+
+  let strength: PasswordStrength = 'weak';
+  if (requirementsMet === 4) {
+    strength = 'strong';
+  } else if (requirementsMet >= 2 && minLength) {
+    strength = 'medium';
+  }
+
+  return {
+    minLength,
+    hasUppercase,
+    hasLowercase,
+    hasNumber,
+    isValid: minLength && hasUppercase && hasLowercase && hasNumber,
+    strength,
+  };
+};
+
+const getApiBase = (): string => {
+  if (typeof window !== 'undefined') {
+    return process.env.NEXT_PUBLIC_API_BASE_URL ?? '';
+  }
+  return '';
+};
+
+// ──────────────────────────────────────────────
+// Password Strength Indicator
+// ──────────────────────────────────────────────
+
+const PasswordStrengthIndicator = ({ strength }: { strength: PasswordStrength }) => {
+  const strengthConfig = {
+    weak: {
+      color: 'bg-red-500',
+      text: 'Debole',
+      textColor: 'text-red-500',
+      width: 'w-1/3',
+    },
+    medium: {
+      color: 'bg-orange-500',
+      text: 'Media',
+      textColor: 'text-orange-500',
+      width: 'w-2/3',
+    },
+    strong: {
+      color: 'bg-green-500',
+      text: 'Forte',
+      textColor: 'text-green-500',
+      width: 'w-full',
+    },
+  };
+
+  const config = strengthConfig[strength];
+
+  return (
+    <div className="space-y-2" role="status" aria-live="polite">
+      <div className="flex justify-between items-center">
+        <span className="text-sm text-slate-600 dark:text-slate-400">Sicurezza password:</span>
+        <span className={`text-sm font-medium ${config.textColor}`}>{config.text}</span>
+      </div>
+      <div className="h-2 bg-slate-200 dark:bg-slate-700 rounded-full overflow-hidden">
+        <motion.div
+          className={`h-full ${config.color}`}
+          initial={{ width: 0 }}
+          animate={{ width: config.width }}
+          transition={{ duration: 0.3 }}
+        />
+      </div>
+    </div>
+  );
+};
+
+// ──────────────────────────────────────────────
+// Main Content Component
+// ──────────────────────────────────────────────
+
+export function SetupAccountContent() {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const token = searchParams?.get('token') ?? null;
+
+  // Token validation state
+  const [validationResult, setValidationResult] = useState<InvitationValidation | null>(null);
+  const [isValidating, setIsValidating] = useState(true);
+
+  // Password form state
+  const [password, setPassword] = useState('');
+  const [confirmPassword, setConfirmPassword] = useState('');
+  const [passwordValidation, setPasswordValidation] = useState<PasswordValidation>({
+    minLength: false,
+    hasUppercase: false,
+    hasLowercase: false,
+    hasNumber: false,
+    isValid: false,
+    strength: 'weak',
+  });
+
+  // UI state
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [errorMessage, setErrorMessage] = useState('');
+  const [activationSuccess, setActivationSuccess] = useState(false);
+
+  // ── Step 1: Validate token on mount ──────────
+  useEffect(() => {
+    if (!token) {
+      setValidationResult({
+        isValid: false,
+        email: null,
+        displayName: null,
+        errorReason: 'invalid',
+      });
+      setIsValidating(false);
+      return;
+    }
+
+    let cancelled = false;
+
+    async function validateToken() {
+      try {
+        const baseUrl = getApiBase();
+        const url = `${baseUrl}/api/v1/auth/validate-invitation?token=${encodeURIComponent(token!)}`;
+        const response = await fetch(url, {
+          method: 'GET',
+          headers: { 'Content-Type': 'application/json' },
+          credentials: 'include',
+        });
+
+        if (cancelled) return;
+
+        if (!response.ok) {
+          setValidationResult({
+            isValid: false,
+            email: null,
+            displayName: null,
+            errorReason: 'invalid',
+          });
+          setIsValidating(false);
+          return;
+        }
+
+        const data = await response.json();
+        setValidationResult({
+          isValid: data.isValid ?? false,
+          email: data.email ?? null,
+          displayName: data.displayName ?? null,
+          errorReason: data.errorReason ?? null,
+        });
+      } catch {
+        if (cancelled) return;
+        setValidationResult({
+          isValid: false,
+          email: null,
+          displayName: null,
+          errorReason: 'invalid',
+        });
+      } finally {
+        if (!cancelled) setIsValidating(false);
+      }
+    }
+
+    validateToken();
+    return () => {
+      cancelled = true;
+    };
+  }, [token]);
+
+  // ── Update password validation on change ──────
+  useEffect(() => {
+    if (password) {
+      setPasswordValidation(validatePassword(password));
+    } else {
+      setPasswordValidation({
+        minLength: false,
+        hasUppercase: false,
+        hasLowercase: false,
+        hasNumber: false,
+        isValid: false,
+        strength: 'weak',
+      });
+    }
+  }, [password]);
+
+  // ── Step 2: Handle form submission ────────────
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+    setErrorMessage('');
+
+    if (!passwordValidation.isValid) {
+      setErrorMessage('La password non soddisfa tutti i requisiti.');
+      return;
+    }
+
+    if (password !== confirmPassword) {
+      setErrorMessage('Le password non coincidono.');
+      return;
+    }
+
+    if (!token) {
+      setErrorMessage('Token mancante.');
+      return;
+    }
+
+    setIsSubmitting(true);
+
+    try {
+      const baseUrl = getApiBase();
+      const response = await fetch(`${baseUrl}/api/v1/auth/activate-account`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ token, password }),
+      });
+
+      if (!response.ok) {
+        const data = await response.json().catch(() => null);
+        const message = data?.error ?? data?.message ?? "Impossibile attivare l'account. Riprova.";
+        setErrorMessage(getErrorMessage(message, "Impossibile attivare l'account. Riprova."));
+        setIsSubmitting(false);
+        return;
+      }
+
+      const data = await response.json();
+      setActivationSuccess(true);
+
+      // Redirect based on requiresOnboarding flag
+      const redirectTo = data.requiresOnboarding ? '/onboarding' : '/dashboard';
+      setTimeout(() => {
+        void router.push(redirectTo);
+      }, 1500);
+    } catch (err) {
+      setErrorMessage(getErrorMessage(err, "Impossibile attivare l'account. Riprova."));
+      setIsSubmitting(false);
+    }
+  };
+
+  // ──────────────────────────────────────────────
+  // Render States
+  // ──────────────────────────────────────────────
+
+  // Loading: validating token
+  if (isValidating) {
+    return (
+      <AuthLayout title="Verifica in corso...">
+        <div className="text-center space-y-4 py-8">
+          <div className="animate-spin text-4xl mb-4">&#9203;</div>
+          <p className="text-slate-400">Verifica del token di invito...</p>
+        </div>
+      </AuthLayout>
+    );
+  }
+
+  // No token in URL
+  if (!token) {
+    return (
+      <AuthLayout title="Token mancante" subtitle="Nessun token di invito fornito">
+        <div className="text-center space-y-4 py-4">
+          <div className="text-6xl mb-4">&#9888;&#65039;</div>
+          <p className="text-sm text-red-400">
+            Token mancante. Utilizza il link ricevuto nell&apos;email di invito.
+          </p>
+          <div className="pt-4">
+            <Button variant="secondary" asChild>
+              <Link href="/login">Vai al Login</Link>
+            </Button>
+          </div>
+        </div>
+      </AuthLayout>
+    );
+  }
+
+  // Invalid token
+  if (validationResult && !validationResult.isValid) {
+    const isAlreadyUsed = validationResult.errorReason === 'already_used';
+
+    return (
+      <AuthLayout
+        title={isAlreadyUsed ? 'Invito gia utilizzato' : 'Invito non valido'}
+        subtitle={
+          isAlreadyUsed
+            ? 'Questo invito e gia stato utilizzato.'
+            : "L'invito non e valido o e scaduto. Contatta l'amministratore."
+        }
+      >
+        <div className="text-center space-y-4 py-4">
+          <div className="text-6xl mb-4">&#9888;&#65039;</div>
+          <div className="pt-4 space-y-2">
+            {isAlreadyUsed && (
+              <Button asChild className="w-full">
+                <Link href="/login">Vai al Login</Link>
+              </Button>
+            )}
+            <Button variant="secondary" asChild className="w-full">
+              <Link href="/">Torna alla Home</Link>
+            </Button>
+          </div>
+        </div>
+      </AuthLayout>
+    );
+  }
+
+  // Activation success
+  if (activationSuccess) {
+    return (
+      <AuthLayout
+        title="Account attivato!"
+        subtitle="Il tuo account e stato configurato con successo"
+      >
+        <div className="text-center space-y-4 py-4">
+          <div className="text-6xl mb-4">&#9989;</div>
+          <p className="text-sm text-slate-500 dark:text-slate-400">Reindirizzamento in corso...</p>
+          <div className="animate-spin text-2xl mx-auto w-fit">&#9203;</div>
+        </div>
+      </AuthLayout>
+    );
+  }
+
+  // Valid token: show password form
+  return (
+    <AuthLayout
+      title="Configura Account"
+      subtitle="Imposta la tua password per attivare il tuo account"
+    >
+      {errorMessage && (
+        <div
+          role="alert"
+          aria-live="polite"
+          className="bg-red-500/10 border border-red-500/30 text-red-400 px-4 py-3 rounded-lg mb-4"
+        >
+          {errorMessage}
+        </div>
+      )}
+
+      <form noValidate onSubmit={handleSubmit} className="space-y-4">
+        {/* Email (readonly) */}
+        <AccessibleFormInput
+          label="Email"
+          type="email"
+          value={validationResult?.email ?? ''}
+          readOnly
+          autoComplete="email"
+          inputClassName="w-full bg-slate-100 dark:bg-slate-800 border border-slate-300 dark:border-slate-600 rounded-lg px-4 py-3 text-slate-900 dark:text-slate-100 cursor-not-allowed"
+        />
+
+        {/* Display Name (readonly) */}
+        {validationResult?.displayName && (
+          <AccessibleFormInput
+            label="Nome"
+            type="text"
+            value={validationResult.displayName}
+            readOnly
+            inputClassName="w-full bg-slate-100 dark:bg-slate-800 border border-slate-300 dark:border-slate-600 rounded-lg px-4 py-3 text-slate-900 dark:text-slate-100 cursor-not-allowed"
+          />
+        )}
+
+        {/* Password */}
+        <AccessibleFormInput
+          label="Password"
+          type="password"
+          value={password}
+          onChange={e => setPassword(e.target.value)}
+          required
+          autoComplete="new-password"
+          placeholder="Inserisci la password"
+          inputClassName="w-full bg-white dark:bg-slate-700 border border-slate-300 dark:border-slate-600 rounded-lg px-4 py-3 text-slate-900 dark:text-slate-100 focus:border-primary focus:ring-2 focus:ring-ring"
+        />
+
+        {/* Password Requirements */}
+        {password && (
+          <div className="space-y-2">
+            <PasswordStrengthIndicator strength={passwordValidation.strength} />
+            <div className="text-sm space-y-1">
+              <div
+                className={`flex items-center gap-2 ${
+                  passwordValidation.minLength
+                    ? 'text-green-400'
+                    : 'text-slate-500 dark:text-slate-400'
+                }`}
+              >
+                <span aria-hidden="true">{passwordValidation.minLength ? '\u2713' : '\u25CB'}</span>
+                <span>Almeno 8 caratteri</span>
+              </div>
+              <div
+                className={`flex items-center gap-2 ${
+                  passwordValidation.hasUppercase
+                    ? 'text-green-400'
+                    : 'text-slate-500 dark:text-slate-400'
+                }`}
+              >
+                <span aria-hidden="true">
+                  {passwordValidation.hasUppercase ? '\u2713' : '\u25CB'}
+                </span>
+                <span>Almeno 1 lettera maiuscola</span>
+              </div>
+              <div
+                className={`flex items-center gap-2 ${
+                  passwordValidation.hasLowercase
+                    ? 'text-green-400'
+                    : 'text-slate-500 dark:text-slate-400'
+                }`}
+              >
+                <span aria-hidden="true">
+                  {passwordValidation.hasLowercase ? '\u2713' : '\u25CB'}
+                </span>
+                <span>Almeno 1 lettera minuscola</span>
+              </div>
+              <div
+                className={`flex items-center gap-2 ${
+                  passwordValidation.hasNumber
+                    ? 'text-green-400'
+                    : 'text-slate-500 dark:text-slate-400'
+                }`}
+              >
+                <span aria-hidden="true">{passwordValidation.hasNumber ? '\u2713' : '\u25CB'}</span>
+                <span>Almeno 1 numero</span>
+              </div>
+            </div>
+          </div>
+        )}
+
+        {/* Confirm Password */}
+        <AccessibleFormInput
+          label="Conferma Password"
+          type="password"
+          value={confirmPassword}
+          onChange={e => setConfirmPassword(e.target.value)}
+          required
+          autoComplete="new-password"
+          placeholder="Conferma la password"
+          error={
+            confirmPassword && password !== confirmPassword
+              ? 'Le password non coincidono'
+              : undefined
+          }
+          inputClassName="w-full bg-white dark:bg-slate-700 border border-slate-300 dark:border-slate-600 rounded-lg px-4 py-3 text-slate-900 dark:text-slate-100 focus:border-primary focus:ring-2 focus:ring-ring"
+        />
+
+        {/* Submit */}
+        <AccessibleButton
+          type="submit"
+          variant="primary"
+          className="w-full mt-6"
+          isLoading={isSubmitting}
+          loadingText="Attivazione in corso..."
+          disabled={
+            !passwordValidation.isValid || password !== confirmPassword || !confirmPassword.trim()
+          }
+        >
+          Configura Account
+        </AccessibleButton>
+      </form>
+
+      <div className="text-center mt-4">
+        <Link
+          href="/login"
+          className="text-sm text-primary hover:text-primary/80 transition-colors focus:outline-none focus:ring-2 focus:ring-primary focus:ring-offset-2 rounded px-2 py-1"
+        >
+          Hai gia un account? Accedi
+        </Link>
+      </div>
+    </AuthLayout>
+  );
+}

--- a/apps/web/src/app/(auth)/setup-account/page.tsx
+++ b/apps/web/src/app/(auth)/setup-account/page.tsx
@@ -1,0 +1,34 @@
+/**
+ * Setup Account Page — Invitation Activation Flow (Issue #124)
+ *
+ * Public page for invited users to set their password and activate their account.
+ * Uses the GET /auth/validate-invitation and POST /auth/activate-account endpoints.
+ *
+ * Flow:
+ * 1. Read `token` from URL search params
+ * 2. Validate token via GET endpoint
+ * 3. If valid: show password form with pre-filled email/displayName
+ * 4. On submit: activate account and redirect to onboarding or dashboard
+ */
+
+import { Suspense } from 'react';
+
+import { AuthLayout } from '@/components/layouts';
+
+import { SetupAccountContent } from './_content';
+
+export default function SetupAccountPage() {
+  return (
+    <Suspense
+      fallback={
+        <AuthLayout title="Caricamento...">
+          <div className="text-center py-8">
+            <div className="animate-pulse text-slate-500">Caricamento...</div>
+          </div>
+        </AuthLayout>
+      }
+    >
+      <SetupAccountContent />
+    </Suspense>
+  );
+}

--- a/docs/superpowers/plans/2026-03-17-admin-invitation-flow.md
+++ b/docs/superpowers/plans/2026-03-17-admin-invitation-flow.md
@@ -1,0 +1,1534 @@
+# Admin Invitation Flow — Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Admin creates user + sends invitation in one action; user sets password, auto-logs in, goes through reduced onboarding, finds pre-added/suggested games.
+
+**Architecture:** Extend existing Authentication BC invitation system. Add `Pending` status to `UserAccountStatus` (moved to SharedKernel). Two-phase activation: sync user activation + async game suggestions via `Channel<T>`. New `GameSuggestion` entity in UserLibrary BC.
+
+**Tech Stack:** .NET 9, ASP.NET Minimal APIs, MediatR (CQRS), EF Core + PostgreSQL, FluentValidation, xUnit + Moq + FluentAssertions, Next.js 16 (frontend)
+
+**Spec:** `docs/superpowers/specs/2026-03-17-admin-invitation-flow-design.md`
+
+---
+
+## File Structure
+
+### New Files
+
+| File | Responsibility |
+|------|---------------|
+| `SharedKernel/Domain/Enums/UserAccountStatus.cs` | Enum moved from Administration BC |
+| `Authentication/Domain/Entities/InvitationGameSuggestion.cs` | Game suggestion value on invitation |
+| `Authentication/Domain/Enums/GameSuggestionType.cs` | PreAdded / Suggested enum |
+| `Authentication/Domain/Events/UserProvisionedEvent.cs` | Domain event for pending user creation |
+| `Authentication/Domain/Events/UserActivatedFromInvitationEvent.cs` | Domain event for activation |
+| `Authentication/Domain/Events/GameSuggestionFailedEvent.cs` | Monitoring event for retry exhaustion |
+| `Authentication/Application/Commands/Invitation/ProvisionAndInviteUserCommand.cs` | Command record |
+| `Authentication/Application/Commands/Invitation/ProvisionAndInviteUserCommandValidator.cs` | Validator |
+| `Authentication/Application/Commands/Invitation/ProvisionAndInviteUserCommandHandler.cs` | Handler |
+| `Authentication/Application/Commands/Invitation/BatchProvisionCommand.cs` | JSON batch command |
+| `Authentication/Application/Commands/Invitation/BatchProvisionCommandHandler.cs` | JSON batch handler |
+| `Authentication/Application/Commands/Invitation/ActivateInvitedAccountCommand.cs` | Command record |
+| `Authentication/Application/Commands/Invitation/ActivateInvitedAccountCommandValidator.cs` | Validator |
+| `Authentication/Application/Commands/Invitation/ActivateInvitedAccountCommandHandler.cs` | Handler |
+| `Authentication/Application/Queries/Invitation/ValidateInvitationTokenQuery.cs` | Query + handler |
+| `Authentication/Application/DTOs/GameSuggestionDto.cs` | DTO for game suggestions |
+| `Authentication/Application/DTOs/BatchInvitationItemDto.cs` | DTO for batch items |
+| `Authentication/Application/DTOs/BatchInvitationResultDto.cs` | DTO for batch results |
+| `Authentication/Application/DTOs/InvitationValidationDto.cs` | DTO for token validation |
+| `Authentication/Application/DTOs/ActivationResultDto.cs` | DTO for activation result |
+| `Authentication/Infrastructure/Services/GameSuggestionChannel.cs` | Channel<T> wrapper |
+| `Infrastructure/BackgroundServices/InvitationCleanupService.cs` | Cleanup pending users |
+| `Infrastructure/BackgroundServices/GameSuggestionProcessorService.cs` | Async game processor |
+| `UserLibrary/Domain/Entities/GameSuggestion.cs` | Suggestion entity |
+| `UserLibrary/Domain/Events/GameSuggestionAcceptedEvent.cs` | Domain event |
+| `UserLibrary/Domain/Events/GamePreAddedToCollectionEvent.cs` | Cross-BC event |
+| `UserLibrary/Domain/Events/GameSuggestedForUserEvent.cs` | Cross-BC event |
+| `UserLibrary/Domain/Repositories/IGameSuggestionRepository.cs` | Repository interface |
+| `UserLibrary/Infrastructure/Persistence/GameSuggestionRepository.cs` | Repository impl |
+| `UserLibrary/Application/EventHandlers/GamePreAddedHandler.cs` | Handles pre-add event |
+| `UserLibrary/Application/EventHandlers/GameSuggestedHandler.cs` | Handles suggestion event |
+| `apps/web/src/app/(auth)/setup-account/page.tsx` | Setup account page |
+
+### Modified Files
+
+| File | Change |
+|------|--------|
+| `Administration/Domain/Enums/EntityStates.cs` | Remove `UserAccountStatus` (moved to SharedKernel) |
+| `Authentication/Domain/Entities/User.cs` | Add `CreatePending()`, `ActivateFromInvitation()`, `InvitedByUserId`, `InvitationExpiresAt` |
+| `Authentication/Domain/Entities/InvitationToken.cs` | Add `CustomMessage`, `PendingUserId`, `GameSuggestions`, `TimeProvider` to `Create()` |
+| `Authentication/Domain/Repositories/IInvitationTokenRepository.cs` | Add `GetExpiredPendingAsync()` |
+| `Authentication/Infrastructure/Repositories/InvitationTokenRepository.cs` | Update mapping for new fields |
+| `Authentication/Application/DTOs/InvitationDto.cs` | Add `EmailSent`, `GameSuggestions` |
+| `Authentication/Application/Commands/Invitation/BulkSendInvitationsCommandHandler.cs` | Extend for new provisioning flow |
+| `Api/Routing/AuthenticationEndpoints.cs` | Add activate-account, validate-invitation endpoints |
+| `Api/Routing/AdminEndpoints.cs` | Add admin invitation endpoints |
+| `Services/IEmailService.cs` | Extend `SendInvitationEmailAsync` signature |
+| `Services/EmailService.cs` | Update implementation |
+| `Infrastructure/Persistence/AppDbContext.cs` | Add `InvitationGameSuggestions`, `GameSuggestions` DbSets |
+| `Program.cs` | Register new services, background services, Channel |
+| All files importing `UserAccountStatus` from Administration BC | Update import to SharedKernel |
+
+---
+
+## Chunk 1: Domain Model Foundation
+
+### Task 1: Move UserAccountStatus to SharedKernel
+
+**Files:**
+- Create: `apps/api/src/Api/SharedKernel/Domain/Enums/UserAccountStatus.cs`
+- Modify: `apps/api/src/Api/BoundedContexts/Administration/Domain/Enums/EntityStates.cs`
+- Modify: All files importing `UserAccountStatus` from Administration BC
+
+- [ ] **Step 1: Create SharedKernel enum with Pending value**
+
+```csharp
+// apps/api/src/Api/SharedKernel/Domain/Enums/UserAccountStatus.cs
+namespace Api.SharedKernel.Domain.Enums;
+
+public enum UserAccountStatus
+{
+    Active = 0,
+    Suspended = 1,
+    Banned = 2,
+    Pending = 3
+}
+```
+
+- [ ] **Step 2: Remove enum from Administration BC EntityStates.cs**
+
+Remove the `UserAccountStatus` enum from `EntityStates.cs`. Keep any other enums in that file.
+
+- [ ] **Step 3: Update all imports project-wide**
+
+Search for `using Api.BoundedContexts.Administration.Domain.Enums` that reference `UserAccountStatus` and change to `using Api.SharedKernel.Domain.Enums`. Run:
+
+```bash
+cd apps/api/src/Api && grep -r "Administration.Domain.Enums" --include="*.cs" -l
+```
+
+**IMPORTANT**: `EntityStates.cs` contains OTHER enums too (`GamePublicationState`, `CollectionVisibility`, `DocumentProcessingState`). The grep will match ALL files using any of those enums. Only update files that specifically reference `UserAccountStatus`. Files using the other three enums must KEEP their `Administration.Domain.Enums` using (or add both usings if they also use `UserAccountStatus`).
+
+Update each file's using statement. Key files likely include:
+- `Authentication/Domain/Entities/User.cs`
+- `Administration/Application/Commands/` (permission handlers)
+- Any handler that checks `UserAccountStatus`
+
+- [ ] **Step 4: Update CheckPermissionHandler and GetUserPermissionsHandler for Pending**
+
+Find these handlers in Administration BC. Add a `Pending` case that denies all permissions / returns empty permissions. Pattern:
+
+```csharp
+UserAccountStatus.Pending => Array.Empty<Permission>(),
+// or for switch expressions:
+UserAccountStatus.Pending => false,
+```
+
+- [ ] **Step 5: Build and verify no compilation errors**
+
+```bash
+cd apps/api/src/Api && dotnet build
+```
+
+- [ ] **Step 6: Run existing tests to verify no regressions**
+
+```bash
+cd apps/api && dotnet test --filter "Category=Unit" --no-build
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add -A && git commit -m "refactor(shared-kernel): move UserAccountStatus to SharedKernel, add Pending status"
+```
+
+---
+
+### Task 2: Extend User Entity — Pending State
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/Authentication/Domain/Entities/User.cs`
+- Create: `apps/api/src/Api/BoundedContexts/Authentication/Domain/Events/UserProvisionedEvent.cs`
+- Create: `apps/api/src/Api/BoundedContexts/Authentication/Domain/Events/UserActivatedFromInvitationEvent.cs`
+- Test: `apps/api/tests/Api.Tests/BoundedContexts/Authentication/Domain/Entities/UserPendingStateTests.cs`
+
+- [ ] **Step 1: Write failing tests for CreatePending and ActivateFromInvitation**
+
+```csharp
+// apps/api/tests/Api.Tests/BoundedContexts/Authentication/Domain/Entities/UserPendingStateTests.cs
+using Api.BoundedContexts.Authentication.Domain.Entities;
+using Api.BoundedContexts.Authentication.Domain.ValueObjects;
+using Api.SharedKernel.Domain.Enums;
+using FluentAssertions;
+using Microsoft.Extensions.Time.Testing;
+
+namespace Api.Tests.BoundedContexts.Authentication.Domain.Entities;
+
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "Authentication")]
+public class UserPendingStateTests
+{
+    private readonly FakeTimeProvider _timeProvider = new(DateTimeOffset.UtcNow);
+
+    [Fact]
+    public void CreatePending_SetsCorrectState()
+    {
+        var email = Email.Create("test@example.com");
+        var user = User.CreatePending(
+            email, "Test User", Role.User, UserTier.Free,
+            Guid.NewGuid(), DateTime.UtcNow.AddDays(7), _timeProvider);
+
+        user.Status.Should().Be(UserAccountStatus.Pending);
+        user.Email.Should().Be(email);
+        user.DisplayName.Should().Be("Test User");
+        user.InvitedByUserId.Should().NotBeNull();
+        user.InvitationExpiresAt.Should().NotBeNull();
+        user.EmailVerified.Should().BeFalse();
+    }
+
+    [Fact]
+    public void CreatePending_CannotAuthenticate()
+    {
+        var user = CreatePendingUser();
+        user.CanAuthenticate().Should().BeFalse();
+    }
+
+    [Fact]
+    public void ActivateFromInvitation_TransitionsPendingToActive()
+    {
+        var user = CreatePendingUser();
+        var passwordHash = PasswordHash.Create("SecureP@ss123");
+
+        user.ActivateFromInvitation(passwordHash, _timeProvider);
+
+        user.Status.Should().Be(UserAccountStatus.Active);
+        user.EmailVerified.Should().BeTrue();
+        user.CanAuthenticate().Should().BeTrue();
+    }
+
+    [Fact]
+    public void ActivateFromInvitation_ThrowsIfNotPending()
+    {
+        // Active user cannot be "activated from invitation"
+        var email = Email.Create("active@example.com");
+        var user = new User(Guid.NewGuid(), email, "Active",
+            PasswordHash.Create("Pass1!"), Role.User);
+
+        var act = () => user.ActivateFromInvitation(PasswordHash.Create("NewPass1!"), _timeProvider);
+        act.Should().Throw<InvalidOperationException>()
+            .WithMessage("*Pending*");
+    }
+
+    [Fact]
+    public void CreatePending_EmitsUserProvisionedEvent()
+    {
+        var user = CreatePendingUser();
+        user.DomainEvents.Should().ContainSingle(e => e is UserProvisionedEvent);
+    }
+
+    [Fact]
+    public void ActivateFromInvitation_EmitsUserActivatedEvent()
+    {
+        var user = CreatePendingUser();
+        user.ClearDomainEvents(); // clear provisioned event
+        user.ActivateFromInvitation(PasswordHash.Create("SecureP@ss123"), _timeProvider);
+        user.DomainEvents.Should().ContainSingle(e => e is UserActivatedFromInvitationEvent);
+    }
+
+    private User CreatePendingUser()
+    {
+        return User.CreatePending(
+            Email.Create("pending@example.com"), "Pending User",
+            Role.User, UserTier.Free,
+            Guid.NewGuid(), DateTime.UtcNow.AddDays(7), _timeProvider);
+    }
+}
+```
+
+- [ ] **Step 2: Run tests — verify they fail**
+
+```bash
+cd apps/api && dotnet test --filter "FullyQualifiedName~UserPendingStateTests" --no-build 2>&1 | head -30
+```
+
+Expected: compilation errors (methods don't exist yet).
+
+- [ ] **Step 3: Create domain events**
+
+```csharp
+// apps/api/src/Api/BoundedContexts/Authentication/Domain/Events/UserProvisionedEvent.cs
+namespace Api.BoundedContexts.Authentication.Domain.Events;
+
+public sealed record UserProvisionedEvent(
+    Guid UserId,
+    string Email,
+    string DisplayName,
+    string Role,
+    string Tier,
+    Guid InvitedByUserId) : IDomainEvent;
+```
+
+```csharp
+// apps/api/src/Api/BoundedContexts/Authentication/Domain/Events/UserActivatedFromInvitationEvent.cs
+namespace Api.BoundedContexts.Authentication.Domain.Events;
+
+public sealed record UserActivatedFromInvitationEvent(
+    Guid UserId,
+    string Email,
+    string Role,
+    string Tier,
+    Guid InvitedByUserId) : IDomainEvent;
+```
+
+- [ ] **Step 4: Add properties and methods to User entity**
+
+Add to `User.cs`:
+
+Properties:
+```csharp
+public Guid? InvitedByUserId { get; private set; }
+public DateTime? InvitationExpiresAt { get; private set; }
+```
+
+Factory method:
+```csharp
+public static User CreatePending(
+    Email email, string displayName, Role role, UserTier tier,
+    Guid invitedByUserId, DateTime expiresAt, TimeProvider timeProvider)
+{
+    var user = new User
+    {
+        Id = Guid.NewGuid(),
+        Email = email,
+        DisplayName = displayName,
+        Role = role,
+        Tier = tier,
+        Status = UserAccountStatus.Pending,
+        InvitedByUserId = invitedByUserId,
+        InvitationExpiresAt = expiresAt,
+        EmailVerified = false,
+        CreatedAt = timeProvider.GetUtcNow().UtcDateTime
+    };
+    user.AddDomainEvent(new UserProvisionedEvent(
+        user.Id, email.Value, displayName, role.ToString(), tier.ToString(), invitedByUserId));
+    return user;
+}
+```
+
+Activation method:
+```csharp
+public void ActivateFromInvitation(PasswordHash passwordHash, TimeProvider timeProvider)
+{
+    if (Status != UserAccountStatus.Pending)
+        throw new InvalidOperationException("Only Pending users can be activated from invitation");
+
+    PasswordHash = passwordHash;
+    Status = UserAccountStatus.Active;
+    EmailVerified = true;
+    EmailVerifiedAt = timeProvider.GetUtcNow().UtcDateTime;
+
+    AddDomainEvent(new UserActivatedFromInvitationEvent(
+        Id, Email.Value, Role.ToString(), Tier.ToString(), InvitedByUserId!.Value));
+}
+```
+
+Update `CanAuthenticate()` if it doesn't already handle `Pending`:
+```csharp
+public bool CanAuthenticate() => Status == UserAccountStatus.Active;
+```
+
+- [ ] **Step 5: Run tests — verify they pass**
+
+```bash
+cd apps/api && dotnet test --filter "FullyQualifiedName~UserPendingStateTests" -v n
+```
+
+Expected: All 6 tests PASS.
+
+- [ ] **Step 6: Run full test suite to check regressions**
+
+```bash
+cd apps/api && dotnet test --filter "Category=Unit&BoundedContext=Authentication" --no-build
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add -A && git commit -m "feat(auth): add Pending state to User entity with CreatePending and ActivateFromInvitation"
+```
+
+---
+
+### Task 3: Extend InvitationToken Entity
+
+**Files:**
+- Modify: `apps/api/src/Api/BoundedContexts/Authentication/Domain/Entities/InvitationToken.cs`
+- Create: `apps/api/src/Api/BoundedContexts/Authentication/Domain/Entities/InvitationGameSuggestion.cs`
+- Create: `apps/api/src/Api/BoundedContexts/Authentication/Domain/Enums/GameSuggestionType.cs`
+- Test: `apps/api/tests/Api.Tests/BoundedContexts/Authentication/Domain/Entities/InvitationTokenExtendedTests.cs`
+
+- [ ] **Step 1: Create GameSuggestionType enum**
+
+```csharp
+// apps/api/src/Api/BoundedContexts/Authentication/Domain/Enums/GameSuggestionType.cs
+namespace Api.BoundedContexts.Authentication.Domain.Enums;
+
+public enum GameSuggestionType
+{
+    PreAdded = 0,
+    Suggested = 1
+}
+```
+
+- [ ] **Step 2: Create InvitationGameSuggestion entity**
+
+```csharp
+// apps/api/src/Api/BoundedContexts/Authentication/Domain/Entities/InvitationGameSuggestion.cs
+namespace Api.BoundedContexts.Authentication.Domain.Entities;
+
+public sealed class InvitationGameSuggestion
+{
+    public Guid Id { get; private set; }
+    public Guid InvitationTokenId { get; private set; }
+    public Guid GameId { get; private set; }
+    public GameSuggestionType Type { get; private set; }
+
+    private InvitationGameSuggestion() { } // EF Core
+
+    public static InvitationGameSuggestion Create(Guid invitationTokenId, Guid gameId, GameSuggestionType type)
+    {
+        return new InvitationGameSuggestion
+        {
+            Id = Guid.NewGuid(),
+            InvitationTokenId = invitationTokenId,
+            GameId = gameId,
+            Type = type
+        };
+    }
+}
+```
+
+- [ ] **Step 3: Write failing tests for InvitationToken extensions**
+
+```csharp
+// apps/api/tests/Api.Tests/BoundedContexts/Authentication/Domain/Entities/InvitationTokenExtendedTests.cs
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "Authentication")]
+public class InvitationTokenExtendedTests
+{
+    private readonly FakeTimeProvider _timeProvider = new(new DateTimeOffset(2026, 3, 17, 12, 0, 0, TimeSpan.Zero));
+
+    [Fact]
+    public void Create_WithTimeProvider_SetsCorrectExpiry()
+    {
+        var token = InvitationToken.Create(
+            Email.Create("test@example.com"), Role.User, Guid.NewGuid(),
+            "Welcome!", 14, _timeProvider, "tokenHash123");
+
+        token.ExpiresAt.Should().Be(new DateTime(2026, 3, 31, 12, 0, 0, DateTimeKind.Utc));
+        token.CustomMessage.Should().Be("Welcome!");
+        token.PendingUserId.Should().NotBeEmpty();
+    }
+
+    [Fact]
+    public void Create_WithGameSuggestions_AttachesSuggestions()
+    {
+        var token = InvitationToken.Create(
+            Email.Create("test@example.com"), Role.User, Guid.NewGuid(),
+            null, 7, _timeProvider, "tokenHash123");
+
+        var gameId = Guid.NewGuid();
+        token.AddGameSuggestion(gameId, GameSuggestionType.PreAdded);
+        token.AddGameSuggestion(Guid.NewGuid(), GameSuggestionType.Suggested);
+
+        token.GameSuggestions.Should().HaveCount(2);
+        token.GameSuggestions.First().GameId.Should().Be(gameId);
+        token.GameSuggestions.First().Type.Should().Be(GameSuggestionType.PreAdded);
+    }
+}
+```
+
+- [ ] **Step 4: Extend InvitationToken entity**
+
+Add to `InvitationToken.cs`:
+
+Properties:
+```csharp
+public string? CustomMessage { get; private set; }
+public Guid? PendingUserId { get; private set; }
+private readonly List<InvitationGameSuggestion> _gameSuggestions = new();
+public IReadOnlyList<InvitationGameSuggestion> GameSuggestions => _gameSuggestions.AsReadOnly();
+```
+
+Update or add overloaded `Create` factory:
+```csharp
+public static InvitationToken Create(
+    Email email, Role role, Guid pendingUserId,
+    string? customMessage, int expiresInDays, TimeProvider timeProvider, string tokenHash)
+{
+    var token = new InvitationToken
+    {
+        Id = Guid.NewGuid(),
+        Email = email,
+        Role = role,
+        TokenHash = tokenHash,
+        PendingUserId = pendingUserId,
+        CustomMessage = customMessage,
+        Status = InvitationStatus.Pending,
+        ExpiresAt = timeProvider.GetUtcNow().UtcDateTime.AddDays(expiresInDays),
+        CreatedAt = timeProvider.GetUtcNow().UtcDateTime
+    };
+    return token;
+}
+```
+
+Add method:
+```csharp
+public void AddGameSuggestion(Guid gameId, GameSuggestionType type)
+{
+    _gameSuggestions.Add(InvitationGameSuggestion.Create(Id, gameId, type));
+}
+```
+
+- [ ] **Step 5: Run tests — verify they pass**
+
+```bash
+cd apps/api && dotnet test --filter "FullyQualifiedName~InvitationTokenExtendedTests" -v n
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A && git commit -m "feat(auth): extend InvitationToken with CustomMessage, PendingUserId, GameSuggestions, TimeProvider"
+```
+
+---
+
+### Task 4: Create GameSuggestion Entity in UserLibrary BC
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/UserLibrary/Domain/Entities/GameSuggestion.cs`
+- Create: `apps/api/src/Api/BoundedContexts/UserLibrary/Domain/Events/GameSuggestionAcceptedEvent.cs`
+- Create: `apps/api/src/Api/BoundedContexts/UserLibrary/Domain/Repositories/IGameSuggestionRepository.cs`
+- Test: `apps/api/tests/Api.Tests/BoundedContexts/UserLibrary/Domain/Entities/GameSuggestionTests.cs`
+
+- [ ] **Step 1: Write failing tests**
+
+```csharp
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "UserLibrary")]
+public class GameSuggestionTests
+{
+    [Fact]
+    public void Create_SetsProperties()
+    {
+        var userId = Guid.NewGuid();
+        var gameId = Guid.NewGuid();
+        var adminId = Guid.NewGuid();
+
+        var timeProvider = new FakeTimeProvider(DateTimeOffset.UtcNow);
+        var suggestion = GameSuggestion.Create(userId, gameId, adminId, "invitation", timeProvider);
+
+        suggestion.UserId.Should().Be(userId);
+        suggestion.GameId.Should().Be(gameId);
+        suggestion.SuggestedByUserId.Should().Be(adminId);
+        suggestion.Source.Should().Be("invitation");
+        suggestion.IsDismissed.Should().BeFalse();
+        suggestion.IsAccepted.Should().BeFalse();
+    }
+
+    [Fact]
+    public void Accept_SetsIsAccepted_EmitsEvent()
+    {
+        var suggestion = GameSuggestion.Create(Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), "invitation", new FakeTimeProvider(DateTimeOffset.UtcNow));
+
+        suggestion.Accept();
+
+        suggestion.IsAccepted.Should().BeTrue();
+        suggestion.DomainEvents.Should().ContainSingle(e => e is GameSuggestionAcceptedEvent);
+    }
+
+    [Fact]
+    public void Dismiss_SetsIsDismissed()
+    {
+        var suggestion = GameSuggestion.Create(Guid.NewGuid(), Guid.NewGuid(), Guid.NewGuid(), "invitation", new FakeTimeProvider(DateTimeOffset.UtcNow));
+
+        suggestion.Dismiss();
+
+        suggestion.IsDismissed.Should().BeTrue();
+    }
+}
+```
+
+- [ ] **Step 2: Implement GameSuggestion entity**
+
+```csharp
+// apps/api/src/Api/BoundedContexts/UserLibrary/Domain/Entities/GameSuggestion.cs
+namespace Api.BoundedContexts.UserLibrary.Domain.Entities;
+
+public sealed class GameSuggestion : AggregateRoot<Guid>
+{
+    public Guid UserId { get; private set; }
+    public Guid GameId { get; private set; }
+    public Guid SuggestedByUserId { get; private set; }
+    public string? Source { get; private set; }
+    public DateTime CreatedAt { get; private set; }
+    public bool IsDismissed { get; private set; }
+    public bool IsAccepted { get; private set; }
+
+    private GameSuggestion() { }
+
+    public static GameSuggestion Create(Guid userId, Guid gameId, Guid suggestedByUserId, string? source, TimeProvider timeProvider)
+    {
+        return new GameSuggestion
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            GameId = gameId,
+            SuggestedByUserId = suggestedByUserId,
+            Source = source,
+            CreatedAt = timeProvider.GetUtcNow().UtcDateTime,
+            IsDismissed = false,
+            IsAccepted = false
+        };
+    }
+
+    public void Accept()
+    {
+        IsAccepted = true;
+        RaiseDomainEvent(new GameSuggestionAcceptedEvent(Id, UserId, GameId));
+    }
+
+    public void Dismiss()
+    {
+        IsDismissed = true;
+    }
+}
+```
+
+```csharp
+// apps/api/src/Api/BoundedContexts/UserLibrary/Domain/Events/GameSuggestionAcceptedEvent.cs
+namespace Api.BoundedContexts.UserLibrary.Domain.Events;
+
+public sealed record GameSuggestionAcceptedEvent(Guid SuggestionId, Guid UserId, Guid GameId) : IDomainEvent;
+```
+
+```csharp
+// apps/api/src/Api/BoundedContexts/UserLibrary/Domain/Repositories/IGameSuggestionRepository.cs
+namespace Api.BoundedContexts.UserLibrary.Domain.Repositories;
+
+public interface IGameSuggestionRepository
+{
+    Task<GameSuggestion?> GetByIdAsync(Guid id, CancellationToken ct = default);
+    Task<IReadOnlyList<GameSuggestion>> GetByUserIdAsync(Guid userId, CancellationToken ct = default);
+    Task AddAsync(GameSuggestion suggestion, CancellationToken ct = default);
+    Task<bool> ExistsAsync(Guid userId, Guid gameId, CancellationToken ct = default);
+}
+```
+
+- [ ] **Step 3: Run tests — verify pass**
+
+```bash
+cd apps/api && dotnet test --filter "FullyQualifiedName~GameSuggestionTests" -v n
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add -A && git commit -m "feat(user-library): add GameSuggestion entity with Accept/Dismiss and repository interface"
+```
+
+---
+
+### Task 5: EF Core Migration — New Tables and Columns
+
+**Files:**
+- Modify: `apps/api/src/Api/Infrastructure/Persistence/AppDbContext.cs` (or per-BC DbContext)
+- Modify: EF configuration files for InvitationToken, User, new entities
+- Create: Migration file
+
+- [ ] **Step 1: Add DbSet and configure InvitationGameSuggestion**
+
+Add `DbSet<InvitationGameSuggestion>` and configure the entity in the appropriate `OnModelCreating` or configuration class:
+
+```csharp
+builder.Entity<InvitationGameSuggestion>(e =>
+{
+    e.ToTable("InvitationGameSuggestions");
+    e.HasKey(x => x.Id);
+    e.Property(x => x.GameId).IsRequired();
+    e.Property(x => x.Type).IsRequired();
+    e.HasOne<InvitationToken>()
+        .WithMany(t => t.GameSuggestions)
+        .HasForeignKey(x => x.InvitationTokenId)
+        .OnDelete(DeleteBehavior.Cascade);
+});
+```
+
+- [ ] **Step 2: Configure User new columns**
+
+```csharp
+builder.Entity<User>(e =>
+{
+    // Add to existing configuration:
+    e.Property(x => x.InvitedByUserId);
+    e.Property(x => x.InvitationExpiresAt);
+});
+```
+
+- [ ] **Step 3: Configure InvitationToken new columns**
+
+```csharp
+builder.Entity<InvitationToken>(e =>
+{
+    // Add to existing configuration:
+    e.Property(x => x.CustomMessage).HasMaxLength(500);
+    e.Property(x => x.PendingUserId);
+    e.HasMany(x => x.GameSuggestions)
+        .WithOne()
+        .HasForeignKey(x => x.InvitationTokenId)
+        .OnDelete(DeleteBehavior.Cascade);
+});
+```
+
+- [ ] **Step 4: Configure GameSuggestion (UserLibrary BC)**
+
+```csharp
+builder.Entity<GameSuggestion>(e =>
+{
+    e.ToTable("GameSuggestions");
+    e.HasKey(x => x.Id);
+    e.Property(x => x.UserId).IsRequired();
+    e.Property(x => x.GameId).IsRequired();
+    e.Property(x => x.SuggestedByUserId).IsRequired();
+    e.Property(x => x.Source).HasMaxLength(50);
+    e.Property(x => x.CreatedAt).IsRequired();
+    e.Property(x => x.IsDismissed).HasDefaultValue(false);
+    e.Property(x => x.IsAccepted).HasDefaultValue(false);
+});
+```
+
+- [ ] **Step 5: Create migration**
+
+```bash
+cd apps/api/src/Api && dotnet ef migrations add AddInvitationFlowTables
+```
+
+- [ ] **Step 6: Review generated migration SQL**
+
+Open the generated migration file and verify:
+- `InvitedByUserId` and `InvitationExpiresAt` added to Users
+- `CustomMessage`, `PendingUserId` added to InvitationTokens (**NOTE: `ExpiresAt` already exists on InvitationTokens from a prior migration — do NOT add it again**)
+- `InvitationGameSuggestions` table with cascade delete on `InvitationTokenId`
+- `GameSuggestions` table
+- `Pending = 3` added to `UserAccountStatus` enum column
+
+- [ ] **Step 7: Apply migration locally**
+
+```bash
+cd apps/api/src/Api && dotnet ef database update
+```
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add -A && git commit -m "feat(db): add migration for invitation flow tables and columns"
+```
+
+---
+
+## Chunk 2: Commands, Handlers & Background Services
+
+### Task 6: ProvisionAndInviteUserCommand + Handler
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/Authentication/Application/DTOs/GameSuggestionDto.cs`
+- Create: `apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/Invitation/ProvisionAndInviteUserCommand.cs`
+- Create: `apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/Invitation/ProvisionAndInviteUserCommandValidator.cs`
+- Create: `apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/Invitation/ProvisionAndInviteUserCommandHandler.cs`
+- Modify: `apps/api/src/Api/BoundedContexts/Authentication/Application/DTOs/InvitationDto.cs`
+- Test: `apps/api/tests/Api.Tests/BoundedContexts/Authentication/Application/Commands/Invitation/ProvisionAndInviteUserCommandHandlerTests.cs`
+
+- [ ] **Step 1: Create DTOs**
+
+```csharp
+// GameSuggestionDto.cs
+namespace Api.BoundedContexts.Authentication.Application.DTOs;
+public sealed record GameSuggestionDto(Guid GameId, string Type);
+```
+
+Update `InvitationDto.cs` — add `bool EmailSent` and `List<GameSuggestionDto> GameSuggestions` fields.
+
+- [ ] **Step 2: Create command record**
+
+```csharp
+// ProvisionAndInviteUserCommand.cs
+namespace Api.BoundedContexts.Authentication.Application.Commands.Invitation;
+
+internal sealed record ProvisionAndInviteUserCommand(
+    string Email,
+    string DisplayName,
+    string Role,
+    string Tier,
+    string? CustomMessage,
+    int ExpiresInDays,
+    List<GameSuggestionDto> GameSuggestions,
+    Guid InvitedByUserId
+) : ICommand<InvitationDto>;
+```
+
+- [ ] **Step 3: Create validator**
+
+```csharp
+// ProvisionAndInviteUserCommandValidator.cs
+internal sealed class ProvisionAndInviteUserCommandValidator : AbstractValidator<ProvisionAndInviteUserCommand>
+{
+    private static readonly string[] ValidRoles = { "User", "Editor", "Admin" };
+    private static readonly string[] ValidTiers = { "Free", "Premium", "Pro" };
+    private static readonly string[] ValidSuggestionTypes = { "PreAdded", "Suggested" };
+
+    public ProvisionAndInviteUserCommandValidator()
+    {
+        RuleFor(x => x.Email).NotEmpty().EmailAddress().MaximumLength(256);
+        RuleFor(x => x.DisplayName).NotEmpty().Length(2, 100);
+        RuleFor(x => x.Role).NotEmpty()
+            .Must(r => ValidRoles.Contains(r, StringComparer.OrdinalIgnoreCase));
+        RuleFor(x => x.Tier).NotEmpty()
+            .Must(t => ValidTiers.Contains(t, StringComparer.OrdinalIgnoreCase));
+        RuleFor(x => x.CustomMessage).MaximumLength(500);
+        RuleFor(x => x.ExpiresInDays).InclusiveBetween(1, 30);
+        RuleFor(x => x.GameSuggestions).Must(g => g == null || g.Count <= 20)
+            .WithMessage("Maximum 20 game suggestions");
+        RuleForEach(x => x.GameSuggestions).ChildRules(g =>
+        {
+            g.RuleFor(s => s.GameId).NotEmpty();
+            g.RuleFor(s => s.Type).Must(t => ValidSuggestionTypes.Contains(t, StringComparer.OrdinalIgnoreCase));
+        });
+    }
+}
+```
+
+- [ ] **Step 4: Write failing handler tests**
+
+Test key scenarios:
+- Happy path: creates pending user + token + sends email
+- Duplicate email: throws ConflictException
+- Email failure: returns `EmailSent = false`, user still created
+
+```csharp
+[Trait("Category", TestCategories.Unit)]
+[Trait("BoundedContext", "Authentication")]
+public class ProvisionAndInviteUserCommandHandlerTests
+{
+    // ... mock setup following existing AcceptInvitationCommandHandlerTests pattern
+
+    [Fact]
+    public async Task Handle_ValidCommand_CreatesPendingUserAndToken()
+    {
+        // Arrange
+        _userRepoMock.Setup(r => r.GetByEmailAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((User?)null);
+        _invitationRepoMock.Setup(r => r.GetPendingByEmailAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((InvitationToken?)null);
+
+        var command = new ProvisionAndInviteUserCommand(
+            "new@example.com", "New User", "User", "Free",
+            "Welcome!", 14, new List<GameSuggestionDto>(), Guid.NewGuid());
+
+        // Act
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        // Assert
+        result.Email.Should().Be("new@example.com");
+        result.Status.Should().Be("Pending");
+        result.EmailSent.Should().BeTrue();
+        _userRepoMock.Verify(r => r.AddAsync(It.Is<User>(u =>
+            u.Status == UserAccountStatus.Pending), It.IsAny<CancellationToken>()), Times.Once);
+    }
+
+    [Fact]
+    public async Task Handle_DuplicateEmail_ThrowsConflict()
+    {
+        _userRepoMock.Setup(r => r.GetByEmailAsync("existing@example.com", It.IsAny<CancellationToken>()))
+            .ReturnsAsync(CreateActiveUser());
+
+        var command = new ProvisionAndInviteUserCommand(
+            "existing@example.com", "Dup", "User", "Free", null, 7, new(), Guid.NewGuid());
+
+        var act = () => _handler.Handle(command, CancellationToken.None);
+        await act.Should().ThrowAsync<ConflictException>();
+    }
+
+    [Fact]
+    public async Task Handle_EmailFailure_ReturnsEmailSentFalse()
+    {
+        _userRepoMock.Setup(r => r.GetByEmailAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((User?)null);
+        _invitationRepoMock.Setup(r => r.GetPendingByEmailAsync(It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ReturnsAsync((InvitationToken?)null);
+        _emailServiceMock.Setup(e => e.SendInvitationEmailAsync(
+            It.IsAny<string>(), It.IsAny<string>(), It.IsAny<string>(),
+            It.IsAny<string>(), It.IsAny<CancellationToken>()))
+            .ThrowsAsync(new Exception("SMTP down"));
+
+        var command = new ProvisionAndInviteUserCommand(
+            "new@example.com", "User", "User", "Free", null, 7, new(), Guid.NewGuid());
+
+        var result = await _handler.Handle(command, CancellationToken.None);
+
+        result.EmailSent.Should().BeFalse();
+        _unitOfWorkMock.Verify(u => u.SaveChangesAsync(It.IsAny<CancellationToken>()), Times.Once);
+    }
+}
+```
+
+- [ ] **Step 5: Implement handler**
+
+Follow existing `SendInvitationCommandHandler` pattern:
+1. Check email uniqueness (user + pending invitation)
+2. Generate token (RandomNumberGenerator.GetBytes(32) → Base64 → SHA256)
+3. `User.CreatePending(...)` with TimeProvider
+4. `InvitationToken.Create(...)` with TimeProvider
+5. Add game suggestions
+6. `SaveChangesAsync()`
+7. Try/catch email send → set `EmailSent`
+8. Return `InvitationDto`
+
+- [ ] **Step 6: Run tests — verify pass**
+
+```bash
+cd apps/api && dotnet test --filter "FullyQualifiedName~ProvisionAndInviteUserCommandHandlerTests" -v n
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add -A && git commit -m "feat(auth): add ProvisionAndInviteUserCommand with handler and validator"
+```
+
+---
+
+### Task 7: ActivateInvitedAccountCommand + Handler
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/Authentication/Application/DTOs/ActivationResultDto.cs`
+- Create: `apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/Invitation/ActivateInvitedAccountCommand.cs`
+- Create: `apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/Invitation/ActivateInvitedAccountCommandValidator.cs`
+- Create: `apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/Invitation/ActivateInvitedAccountCommandHandler.cs`
+- Create: `apps/api/src/Api/BoundedContexts/Authentication/Infrastructure/Services/GameSuggestionChannel.cs`
+- Test: `apps/api/tests/Api.Tests/BoundedContexts/Authentication/Application/Commands/Invitation/ActivateInvitedAccountCommandHandlerTests.cs`
+
+- [ ] **Step 1: Create ActivationResultDto**
+
+```csharp
+namespace Api.BoundedContexts.Authentication.Application.DTOs;
+public sealed record ActivationResultDto(string SessionToken, bool RequiresOnboarding);
+```
+
+- [ ] **Step 2: Create GameSuggestionChannel (Channel<T> wrapper)**
+
+```csharp
+// apps/api/src/Api/BoundedContexts/Authentication/Infrastructure/Services/GameSuggestionChannel.cs
+namespace Api.BoundedContexts.Authentication.Infrastructure.Services;
+
+public sealed record GameSuggestionEvent(
+    Guid UserId,
+    Guid InvitedByUserId,
+    IReadOnlyList<InvitationGameSuggestion> Suggestions);
+
+public sealed class GameSuggestionChannel
+{
+    private readonly Channel<GameSuggestionEvent> _channel;
+
+    public GameSuggestionChannel()
+    {
+        _channel = Channel.CreateUnbounded<GameSuggestionEvent>(new UnboundedChannelOptions
+        {
+            SingleReader = true,
+            SingleWriter = false
+        });
+    }
+
+    public ChannelWriter<GameSuggestionEvent> Writer => _channel.Writer;
+    public ChannelReader<GameSuggestionEvent> Reader => _channel.Reader;
+}
+```
+
+- [ ] **Step 3: Create command + validator**
+
+```csharp
+// ActivateInvitedAccountCommand.cs
+internal sealed record ActivateInvitedAccountCommand(
+    string Token,
+    string Password
+) : ICommand<ActivationResultDto>;
+```
+
+```csharp
+// ActivateInvitedAccountCommandValidator.cs
+// Reuse password rules from AcceptInvitationCommandValidator
+internal sealed class ActivateInvitedAccountCommandValidator : AbstractValidator<ActivateInvitedAccountCommand>
+{
+    public ActivateInvitedAccountCommandValidator()
+    {
+        RuleFor(x => x.Token).NotEmpty();
+        RuleFor(x => x.Password)
+            .NotEmpty()
+            .MinimumLength(8)
+            .Matches("[A-Z]").WithMessage("Password must contain at least one uppercase letter")
+            .Matches("[a-z]").WithMessage("Password must contain at least one lowercase letter")
+            .Matches("[0-9]").WithMessage("Password must contain at least one digit")
+            .Matches("[^a-zA-Z0-9]").WithMessage("Password must contain at least one special character");
+    }
+}
+```
+
+- [ ] **Step 4: Write failing handler tests**
+
+Key scenarios: valid activation, expired token, double activation, Pending user not found.
+
+- [ ] **Step 5: Implement handler**
+
+Phase 1 (sync): validate token → find user → `ActivateFromInvitation` → mark token accepted → create session → `SaveChangesAsync` → return result.
+Phase 2 (async): write to `GameSuggestionChannel` after successful save.
+
+- [ ] **Step 6: Run tests — verify pass**
+
+```bash
+cd apps/api && dotnet test --filter "FullyQualifiedName~ActivateInvitedAccountCommandHandlerTests" -v n
+```
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add -A && git commit -m "feat(auth): add ActivateInvitedAccountCommand with two-phase activation and Channel dispatch"
+```
+
+---
+
+### Task 8: Replace ValidateInvitationTokenQuery + Add Admin Read Queries
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/Authentication/Application/DTOs/InvitationValidationDto.cs`
+- Modify: `apps/api/src/Api/BoundedContexts/Authentication/Application/Queries/Invitation/ValidateInvitationTokenQuery.cs` (REPLACE existing — old one returns `ValidateInvitationTokenResponse(Valid, Role, ExpiresAt)`)
+- Modify: `apps/api/src/Api/BoundedContexts/Authentication/Application/Queries/Invitation/ValidateInvitationTokenQueryHandler.cs` (REPLACE existing handler)
+- Modify: `apps/api/src/Api/Routing/AuthenticationEndpoints.cs` (update existing `MapValidateInvitationEndpoint` to use new response shape)
+- Create: `apps/api/src/Api/BoundedContexts/Authentication/Application/Queries/Invitation/GetPendingInvitationsQuery.cs`
+- Create: `apps/api/src/Api/BoundedContexts/Authentication/Application/Queries/Invitation/GetInvitationByIdQuery.cs`
+- Test: `apps/api/tests/Api.Tests/BoundedContexts/Authentication/Application/Queries/Invitation/ValidateInvitationTokenQueryTests.cs`
+
+**IMPORTANT**: A `ValidateInvitationTokenQuery` already exists in the codebase with a different response shape (`ValidateInvitationTokenResponse(Valid, Role, ExpiresAt)`). We are REPLACING it with the new security-hardened version that returns uniform errors. Delete the old `ValidateInvitationTokenResponse` record and update the existing endpoint in `AuthenticationEndpoints.cs`.
+
+- [ ] **Step 1: Create InvitationValidationDto**
+
+```csharp
+namespace Api.BoundedContexts.Authentication.Application.DTOs;
+public sealed record InvitationValidationDto(
+    bool IsValid, string? Email, string? DisplayName, string? ErrorReason);
+```
+
+- [ ] **Step 2: Replace existing ValidateInvitationTokenQuery and handler**
+
+Replace the existing query record to return `InvitationValidationDto` instead of the old response. Replace the handler to use uniform error responses ("invalid" for expired/revoked/not-found, "already_used" for accepted tokens).
+
+```csharp
+internal sealed record ValidateInvitationTokenQuery(string Token) : IQuery<InvitationValidationDto>;
+
+internal sealed class ValidateInvitationTokenQueryHandler
+    : IQueryHandler<ValidateInvitationTokenQuery, InvitationValidationDto>
+{
+    // Hash token → lookup → check status → return uniform errors
+    // Delete old ValidateInvitationTokenResponse record
+}
+```
+
+- [ ] **Step 3: Update AuthenticationEndpoints.cs**
+
+Update the existing `MapValidateInvitationEndpoint` to use the new `InvitationValidationDto` response. Remove any `using` alias for the old response type.
+
+- [ ] **Step 4: Write failing tests**
+
+Test all 5 states: valid token, expired → "invalid", revoked → "invalid", not found → "invalid", already used → "already_used". Verify Email/DisplayName are null when `IsValid=false` (except "already_used").
+
+- [ ] **Step 5: Implement GetPendingInvitationsQuery and GetInvitationByIdQuery**
+
+```csharp
+// GetPendingInvitationsQuery.cs — returns List<InvitationDto> filtered by status
+// Supports tab filtering: Pending, Accepted, Expired, Revoked
+internal sealed record GetPendingInvitationsQuery(string? StatusFilter) : IQuery<List<InvitationDto>>;
+
+// GetInvitationByIdQuery.cs — returns single InvitationDto with GameSuggestions
+internal sealed record GetInvitationByIdQuery(Guid Id) : IQuery<InvitationDto>;
+```
+
+These are needed by the admin endpoints in Task 10 Step 2.
+
+- [ ] **Step 6: Run tests — verify pass**
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add -A && git commit -m "feat(auth): replace ValidateInvitationTokenQuery with uniform errors, add admin read queries"
+```
+
+---
+
+### Task 9: Background Services
+
+**Files:**
+- Create: `apps/api/src/Api/Infrastructure/BackgroundServices/InvitationCleanupService.cs`
+- Create: `apps/api/src/Api/Infrastructure/BackgroundServices/GameSuggestionProcessorService.cs`
+- Create: `apps/api/src/Api/BoundedContexts/UserLibrary/Application/EventHandlers/GamePreAddedHandler.cs`
+- Create: `apps/api/src/Api/BoundedContexts/UserLibrary/Application/EventHandlers/GameSuggestedHandler.cs`
+- Test: `apps/api/tests/Api.Tests/Infrastructure/BackgroundServices/InvitationCleanupServiceTests.cs`
+- Test: `apps/api/tests/Api.Tests/Infrastructure/BackgroundServices/GameSuggestionProcessorServiceTests.cs`
+
+- [ ] **Step 1: Write failing tests for InvitationCleanupService**
+
+Test: expired pending users are hard-deleted, tokens marked expired, non-expired users untouched.
+
+- [ ] **Step 2: Implement InvitationCleanupService**
+
+Follow `SessionAutoSaveBackgroundService` pattern:
+- `IServiceScopeFactory` + `ILogger` + `TimeProvider`
+- While loop with `Task.Delay(TimeSpan.FromHours(1))`
+- Acquire Redis distributed lock (`invitation-cleanup-lock`, TTL 5 minutes) before processing. If lock held, skip cycle and log info. Use `IConnectionMultiplexer` (already in DI from Redis/HybridCache setup).
+- Query expired pending users
+- Hard delete user + mark token expired
+- Emit `InvitationExpiredEvent` with denormalized email+displayName for audit
+- Log cleanup count
+- Release lock in finally block
+
+- [ ] **Step 3: Run tests — verify pass**
+
+- [ ] **Step 4: Write failing tests for GameSuggestionProcessorService**
+
+Test: processes events from channel, retries on failure, logs on retry exhaustion.
+
+- [ ] **Step 5: Implement GameSuggestionProcessorService**
+
+```csharp
+// Reads from GameSuggestionChannel.Reader
+// For each suggestion: dispatch to IMediator (GamePreAddedToCollectionEvent or GameSuggestedForUserEvent)
+// Retry with backoff: 1s, 2s, 4s
+// On exhaustion: log error
+```
+
+- [ ] **Step 6: Implement UserLibrary event handlers**
+
+`GamePreAddedHandler`: adds game to collection (reuse existing add-to-collection logic), idempotent.
+`GameSuggestedHandler`: creates `GameSuggestion` entity, idempotent (check exists first).
+
+- [ ] **Step 7: Run all tests — verify pass**
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add -A && git commit -m "feat(services): add InvitationCleanupService and GameSuggestionProcessorService with UserLibrary handlers"
+```
+
+---
+
+## Chunk 3: API Endpoints, DI Registration & Frontend
+
+### Task 10: API Endpoints
+
+**Files:**
+- Modify: `apps/api/src/Api/Routing/AuthenticationEndpoints.cs`
+- Modify: `apps/api/src/Api/Routing/AdminUserEndpoints.cs` (existing admin invitation routing lives here via `MapInvitationEndpoints`)
+
+- [ ] **Step 1: Add public auth endpoints**
+
+In `AuthenticationEndpoints.cs`, add:
+
+```csharp
+// POST /api/v1/auth/activate-account
+private static void MapActivateAccountEndpoint(RouteGroupBuilder group)
+{
+    group.MapPost("/auth/activate-account", async (
+        ActivateInvitedAccountCommand command,
+        IMediator mediator,
+        HttpContext context,
+        CancellationToken ct) =>
+    {
+        var result = await mediator.Send(command, ct);
+        // Set session cookie (follow existing login pattern)
+        CookieHelpers.WriteSessionCookie(context, result.SessionToken, /* expiry */);
+        return Results.Ok(new { sessionToken = result.SessionToken, requiresOnboarding = result.RequiresOnboarding });
+    })
+    .AllowAnonymous()
+    .WithName("ActivateInvitedAccount");
+}
+
+// GET /api/v1/auth/validate-invitation?token=x
+private static void MapValidateInvitationEndpoint(RouteGroupBuilder group)
+{
+    group.MapGet("/auth/validate-invitation", async (
+        [FromQuery] string token,
+        IMediator mediator,
+        CancellationToken ct) =>
+    {
+        var result = await mediator.Send(new ValidateInvitationTokenQuery(token), ct);
+        return Results.Ok(result);
+    })
+    .AllowAnonymous()
+    .WithName("ValidateInvitationToken");
+}
+```
+
+- [ ] **Step 2: Add admin invitation endpoints**
+
+In `AdminUserEndpoints.cs`, extend the existing `MapInvitationEndpoints` method with:
+- `POST /api/v1/admin/invitations` → `ProvisionAndInviteUserCommand`
+- `POST /api/v1/admin/invitations/batch` → `BatchProvisionCommand` (JSON)
+- `POST /api/v1/admin/invitations/batch/csv` → `BatchProvisionCommand` (CSV)
+- `POST /api/v1/admin/invitations/{id}/resend` → `ResendInvitationCommand`
+- `DELETE /api/v1/admin/invitations/{id}` → `RevokeInvitationCommand`
+- `GET /api/v1/admin/invitations` → `GetPendingInvitationsQuery`
+- `GET /api/v1/admin/invitations/{id}` → `GetInvitationByIdQuery`
+
+All require Admin role via `.RequireAuthorization("Admin")`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add -A && git commit -m "feat(api): add invitation flow API endpoints for auth and admin"
+```
+
+---
+
+### Task 11: DI Registration & Program.cs
+
+**Files:**
+- Modify: `apps/api/src/Api/Program.cs`
+- Modify: Authentication BC DI extension
+- Modify: UserLibrary BC DI extension
+
+- [ ] **Step 1: Register GameSuggestionChannel as singleton**
+
+```csharp
+builder.Services.AddSingleton<GameSuggestionChannel>();
+```
+
+- [ ] **Step 2: Register background services**
+
+```csharp
+builder.Services.AddHostedService<InvitationCleanupService>();
+builder.Services.AddHostedService<GameSuggestionProcessorService>();
+```
+
+- [ ] **Step 3: Register GameSuggestionRepository**
+
+```csharp
+builder.Services.AddScoped<IGameSuggestionRepository, GameSuggestionRepository>();
+```
+
+- [ ] **Step 4: Build and verify**
+
+```bash
+cd apps/api/src/Api && dotnet build
+```
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add -A && git commit -m "feat(di): register invitation flow services, channel, and background workers"
+```
+
+---
+
+### Task 12: Extend IEmailService for Invitation
+
+**Files:**
+- Modify: `apps/api/src/Api/Services/IEmailService.cs`
+- Modify: `apps/api/src/Api/Services/EmailService.cs`
+
+- [ ] **Step 1: Add extended invitation email method**
+
+```csharp
+// In IEmailService.cs — add overload or new method:
+Task SendInvitationEmailAsync(
+    string toEmail,
+    string displayName,
+    string role,
+    string token,
+    string invitedByName,
+    string? customMessage,
+    DateTime expiresAt,
+    CancellationToken ct = default);
+```
+
+- [ ] **Step 2: Implement in EmailService.cs**
+
+Build email body with:
+- MeepleAI logo header
+- Custom message (HTML-escaped) in quote block
+- Platform intro text
+- CTA button linking to `/setup-account?token={token}`
+- Expiry notice
+- Plain-text fallback
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add -A && git commit -m "feat(email): extend invitation email with custom message, platform intro, and expiry notice"
+```
+
+---
+
+### Task 13: Frontend — Setup Account Page
+
+**Files:**
+- Create: `apps/web/src/app/(auth)/setup-account/page.tsx`
+
+- [ ] **Step 1: Create setup-account page**
+
+```tsx
+// apps/web/src/app/(auth)/setup-account/page.tsx
+'use client';
+
+import { useSearchParams, useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
+// Follow existing auth page patterns (login, register)
+
+export default function SetupAccountPage() {
+    const searchParams = useSearchParams();
+    const token = searchParams.get('token');
+    const router = useRouter();
+
+    const [validation, setValidation] = useState(null);
+    const [password, setPassword] = useState('');
+    const [confirmPassword, setConfirmPassword] = useState('');
+    const [loading, setLoading] = useState(true);
+    const [error, setError] = useState('');
+
+    // 1. On mount: GET /api/v1/auth/validate-invitation?token=xxx
+    // 2. If valid: show form with pre-filled email (readonly)
+    // 3. If invalid: show error message
+    // 4. On submit: POST /api/v1/auth/activate-account
+    // 5. On success: redirect to onboarding
+
+    // Follow existing auth page styling and patterns
+}
+```
+
+- [ ] **Step 2: Add route to auth layout if needed**
+
+Verify the `(auth)` layout handles `/setup-account` correctly (public route, no auth required).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add -A && git commit -m "feat(web): add setup-account page for invitation activation flow"
+```
+
+---
+
+## Chunk 4: Integration Testing & Final Wiring
+
+### Task 14: Integration Tests
+
+**Files:**
+- Create: `apps/api/tests/Api.Tests/Integration/Authentication/InvitationFlowIntegrationTests.cs`
+
+- [ ] **Step 1: Write end-to-end integration test**
+
+```csharp
+[Trait("Category", TestCategories.Integration)]
+[Trait("BoundedContext", "Authentication")]
+public class InvitationFlowIntegrationTests : IClassFixture<TestDatabaseFixture>
+{
+    [Fact]
+    public async Task FullFlow_ProvisionActivateAndVerifyGames()
+    {
+        // 1. Admin provisions user with game suggestions
+        // 2. Verify: User exists with Pending status
+        // 3. Activate account with valid token + password
+        // 4. Verify: User is Active, EmailVerified, session created
+        // 5. Verify: PreAdded games in collection (after async processing)
+        // 6. Verify: Suggested games visible
+    }
+
+    [Fact]
+    public async Task ExpiredToken_ReturnsInvalid()
+    {
+        // 1. Create invitation with 0-day expiry (already expired)
+        // 2. Validate token → errorReason = "invalid"
+    }
+
+    [Fact]
+    public async Task BatchWithPartialFailure_ReturnsCorrectResults()
+    {
+        // 1. Create existing user
+        // 2. Batch: 2 new + 1 existing
+        // 3. Verify: 2 succeeded, 1 failed
+    }
+}
+```
+
+- [ ] **Step 2: Run integration tests**
+
+```bash
+cd apps/api && dotnet test --filter "FullyQualifiedName~InvitationFlowIntegrationTests" -v n
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add -A && git commit -m "test(auth): add integration tests for invitation flow end-to-end"
+```
+
+---
+
+### Task 15: Security Tests
+
+**Files:**
+- Create: `apps/api/tests/Api.Tests/Security/InvitationSecurityTests.cs`
+
+- [ ] **Step 1: Write security tests**
+
+```csharp
+[Trait("Category", "Security")]
+public class InvitationSecurityTests
+{
+    [Fact]
+    public async Task NonAdminCannotCreateInvitation() { /* 403 */ }
+
+    [Fact]
+    public async Task WeakPasswordRejected() { /* validation error */ }
+
+    [Fact]
+    public async Task UniformErrorForExpiredRevokedNotFound() { /* all return "invalid" */ }
+
+    [Fact]
+    public async Task CsvInjectionSanitized() { /* =cmd formula in DisplayName */ }
+
+    [Fact]
+    public async Task XssInCustomMessageEscaped() { /* <script> tag */ }
+}
+```
+
+- [ ] **Step 2: Run security tests**
+
+```bash
+cd apps/api && dotnet test --filter "Category=Security" -v n
+```
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add -A && git commit -m "test(security): add invitation flow security tests for auth, XSS, CSV injection"
+```
+
+---
+
+### Task 16: Batch Commands — JSON and CSV Paths
+
+**Files:**
+- Create: `apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/Invitation/BatchProvisionCommand.cs`
+- Create: `apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/Invitation/BatchProvisionCommandHandler.cs`
+- Modify: `apps/api/src/Api/BoundedContexts/Authentication/Application/Commands/Invitation/BulkSendInvitationsCommandHandler.cs`
+- Test: `apps/api/tests/Api.Tests/BoundedContexts/Authentication/Application/Commands/Invitation/BatchProvisionCommandHandlerTests.cs`
+
+The spec defines TWO batch modes: JSON body (`POST /admin/invitations/batch`) and CSV (`POST /admin/invitations/batch/csv`). The existing `BulkSendInvitationsCommand` handles CSV only.
+
+- [ ] **Step 1: Create BatchProvisionCommand for JSON path**
+
+```csharp
+// BatchProvisionCommand.cs — NEW command for JSON batch
+internal sealed record BatchProvisionCommand(
+    List<BatchInvitationItemDto> Invitations,
+    Guid InvitedByUserId
+) : ICommand<BatchInvitationResultDto>;
+```
+
+- [ ] **Step 2: Implement BatchProvisionCommandHandler**
+
+```csharp
+// Iterates Invitations, constructs ProvisionAndInviteUserCommand per item,
+// dispatches via IMediator.Send(). Collects successes/failures.
+// Does NOT abort on individual failures.
+```
+
+- [ ] **Step 3: Write tests for BatchProvisionCommand**
+
+Test: partial failure (2 succeed, 1 duplicate), all succeed, all fail. Verify `EmailSent` tracking.
+
+- [ ] **Step 4: Update BulkSendInvitationsCommandHandler for CSV path**
+
+Update the existing CSV handler to dispatch `ProvisionAndInviteUserCommand` instead of `SendInvitationCommand` for each CSV row. Follow existing CSV parsing logic but construct the new command.
+
+- [ ] **Step 5: Run all batch tests**
+
+```bash
+cd apps/api && dotnet test --filter "FullyQualifiedName~BulkSend|FullyQualifiedName~BatchProvision" -v n
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add -A && git commit -m "feat(auth): add BatchProvisionCommand for JSON path, update CSV bulk handler"
+```
+
+---
+
+### Task 17: Final Verification & Cleanup
+
+- [ ] **Step 1: Full build**
+
+```bash
+cd apps/api/src/Api && dotnet build
+```
+
+- [ ] **Step 2: Run all unit tests**
+
+```bash
+cd apps/api && dotnet test --filter "Category=Unit"
+```
+
+- [ ] **Step 3: Run all integration tests**
+
+```bash
+cd apps/api && dotnet test --filter "Category=Integration"
+```
+
+- [ ] **Step 4: Run frontend build**
+
+```bash
+cd apps/web && pnpm build
+```
+
+- [ ] **Step 5: Verify API starts and endpoints respond**
+
+```bash
+cd apps/api/src/Api && dotnet run &
+# Test endpoints:
+curl -s http://localhost:8080/api/v1/auth/validate-invitation?token=test | jq .
+```
+
+- [ ] **Step 6: Final commit**
+
+```bash
+git add -A && git commit -m "chore: final wiring and verification for invitation flow"
+```
+
+---
+
+## Task Dependency Graph
+
+```
+Task 1 (SharedKernel enum) ──→ Task 2 (User Pending) ──→ Task 6 (Provision cmd)
+                                                      ──→ Task 7 (Activate cmd) ──→ Task 9 (Background services)
+                              Task 3 (InvitationToken) ──→ Task 6
+                              Task 4 (GameSuggestion) ──→ Task 9
+                              Task 5 (Migration) ──→ Task 6, Task 7
+Task 6 + Task 7 + Task 8 ──→ Task 10 (Endpoints) ──→ Task 11 (DI) ──→ Task 14 (Integration tests)
+Task 12 (Email) ──→ Task 6
+Task 13 (Frontend) — independent, can run in parallel
+Task 15 (Security tests) — after Task 10
+Task 16 (Batch update) — after Task 6
+Task 17 (Final) — last
+```
+
+## Estimated Tasks: 17 tasks, ~85 steps

--- a/docs/superpowers/specs/2026-03-17-admin-invitation-flow-design.md
+++ b/docs/superpowers/specs/2026-03-17-admin-invitation-flow-design.md
@@ -1,0 +1,824 @@
+# Admin Invitation Flow — Design Spec
+
+**Date**: 2026-03-17
+**Status**: Draft (reviewed, all issues resolved)
+**Approach**: Hybrid — extend existing invitation system (Authentication BC)
+**Review Score**: 5.6/10 → fixes applied for all Critical/High issues
+
+## Overview
+
+Admin creates a user account and sends an invitation in one action. The system creates a "pending" user, sends an email with a setup link, custom message, and platform intro. The invited user sets their password, gets auto-logged in, goes through a reduced onboarding (skipping admin-configured fields), and finds pre-added or suggested games in their collection/dashboard.
+
+## User Flow
+
+```
+Admin                           System                          Invited User
+──────                          ──────                          ────────────
+Fill form (email, role,    →    Create User (Pending)
+tier, message, games,           Create InvitationToken
+expiry)                         Send invitation email       →   Receives email
+                                                                (link + admin message
+                                                                 + platform intro)
+
+                                                                Clicks link
+                                                            →   /setup-account?token=xxx
+                                                                Sets password
+                                                            →   POST /activate-account
+                                Validate token
+                                Activate user (Pending→Active)
+                                Create session (auto-login)
+                                                            →   Reduced onboarding
+                                                                (avatar, preferences)
+                                Game suggestions processed  →   Dashboard
+                                (async, post-activation)        (pre-added games in
+                                                                 collection, suggested
+                                                                 games highlighted)
+```
+
+## Key Examples
+
+### Example 1: Happy Path — Single Invitation
+
+```
+Given: Admin "Marco" is logged in with role=Admin
+And: Game "Catan" (id=aaa-111) exists in SharedGameCatalog
+And: Game "Azul" (id=bbb-222) exists in SharedGameCatalog
+And: No user exists with email "luca@example.com"
+
+When: Admin submits POST /api/v1/admin/invitations with:
+  {
+    "email": "luca@example.com",
+    "displayName": "Luca Bianchi",
+    "role": "User",
+    "tier": "Premium",
+    "customMessage": "Benvenuto nel gruppo MeepleAI!",
+    "expiresInDays": 14,
+    "gameSuggestions": [
+      { "gameId": "aaa-111", "type": "PreAdded" },
+      { "gameId": "bbb-222", "type": "Suggested" }
+    ]
+  }
+
+Then: System creates User(status=Pending, email="luca@example.com", role=User, tier=Premium)
+And: System creates InvitationToken(pendingUserId=<new-user-id>, expiresAt=2026-03-31)
+And: System sends email to "luca@example.com" containing:
+  - Subject: "Sei stato invitato su MeepleAI!"
+  - Body includes: "Benvenuto nel gruppo MeepleAI!" (admin message)
+  - Body includes: platform intro text
+  - Body includes: CTA link to /setup-account?token=<token>
+  - Body includes: "Questo invito scade il 31 marzo 2026"
+And: Response is 200 with InvitationDto { emailSent: true, status: "Pending" }
+```
+
+### Example 2: User Activates Account
+
+```
+Given: Pending user "luca@example.com" exists with InvitationToken(token-hash=xxx)
+And: Token is not expired (expiresAt > now)
+And: Token has GameSuggestions: [Catan=PreAdded, Azul=Suggested]
+
+When: User submits POST /api/v1/auth/activate-account with:
+  { "token": "<valid-token>", "password": "SecureP@ss123" }
+
+Then: User status transitions Pending → Active
+And: User password is set (hashed)
+And: User emailVerified = true
+And: InvitationToken marked as accepted
+And: Session created (auto-login)
+And: Response is 200 with { sessionToken: "xxx", requiresOnboarding: true }
+And: (async) Catan is added to user's collection (PreAdded)
+And: (async) Azul appears as "Suggested for you by Marco" in dashboard
+```
+
+### Example 3: Batch with Partial Failure
+
+```
+Given: User "anna@example.com" already exists in the system
+
+When: Admin submits POST /api/v1/admin/invitations/batch with:
+  {
+    "invitations": [
+      { "email": "paolo@example.com", "displayName": "Paolo", "role": "User", "tier": "Free", "expiresInDays": 7 },
+      { "email": "anna@example.com", "displayName": "Anna", "role": "User", "tier": "Free", "expiresInDays": 7 },
+      { "email": "sara@example.com", "displayName": "Sara", "role": "Editor", "tier": "Premium", "expiresInDays": 14 }
+    ]
+  }
+
+Then: Response is 200 with:
+  {
+    "succeeded": [
+      { "email": "paolo@example.com", "emailSent": true, "status": "Pending" },
+      { "email": "sara@example.com", "emailSent": true, "status": "Pending" }
+    ],
+    "failed": [
+      { "email": "anna@example.com", "error": "A user with this email already exists" }
+    ]
+  }
+And: paolo@example.com and sara@example.com have pending User records
+And: anna@example.com is unchanged
+```
+
+### Example 4: Token Validation States
+
+```
+Given: Token "tok-expired" is associated with an expired invitation
+And: Token "tok-revoked" is associated with a revoked invitation
+And: Token "tok-used" is associated with an already-activated invitation
+And: Token "tok-invalid" does not exist
+
+When: GET /api/v1/auth/validate-invitation?token=tok-expired
+Then: { "isValid": false, "email": null, "displayName": null, "errorReason": "invalid" }
+
+When: GET /api/v1/auth/validate-invitation?token=tok-revoked
+Then: { "isValid": false, "email": null, "displayName": null, "errorReason": "invalid" }
+
+When: GET /api/v1/auth/validate-invitation?token=tok-used
+Then: { "isValid": false, "email": null, "displayName": null, "errorReason": "already_used" }
+
+When: GET /api/v1/auth/validate-invitation?token=tok-invalid
+Then: { "isValid": false, "email": null, "displayName": null, "errorReason": "invalid" }
+```
+
+### Example 5: Race Conditions
+
+```
+Scenario: Two admins invite same email simultaneously
+Given: No user exists with email "same@example.com"
+When: Admin A and Admin B both POST /api/v1/admin/invitations for "same@example.com" within 1 second
+Then: Exactly one succeeds (first-writer-wins via unique constraint on email)
+And: The other receives 409 ConflictException("A pending invitation for this email already exists")
+
+Scenario: User activates while admin revokes
+Given: Pending user with valid token
+When: User POSTs /activate-account AND admin DELETEs /invitations/{id} concurrently
+Then: First-writer-wins at database level (row lock on User + InvitationToken)
+  - If activation commits first: user is Active, revoke returns 400 "Invitation already accepted"
+  - If revoke commits first: activation returns 400 with errorReason "invalid"
+
+Scenario: Double activation with same token
+Given: Valid token "tok-abc" for pending user
+When: User submits /activate-account with "tok-abc" twice (e.g., double-click)
+Then: First request succeeds, second returns 400 with errorReason "already_used"
+```
+
+### Example 6: Email Delivery Failure — Admin Workflow
+
+```
+Given: SMTP server is down
+
+When: Admin invites "user@example.com"
+Then: User and InvitationToken are created (committed to DB)
+And: Email delivery fails (logged as warning)
+And: Response: InvitationDto { emailSent: false, status: "Pending" }
+And: Admin panel shows warning icon next to this invitation
+
+When: Admin clicks "Resend" on the invitation
+And: SMTP server is now available
+Then: New token generated, email sent successfully
+And: InvitationDto updated: { emailSent: true }
+
+When: Admin realizes email address was wrong
+Then: Admin clicks "Revoke" → pending user hard-deleted
+Then: Admin creates new invitation with correct email
+```
+
+### Example 7: Stale Game Reference
+
+```
+Given: Admin created invitation with GameSuggestion for "Catan" (id=aaa-111)
+And: "Catan" was deleted from SharedGameCatalog after invitation was created
+
+When: User activates their account
+
+Then: Phase 1 (activation) succeeds — user is Active, session created
+And: Phase 2 (async game suggestions): handler for Catan logs warning "Game aaa-111 not found, skipping"
+And: Other game suggestions (if any) are processed normally
+And: User activation is NOT affected by stale game reference
+```
+
+## Domain Model Changes
+
+### User Entity (Authentication BC) — Extended
+
+New properties:
+- `InvitedByUserId` (Guid?) — admin who sent the invitation
+- `InvitationExpiresAt` (DateTime?) — when the pending state expires
+
+New status value:
+- `UserAccountStatus.Pending` — created by admin, awaiting password setup
+
+**BC boundary resolution**: `UserAccountStatus` lives in Administration BC (`EntityStates.cs`). To manage this cross-BC coupling:
+- Move `UserAccountStatus` to a **SharedKernel** project referenced by both BCs
+- This makes the coupling explicit and avoids hidden cross-BC surgery for future status values
+- Update all consumers in both BCs: `CheckPermissionHandler` (deny all for Pending), `GetUserPermissionsHandler` (empty permissions for Pending), and any `switch`/`if` chain discovered during implementation
+
+New factory method:
+```csharp
+User.CreatePending(Email email, string displayName, UserRole role,
+    UserTier tier, Guid invitedByUserId, DateTime expiresAt, TimeProvider timeProvider)
+```
+- Sets `Status = Pending`, no password hash
+- `EmailVerified = false`
+- Uses `TimeProvider` for `CreatedAt` timestamp
+- Emits `UserProvisionedEvent`
+
+New method:
+```csharp
+User.ActivateFromInvitation(PasswordHash passwordHash)
+```
+- Transitions `Pending → Active`
+- Sets password hash
+- Sets `EmailVerified = true` (admin-verified email)
+- Emits `UserActivatedFromInvitationEvent`
+
+Rules:
+- `CanAuthenticate()` returns `false` when `Pending`
+- Pending users cannot login, reset password, or use OAuth
+- Hard-deleted (not soft-deleted) on expiry — audit records are denormalized (see Audit Strategy)
+
+### InvitationToken Entity — Extended
+
+New properties:
+- `CustomMessage` (string?, max 500 chars) — admin's personal message
+- `ExpiresAt` (DateTime) — configurable, default 7 days, range 1-30 days
+- `PendingUserId` (Guid) — link to the pending user created alongside
+- `GameSuggestions` (List\<InvitationGameSuggestion\>) — games to pre-add or suggest
+
+Factory method must accept `TimeProvider`:
+```csharp
+InvitationToken.Create(Email email, UserRole role, Guid pendingUserId,
+    string? customMessage, int expiresInDays, TimeProvider timeProvider)
+```
+This fixes the existing `DateTime.UtcNow` usage and enables deterministic testing.
+
+### InvitationGameSuggestion — New Entity
+
+```csharp
+public class InvitationGameSuggestion
+{
+    public Guid Id { get; private set; }
+    public Guid InvitationTokenId { get; private set; }
+    public Guid GameId { get; private set; }          // SharedGameCatalog reference
+    public GameSuggestionType Type { get; private set; } // PreAdded | Suggested
+}
+
+public enum GameSuggestionType
+{
+    PreAdded,   // Auto-added to user's collection on activation
+    Suggested   // Shown as "suggested for you" in dashboard
+}
+```
+
+Validation: `GameId` must exist in SharedGameCatalog.
+
+**Cascade delete**: FK `InvitationTokenId` must be configured with `ON DELETE CASCADE` so that when an `InvitationToken` is deleted (expiry/revoke), associated `InvitationGameSuggestions` are cleaned up automatically.
+
+## Commands & Handlers
+
+### Admin Commands
+
+#### ProvisionAndInviteUserCommand
+
+```csharp
+public record ProvisionAndInviteUserCommand(
+    string Email,
+    string DisplayName,
+    string Role,           // "User", "Editor", "Admin"
+    string Tier,           // "Free", "Premium", "Pro"
+    string? CustomMessage,
+    int ExpiresInDays,     // default 7, range 1-30
+    List<GameSuggestionDto> GameSuggestions
+) : IRequest<InvitationDto>;
+
+public record GameSuggestionDto(Guid GameId, string Type); // "PreAdded" | "Suggested"
+```
+
+Response includes email delivery status:
+```csharp
+public record InvitationDto(
+    Guid Id,
+    string Email,
+    string DisplayName,
+    string Role,
+    string Status,        // "Pending", "Accepted", "Expired", "Revoked"
+    DateTime ExpiresAt,
+    bool EmailSent,       // false if email delivery failed
+    List<GameSuggestionDto> GameSuggestions
+);
+```
+
+Handler flow:
+1. Validate email uniqueness (no existing user or pending invitation)
+2. Validate all GameIds exist in SharedGameCatalog
+3. `User.CreatePending(...)` with `TimeProvider` — persist
+4. `InvitationToken.Create(...)` with `PendingUserId` and `TimeProvider` — persist
+5. Add `GameSuggestions` to token
+6. `SaveChangesAsync()` — commit user + token + suggestions atomically
+7. Send invitation email via `IEmailService.SendInvitationEmailAsync`
+   - On success: `EmailSent = true`
+   - On failure: log error, `EmailSent = false` (user+token still created)
+8. Return `InvitationDto` with `EmailSent` status
+
+Validator (FluentValidation):
+- Email: valid format, required
+- DisplayName: required, 2-100 chars
+- Role: valid enum value
+- Tier: valid enum value
+- CustomMessage: max 500 chars
+- ExpiresInDays: 1-30
+- GameSuggestions: max 20 items, valid GameIds
+
+#### BatchProvisionCommand
+
+```csharp
+public record BatchProvisionCommand(
+    List<BatchInvitationItemDto> Invitations
+) : IRequest<BatchInvitationResultDto>;
+
+// Plain DTO, NOT a command — handler constructs ProvisionAndInviteUserCommand per item
+public record BatchInvitationItemDto(
+    string Email,
+    string DisplayName,
+    string Role,
+    string Tier,
+    string? CustomMessage,
+    int ExpiresInDays,
+    List<GameSuggestionDto> GameSuggestions
+);
+
+public record BatchInvitationResultDto(
+    List<InvitationDto> Succeeded,       // EmailSent field indicates delivery status
+    List<BatchInvitationError> Failed
+);
+
+public record BatchInvitationError(string Email, string Error);
+```
+
+Handler: constructs a `ProvisionAndInviteUserCommand` per `BatchInvitationItemDto` and dispatches each via `IMediator.Send()`. This ensures FluentValidation fires per-item. Collects successes and failures. Does not abort on individual failures.
+
+Supports two input modes:
+- **JSON body** (form multi-riga): `POST /api/v1/admin/invitations/batch`
+- **CSV upload**: `POST /api/v1/admin/invitations/batch/csv`
+
+CSV format:
+```csv
+Email,DisplayName,Role,Tier,ExpiresInDays,CustomMessage,GameIds,GameTypes
+mario@example.com,Mario Rossi,User,Free,7,"Benvenuto!",aaa-111;bbb-222,PreAdded;Suggested
+```
+
+CSV limits: max 100 rows, max 5MB file size.
+
+#### ResendInvitationCommand (existing, extended)
+
+Regenerates token, updates `ExpiresAt`, re-sends email. Keeps same pending user. No cooldown — admin can resend immediately. Each resend invalidates the previous token.
+
+#### RevokeInvitationCommand (existing, extended)
+
+Revokes token. Cascade delete handles `InvitationGameSuggestions`. Hard-deletes associated pending user (no `GameSuggestions` in UserLibrary exist yet since user was never activated). Returns `{ "userDeleted": true }` in response body to make cascade visible to API consumers.
+
+### User Commands
+
+#### ActivateInvitedAccountCommand
+
+```csharp
+public record ActivateInvitedAccountCommand(
+    string Token,
+    string Password
+) : IRequest<ActivationResultDto>;
+
+public record ActivationResultDto(
+    string SessionToken,
+    bool RequiresOnboarding
+);
+```
+
+Validator (FluentValidation):
+- Token: required, non-empty
+- Password: **same rules as `RegisterCommand` validator** — reuse existing `PasswordValidator` class (min 8 chars, 1 uppercase, 1 lowercase, 1 number, 1 special character)
+
+Handler flow (two-phase commit):
+
+**Phase 1 — Activation (single transaction, must succeed atomically):**
+1. Validate token (not expired, not revoked, not already used)
+2. Find pending user via `PendingUserId`
+3. `User.ActivateFromInvitation(passwordHash)`
+4. Mark `InvitationToken` as accepted
+5. Create session (auto-login)
+6. `SaveChangesAsync()` — commits user activation + token + session atomically
+7. Return `{SessionToken, RequiresOnboarding: true}`
+
+**Phase 2 — Game suggestions (async via Channel, idempotent):**
+8. After successful Phase 1, enqueue game suggestion events to `Channel<GameSuggestionEvent>`
+9. `GameSuggestionProcessorService` (BackgroundService) consumes from channel
+10. For each event, dispatches to UserLibrary BC handler
+11. Retry: exponential backoff (1s, 2s, 4s), max 3 attempts per event
+12. If all retries fail: log error, emit `GameSuggestionFailedEvent` for monitoring — user activation is NOT rolled back
+13. Frontend polls/refreshes collection after onboarding to pick up pre-added games
+14. Events lost on process restart are acceptable (not mission-critical)
+
+**Rationale**: User activation is the critical path. Game suggestions are nice-to-have side effects that must not block or roll back activation.
+
+#### ValidateInvitationTokenQuery
+
+```csharp
+public record ValidateInvitationTokenQuery(string Token)
+    : IRequest<InvitationValidationDto>;
+
+public record InvitationValidationDto(
+    bool IsValid,
+    string? Email,           // shown pre-filled in setup form (only when IsValid=true)
+    string? DisplayName,     // only when IsValid=true
+    string? ErrorReason      // "invalid" (uniform) or "already_used" (redirect to login)
+);
+```
+
+**Security**: Uses only two error reasons to prevent invitation state enumeration:
+- `"invalid"` — covers expired, revoked, and not-found (no distinction exposed)
+- `"already_used"` — allows redirect to login page (acceptable disclosure since user exists)
+
+When `IsValid = false` and `ErrorReason != "already_used"`, `Email` and `DisplayName` are null.
+
+## Domain Events
+
+| Event | Emitted By | Listeners |
+|-------|-----------|-----------|
+| `UserProvisionedEvent` | `User.CreatePending()` | AuditLog (denormalized), Analytics |
+| `UserActivatedFromInvitationEvent` | `User.ActivateFromInvitation()` | AuditLog, Analytics |
+| `GamePreAddedToCollectionEvent` | `GameSuggestionProcessorService` (async Phase 2) | UserLibrary BC → add to collection |
+| `GameSuggestedForUserEvent` | `GameSuggestionProcessorService` (async Phase 2) | UserLibrary BC → create suggestion |
+| `GameSuggestionFailedEvent` | `GameSuggestionProcessorService` (retry exhausted) | Monitoring/Alerting |
+| `InvitationExpiredEvent` | Cleanup service | AuditLog (denormalized) |
+
+### Cross-BC Event Dispatch Strategy
+
+Game suggestion events are dispatched via a **`Channel<GameSuggestionEvent>`** consumed by a dedicated `GameSuggestionProcessorService : BackgroundService`:
+
+```csharp
+// In ActivateInvitedAccountHandler, after Phase 1 SaveChangesAsync:
+await _gameSuggestionChannel.Writer.WriteAsync(new GameSuggestionEvent(
+    UserId, token.GameSuggestions));
+
+// GameSuggestionProcessorService consumes:
+await foreach (var evt in _channel.Reader.ReadAllAsync(ct))
+{
+    foreach (var suggestion in evt.Suggestions)
+    {
+        await ProcessWithRetryAsync(suggestion, maxRetries: 3);
+    }
+}
+```
+
+- Handlers in UserLibrary BC are **idempotent** (no error if game already in collection or suggestion already exists)
+- Failures are logged and emit `GameSuggestionFailedEvent` for monitoring
+- Events lost on process restart are acceptable — admin can manually add games if needed
+
+### UserLibrary BC Listeners
+
+`GamePreAddedToCollectionEvent` handler:
+- Adds game to user's collection (same logic as manual "add to collection")
+- Idempotent (no error if already exists)
+- If GameId no longer exists in SharedGameCatalog: log warning, skip (do not fail)
+
+`GameSuggestedForUserEvent` handler:
+- Creates a `GameSuggestion` record (new entity in UserLibrary)
+- Displayed in dashboard as "Suggested for you by [admin name]"
+- User can accept (→ add to collection) or dismiss
+- If GameId no longer exists: log warning, skip
+
+## API Endpoints
+
+### Admin Endpoints (require Admin role)
+
+```
+POST   /api/v1/admin/invitations              → ProvisionAndInviteUserCommand
+POST   /api/v1/admin/invitations/batch         → BatchProvisionCommand (JSON)
+POST   /api/v1/admin/invitations/batch/csv     → BatchProvisionCommand (CSV)
+POST   /api/v1/admin/invitations/{id}/resend   → ResendInvitationCommand
+DELETE /api/v1/admin/invitations/{id}           → RevokeInvitationCommand
+GET    /api/v1/admin/invitations                → GetPendingInvitationsQuery
+GET    /api/v1/admin/invitations/{id}           → GetInvitationByIdQuery
+```
+
+### Public Endpoints (no auth required)
+
+```
+POST   /api/v1/auth/activate-account            → ActivateInvitedAccountCommand
+GET    /api/v1/auth/validate-invitation?token=x  → ValidateInvitationTokenQuery
+```
+
+## Email Template
+
+**Subject**: "Sei stato invitato su MeepleAI!"
+
+**Structure**:
+1. **Header**: MeepleAI logo
+2. **Admin message** (if CustomMessage present): styled quote block with admin name
+3. **Platform intro**: "MeepleAI e il tuo assistente AI per giochi da tavolo. Gestisci la tua collezione, ottieni risposte dalle regole dei tuoi giochi, e scopri nuovi titoli."
+4. **CTA button**: "Configura il tuo account" → `{base_url}/setup-account?token={token}`
+5. **Expiry notice**: "Questo invito scade il {ExpiresAt:dd MMMM yyyy}"
+6. **Footer**: link supporto, unsubscribe info
+
+Plain-text fallback version included.
+
+## Frontend Pages
+
+### /setup-account?token=xxx (public)
+
+1. On load: `GET /validate-invitation?token=xxx`
+2. If valid:
+   - Show pre-filled email (readonly) and display name
+   - Password field + confirm password (same rules as registration)
+   - Submit → `POST /activate-account`
+   - On success: set session cookie, redirect to onboarding
+3. If invalid:
+   - `"invalid"` → "L'invito non e valido o e scaduto. Contatta l'amministratore."
+   - `"already_used"` → "Questo invito e gia stato utilizzato." + link login
+
+### /admin/invitations (admin panel)
+
+- **Tabs**: Pending | Accepted | Expired | Revoked
+- **Single invite form**: email, display name, role, tier, custom message, expiry days slider (1-30), game picker
+- **Email status indicator**: green checkmark if `EmailSent=true`, warning icon if `false` with "Resend" action
+- **Batch form**: multi-row table with same fields + "Add row" button
+- **CSV import**: file upload with template download link
+- **Game picker**: search games from SharedGameCatalog, toggle PreAdded/Suggested per game
+- **Actions per invitation**: Resend, Revoke, View details
+
+### Onboarding (reduced for invited users)
+
+Concrete step list for invited users (`User.InvitedByUserId != null`):
+
+| Step ID | Step Name | Shown for invited? | Shown for self-registered? |
+|---------|-----------|--------------------|-----------------------------|
+| `profile-setup` | Avatar, display name | Yes (name pre-filled) | Yes |
+| `role-selection` | Choose role | **No** (admin set it) | Yes |
+| `tier-selection` | Choose tier/plan | **No** (admin set it) | Yes |
+| `game-preferences` | Categories, complexity, player count | Yes | Yes |
+| `notification-settings` | Email/push preferences | Yes | Yes |
+| `first-game` | Add your first game | **No** (admin may have pre-added) | Yes |
+
+Detection: `User.InvitedByUserId != null` → filter step list. This is a server-side decision returned in the onboarding configuration endpoint, not a frontend-only check.
+
+## Background Services
+
+### InvitationCleanupService
+
+```csharp
+public class InvitationCleanupService : BackgroundService
+{
+    // Runs every hour
+    // Uses TimeProvider for testability (project convention)
+    //
+    // 1. Acquire Redis distributed lock ("invitation-cleanup-lock", TTL 5 minutes)
+    //    - If lock held by another instance, skip this cycle (log info)
+    // 2. Query: Users WHERE Status=Pending AND InvitationExpiresAt < timeProvider.GetUtcNow()
+    // 3. For each expired pending user:
+    //    a. Mark InvitationToken as expired
+    //    b. Cascade delete handles InvitationGameSuggestions
+    //    c. Hard delete pending user
+    //    d. Emit InvitationExpiredEvent (with denormalized email + displayName for audit)
+    // 4. Log: cleanup count for monitoring
+    // 5. Release lock
+}
+```
+
+**Distributed lock**: Required for multi-instance deployments (load-balanced API). Uses Redis (already in stack) to prevent duplicate processing. TTL of 5 minutes ensures lock is released even if process crashes.
+
+### GameSuggestionProcessorService
+
+```csharp
+public class GameSuggestionProcessorService : BackgroundService
+{
+    // Consumes from Channel<GameSuggestionEvent>
+    // For each event: process suggestions with retry (1s, 2s, 4s backoff, max 3)
+    // On retry exhaustion: emit GameSuggestionFailedEvent, log error
+    // Idempotent: safe to replay events
+}
+```
+
+## GameSuggestion Entity (UserLibrary BC)
+
+New entity to support the "suggested games" feature:
+
+```csharp
+public class GameSuggestion
+{
+    public Guid Id { get; private set; }
+    public Guid UserId { get; private set; }
+    public Guid GameId { get; private set; }
+    public Guid SuggestedByUserId { get; private set; }  // admin
+    public string? Source { get; private set; }           // "invitation"
+    public DateTime CreatedAt { get; private set; }
+    public bool IsDismissed { get; private set; }
+    public bool IsAccepted { get; private set; }
+
+    // Domain state changes only — no cross-aggregate logic
+    public void Accept()
+    {
+        IsAccepted = true;
+        // Emits GameSuggestionAcceptedEvent
+        // Application handler dispatches AddGameToLibraryCommand
+    }
+
+    public void Dismiss() { IsDismissed = true; }
+}
+```
+
+`GameSuggestion.Accept()` only updates its own state and emits `GameSuggestionAcceptedEvent`. The application-layer handler for that event dispatches `AddGameToLibraryCommand` to add the game to the user's collection. This respects DDD aggregate boundaries.
+
+## Non-Functional Requirements
+
+| Requirement | Target | Measurement |
+|-------------|--------|-------------|
+| Single invitation creation | < 2s response time | API latency p99 |
+| Batch of 100 invitations | < 60s total processing | API latency |
+| Email delivery | < 30s after provisioning | Email service logs |
+| Setup-account page load | < 2s | Frontend metrics |
+| Cleanup service SLA | Expired users removed within 2h of expiry | Cleanup metric timestamp |
+| Game suggestion processing | < 10s after activation | Channel consumer latency |
+| Token validation | < 200ms | API latency p99 |
+
+## Testing Strategy
+
+### Unit Tests
+- `User.CreatePending()` — correct status, no password, properties set, uses TimeProvider
+- `User.ActivateFromInvitation()` — Pending→Active transition, password set, email verified
+- `CanAuthenticate()` returns false for Pending
+- `InvitationToken.Create()` with TimeProvider — correct expiry calculation
+- `InvitationToken` expiry and revocation logic
+- `BatchProvisionCommand` — partial failure handling
+- `InvitationGameSuggestion` validation
+- `GameSuggestion.Accept()` — sets IsAccepted, emits event (no collection logic)
+- `GameSuggestion.Dismiss()` — sets IsDismissed
+- `ValidateInvitationTokenQuery` — uniform error for expired/revoked/not-found
+- `ActivateInvitedAccountCommand` password validation — reuses existing PasswordValidator
+
+### Integration Tests
+- Full flow: provision → activate → session created → games processed (async)
+- Cleanup service: pending user deleted after expiry, cascade deletes suggestions
+- Cleanup service: Redis distributed lock prevents duplicate processing
+- Batch: CSV + JSON, mixed successes and failures, EmailSent status tracking
+- Game suggestions: PreAdded in collection, Suggested visible (after async processing)
+- Token expired/revoked → uniform "invalid" error response
+- Duplicate email → ConflictException (409)
+- Resend → new token, same pending user
+- `UserAccountStatus.Pending` handled correctly by CheckPermissionHandler (deny all)
+- Stale GameId in suggestion → logged warning, skipped, activation not affected
+- Email delivery: mock `IEmailService` captures sent emails in-memory
+  - Verify: correct recipient, token URL present, CustomMessage in body, expiry date formatted
+  - Email template snapshot tests for layout/content verification
+
+### Edge Case Tests
+- **Double activation**: second attempt with same token returns `"already_used"`
+- **Concurrent same-email invite**: exactly one succeeds, other gets 409
+- **Activation vs revoke race**: first-writer-wins, loser gets appropriate error
+- **Stale GameId**: handler logs warning, skips game, does not fail activation
+- **Cleanup vs activation race**: activation transaction holds row lock, cleanup skips that user
+- **Unicode email/displayName**: test with accented characters (e.g., "Francois@example.com", "Rene")
+- **Max batch size**: 100 rows CSV processed within NFR target
+- **Expired token re-use**: returns "invalid", not "already_used"
+
+### Security Tests
+- **Rate limiting**: 100 rapid requests to `/validate-invitation` from same IP → 429 after threshold
+- **CSV injection**: upload CSV with `=cmd|'/C calc'!A0` in DisplayName → verify sanitized/escaped
+- **XSS in CustomMessage**: `<script>alert(1)</script>` → verify HTML-escaped in email output
+- **Authorization**: User role calling `POST /admin/invitations` → 403 Forbidden
+- **Token brute-force**: random tokens always return same-timing "invalid" (EF Core parameterized query)
+- **Password policy**: activation with weak password ("123") → validation error matching RegisterCommand rules
+
+### E2E Tests
+- Admin creates invitation → user receives email → setup password → reduced onboarding → dashboard with games
+- Admin batch invite via CSV → all users created, email status visible in admin panel
+- Invalid invitation → generic error page ("L'invito non e valido o e scaduto")
+- Already-used invitation → redirect to login
+
+## Audit Strategy
+
+Pending users are hard-deleted on expiry, but audit records must survive. All audit log entries for invitation-related events are **denormalized** — they store the email and display name directly, not just a UserId FK:
+
+```csharp
+// AuditLog record for UserProvisionedEvent:
+{
+    Action: "UserProvisioned",
+    TargetEntityType: "User",
+    TargetEntityId: "<user-id>",      // Will be deleted on expiry
+    Metadata: {
+        "email": "luca@example.com",  // Denormalized — survives user deletion
+        "displayName": "Luca Bianchi",
+        "invitedBy": "<admin-id>",
+        "role": "User",
+        "tier": "Premium"
+    }
+}
+
+// AuditLog record for InvitationExpiredEvent:
+{
+    Action: "InvitationExpired",
+    TargetEntityType: "InvitationToken",
+    TargetEntityId: "<token-id>",
+    Metadata: {
+        "email": "luca@example.com",  // Denormalized
+        "displayName": "Luca Bianchi",
+        "pendingUserId": "<deleted-user-id>",
+        "expiredAt": "2026-03-31T00:00:00Z"
+    }
+}
+```
+
+This ensures audit queries do not produce dangling FK references and the full invitation lifecycle is traceable even after cleanup.
+
+## Observability
+
+### Metrics
+
+| Metric | Type | Description |
+|--------|------|-------------|
+| `invitations_provisioned_total` | Counter | Total invitations created (labels: role, tier) |
+| `invitations_activated_total` | Counter | Total successful activations |
+| `invitations_expired_total` | Counter | Total expired (cleaned up by service) |
+| `invitations_revoked_total` | Counter | Total admin-revoked |
+| `invitation_email_sent_total` | Counter | Emails sent (labels: success, failure) |
+| `invitation_email_failure_rate` | Gauge | Rolling 5min email failure percentage |
+| `game_suggestion_processed_total` | Counter | Game suggestions processed (labels: type, success/failure) |
+| `game_suggestion_retry_exhausted_total` | Counter | Game suggestions that failed all retries |
+| `cleanup_service_last_run_at` | Gauge | Timestamp of last successful cleanup run |
+| `cleanup_service_users_deleted` | Counter | Pending users deleted per cleanup cycle |
+| `invitation_activation_duration_seconds` | Histogram | Phase 1 activation latency |
+
+### Alerts
+
+| Alert | Condition | Severity |
+|-------|-----------|----------|
+| Email failure spike | `invitation_email_failure_rate > 10%` for 5 min | Warning |
+| Cleanup service stale | `cleanup_service_last_run_at` > 2 hours ago | Critical |
+| Game suggestion failures | `game_suggestion_retry_exhausted_total` increase > 5 in 1h | Warning |
+| Activation latency | `invitation_activation_duration_seconds` p99 > 5s | Warning |
+
+### Health Check
+
+Expose via existing `/health` endpoint:
+- `InvitationCleanupService`: last run timestamp, pending user count
+- `GameSuggestionProcessorService`: channel queue depth, processing status
+
+## Migration
+
+New database objects:
+- `ALTER TABLE Users ADD InvitedByUserId UUID NULL`
+- `ALTER TABLE Users ADD InvitationExpiresAt TIMESTAMPTZ NULL`
+- `ALTER TABLE InvitationTokens ADD CustomMessage VARCHAR(500) NULL`
+- `ALTER TABLE InvitationTokens ADD ExpiresAt TIMESTAMPTZ NOT NULL DEFAULT (NOW() + INTERVAL '7 days')`
+- `ALTER TABLE InvitationTokens ADD PendingUserId UUID NULL`
+- `CREATE TABLE InvitationGameSuggestions (Id UUID PK, InvitationTokenId UUID FK ON DELETE CASCADE, GameId UUID NOT NULL, Type INT NOT NULL)`
+- `CREATE TABLE GameSuggestions (Id UUID PK, UserId UUID FK, GameId UUID NOT NULL, SuggestedByUserId UUID NOT NULL, Source VARCHAR(50), CreatedAt TIMESTAMPTZ, IsDismissed BOOLEAN DEFAULT FALSE, IsAccepted BOOLEAN DEFAULT FALSE)`
+- Move `UserAccountStatus` to SharedKernel, add `Pending = 3`
+- Update `CheckPermissionHandler` and `GetUserPermissionsHandler` to handle `Pending` status
+
+Note: PostgreSQL syntax (project uses PostgreSQL, not SQL Server).
+
+## Security Considerations
+
+- Invitation tokens: 32-byte cryptographically random, URL-safe Base64, hashed (SHA-256) in DB
+- Token lookup via EF Core parameterized queries (timing-safe at DB level)
+- Setup-account page: rate-limited to prevent brute force
+- Pending users cannot authenticate — enforced at domain level
+- Admin-only endpoints: require `Admin` role via auth middleware
+- CSV upload: validate file size (max 5MB), row count limits (max 100), sanitize inputs (CSV injection protection)
+- Custom message: HTML-escaped in email template to prevent XSS
+- ValidateInvitationTokenQuery: uniform "invalid" error to prevent state enumeration
+- Email/DisplayName only returned when token is valid (not on error responses)
+- Password validation: reuses `RegisterCommand` validator — consistent policy across all entry points
+
+## Review Resolution Log
+
+### Round 1 — Code Reviewer (8 issues)
+
+| # | Severity | Issue | Resolution |
+|---|----------|-------|------------|
+| 1 | Critical | `UserAccountStatus.Pending` modifies Administration BC enum | Move to SharedKernel, update all consumers explicitly |
+| 2 | Critical | Cross-BC events have no atomicity strategy | Two-phase: sync activation + async Channel-based game suggestions |
+| 3 | Critical | Batch email failures indistinguishable from successes | Added `EmailSent: bool` to `InvitationDto`, admin UI shows status |
+| 4 | High | `InvitationToken.Create()` bypasses TimeProvider | Added `TimeProvider` to factory method signature |
+| 5 | High | `GameSuggestion.Accept()` embeds application logic | Emits `GameSuggestionAcceptedEvent`, handler dispatches command |
+| 6 | High | ValidateInvitationTokenQuery discloses state | Uniform "invalid" + "already_used" only |
+| 7 | High | No cascade-delete for InvitationGameSuggestions | `ON DELETE CASCADE` on `InvitationTokenId` FK |
+| 8 | High | BatchProvisionCommand uses command-of-commands | Changed to `List<BatchInvitationItemDto>` (DTO) |
+
+### Round 2 — Spec Panel (5 experts, 13 issues)
+
+| # | Severity | Expert | Issue | Resolution |
+|---|----------|--------|-------|------------|
+| W1 | High | Wiegers | Missing password acceptance criteria | Added validator referencing existing `PasswordValidator` |
+| W2 | Medium | Wiegers | No NFR section | Added NFR table with measurable targets |
+| W3 | Medium | Wiegers | Ambiguous reduced onboarding | Added concrete step ID table with show/skip per user type |
+| A1 | Critical | Adzic | Zero concrete examples | Added 7 Given/When/Then examples covering all key flows |
+| A2 | High | Adzic | Email failure scenario underspecified | Added Example 6 with admin workflow for email failures |
+| A3 | Medium | Adzic | Race condition examples missing | Added Example 5 with 3 race condition scenarios |
+| F1 | High | Fowler | Cross-BC enum is shared kernel anti-pattern | Resolved: move to SharedKernel project |
+| F2 | Medium | Fowler | `Task.Run()` vs Channel ambiguity | Resolved: specified `Channel<T>` + BackgroundService explicitly |
+| F3 | Low | Fowler | DELETE cascades silently to User | Added `{ "userDeleted": true }` in revoke response |
+| N1 | Critical | Nygard | No monitoring or alerting | Added Observability section with metrics, alerts, health checks |
+| N2 | High | Nygard | Hard delete creates audit gaps | Added Audit Strategy with denormalized records |
+| N3 | Medium | Nygard | Cleanup service no distributed lock | Added Redis distributed lock |
+| C1 | High | Crispin | Missing edge case coverage | Added Edge Case Tests subsection |
+| C2 | High | Crispin | No security testing | Added Security Tests subsection |
+| C3 | Medium | Crispin | Email not testable | Added email mock strategy with snapshot tests |


### PR DESCRIPTION
## Summary

- **Admin Invitation Flow**: One-action user provisioning + invitation. Admin fills form (email, role, tier, games, custom message) → system creates pending user + sends branded email
- **Account Activation**: Invited user clicks link → sets password → auto-login → reduced onboarding → dashboard with pre-added/suggested games
- **Batch Invitations**: JSON body and CSV upload paths, partial failure support, EmailSent tracking
- **Security Hardening**: Uniform token validation errors (prevents state enumeration), TimeProvider everywhere, XSS-escaped custom messages

### Architecture

- `UserAccountStatus.Pending` moved to SharedKernel (resolves cross-BC coupling)
- Two-phase activation: sync (user + session) + async game suggestions via `Channel<T>`
- New `GameSuggestion` entity in UserLibrary BC with Accept/Dismiss domain events
- `InvitationCleanupService` (hourly) hard-deletes expired pending users
- `GameSuggestionProcessorService` consumes Channel with 3x exponential backoff retry

### New API Endpoints

| Method | Path | Description |
|--------|------|-------------|
| POST | `/auth/activate-account` | Set password + auto-login |
| GET | `/auth/validate-invitation?token=x` | Validate token (uniform errors) |
| POST | `/admin/invitations` | Provision + invite user |
| POST | `/admin/invitations/batch` | JSON batch |
| POST | `/admin/invitations/batch/csv` | CSV batch |
| GET | `/admin/invitations` | List invitations by status |
| GET | `/admin/invitations/{id}` | Get invitation detail |
| POST | `/admin/invitations/{id}/resend` | Resend invitation |
| DELETE | `/admin/invitations/{id}` | Revoke invitation |

### Test Coverage

- **170 invitation-specific tests** (unit + integration + security)
- Integration tests caught and fixed 6 critical bugs (repo mapping, FK violations, missing UpdateAsync)
- Security tests: password policy, uniform errors, CSV injection, XSS, authorization

### Files

76 files changed, 21,576 additions, 98 deletions

## Test plan

- [ ] Backend build passes (0 errors, 0 warnings)
- [ ] 170/170 invitation tests pass
- [ ] 16,129 unit tests pass (35 pre-existing failures unrelated)
- [ ] Frontend build passes
- [ ] Manual: admin creates invitation → email received → setup password → auto-login → games in collection
- [ ] Manual: batch CSV upload with mixed valid/invalid rows

🤖 Generated with [Claude Code](https://claude.com/claude-code)
